### PR TITLE
check if conditions value_type is 'Value' before trying to fix the formatting

### DIFF
--- a/modules/AOW_Conditions/AOW_Condition.php
+++ b/modules/AOW_Conditions/AOW_Condition.php
@@ -80,7 +80,7 @@ class AOW_Condition extends Basic {
                                 default:
                                     $post_data[$key.$field_def['name']][$i] = encodeMultienumValue($post_data[$key.$field_def['name']][$i]);
                             }
-                        } else if($field_def['name'] == 'value') {
+                        } else if($field_def['name'] === 'value' && $post_data[$key.'value_type'][$i] === 'Value') {
                             $post_data[$key.$field_def['name']][$i] = fixUpFormatting($_REQUEST['flow_module'], $condition->field, $post_data[$key.$field_def['name']][$i]);
                         }
                         $condition->$field_def['name'] = $post_data[$key.$field_def['name']][$i];


### PR DESCRIPTION
condition value fields should not be formatted if their value_type is not 'Value', otherwise, for value_type 'Field', the fields name will be lost if the field type is not 'string'
