### PR TITLE
Switch requesttoken function so that it works

### DIFF
--- a/include/SugarOAuthServer.php
+++ b/include/SugarOAuthServer.php
@@ -167,7 +167,7 @@ class SugarOAuthServer
 		    $this->provider->setTimestampNonceHandler(array($this,'timestampNonceChecker'));
 		    $this->provider->setTokenHandler(array($this,'tokenHandler'));
 	        if(!empty($req_path)) {
-		        $this->provider->setRequestTokenPath($req_path);  // No token needed for this end point
+		        $this->provider->isRequestTokenEndpoint($req_path);  // No token needed for this end point
 	        }
 	    	$this->provider->checkOAuthRequest(null, $this->decodePostGet());
 	    	if(mt_rand() % 10 == 0) {


### PR DESCRIPTION
This is a carbon copy of a pull request I have on sugarCE ( https://github.com/sugarcrm/sugarcrm_dev/pull/200 ) and the corresponding (rambling) bug at https://web.sugarcrm.com/support/issues/632e7f17-63a6-6797-41e0-532a4f224ab3.

TLDR: The constructor set up right now in SugarOAuthServer doesn't actually allow requestTokens to be created (it keeps demanding a token be passed). This pull fixes that. It likely isn't the most perfect response (which was probably caused "long ago" by a change in Zend ) but is what appears to be the easiest fix to solve the issue and has not caused any issues in extensive use/testing on our side and reading through the code.

I verified the bug on sutieCRM side manually before submitting obviously.
