### PR TITLE
Fixed "main menu (Tab All) not with 2 column layout"

### DIFF
--- a/themes/Suite7/tpls/_headerModuleList.tpl
+++ b/themes/Suite7/tpls/_headerModuleList.tpl
@@ -96,7 +96,7 @@
                     <a href="#" id="grouptab_{$smarty.foreach.groupList.index}">{$group}</a>
                     </span>
                 <span class="notCurrentTabRight">&nbsp;</span>
-                <ul class="cssmenu" id="{$group}">
+                <ul class="cssmenu"{if $smarty.foreach.groupList.last} id="All"{/if}>
                     {foreach from=$modules.modules item=module key=modulekey}
                         <li>
                             {capture name=moduleTabId assign=moduleTabId}moduleTab_{$smarty.foreach.moduleList.index}_{$module}{/capture}


### PR DESCRIPTION
Main menu (Tab All) not with 2 column layout when language is not
English. The value of the id attribute of the UL tag was language
dependent.
