### PR TITLE
Email User Variable fix for Users module condition

### DIFF
--- a/modules/AOW_Actions/actions/actionSendEmail.php
+++ b/modules/AOW_Actions/actions/actionSendEmail.php
@@ -240,8 +240,13 @@ class actionSendEmail extends actionBase {
                 }
             }
         }
-
-        $object_arr['Users'] = $bean->assigned_user_id;
+        
+        if (is_a($bean, 'User')) {
+            $object_arr['Users'] = $bean->id;
+        }
+        else {
+            $object_arr['Users'] = $bean->assigned_user_id;
+        }
 
         $parsedSiteUrl = parse_url($sugar_config['site_url']);
         $host = $parsedSiteUrl['host'];


### PR DESCRIPTION
The problem arises when you set a condition based on the Users module in a Workflow. When you try to send an email as an action, the Contact and User variables are not parsed correctly. The reason is the User record is passed as a bean to the run_action() function in the actionSendEmail.php and code on line 244 tries to store the $bean->assigned_user_id to an array that is then passed to the static aowTemplateParser::parse_template() function. The issue is the user record does not have an assigned_user_id property so it is set as NULL and none of the email variable are parsed correctly.