### PR TITLE
Support for relationshipfields

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -3246,6 +3246,22 @@ class SugarBean
 
         $used_join_key = array();
 
+	//walk through the fields and for every relationship field add their relationship_info field
+	//relationshipfield-aliases are resolved in SugarBean::create_new_list_query through their relationship_info field
+	$addrelate = array();
+	foreach($fields as $field=>$value)
+	{
+		if (isset($this->field_defs[$field]) && isset($this->field_defs[$field]['source']) && 
+			$this->field_defs[$field]['source'] == 'non-db')
+		{
+			$addrelatefield = $this->get_relationship_field($field);
+			if ($addrelatefield)
+				$addrelate[$addrelatefield] = true;
+		}
+	}
+
+	$fields = array_merge($addrelate, $fields);
+
         foreach($fields as $field=>$value)
         {
             //alias is used to alias field names
@@ -3275,20 +3291,20 @@ class SugarBean
             //ignore fields that are a part of the collection and a field has been removed as a result of
             //layout customization.. this happens in subpanel customizations, use case, from the contacts subpanel
             //in opportunities module remove the contact_role/opportunity_role field.
-            $process_field=true;
             if (isset($data['relationship_fields']) and !empty($data['relationship_fields']))
             {
+		$process_field = false;
                 foreach ($data['relationship_fields'] as $field_name)
                 {
-                    if (!isset($fields[$field_name]))
+                    if (isset($fields[$field_name]))
                     {
-                        $process_field=false;
+                        $process_field = true;
+                        break;
                     }
                 }
-            }
-            if (!$process_field)
-            {
-                continue;
+		
+            	if (!$process_field)
+                	continue;
             }
 
             if(  (!isset($data['source']) || $data['source'] == 'db') && (!empty($alias) || !empty($filter) ))
@@ -3547,9 +3563,22 @@ class SugarBean
                     	{
 	                       $db_field = $this->db->concat($params['join_table_alias'], $data['db_concat_fields']);
 	                       $where = preg_replace('/'.$data['name'].'/', $db_field, $where);
+
+				// For relationship fields replace their alias by the corresponsding link table and r_name
+				if(isset($data['relationship_fields']))
+					foreach($data['relationship_fields'] as $r_name=>$alias_name)
+					{
+						$db_field = $this->db->concat($params['join_table_link_alias'], $r_name);
+						$where = preg_replace('/' . $alias_name . '/', $db_field, $where);
+					}
                     	}
                     }else{
                         $where = preg_replace('/(^|[\s(])' . $data['name'] . '/', '${1}' . $params['join_table_alias'] . '.'.$data['rname'], $where);
+
+			// For relationship fields replace their alias by the corresponsding link table and r_name
+			if(isset($data['relationship_fields']))
+				foreach($data['relationship_fields'] as $r_name=>$alias_name)
+					$where = preg_replace('/(^|[\s(])' . $alias_name . '/', '${1}' . $params['join_table_link_alias'] . '.'.$r_name, $where);
                     }
                     if(!$table_joined)
                     {
@@ -3617,6 +3646,20 @@ class SugarBean
 
         return  $ret_array['select'] . $ret_array['from'] . $ret_array['where']. $ret_array['order_by'];
     }
+
+	// Check if field is defined through a relationship_info field, add this field when not present 
+	function get_relationship_field($field)
+	{
+		foreach ($this->field_defs as $field_def => $value)
+		{
+			if (isset($value['relationship_fields']) && 
+				in_array($field, $value['relationship_fields']) )
+				return $field_def;
+		}
+
+		return false;
+	}
+
     /**
      * Returns parent record data for objects that store relationship information
      *

--- a/include/SearchForm/SearchForm2.php
+++ b/include/SearchForm/SearchForm2.php
@@ -741,10 +741,21 @@ require_once('include/EditView/EditView2.php');
                          // construct the query for multenums
                          // use the 'like' query as both custom and OOB multienums are implemented with types that cannot be used with an 'in'
                          $operator = 'custom_enum';
-                         $table_name = $this->seed->table_name ;
-                         if ($customField)
-                             $table_name .= "_cstm" ;
-                         $db_field = $table_name . "." . $field;
+			// Relationshipfields get their field name directly from the field name map,
+			// this alias-name is automatically replaced by the join table and rname through sugarbean::create_new_list_query
+			if (isset($this->seed->field_name_map[$field]) && 
+				isset($this->seed->field_name_map[$field]['source']) && 
+				$this->seed->field_name_map[$field]['source'] == 'non-db')
+			{
+				$db_field = $this->seed->field_name_map[$field]['name'];
+			}
+			else
+			{
+				$table_name = $this->seed->table_name ;
+				if ($customField)
+					$table_name .= "_cstm" ;
+				$db_field = $table_name . "." . $field;
+			}
 
                          foreach($parms['value'] as $val) {
                              if($val != ' ' and $val != '') {
@@ -823,7 +834,6 @@ require_once('include/EditView/EditView2.php');
                              if ($type == 'relate' && !empty($this->seed->field_name_map[$field]['link'])
                                  && !empty($this->seed->field_name_map[$field]['rname'])) {
                                      $link = $this->seed->field_name_map[$field]['link'];
-                                     $relname = $link['relationship'];
                                      if (($this->seed->load_relationship($link))){
                                          //Martin fix #27494
                                          $db_field = $this->seed->field_name_map[$field]['name'];
@@ -834,6 +844,13 @@ require_once('include/EditView/EditView2.php');
 
 
                              }
+				// Relationship fields get the name directly from the field_name_map
+				else if (isset($this->seed->field_name_map[$field]) && 
+					isset($this->seed->field_name_map[$field]['source']) && 
+					$this->seed->field_name_map[$field]['source'] == 'non-db')
+				{
+					$db_field = $this->seed->field_name_map[$field]['name'];
+				}
                              else if ($type == 'parent') {
                                  if (!empty($this->searchFields['parent_type'])) {
                                      $parentType = $this->searchFields['parent_type'];


### PR DESCRIPTION
Modification implements to proper handling when a relationship field (like contact_role) is used for searching.

It drastically simplifies the implementation of relationship fields, as after defining the vardefs for this field (and implementing all necessary widget and subpanel stuff), these fields can easily be added to the vardefs of the related modules and included in searches.

For example: search for all contacts that have the contact role "primary decision maker"
