### PR TITLE
Creating or editing a pdf template throws a php fatal error (eg. a blank page)

### DIFF
--- a/modules/AOS_PDF_Templates/views/view.edit.php
+++ b/modules/AOS_PDF_Templates/views/view.edit.php
@@ -23,6 +23,13 @@ class AOS_PDF_TemplatesViewEdit extends ViewEdit {
         if ($handle = opendir('modules/AOS_PDF_Templates/samples')) {
             $sample_options_array[] = ' ';
             while (false !== ($file = readdir($handle))) {
+
+            	//OPENSYMBOLMOD simo - too confident to not exclude directories...think about .svn for example
+                if ( !is_file($file) ) {
+                    continue;
+                }
+                //OPENSYMBOLMOD simo
+
                 if($value = ltrim(rtrim($file,'.php'),'smpl_')){
                     require_once('modules/AOS_PDF_Templates/samples/'.$file);
                     $file = rtrim($file,'.php');


### PR DESCRIPTION
Passing a directory as argument for a require_once() php call throws a fatal error, i added a simple check to skip everything that is not a regular file.

This problem occured on our environments because of automatically created subversion directories