### PR TITLE
Remove backticks for MSSQL compatibility

### DIFF
--- a/custom/include/social/twitter/twitter_helper.php
+++ b/custom/include/social/twitter/twitter_helper.php
@@ -3,7 +3,7 @@
 function check_enabled($db, $type)
 {
 
-    $query = "SELECT * FROM `config` where name = 'module_" . $type . "' and value =  1;";
+    $query = "SELECT * FROM config where name = 'module_" . $type . "' and value =  1;";
     $results = $db->query($query);
 
     while ($row = $db->fetchByAssoc($results)) {

--- a/custom/modules/SugarFeed/Dashlets/SugarFeedDashlet/SugarFeedDashlet.php
+++ b/custom/modules/SugarFeed/Dashlets/SugarFeedDashlet/SugarFeedDashlet.php
@@ -576,7 +576,7 @@ enableQS(false);
 
     function check_enabled($type){
         global $db;
-        $query = "SELECT * FROM `config` where name = 'module_" .$type . "' and value =  1;";
+        $query = "SELECT * FROM config where name = 'module_" .$type . "' and value =  1;";
         $results = $db->query($query);
 
         while ($row = $db->fetchByAssoc($results)) {


### PR DESCRIPTION
Errors are seen on the Home page for some users, even with Twitter/FB connectors disabled.

"SQL Error : Incorrect syntax near '`'.SQL Error : Incorrect syntax near '`'.SQL Error : Incorrect syntax near '`'.SQL Error : Incorrect syntax near '`'."

More details here:https://suitecrm.com/index.php?option=com_kunena&view=topic&catid=7&id=2174&Itemid=1136
