### PR TITLE
Create composer.json in order to get SuiteCRM installable via Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "salesagility/SuiteCRM",
+    "description": "SuiteCRM",
+    "keywords": [
+        "SuiteCRM",
+        "SugarCRM",
+        "CRM"
+    ],
+    "homepage": "http://www.suitecrm.com/",
+    "type": "library"
+}


### PR DESCRIPTION
[Composer](http://getcomposer.org) is a great tool, which is widely spread and is de-facto the standard of managing PHP dependencies.
This commit introduces Composer support - so now SuiteCRM could be installed via Composer, just add these lines to `composer.json` of your own project:
```
        "repositories": [
                {
                        "url": "https://github.com/salesagility/SuiteCRM.git",
                        "type": "git"
                }
        ],
        "require": {
                "salesagility/SuiteCRM": "*"
        }
```