### PR TITLE
Update dbConfig_a.php to fix constant 'passwords do not match' error on new database user creation

### DIFF
--- a/install/dbConfig_a.php
+++ b/install/dbConfig_a.php
@@ -219,7 +219,6 @@ $out2 .=<<<EOQ2
     <td>&nbsp;</td>
     <td nowrap><b>{$mod_strings['LBL_DBCONF_DB_PASSWORD']}</b></td>
     <td nowrap align="left"><input type="password" name="setup_db_sugarsales_password_entry" value="{$setup_db_sugarsales_password}" /><input type="hidden" name="setup_db_sugarsales_password" value="{$setup_db_sugarsales_password}" /></td>
-    <input type="hidden" name="setup_db_sugarsales_password" value="{$_SESSION['setup_db_sugarsales_password']}" /></td>
 </tr>
 <tr>
     <td>&nbsp;</td>


### PR DESCRIPTION
The original file continuously fails with 'password mismatch' when the 2nd hidden input box is present. Looking at the double </td> tags, this looks like a hangover from development. With this change, the password mismatch error disappears and the install continues on.
