### PR TITLE
Fix for issue #65 - JotPad with &

### DIFF
--- a/modules/Home/Dashlets/JotPadDashlet/JotPadDashletScript.tpl
+++ b/modules/Home/Dashlets/JotPadDashlet/JotPadDashletScript.tpl
@@ -66,7 +66,7 @@ if(typeof JotPad == 'undefined') { // since the dashlet can be included multiple
 				ta = document.getElementById('jotpad_textarea_' + id);
 				if(SUGAR.isIE) ta.value = divObj.innerHTML.replace(/<br>/gi, "\n");
 				else ta.value = divObj.innerHTML.replace(/<br>/gi, '');
-				ta.value = ta.value.replace(/&amp;/, "&");
+				ta.value = ta.value.replace(/&amp;/gi, "&");
 				divObj.style.display = 'none';
 				ta.style.display = '';
 				ta.focus();


### PR DESCRIPTION
Because the JS is calling the URL as a POST request, any **&** character in the data is being interpreted by the receiving **$_REQUEST** as a different field. Therefore, the data is truncated when it hits **json_decode** in **includes/JSON.php** and the function returns an error. Because it is an error code being returned by **json_decode**, the JotPad has nothing to save, therefore the data 'disappears'.

The solution is to URL encode the data far up in the execution path, so that the **&** is encoded before it becomes part of the POST data,
