### PR TITLE
MysqliManager.php - add support for the db_port configuration option

### DIFF
--- a/include/database/MysqliManager.php
+++ b/include/database/MysqliManager.php
@@ -271,7 +271,8 @@ class MysqliManager extends MysqlManager
 
 			//mysqli connector has a separate parameter for port.. We need to separate it out from the host name
 			$dbhost=$configOptions['db_host_name'];
-			$dbport=null;
+			$dbport=$configOptions['db_port'];
+			
 			$pos=strpos($configOptions['db_host_name'],':');
 			if ($pos !== false) {
 				$dbhost=substr($configOptions['db_host_name'],0,$pos);


### PR DESCRIPTION
MysqliManager currently only supports a port being defined within the db_host_name option as `host:port` - however the `config.php` has an option for db_port (`$sugar_config['dbconfig']['db_port']`). 

This pull request is intended to allow users to specify the port in either place.
