### PR TITLE
Stay on Tab that was opened in Detailview, when clicking Edit-Button

### DIFF
--- a/include/EditView/EditView.tpl
+++ b/include/EditView/EditView.tpl
@@ -50,9 +50,9 @@ class="yui-navset"
     {{counter name="tabCount" start=-1 print=false assign="tabCount"}}
     <ul class="yui-nav">
     {{foreach name=section from=$sectionPanels key=label item=panel}}
-        {{counter name="tabCount" print=false}}
         {{capture name=label_upper assign=label_upper}}{{$label|upper}}{{/capture}}
         {{if (isset($tabDefs[$label_upper].newTab) && $tabDefs[$label_upper].newTab == true)}}
+        {{counter name="tabCount" print=false}}
         <li class="selected"><a id="tab{{$tabCount}}" href="javascript:void({{$tabCount}})"><em>{sugar_translate label='{{$label}}' module='{{$module}}'}</em></a></li>
         {{/if}}
     {{/foreach}}

--- a/include/EditView/EditView.tpl
+++ b/include/EditView/EditView.tpl
@@ -275,4 +275,6 @@ $(document).ready(function() {ldelim}
     $(".collapseLink,.expandLink").click(function (e) {ldelim} e.preventDefault(); {rdelim});
   {rdelim});
 {rdelim}
+    opened_tab="{$opened_tab}";
+    {{$form_name}}_tabs.selectTab(opened_tab.substr(3,4));
 </script>

--- a/include/EditView/EditView.tpl
+++ b/include/EditView/EditView.tpl
@@ -275,6 +275,8 @@ $(document).ready(function() {ldelim}
     $(".collapseLink,.expandLink").click(function (e) {ldelim} e.preventDefault(); {rdelim});
   {rdelim});
 {rdelim}
+    {{if !empty($opened_tab)}}
     opened_tab="{$opened_tab}";
     {{$form_name}}_tabs.selectTab(opened_tab.substr(3,4));
+    {{/if}}
 </script>

--- a/include/EditView/EditView2.php
+++ b/include/EditView/EditView2.php
@@ -588,7 +588,9 @@ class EditView
                 $this->th->ss->assign('scriptBlocks', $this->defs['templateMeta']['javascript']);
             }
         }
-
+        if(isset($_REQUEST['opened_tab'])){
+            $this->th->ss->assign('opened_tab', $_REQUEST['opened_tab']);
+        }
         $this->th->ss->assign('id', $this->fieldDefs['id']['value']);
         $this->th->ss->assign('offset', $this->offset + 1);
         $this->th->ss->assign('APP', $app_strings);

--- a/include/Smarty/plugins/function.sugar_button.php
+++ b/include/Smarty/plugins/function.sugar_button.php
@@ -325,7 +325,8 @@ function smarty_function_sugar_button($params, &$smarty)
             break;
 
 			case "EDIT";
-			    $output = '{if $bean->aclAccess("edit")}<input title="{$APP.LBL_EDIT_BUTTON_TITLE}" accessKey="{$APP.LBL_EDIT_BUTTON_KEY}" class="button primary" onclick="'.$js_form.' _form.return_module.value=\'' . $module . '\'; _form.return_action.value=\'DetailView\'; _form.return_id.value=\'{$id}\'; _form.action.value=\'EditView\';SUGAR.ajaxUI.submitForm(_form);" type="button" name="Edit" id="edit_button" value="{$APP.LBL_EDIT_BUTTON_LABEL}">{/if} ';
+                            $myonclick="{literal}$('<input>').attr({ type: 'hidden', id: 'opened_tab', name: 'opened_tab', value: $('.detailview_tabs .selected a').attr('id')}).appendTo('#formDetailView');{/literal}";
+			    $output = '{if $bean->aclAccess("edit")}<input title="{$APP.LBL_EDIT_BUTTON_TITLE}" accessKey="{$APP.LBL_EDIT_BUTTON_KEY}" class="button primary" onclick="'.$js_form.' _form.return_module.value=\'' . $module . '\'; _form.return_action.value=\'DetailView\'; _form.return_id.value=\'{$id}\'; _form.action.value=\'EditView\';' . $myonclick . 'SUGAR.ajaxUI.submitForm(_form);" type="button" name="Edit" id="edit_button" value="{$APP.LBL_EDIT_BUTTON_LABEL}">{/if} ';
             break;
 
 			case "FIND_DUPLICATES":

--- a/include/generic/SugarWidgets/SugarWidgetField.php
+++ b/include/generic/SugarWidgets/SugarWidgetField.php
@@ -104,11 +104,7 @@ class SugarWidgetField extends SugarWidget {
 		$this->local_current_module = $_REQUEST['module'];
 		$this->is_dynamic = true;
 		// don't show sort links if name isn't defined
-		if ((empty ($layout_def['name']) || (isset ($layout_def['sortable']) && !$layout_def['sortable']))
-        && !empty ($layout_def['label'])) {
-			return $layout_def['label'];
-		}
-		if (isset ($layout_def['sortable']) && !$layout_def['sortable']) {
+		if (empty ($layout_def['name']) || (isset ($layout_def['sortable']) && !$layout_def['sortable'])) {
 			return $this->displayHeaderCellPlain($layout_def);
 		}
 


### PR DESCRIPTION
If you got Tabs on your Detailview, this patch opens the tab you were looking at, when clicking the Edit-Button.