### PR TITLE
Bug Fix for 1934

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository has been created to allow community members to collaborate and c
 
 ### Contributing to the repository ###
 
-#####mportant: Please read before developing code intended for inclusion in the SuiteCRM repository.#####
+#####Important: Please read before developing code intended for inclusion in the SuiteCRM repository.#####
 
 Please read, print, sign, scan and email the following [contributor agreement][cont_agrmt]
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This repository has been created to allow community members to collaborate and c
 
 ### Contributing to the repository ###
 
+####Important: Please read before developing code intended for inclusion in the SuiteCRM repository.####
+
 Please read, print, sign, scan and email the following [contributor agreement][cont_agrmt]
 
 [cont_agrmt]: http://suitecrm.com/git/suitecrmcontributorlicenseagreement.pdf

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This is the git repository for the SuiteCRM project, the fully open source & sup
 
 This repository has been created to allow community members to collaborate and contribute to the project, helping to develop the SuiteCRM ecosystem.
 
-### Contributing to the repository ###
+### Contributing to the project ###
 
-#####Important: Please read before developing code intended for inclusion in the SuiteCRM repository.#####
+#####Important: Please read before developing code intended for inclusion in the SuiteCRM project.#####
 
 Please read, print, sign, scan and email the following [contributor agreement][cont_agrmt]
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository has been created to allow community members to collaborate and c
 
 ### Contributing to the repository ###
 
-####Important: Please read before developing code intended for inclusion in the SuiteCRM repository.####
+#####mportant: Please read before developing code intended for inclusion in the SuiteCRM repository.#####
 
 Please read, print, sign, scan and email the following [contributor agreement][cont_agrmt]
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ This is the git repository for the SuiteCRM project, the fully open source & sup
 
 This repository has been created to allow community members to collaborate and contribute to the project, helping to develop the SuiteCRM ecosystem.
 
+### Contributing to the repository ###
+
+Please read, print, sign, scan and email the following [contributor agreement][cont_agrmt]
+
+[cont_agrmt]: http://suitecrm.com/git/suitecrmcontributorlicenseagreement.pdf
+
+The Contributor Agreement only needs to be signed once for all pull requests and contributions. Once signed and confirmed, any pull requests will be considered for inclusion in the SuiteCRM project.
+
 ### Helpful links for the community###
 
 The following links offer various ways to view, contribute and collaborate to the SuiteCRM project:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Please read, print, sign, scan and email the following [contributor agreement][c
 
 [cont_agrmt]: http://suitecrm.com/git/suitecrmcontributorlicenseagreement.pdf
 
-The Contributor Agreement only needs to be signed once for all pull requests and contributions. Once signed and confirmed, any pull requests will be considered for inclusion in the SuiteCRM project.
+The Contributor Agreement only needs to be signed once for all pull requests and contributions. 
+
+Once signed and confirmed, any pull requests will be considered for inclusion in the SuiteCRM project.
 
 ### Helpful links for the community###
 

--- a/README.md
+++ b/README.md
@@ -45,5 +45,5 @@ The following links offer various ways to view, contribute and collaborate to th
 
 SuiteCRM is an open source project. As such please do not contact us directly via email or phone for SuiteCRM support. Instead please use our support forum. By using the forum the knowledge is shared with everyone in the community. Our developers answer questions on the forum daily but it also gives the other members of the community the opportunity to contribute. If you would like customisations to specifically fit your SuiteCRM  needs then please use our contact form.
 
-SuiteCRM is published under the GNU Affero GPLv3 license.
+SuiteCRM is published under the AGPLv3 license.
 


### PR DESCRIPTION
Update to versions of PHP 5.5.1 have PCRE 8.34, which changes prep_ pattern matching, causing a Bug where Charts do not display.

See Bug report

I have replaced the pattern in JsCharts.php correcting a compilation error

I also added Kdevelop IDE files to .gitignore ( .kdev4 ), for my own convenience, but if others wish to use Kdevelop this might be useful.

Contributors agreement is in your inbox.

Hope this is useful

Thanks
Rick