### PR TITLE
Fix HTTP 500 with +SymLinksIfOwnerMatch.  Email Open Notification (MDN/Read receipt).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,3 +84,5 @@ branches:
     - hotfix
     - develop
     - /feature.*/
+    - /patch-*/
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,86 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - hhvm
+  - 7.0
+  - 7.1
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - $HOME/.app/cache
+
+env:
+  global:
+    - deps="no"
+    - SYMFONY_VERSION=""
+    - PHP_CS="yes"
+    - SYMFONY_DEPRECATIONS_HELPER=weak
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.3
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 5.6
+      env: SYMFONY_VERSION=2.3.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.7.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.8.*
+    - php: 5.6
+      env: TWIG_VERSION="2.0.x-dev"
+    - php: 7.0
+      env: PHP_CS=yes
+  allow_failures:
+    - php: hhvm
+    - env: TWIG_VERSION="2.0.x-dev"
+    - php: 5.4
+
+
+
+before_install:
+  - if [[ "SYMFONY_VERSION" == "2.8.*" || "SYMFONY_VERSION" == "3.0.*" ]]; then export SYMFONY_DEPRECATIONS_HELPER="strict"; fi;
+  - if [[ "$SYMFONY_VERSION" = "" ]] && [[ "$TWIG_VERSION" = "" ]] && [[ "$TRAVIS_PHP_VERSION" =~ 5.[45] ]] && [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then export skip="yes"; fi;
+  - if [[ "$skip" != "yes" ]]; then composer selfupdate; fi
+  - if [[ "$skip" != "yes" && "$SYMFONY_VERSION" != "" ]]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+  - if [[ "$skip" != "yes" && "$TWIG_VERSION" != "" ]]; then composer require "twig/twig:${TWIG_VERSION}" --no-update; fi;
+  - if [[ "$skip" != "yes" && "$TRAVIS_PHP_VERSION" != 7.0 && "$TRAVIS_PHP_VERSION" != hhvm ]]; then phpenv config-rm xdebug.ini; fi;
+
+install:
+  - if [[ "$PHP_CS" == "yes" ]]; then curl http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer; fi;
+  - if [[ "$skip" != "yes" ]]; then composer update --prefer-dist --no-interaction $COMPOSER_FLAGS; fi
+  - if [[ "$skip" != "yes" && "$TRAVIS_PHP_VERSION" == 7.0 ]]; then composer require --dev satooshi/php-coveralls:~0.6; fi
+
+before_script:
+  - composer self-update
+  - composer install --no-interaction
+  - \[ -f "config_si.php" \] || cp tests/travis_config_si.php config_si.php
+  - php tests/testinstall.php
+
+script:
+  - cd tests
+  - ../vendor/bin/phpunit
+  - cat ../suitecrm.log
+  - if [[ "$skip" != "yes" && "$TRAVIS_PHP_VERSION" == 7.0 ]]; then phpunit --coverage-text --coverage-clover build/logs/clover.xml; else if [[ "$skip" != "yes" ]]; then phpunit; fi; fi
+  - if [[ "$skip" == "yes" ]]; then echo "Skipping matrix entry for pull requests"; fi
+  - if [[ "$PHP_CS" == "yes" ]]; then php php-cs-fixer --no-interaction --dry-run --diff -v fix; fi;
+  - if [[ "$PHP_CS" == "yes" ]]; then mv ./.php_cs.cache $HOME/.app/cache/.php_cs.cache; fi;
+
+after_success: |
+    if [[ "$TRAVIS_PHP_VERSION" == 7.0 ]]; then php vendor/bin/coveralls -v --config .coveralls.yml; fi;
+
+services:
+  - mysql
+branches:
+  only:
+    - master
+    - hotfix
+    - develop
+    - /feature.*/

--- a/config_override.php
+++ b/config_override.php
@@ -1,3 +1,4 @@
 <?php
 /***CONFIGURATOR***/
 /***CONFIGURATOR***/
+$sugar_config['enable_email_open_notification'] = false;

--- a/include/SugarPHPMailer.php
+++ b/include/SugarPHPMailer.php
@@ -421,11 +421,15 @@ eoq;
 	// or change the word true to false to disable these notifications.
 	// Default setting is false/disable.
         global $sugar_config; //EspaceNetworks.com
-	if (!empty($sugar_config)) //EspaceNetworks.com
-		if (isset($sugar_config['enable_email_open_notification'])) //EspaceNetworks.com
-			if ($sugar_config['enable_email_open_notification'] == true) { //EspaceNetworks.com
-				$this->ConfirmReadingTo = $this->From;	//EspaceNetworks.com
-	}	//EspaceNetworks.com -- end of Email Open Notification (MDN).
+        $feature = 'enable_email_open_notification';
+	if (!empty($sugar_config)) {
+		if (isset($sugar_config[$feature])) {
+			if ($sugar_config[$feature] == true) {
+				$this->ConfirmReadingTo = $this->From;
+			}
+		}
+		else $sugar_config[$feature] = false;
+	}	//EspaceNetworks.com -- end of Email Open Notification (MDN/Read Receipt).
         return parent::PreSend();
     }
 

--- a/include/SugarPHPMailer.php
+++ b/include/SugarPHPMailer.php
@@ -414,6 +414,18 @@ eoq;
             //PHPMailer will throw an error if the body is empty, so insert a blank space if body is empty
             $this->Body = " ";
         }
+	// EMAIL OPEN NOTIFICATION (MDN). EspaceNetworks.com 14-Aug-2015
+	// To enable/disable this feature,
+	// Edit config_override.php in the root folder of suitecrm.
+	//   $sugar_config['enable_email_open_notification'] == true;
+	// or change the word true to false to disable these notifications.
+	// Default setting is false/disable.
+        global $sugar_config; //EspaceNetworks.com
+	if (!empty($sugar_config)) //EspaceNetworks.com
+		if (isset($sugar_config['enable_email_open_notification'])) //EspaceNetworks.com
+			if ($sugar_config['enable_email_open_notification'] == true) { //EspaceNetworks.com
+				$this->ConfirmReadingTo = $this->From;	//EspaceNetworks.com
+	}	//EspaceNetworks.com -- end of Email Open Notification (MDN).
         return parent::PreSend();
     }
 

--- a/install/install_utils.php
+++ b/install/install_utils.php
@@ -945,7 +945,7 @@ EOQ;
 $cache_headers = <<<EOQ
 
 <IfModule mod_rewrite.c>
-    Options +FollowSymLinks
+    Options +SymLinksIfOwnerMatch
     RewriteEngine On
     RewriteBase {$basePath}
     RewriteRule ^cache/jsLanguage/(.._..).js$ index.php?entryPoint=jslang&module=app_strings&lang=$1 [L,QSA]

--- a/modules/Administration/UpgradeAccess.php
+++ b/modules/Administration/UpgradeAccess.php
@@ -60,7 +60,7 @@ RedirectMatch 403 {$ignoreCase}/+upload
 RedirectMatch 403 {$ignoreCase}/+cache/+diagnostic
 RedirectMatch 403 {$ignoreCase}/+files\.md5\$
 <IfModule mod_rewrite.c>
-    Options +FollowSymLinks
+    Options +SymLinksIfOwnerMatch
     RewriteEngine On
     RewriteBase {$basePath}
     RewriteRule ^cache/jsLanguage/(.._..).js$ index.php?entryPoint=jslang&module=app_strings&lang=$1 [L,QSA]


### PR DESCRIPTION
1. Fixes #169  +FollowSymLinks is deprecated and causes HTTP 500 Internal Server Error crash when enforced by secure server control panels such as VirtualMin.  
   Use of +SymLinksIfOwnerMatch instead is required by current security standards.
2. Fixes issue, where user asked for return receipts on email messages sent out by the CRM system.  Add enhancement. Email Open Notification (also called MDN or "read receipt").  With one setting in config_override.php, all your emails that you write in the Email module will request an "open notification" from the receiver.  If the receiver accepts, you will receive a message back from their email system when they open or delete the email message.  They can always refuse to provide the email open notification (due to privacy rules etc).
