### PR TITLE
Update MySugar.php - fix for cannot add dashlets

### DIFF
--- a/custom/include/MySugar/MySugar.php
+++ b/custom/include/MySugar/MySugar.php
@@ -113,6 +113,10 @@ class CustomMySugar extends MySugar{
 			                             'fileLocation' => $dashletsFiles[$_REQUEST['id']]['file']);
 
 
+		    if(!array_key_exists('current_tab',$_SESSION)){
+			$_SESSION["current_tab"] = '0';
+		    }
+
 		    array_unshift($pages[$_SESSION['current_tab']]['columns'][0]['dashlets'], $guid);
 
 		    $current_user->setPreference('dashlets', $dashlets, 0, $this->type);


### PR DESCRIPTION
Full credit to this fix goes to adesimone from suiteforge.org:
https://suitecrm.com/forum/developer-help/1823-unable-to-add-dashlet-at-home-page-screen

Applied fix to my build and it works.