### PR TITLE
remove Sugar search engine references

### DIFF
--- a/include/utils/autoloader.php
+++ b/include/utils/autoloader.php
@@ -44,8 +44,6 @@ class SugarAutoLoader{
 		'ListView'=>'include/ListView/ListView.php',
 		'Sugar_Smarty'=>'include/Sugar_Smarty.php',
 		'Javascript'=>'include/javascript/javascript.php',
-        'SugarSearchEngineFullIndexer'=>'include/SugarSearchEngine/SugarSearchEngineFullIndexer.php',
-        'SugarSearchEngineSyncIndexer'=>'include/SugarSearchEngine/SugarSearchEngineSyncIndexer.php',
 	);
 
 	public static $noAutoLoad = array(

--- a/include/utils/file_utils.php
+++ b/include/utils/file_utils.php
@@ -440,7 +440,7 @@ function get_mime_content_type_from_filename($filename)
 
     return '';
 }
-
+/*
 function createFTSLogicHook($filePath = 'application/Ext/LogicHooks/logichooks.ext.php')
 {
     $customFileLoc = create_custom_directory($filePath);
@@ -460,7 +460,7 @@ CIA;
     fclose($fp);
 
 }
-
+*/
 function cleanFileName($name)
 {
     return preg_replace('/[^\w-._]+/i', '', $name);

--- a/modules/Administration/views/view.globalsearchsettings.php
+++ b/modules/Administration/views/view.globalsearchsettings.php
@@ -89,7 +89,7 @@ class AdministrationViewGlobalsearchsettings extends SugarView
         echo $sugar_smarty->fetch($tpl);
 
     }
-
+/*
     protected function isFTSConnectionValid()
     {
         require_once('include/SugarSearchEngine/SugarSearchEngineFactory.php');
@@ -100,4 +100,5 @@ class AdministrationViewGlobalsearchsettings extends SugarView
         else
             return FALSE;
     }
+	*/
 }

--- a/modules/UpgradeWizard/end.php
+++ b/modules/UpgradeWizard/end.php
@@ -52,7 +52,7 @@ global $sugar_config;
 if($unzip_dir == null ) {
 	$unzip_dir = $_SESSION['unzip_dir'];
 }
-
+/*
 // creating full text search logic hooks
 // this will be merged into application/Ext/LogicHooks/logichooks.ext.php
 // when rebuild_extensions is called
@@ -76,7 +76,7 @@ CIA;
 } else {
     createFTSLogicHook('Extension/application/Ext/LogicHooks/SugarFTSHooks.php');
 }
-
+*/
 //First repair the databse to ensure it is up to date with the new vardefs/tabledefs
 logThis('About to repair the database.', $path);
 //Use Repair and rebuild to update the database.

--- a/modules/UpgradeWizard/silentUpgrade_step2.php
+++ b/modules/UpgradeWizard/silentUpgrade_step2.php
@@ -377,7 +377,7 @@ if(function_exists('deleteCache'))
 	logThis('Call deleteCache', $path);
 	@deleteCache();
 }
-
+/*
 // creating full text search logic hooks
 // this will be merged into application/Ext/LogicHooks/logichooks.ext.php
 // when rebuild_extensions is called
@@ -401,7 +401,7 @@ CIA;
 } else {
     createFTSLogicHook('Extension/application/Ext/LogicHooks/SugarFTSHooks.php');
 }
-
+*/
 //First repair the databse to ensure it is up to date with the new vardefs/tabledefs
 logThis('About to repair the database.', $path);
 //Use Repair and rebuild to update the database.


### PR DESCRIPTION
#103

AFAICT, the Sugar Search Engine is part of SugarCRM 7.x.  Either way, the CE lacks the necessary files.

Removing these references then stop the constant spam in the errorlog, caused by the creation of a logic hook that doesn't exist.

This PR just removes/comments out the references; it does not fix existing installations or hooks.