### PR TITLE
Fix for #175 fatal error for project task end dates

### DIFF
--- a/modules/AM_ProjectTemplates/controller.php
+++ b/modules/AM_ProjectTemplates/controller.php
@@ -111,6 +111,7 @@ class AM_ProjectTemplatesController extends SugarController {
                 $end = $enddate->format('Y-m-d');
                 $project_task->date_finish = $end;
                 $enddate = $end;
+                $enddate_array[$count] = $end;
             }
             $project_task->save();
             //link tasks to the newly created project


### PR DESCRIPTION
Include end date of project tasks in array in the case when there is more than one project task in the template.

https://github.com/salesagility/SuiteCRM/issues/175