### PR TITLE
Dynamic Dropdown does not behave like Dropdown in Workflow or AOR_Reports

### DIFF
--- a/modules/AOR_Reports/controller.php
+++ b/modules/AOR_Reports/controller.php
@@ -337,6 +337,7 @@ class AOR_ReportsController extends SugarController {
                 $valid_opp = array('Value','Field', 'Date');
                 break;
             case 'enum':
+            case 'dynamicenum': 
             case 'multienum':
                 $valid_opp = array('Value','Field', 'Multi');
                 break;

--- a/modules/AOW_WorkFlow/controller.php
+++ b/modules/AOW_WorkFlow/controller.php
@@ -184,6 +184,7 @@ class AOW_WorkFlowController extends SugarController {
                 $valid_opp = array('Value','Field','Any_Change','Date');
                 break;
             case 'enum':
+            case 'dynamicenum':    
             case 'multienum':
                 $valid_opp = array('Value','Field','Any_Change', 'Multi');
                 break;


### PR DESCRIPTION
Dynamic Dropdown field type does not work the same in Workflow or AOR_Reports.
User should be allowed to select multiple values like the Dropdown field type.

See Bug 222:  Workflow doesn't work correctly with dynamic dropdowns bug