### PR TITLE
Fix Post-Auth RCE vulnerability

### DIFF
--- a/include/utils.php
+++ b/include/utils.php
@@ -330,7 +330,7 @@ function get_sugar_config_defaults() {
 	return_session_value_or_default('translation_string_prefix', false),
 	'upload_badext' => array (
 	'php', 'php3', 'php4', 'php5', 'pl', 'cgi', 'py',
-	'asp', 'cfm', 'js', 'vbs', 'html', 'htm' ),
+	'asp', 'cfm', 'js', 'vbs', 'html', 'htm', 'phtml' ),
 	'upload_maxsize' => 30000000,
 	'import_max_execution_time' => 3600,
 //	'use_php_code_json' => returnPhpJsonStatus(),


### PR DESCRIPTION
Hotfix for the post-auth RCE vulnerability disclosed here: https://github.com/XiphosResearch/exploits/tree/master/suiteshell

Obviously, its not a real fix - the uploader needs to be completely rewritten to use whitelisting instead, amongst other things, but I am not a PHP developer with time to do this.