### PR TITLE
Fix search for custom modules related through flexrelate

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -3343,7 +3343,7 @@ class SugarBean
             //Parent Field
             if ($data['type'] == 'parent') {
                 //See if we need to join anything by inspecting the where clause
-                $match = preg_match('/(^|[\s(])parent_(\w+)_(\w+)\.name/', $where, $matches);
+                $match = preg_match('/(^|[\s(])parent_([a-zA-Z]+_?[a-zA-Z]+)_([a-zA-Z]+_?[a-zA-Z]+)\.name/', $where, $matches);
                 if ($match) {
                     $joinTableAlias = 'jt' . $jtcount;
                     $joinModule = $matches[2];


### PR DESCRIPTION
If you create a custom module usualy module name looks like "key_module" stock modules look like "module".
The old regex works only for modulenames that contain no underscores. This fixes that.