### PR TITLE
PHP 5.5 compatibility

### DIFF
--- a/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButton.php
@@ -104,7 +104,7 @@ class SugarWidgetSubPanelRemoveButton extends SugarWidgetField
 		}
 		$return_url = "index.php?module=$return_module&action=$return_action&subpanel=$subpanel&record=$return_id&sugar_body_only=1&inline=1";
 
-		$icon_remove_text = strtolower($app_strings['LBL_ID_FF_REMOVE']);
+		$icon_remove_text = mb_strtolower($app_strings['LBL_ID_FF_REMOVE'], 'UTF-8');
 		
          if($linked_field == 'get_emails_by_assign_or_link')
             $linked_field = 'emails';

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelTopArchiveEmailButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelTopArchiveEmailButton.php
@@ -73,11 +73,11 @@ class SugarWidgetSubPanelTopArchiveEmailButton extends SugarWidgetSubPanelTopBut
 			$additionalFormFields['to_email_addrs'] = $defines['focus']->email1;
 		}
 		if(ACLController::moduleSupportsACL($defines['module'])  && !ACLController::checkAccess($defines['module'], 'edit', true)){
-			$button = "<input id='".preg_replace('[ ]', '', $value)."_button'  title='$title' class='button' type='button' name='".preg_replace('[ ]', '', strtolower($value))."_button' value='$value' disabled/>\n";
+			$button = "<input id='".preg_replace('[ ]', '', $value)."_button'  title='$title' class='button' type='button' name='".preg_replace('[ ]', '', mb_strtolower($value, 'UTF-8'))."_button' value='$value' disabled/>\n";
 			return $button;
 		}
 		$button = $this->_get_form($defines, $additionalFormFields);
-		$button .= "<input id='".preg_replace('[ ]', '', $value)."_button' title='$title' class='button' type='submit' name='".preg_replace('[ ]', '', strtolower($value))."_button' value='$value'/>\n";
+		$button .= "<input id='".preg_replace('[ ]', '', $value)."_button' title='$title' class='button' type='submit' name='".preg_replace('[ ]', '', mb_strtolower($value, 'UTF-8'))."_button' value='$value'/>\n";
 		$button .= "</form>";
 		return $button;
 	}

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelTopButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelTopButton.php
@@ -96,7 +96,7 @@ class SugarWidgetSubPanelTopButton extends SugarWidget
 
     public function getWidgetId($buttonSuffix = true)
     {
-    	$widgetID = parent::getWidgetId() . '_'.preg_replace('[ ]', '', strtolower($this->form_value));
+    	$widgetID = parent::getWidgetId() . '_'.preg_replace('[ ]', '', mb_strtolower($this->form_value, 'UTF-8'));
     	if($buttonSuffix){
     		$widgetID .= '_button';
     	}

--- a/include/utils/file_utils.php
+++ b/include/utils/file_utils.php
@@ -130,7 +130,13 @@ function write_array_to_file( $the_name, $the_array, $the_file, $mode="w", $head
                     var_export_helper( $the_array ) .
                     ";";
 
-    return sugar_file_put_contents($the_file, $the_string, LOCK_EX) !== false;
+    $result = sugar_file_put_contents($the_file, $the_string, LOCK_EX) !== false;
+
+    if (function_exists('opcache_invalidate')) {
+        opcache_invalidate($the_file, true);
+    }
+
+    return $result;
 }
 
 function write_encoded_file( $soap_result, $write_to_dir, $write_to_file="" )

--- a/modules/Import/controller.php
+++ b/modules/Import/controller.php
@@ -60,6 +60,10 @@ class ImportController extends SugarController
     {
         global $mod_strings;
 
+	// Don't load the bean for AJAX request "RefreshTable"
+	if (isset($_REQUEST['action']) && $_REQUEST['action'] == 'RefreshTable')
+		return;
+
         $this->importModule = isset($_REQUEST['import_module']) ? $_REQUEST['import_module'] : '';
 
         $this->bean = loadBean($this->importModule);

--- a/modules/Import/controller.php
+++ b/modules/Import/controller.php
@@ -60,10 +60,6 @@ class ImportController extends SugarController
     {
         global $mod_strings;
 
-	// Don't load the bean for AJAX request "RefreshTable"
-	if (isset($_REQUEST['action']) && $_REQUEST['action'] == 'RefreshTable')
-		return;
-
         $this->importModule = isset($_REQUEST['import_module']) ? $_REQUEST['import_module'] : '';
 
         $this->bean = loadBean($this->importModule);


### PR DESCRIPTION
Includes 2 commits that concern the compatibility to PHP 5.5

 - Issue with strtolower for non-latin characters: they lead to characters that cannot be parsed by JSON. JSON doesn't accept non UTF-8 since PHP 5.5
 - Issue with Module Builder/Studio concerning the creation of fields: Vardefs are being written and reread. The Zend op-cache causes the cached version to be read, instead of the newly written file

Please ignore the first two commits.