### PR TITLE
Cleanup useless code

### DIFF
--- a/include/generic/SugarWidgets/SugarWidgetField.php
+++ b/include/generic/SugarWidgets/SugarWidgetField.php
@@ -108,11 +108,7 @@ class SugarWidgetField extends SugarWidget {
 		$this->local_current_module = $_REQUEST['module'];
 		$this->is_dynamic = true;
 		// don't show sort links if name isn't defined
-		if ((empty ($layout_def['name']) || (isset ($layout_def['sortable']) && !$layout_def['sortable']))
-        && !empty ($layout_def['label'])) {
-			return $layout_def['label'];
-		}
-		if (isset ($layout_def['sortable']) && !$layout_def['sortable']) {
+		if (empty ($layout_def['name']) || (isset ($layout_def['sortable']) && !$layout_def['sortable'])) {
 			return $this->displayHeaderCellPlain($layout_def);
 		}
 


### PR DESCRIPTION
If $layout_def['name'] is empty we can return displayheadercellplain (as it returns $layout_def['label'] anyway).
We dont need to check !empty ($layout_def['label']) anymore, because its checked in displayheadercellplain.

Just cleaner code, no other change here.