### PR TITLE
For imported Module inline edit is empty gives php error

### DIFF
--- a/modules/ModuleBuilder/MB/MBModule.php
+++ b/modules/ModuleBuilder/MB/MBModule.php
@@ -458,7 +458,7 @@ class MBModule
             $class [ 'requires' ] [] = MB_TEMPLATES . '/' . $template . '/' . ucfirst ( $template ) . '.php' ;
         }
         $class [ 'importable' ] = $this->config [ 'importable' ] ;
-        $class [ 'inline_edit' ] = $this->config [ 'inline_edit' ] ;
+        $class [ 'inline_edit' ] = empty($this->config [ 'inline_edit' ])?"false":$this->config['inline_edit'] ;
         $this->mbvardefs->updateVardefs () ;
         $class [ 'fields' ] = $this->mbvardefs->vardefs [ 'fields' ] ;
         $class [ 'fields_string' ] = var_export_helper ( $this->mbvardefs->vardef [ 'fields' ] ) ;


### PR DESCRIPTION
Modules before inline_edit have inline_edit empty resulting in corrupt vardefs.php:

 $dictionary['custom_module'] = array(
        'table'=>'custom_module',
        'audited'=>true,
        'inline_edit'=>,       // PHP error
        'duplicate_merge'=>true,