### PR TITLE
Fix for : "Warning: Creating default object from empty value in …

### DIFF
--- a/modules/ModuleBuilder/views/view.modulefield.php
+++ b/modules/ModuleBuilder/views/view.modulefield.php
@@ -151,6 +151,9 @@ class ViewModulefield extends SugarView
 
             VardefManager::loadVardef($moduleName, $objectName,true);
             global $dictionary;
+						if(!isset($module->mbvardefs) || is_null($module->mbvardefs)) {
+							$module->mbvardefs = new stdClass();
+						}
             $module->mbvardefs->vardefs =  $dictionary[$objectName];
 			
             $module->name = $moduleName;


### PR DESCRIPTION
C:\wamp\www\SuiteCRM\modules\ModuleBuilder\views\view.modulefield.php on line 154"

when editing an existing custom field.
Same as: https://suitecrm.com/forum/bug-tracker/278-fixed-creating-editing-new-fields-with-studio-error