### PR TITLE
Skip .git folder on file system checks

### DIFF
--- a/modules/UpgradeWizard/systemCheck.php
+++ b/modules/UpgradeWizard/systemCheck.php
@@ -58,6 +58,7 @@ $filesNWPerms = array();
 $skipDirs = array(
 	$sugar_config['upload_dir'],
 	'.svn',
+	'.git',
 );
 $files = uwFindAllFiles(getcwd(), array(), true, $skipDirs);
 


### PR DESCRIPTION
.git folder does not need to be checked for Upgrades.