### PR TITLE
Only display Menu Buttons if there is at least one button

### DIFF
--- a/include/DetailView/header.tpl
+++ b/include/DetailView/header.tpl
@@ -96,7 +96,9 @@ SUGAR.util.doWhen(function(){
 {{/foreach}}
 {{/if}}
 </form>
+{{if count($form.buttons) > 0}}
 {{sugar_action_menu id="detail_header_action_menu" buttons=$detail_header_buttons class="fancymenu" }}
+{{/if}}
 
 </div>
 


### PR DESCRIPTION
If a Module defines 'buttons' => array() in detailviewdefs, suitecrm displays the list without buttons (If "Display actions within menus" is active ) This gives a minor layout error.