### PR TITLE
firefighting bug #419. 

### DIFF
--- a/modules/AOS_Products/metadata/quickcreatedefs.php
+++ b/modules/AOS_Products/metadata/quickcreatedefs.php
@@ -108,6 +108,11 @@ array (
             'name' => 'product_image',
             'customCode' => '{$PRODUCT_IMAGE}',
           ),
+            1 =>
+                array (
+                    'name' => 'aos_product_category_name',
+                    'label' => 'LBL_AOS_PRODUCT_CATEGORYS_NAME',
+                ),
         ),
       ),
     ),


### PR DESCRIPTION
This is not a complete fix as the user still needs to click on the popup to choose which product type it is instead instantly knowing which product type the product should be. However this small patch will allow the user to create a product and specify which category it belongs to without leaving the page

#419 