### PR TITLE
Using a better method to set the charset

### DIFF
--- a/include/database/MysqliManager.php
+++ b/include/database/MysqliManager.php
@@ -308,13 +308,13 @@ class MysqliManager extends MysqlManager
 	    }
 
 		// cn: using direct calls to prevent this from spamming the Logs
-	    mysqli_query($this->database,"SET CHARACTER SET utf8");
-	    $names = "SET NAMES 'utf8'";
+	    
 	    $collation = $this->getOption('collation');
 	    if(!empty($collation)) {
-	        $names .= " COLLATE '$collation'";
+	    	$names = "SET NAMES 'utf8' COLLATE '$collation'";
+	    	mysqli_query($this->database,$names);
 		}
-	    mysqli_query($this->database,$names);
+	    mysqli_set_charset ($this->database , "utf8" );
 
 		if($this->checkError('Could Not Connect', $dieOnError))
 			$GLOBALS['log']->info("connected to db");


### PR DESCRIPTION
Setting charset by the function should be the prefered way, like stated on: http://php.net/manual/de/mysqli.set-charset.php
As i am not sure if setting the collation can be done this way, i kept setting the collation in old way if a collation is set.