### PR TITLE
Fix for issue #370

### DIFF
--- a/modules/ModuleBuilder/javascript/ModuleBuilder.js
+++ b/modules/ModuleBuilder/javascript/ModuleBuilder.js
@@ -649,7 +649,7 @@ if (typeof(ModuleBuilder) == 'undefined') {
 						ModuleBuilder.preloader.off();
 						// call the original callback
 						if(ModuleBuilder.updateContent(o)) {
-							// show results
+							// show results - this confirmation/response also adresses issue #370
 							YAHOO.SUGAR.MessageBox.show({
 								title: SUGAR.language.get('ModuleBuilder', 'LBL_AJAX_RESPONSE_TITLE'), // Result
 								msg: SUGAR.language.get('ModuleBuilder', 'LBL_AJAX_RESPONSE_MESSAGE'), // This operation is completed successfully


### PR DESCRIPTION
This issue was already addressed by Gyula in his fix in lines 626 -710 modules/ModuleBuilder/javascript/ModuleBuilder.js  which provide confirmation/response and preloader.
The new code has not been included into the download zip yet and therefore there is no confirmation/response. 