### PR TITLE
Vardefs definitions and custom data from view to JS DOM

### DIFF
--- a/include/MVC/View/SugarView.php
+++ b/include/MVC/View/SugarView.php
@@ -84,6 +84,8 @@ class SugarView
     var $fileResources;
 
     private $settings = array();
+    private $_js = array();
+
     /**
      * Constructor which will peform the setup.
      */
@@ -328,6 +330,13 @@ class SugarView
 
         $ss->assign("SUGAR_JS",ob_get_contents().$themeObject->getJS());
         ob_end_clean();
+
+
+        // Add custom JS files from the view
+        if($this->hasCustomJS())
+        {
+            $ss->assign('GCOOP_JS', $this->getCustomJSURL());
+        }
 
         // get favicon
         if(isset($GLOBALS['sugar_config']['default_module_favicon']))
@@ -827,6 +836,11 @@ EOHTML;
             $config_js = $this->getSugarConfigJS();
             if(!empty($config_js)){
                 echo "<script>\n".implode("\n", $config_js)."</script>\n";
+            }
+
+            if ($this->hasCustomJS())
+            {
+                echo getVersionedScript($this->getCustomJSURL());
             }
 
             if ($this->hasDomJS())
@@ -1676,9 +1690,87 @@ EOHTML;
         return false;
     }
 
+
+    /**
+     * Add custom JS files to the _js property
+     * This function should be called in the constructor of the view like this:
+     *
+     * $this->addCustomJS('custom/include/js/dom_selector.js');
+     *
+     **/
+
+    public function addCustomJS($path)
+    {
+        $this->_js[] = $path;
+    }
+
+    public function delCustomJS($path)
+    {
+        $key = array_search($path, $this->_js);
+        if ($key !== false)
+        {
+            unset($this->_js[$key]);
+        }
+    }
+
+    public function getCustomJS()
+    {
+        return($this->_js);
+    }
+
+    public function hasCustomJS()
+    {
+        return(!empty($this->_js));
+    }
+
     public function addDomJS($data, $scope)
     {
         $this->settings[$scope] = $this->suite_array_merge_deep_array($data);
+    }
+
+    private function getCustomJSURL()
+    {
+        $customJSURL = '';
+
+        if ($this->hasCustomJS())
+        {
+            $jsFiles = $this->getCustomJS();
+
+            $target = SugarThemeRegistry::current()->getJSPath() . '/' . md5(implode('|', $jsFiles)) . '.js';
+            if (!sugar_is_file(sugar_cached($target)))
+            {
+                $customJSContents = '';
+
+                foreach ($jsFiles as $jsFileName)
+                {
+                    $jsFileContents = '';
+
+                    if (sugar_is_file('custom/' . $jsFileName))
+                    {
+                        $jsFileContents .= sugar_file_get_contents('custom/' . $jsFileName);
+                    }
+                    elseif (sugar_is_file($jsFileName))
+                    {
+                        $jsFileContents .= sugar_file_get_contents($jsFileName);
+                    }
+                    if (empty($jsFileContents))
+                    {
+                        $GLOBALS['log']->warn("JS File $jsFileName not found");
+                    }
+                    $customJSContents .= $jsFileContents;
+                }
+
+                $customJSPath = create_cache_directory($target);
+
+                if ((!inDeveloperMode()) && (!sugar_is_file($customJSPath)))
+                {
+                    $customJSContents = SugarMin::minify($customJSContents);
+                }
+                sugar_file_put_contents($customJSPath, $customJSContents);
+            }
+            $customJSURL = sugar_cached($target);
+        }
+        return($customJSURL);
     }
 
     public function getDomJS()

--- a/include/MVC/View/views/view.edit.php
+++ b/include/MVC/View/views/view.edit.php
@@ -91,8 +91,7 @@ require_once('include/EditView/EditView2.php');
          {
              foreach($bean->field_defs as $field_name => $def)
              {
-
-                 $data[$module_dir][$field_name]['name'] = $def['name'];
+                 $data[$module_dir][$field_name] = $def;
 
                  if (isset($def['required']))
                  {

--- a/include/MVC/View/views/view.edit.php
+++ b/include/MVC/View/views/view.edit.php
@@ -80,5 +80,31 @@ require_once('include/EditView/EditView2.php');
     {
         return new EditView();
     }
-}
 
+
+     function getVardefsData($module_dir)
+     {
+         $data = array();
+         $bean = SugarModule::get($module_dir)->loadBean();
+
+         if($bean !== false)
+         {
+             foreach($bean->field_defs as $field_name => $def)
+             {
+
+                 $data[$module_dir][$field_name]['name'] = $def['name'];
+
+                 if (isset($def['required']))
+                 {
+                     $data[$module_dir][$field_name]['required'] = $def['required'];
+                 }
+                 else
+                 {
+                     $data[$module_dir][$field_name]['required'] = false;
+                 }
+             }
+         }
+         unset($bean);
+         return array($data);
+     }
+}


### PR DESCRIPTION
When developing some complex JS functionality is very useful to have module vardefs definitions in the DOM so you can read it from JS.

Adding vardefs.php definitions to a specific view is very simple:

![view edit php](https://cloud.githubusercontent.com/assets/939888/10033310/26970c0c-615f-11e5-85e6-3fe7d90d4079.png)

After that, you can access vardefs definitions from JS easily

![accounts_edit](https://cloud.githubusercontent.com/assets/939888/10033420/cb8035c2-615f-11e5-881a-9d884867c346.png)

But we can also add other relevant information to the DOM, like for example developer's data ;-)

![view edit php 2](https://cloud.githubusercontent.com/assets/939888/10033829/3a82d978-6162-11e5-89eb-62d584c0317e.png)

And this data can be retrieved like this:

![accounts_edit_2](https://cloud.githubusercontent.com/assets/939888/10033842/4ad4bf1c-6162-11e5-9b00-6bf161999e12.png)
