### PR TITLE
Update generatePdf.php to avoid blank pages

### DIFF
--- a/modules/AOS_PDF_Templates/generatePdf.php
+++ b/modules/AOS_PDF_Templates/generatePdf.php
@@ -95,6 +95,7 @@
 	$header = preg_replace($search, $replace, $template->pdfheader);
 	$footer = preg_replace($search, $replace, $template->pdffooter);
 	$text = preg_replace($search, $replace, $template->description);
+	$text = str_replace("<p><pagebreak /></p>", "<pagebreak />", $text);
 	$text = preg_replace_callback('/\{DATE\s+(.*?)\}/',
 		function ($matches) { return date($matches[1]); },
 		$text );


### PR DESCRIPTION
Tinymce places< p > tags around page breaks which can cause blank pages when generating a pdf