### PR TITLE
Modify EmailsUI.php to escape strings containing single quote

### DIFF
--- a/modules/Emails/EmailUI.php
+++ b/modules/Emails/EmailUI.php
@@ -428,6 +428,7 @@ eoq;
 		$lang = "var app_strings = new Object();\n";
 		foreach($app_strings as $k => $v) {
 			if(strpos($k, 'LBL_EMAIL_') !== false) {
+				$v = str_replace("'", "\'", $v);
 				$lang .= "app_strings.{$k} = '{$v}';\n";
 			}
 		}


### PR DESCRIPTION
Single quote used in translation file will lead to JS error and make e-mail module unusable