### PR TITLE
firefight fix for inline editing textAreas

### DIFF
--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -164,8 +164,10 @@ function validateFormAndSave(field,id,module,type){
     });
     // also want to save on enter/return being pressed
     $(document).keypress(function(e) {
-
-        if (e.which == 13) {
+        console.log(e);
+        if ((e.which == 13) && (e.shiftKey)) {
+        }
+        else if (e.which == 13) {
             e.preventDefault();
             $("#inlineEditSaveButton").click();
         }


### PR DESCRIPTION
When in a text areas, users cannot add new lines without saving. This branch fixes that... however the line breaks are not shown initially unless the page is refreshed after the save. Currently working on a fix for that also