### PR TITLE
Develop

### DIFF
--- a/include/SugarPHPMailer.php
+++ b/include/SugarPHPMailer.php
@@ -39,6 +39,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  ********************************************************************************/
 
 require_once('include/phpmailer/class.phpmailer.php');
+require_once('include/phpmailer/class.smtp.php');
 require_once('include/OutboundEmail/OutboundEmail.php');
 
 /**


### PR DESCRIPTION
I noticed that PHPMailer was updated to version 5.2.13. However ,due to the upgrade, SuiteCRM 7.4RC is not sending emails through SMTP.

While reading the logfile, I found the error "Class 'SMTP' not found". That means the class "class.smtp.php" is not being loaded .

In older releases of PHPMailer, the class was loaded in the function SmtpSend of "class.phpmailer.php". On the latest release of PHPMailer, that call is not being done anymore.

In order to correct the error, the class "class.smtp.php" should be included anywhere in SuiteCRM 7.4. I suggest to include a line on "/include/SugarPHPMailer.php" calling "class.smtp.php". Example:
<?php
....
require_once('include/phpmailer/class.phpmailer.php');
require_once('include/phpmailer/class.smtp.php');
require_once('include/OutboundEmail/OutboundEmail.php');
...
>