### PR TITLE
Fix for Issue#631

### DIFF
--- a/modules/Emails/javascript/Email.js
+++ b/modules/Emails/javascript/Email.js
@@ -884,7 +884,7 @@ function button_change_onclick(obj) {
 	var acct_name = '';
 
 	if(document.EditView.parent_type.value  == 'Accounts' && typeof(document.EditView.parent_name.value) != 'undefined' && document.EditView.parent_name.value != '') {
-		filter = "&form_submit=false&query=true&html=Email_picker&account_name=" + escape(document.EditView.parent_name.value);
+		filter = "&form_submit=false&query=true&html=Email_picker&account_name=" + escape(document.EditView.parent_name.value) + "&account_id=" + escape(document.EditView.parent_id.value);
 		acct_name = document.EditView.parent_name.value;
 	}
 


### PR DESCRIPTION
Users are able to create Contacts via the Email To/CC/BCC fields by the QuickCreate Popup.

