### PR TITLE
Closes bug #632

### DIFF
--- a/modules/Emails/EditViewArchive.html
+++ b/modules/Emails/EditViewArchive.html
@@ -309,7 +309,7 @@
 </form>
 <script type="text/javascript">
 Calendar.setup ({
-        inputField : "date_start_date", ifFormat : "{CALENDAR_DATEFORMAT}", showsTime : false, button : "jscal_trigger", singleClick : true, step : 1, , startWeekday: {CALENDAR_FDOW}
+        inputField : "date_start_date", ifFormat : "{CALENDAR_DATEFORMAT}", showsTime : false, button : "jscal_trigger", singleClick : true, step : 1, startWeekday: {CALENDAR_FDOW}
 });
 </script>
 {TINY}


### PR DESCRIPTION
There was an extra comma in the object that was causing the issue.  This has been removed and the calendar popup is now appearing without issue.