### PR TITLE
This closes #625.  

### DIFF
--- a/custom/Extension/modules/Cases/Ext/Vardefs/cases_aop_case_updates.php
+++ b/custom/Extension/modules/Cases/Ext/Vardefs/cases_aop_case_updates.php
@@ -91,6 +91,7 @@ $dictionary["Case"]["fields"]['aop_case_updates_threaded'] =
         'duplicate_merge_dom_value' => 0,
         'audited' => false,
         'reportable' => false,
+        'inline_edit' => 0,
         'function' =>
         array (
             'name' => 'display_updates',

--- a/modules/AOP_Case_Updates/Case_Updates.php
+++ b/modules/AOP_Case_Updates/Case_Updates.php
@@ -128,7 +128,7 @@ function caseUpdates(record){
 A;
 
     $updates = $focus->get_linked_beans('aop_case_updates',"AOP_Case_Updates");
-    if(!$updates){
+    if(!$updates || is_null($focus->id)){
         $html .= quick_edit_case_updates();
         return $html;
         //return $mod_strings['LBL_NO_CASE_UPDATES'];


### PR DESCRIPTION
The change in cases_aop_case_updates.php stops the inline editing of the update (as advised by Jim).  The change to case_update.php stops the loading of call updates if the call id is null.  This was causing the system to retrieve any updates with a null case id to be returned.