### PR TITLE
Closes bug #130

### DIFF
--- a/include/database/DBManager.php
+++ b/include/database/DBManager.php
@@ -429,7 +429,7 @@ protected function checkQuery($sql, $object_name = false)
 			$orderBy = trim($orderBy);
 			if (empty($orderBy))
 				continue;
-			$orderBy = strtolower($orderBy);
+			$orderBy = suite_strtolower($orderBy);
 			if ($orderBy == 'asc' || $orderBy == 'desc')
 				continue;
 
@@ -518,7 +518,7 @@ protected function checkQuery($sql, $object_name = false)
 				// clean the incoming value..
 				$val = from_html($data[$field]);
 			} else {
-				if(isset($fieldDef['default']) && strlen($fieldDef['default']) > 0) {
+				if(isset($fieldDef['default']) && suite_strlen($fieldDef['default']) > 0) {
 					$val = $fieldDef['default'];
 				} else {
 					$val = null;
@@ -730,7 +730,7 @@ protected function checkQuery($sql, $object_name = false)
 	protected function isNullable($vardef)
 	{
 
-		if(isset($vardef['isnull']) && (strtolower($vardef['isnull']) == 'false' || $vardef['isnull'] === false)
+		if(isset($vardef['isnull']) && (suite_strtolower($vardef['isnull']) == 'false' || $vardef['isnull'] === false)
 			&& !empty($vardef['required'])) {
 				/* required + is_null=false => not null */
 			return false;
@@ -799,7 +799,7 @@ protected function checkQuery($sql, $object_name = false)
                 continue;
             }
 
-			$name = strtolower($value['name']);
+			$name = suite_strtolower($value['name']);
 			// add or fix the field defs per what the DB is expected to give us back
 			$this->massageFieldDef($value,$tablename);
 
@@ -873,8 +873,8 @@ protected function checkQuery($sql, $object_name = false)
 
 		// do indices comparisons case-insensitive
 		foreach($compareIndices as $k => $value){
-			$value['name'] = strtolower($value['name']);
-			$compareIndices_case_insensitive[strtolower($k)] = $value;
+			$value['name'] = suite_strtolower($value['name']);
+			$compareIndices_case_insensitive[suite_strtolower($k)] = $value;
 		}
 		$compareIndices = $compareIndices_case_insensitive;
 		unset($compareIndices_case_insensitive);
@@ -888,7 +888,7 @@ protected function checkQuery($sql, $object_name = false)
 			if (isset($compareIndices[$validDBName])) {
 				$value['name'] = $validDBName;
 			}
-		    $name = strtolower($value['name']);
+		    $name = suite_strtolower($value['name']);
 
 			//Don't attempt to fix the same index twice in one pass;
 			if (isset($correctedIndexs[$name]))
@@ -977,14 +977,14 @@ protected function checkQuery($sql, $object_name = false)
             {
                 if (!is_array($fielddef1[$key]) && !is_array($fielddef2[$key]))
                 {
-                    if (strtolower($fielddef1[$key]) == strtolower($fielddef2[$key]))
+                    if (suite_strtolower($fielddef1[$key]) == suite_strtolower($fielddef2[$key]))
                     {
                         continue;
                     }
                 }
                 else
                 {
-                    if (array_map('strtolower', $fielddef1[$key]) == array_map('strtolower',$fielddef2[$key]))
+                    if (array_map('suite_strtolower', $fielddef1[$key]) == array_map('suite_strtolower',$fielddef2[$key]))
                     {
                         continue;
                     }
@@ -1429,7 +1429,7 @@ protected function checkQuery($sql, $object_name = false)
 			if(!empty($values)){
 				$row_array[] = $values;
 			}
-			if(!empty($cstm_values) && !empty($cstm_values['id_c']) && (strlen($cstm_values['id_c']) > 7)){
+			if(!empty($cstm_values) && !empty($cstm_values['id_c']) && (suite_strlen($cstm_values['id_c']) > 7)){
 				$cstm_row_array[] = $cstm_values;
 			}
 		}
@@ -1753,7 +1753,7 @@ protected function checkQuery($sql, $object_name = false)
 	{
 		if ( is_numeric($len) && $len > 0)
 		{
-			$string = mb_substr($string,0,(int) $len, "UTF-8");
+			$string = suite_substr($string,0,(int) $len, "UTF-8");
 		}
 		return $string;
 	}
@@ -1951,15 +1951,15 @@ protected function checkQuery($sql, $object_name = false)
     			$val = $bean->getFieldValue($field);
     		}
 
-    		if(strlen($val) == 0) {
-    			if(isset($fieldDef['default']) && strlen($fieldDef['default']) > 0) {
+    		if(suite_strlen($val) == 0) {
+    			if(isset($fieldDef['default']) && suite_strlen($fieldDef['default']) > 0) {
     				$val = $fieldDef['default'];
     			} else {
     				$val = null;
     			}
     		}
 
-    		if(!empty($val) && !empty($fieldDef['len']) && strlen($val) > $fieldDef['len']) {
+    		if(!empty($val) && !empty($fieldDef['len']) && suite_strlen($val) > $fieldDef['len']) {
 			    $val = $this->truncate($val, $fieldDef['len']);
 			}
 		$columnName = $this->quoteIdentifier($fieldDef['name']);
@@ -2113,7 +2113,7 @@ protected function checkQuery($sql, $object_name = false)
 					break;
 			}
 		} else {
-		    if(!empty($val) && !empty($fieldDef['len']) && strlen($val) > $fieldDef['len']) {
+		    if(!empty($val) && !empty($fieldDef['len']) && suite_strlen($val) > $fieldDef['len']) {
 			    $val = $this->truncate($val, $fieldDef['len']);
 			}
 		}
@@ -2172,14 +2172,14 @@ protected function checkQuery($sql, $object_name = false)
 	public function getSelectFieldsFromQuery($selectStatement)
 	{
 		$selectStatement = trim($selectStatement);
-		if (strtoupper(substr($selectStatement, 0, 6)) == "SELECT")
-			$selectStatement = trim(substr($selectStatement, 6));
+		if (suite_strtoupper(suite_substr($selectStatement, 0, 6)) == "SELECT")
+			$selectStatement = trim(suite_substr($selectStatement, 6));
 
 		//Due to sql functions existing in many selects, we can't use php explode
 		$fields = array();
 		$level = 0;
 		$selectField = "";
-		$strLen = strlen($selectStatement);
+		$strLen = suite_strlen($selectStatement);
 		for($i = 0; $i < $strLen; $i++)
 		{
 			$char = $selectStatement[$i];
@@ -2216,17 +2216,17 @@ protected function checkQuery($sql, $object_name = false)
 	protected function getFieldNameFromSelect($string)
 	{
 		if(strncasecmp($string, "DISTINCT ", 9) == 0) {
-			$string = substr($string, 9);
+			$string = suite_substr($string, 9);
 		}
 		if (stripos($string, " as ") !== false)
 			//"as" used for an alias
-			return trim(substr($string, strripos($string, " as ") + 4));
-		else if (strrpos($string, " ") != 0)
+			return trim(suite_substr($string, strripos($string, " as ") + 4));
+		else if (suite_strrpos($string, " ") != 0)
 			//Space used as a delimiter for an alias
-			return trim(substr($string, strrpos($string, " ")));
-		else if (strpos($string, ".") !== false)
+			return trim(suite_substr($string, suite_strrpos($string, " ")));
+		else if (suite_strpos($string, ".") !== false)
 			//No alias, but a table.field format was used
-			return substr($string, strpos($string, ".") + 1);
+			return suite_substr($string, suite_strpos($string, ".") + 1);
 		else
 			//Give up and assume the whole thing is the field name
 			return $string;
@@ -2454,7 +2454,7 @@ protected function checkQuery($sql, $object_name = false)
           	    $colType = "$colBaseType(${fieldDef['len']})";
             } elseif(($colBaseType == 'decimal' || $colBaseType == 'float')){
                   if(!empty($fieldDef['precision']) && is_numeric($fieldDef['precision']))
-                      if(strpos($fieldDef['len'],',') === false){
+                      if(suite_strpos($fieldDef['len'],',') === false){
                           $colType = $colBaseType . "(".$fieldDef['len'].",".$fieldDef['precision'].")";
                       }else{
                           $colType = $colBaseType . "(".$fieldDef['len'].")";
@@ -2475,7 +2475,7 @@ protected function checkQuery($sql, $object_name = false)
         {
             // nothing to do
         }
-        elseif (isset($fieldDef['default']) && strlen($fieldDef['default']) > 0)
+        elseif (isset($fieldDef['default']) && suite_strlen($fieldDef['default']) > 0)
         {
             $default = " DEFAULT ".$this->quoted($fieldDef['default']);
         }
@@ -2490,13 +2490,13 @@ protected function checkQuery($sql, $object_name = false)
 
 		$required = 'NULL';  // MySQL defaults to NULL, SQL Server defaults to NOT NULL -- must specify
 		//Starting in 6.0, only ID and auto_increment fields will be NOT NULL in the DB.
-		if ((empty($fieldDef['isnull']) || strtolower($fieldDef['isnull']) == 'false') &&
+		if ((empty($fieldDef['isnull']) || suite_strtolower($fieldDef['isnull']) == 'false') &&
 			(!empty($auto_increment) || $name == 'id' || ($fieldDef['type'] == 'id' && !empty($fieldDef['required'])))) {
 			$required =  "NOT NULL";
 		}
 		// If the field is marked both required & isnull=>false - alwqys make it not null
 		// Use this to ensure primary key fields never defined as null
-		if(isset($fieldDef['isnull']) && (strtolower($fieldDef['isnull']) == 'false' || $fieldDef['isnull'] === false)
+		if(isset($fieldDef['isnull']) && (suite_strtolower($fieldDef['isnull']) == 'false' || $fieldDef['isnull'] === false)
 			&& !empty($fieldDef['required'])) {
 			$required =  "NOT NULL";
 		}
@@ -2720,21 +2720,21 @@ protected function checkQuery($sql, $object_name = false)
 		    }
 			// first strip any invalid characters - all but word chars (which is alphanumeric and _)
 			$name = preg_replace( '/[^\w]+/i', '', $name ) ;
-			$len = strlen( $name ) ;
+			$len = suite_strlen( $name ) ;
 			$maxLen = empty($this->maxNameLengths[$type]) ? $this->maxNameLengths[$type]['column'] : $this->maxNameLengths[$type];
 			if ($len <= $maxLen && !$force) {
-				return strtolower($name);
+				return suite_strtolower($name);
 			}
 			if ($ensureUnique) {
 				$md5str = md5($name);
-				$tail = substr ( $name, -11) ;
-				$temp = substr($md5str , strlen($md5str)-4 );
-				$result = substr( $name, 0, 10) . $temp . $tail ;
+				$tail = suite_substr ( $name, -11) ;
+				$temp = suite_substr($md5str , suite_strlen($md5str)-4 );
+				$result = suite_substr( $name, 0, 10) . $temp . $tail ;
 			} else {
-				$result = substr( $name, 0, 11) . substr( $name, 11 - $maxLen);
+				$result = suite_substr( $name, 0, 11) . suite_substr( $name, 11 - $maxLen);
 			}
 
-			return strtolower( $result ) ;
+			return suite_strtolower( $result ) ;
 		}
 	}
 
@@ -3233,9 +3233,9 @@ protected function checkQuery($sql, $object_name = false)
 	protected function isSelect($query)
 	{
 		$query = trim($query);
-		$select_check = strpos(strtolower($query), strtolower("SELECT"));
+		$select_check = suite_strpos(suite_strtolower($query), suite_strtolower("SELECT"));
 		//Checks to see if there is union select which is valid
-		$select_check2 = strpos(strtolower($query), strtolower("(SELECT"));
+		$select_check2 = suite_strpos(suite_strtolower($query), suite_strtolower("(SELECT"));
 		if($select_check==0 || $select_check2==0){
 			//Returning false means query is ok!
 			return true;
@@ -3271,14 +3271,14 @@ protected function checkQuery($sql, $object_name = false)
 				$item = trim($item, '"');
 			}
 			if($item[0] == '+') {
-                if (strlen($item) > 1) {
-                    $must_terms[] = substr($item, 1);
+                if (suite_strlen($item) > 1) {
+                    $must_terms[] = suite_substr($item, 1);
                 }
                 continue;
 			}
 			if($item[0] == '-') {
-                if (strlen($item) > 1) {
-				    $not_terms[] = substr($item, 1);
+                if (suite_strlen($item) > 1) {
+				    $not_terms[] = suite_substr($item, 1);
                 }
                 continue;
 			}
@@ -3308,9 +3308,9 @@ protected function checkQuery($sql, $object_name = false)
         $query = preg_replace('/[^A-Za-z0-9_\s]/', "", $query);
         $query = trim(str_replace(array_keys($this->standardQueries), '', $query));
 
-        $firstSpc = strpos($query, " ");
-        $end = ($firstSpc > 0) ? $firstSpc : strlen($query);
-        $table = substr($query, 0, $end);
+        $firstSpc = suite_strpos($query, " ");
+        $end = ($firstSpc > 0) ? $firstSpc : suite_strlen($query);
+        $table = suite_substr($query, 0, $end);
 
         return $table;
 	}
@@ -3326,7 +3326,7 @@ protected function checkQuery($sql, $object_name = false)
 	{
 		$query = trim($query);
 		foreach($this->standardQueries as $qstart => $check) {
-			if(strncasecmp($qstart, $query, strlen($qstart)) == 0) {
+			if(strncasecmp($qstart, $query, suite_strlen($qstart)) == 0) {
 				if(is_callable(array($this, $check))) {
 					$table = $this->extractTableName($query);
 					if(!in_array($table, $skipTables)) {
@@ -3358,7 +3358,7 @@ protected function checkQuery($sql, $object_name = false)
 		$tempname = $table."__uw_temp";
 		$tempTableQuery = str_replace("CREATE TABLE {$table}", "CREATE TABLE $tempname", $query);
 
-		if(strpos($tempTableQuery, '__uw_temp') === false) {
+		if(suite_strpos($tempTableQuery, '__uw_temp') === false) {
 			return 'Could not use a temp table to test query!';
 		}
 

--- a/include/database/DBManagerFactory.php
+++ b/include/database/DBManagerFactory.php
@@ -195,10 +195,10 @@ class DBManagerFactory
         $scandir = opendir($dir);
         if($scandir === false) return;
         while(($name = readdir($scandir)) !== false) {
-            if(substr($name, -11) != "Manager.php") continue;
+            if(suite_substr($name, -11) != "Manager.php") continue;
             if($name == "DBManager.php") continue;
             require_once("$dir/$name");
-            $classname = substr($name, 0, -4);
+            $classname = suite_substr($name, 0, -4);
             if(!class_exists($classname)) continue;
             $driver = new $classname;
             if(!$validate || $driver->valid()) {
@@ -261,7 +261,7 @@ class DBManagerFactory
     		$info=ob_get_contents();
     		ob_end_clean();
 
-    		$is_freetds = (strpos($info,'FreeTDS') !== false);
+    		$is_freetds = (suite_strpos($info,'FreeTDS') !== false);
         }
 
         return $is_freetds;

--- a/include/database/MssqlManager.php
+++ b/include/database/MssqlManager.php
@@ -304,9 +304,9 @@ class MssqlManager extends DBManager
             // 				  and difficult to reproduce error. The message is only a warning, and does
             //				  not affect the functionality of the query
             $sqlmsg = mssql_get_last_message();
-            $sqlpos = strpos($sqlmsg, 'Changed database context to');
-			$sqlpos2 = strpos($sqlmsg, 'Warning:');
-			$sqlpos3 = strpos($sqlmsg, 'Checking identity information:');
+            $sqlpos = suite_strpos($sqlmsg, 'Changed database context to');
+			$sqlpos2 = suite_strpos($sqlmsg, 'Warning:');
+			$sqlpos3 = suite_strpos($sqlmsg, 'Checking identity information:');
 
 			if ($sqlpos !== false || $sqlpos2 !== false || $sqlpos3 !== false)		// if sqlmsg has 'Changed database context to', just log it
 				$GLOBALS['log']->debug($sqlmsg . ": " . $sql );
@@ -348,7 +348,7 @@ class MssqlManager extends DBManager
         $this->lastsql = $sql;
 
         //change the casing to lower for easier string comparison, and trim whitespaces
-        $sql = strtolower(trim($sql)) ;
+        $sql = suite_strtolower(trim($sql)) ;
 
         //set default sql
         $limitUnionSQL = $sql;
@@ -383,7 +383,7 @@ class MssqlManager extends DBManager
 
             //if last element contains a "select", then this is part of the union query,
             //and there is no order by to use
-            if (strpos($unionOrderBy, "select")) {
+            if (suite_strpos($unionOrderBy, "select")) {
                 $unionsql = $sql;
                 //with no guidance on what to use for required order by in rownumber function,
                 //resort to using name column.
@@ -436,7 +436,7 @@ class MssqlManager extends DBManager
         $count = (int)$count;
         $newSQL = $sql;
         $distinctSQLARRAY = array();
-        if (strpos($sql, "UNION") && !preg_match("/(')(UNION).?(')/i", $sql))
+        if (suite_strpos($sql, "UNION") && !preg_match("/(')(UNION).?(')/i", $sql))
             $newSQL = $this->handleUnionLimitQuery($sql,$start,$count);
         else {
             if ($start < 0)
@@ -447,8 +447,8 @@ class MssqlManager extends DBManager
             preg_match('/^(.*SELECT\b)(.*?\bFROM\b.*\bWHERE\b)(.*)$/isU',$sql, $matches);
             if (!empty($matches[3])) {
                 if ($start == 0) {
-                    $match_two = strtolower($matches[2]);
-                    if (!strpos($match_two, "distinct")> 0 && strpos($match_two, "distinct") !==0) {
+                    $match_two = suite_strtolower($matches[2]);
+                    if (!suite_strpos($match_two, "distinct")> 0 && suite_strpos($match_two, "distinct") !==0) {
                         $orderByMatch = array();
                         preg_match('/^(.*)(\bORDER BY\b)(.*)$/is',$matches[3], $orderByMatch);
                         if (!empty($orderByMatch[3])) {
@@ -467,10 +467,10 @@ class MssqlManager extends DBManager
                         }
                     }
                     else {
-                        $distinct_o = strpos($match_two, "distinct");
-                        $up_to_distinct_str = substr($match_two, 0, $distinct_o);
+                        $distinct_o = suite_strpos($match_two, "distinct");
+                        $up_to_distinct_str = suite_substr($match_two, 0, $distinct_o);
                         //check to see if the distinct is within a function, if so, then proceed as normal
-                        if (strpos($up_to_distinct_str,"(")) {
+                        if (suite_strpos($up_to_distinct_str,"(")) {
                             //proceed as normal
                             $newSQL = $matches[1] . " TOP $count " . $matches[2] . $matches[3];
                         }
@@ -478,14 +478,14 @@ class MssqlManager extends DBManager
                             //if distinct is not within a function, then parse
                             //string contains distinct clause, "TOP needs to come after Distinct"
                             //get position of distinct
-                            $match_zero = strtolower($matches[0]);
-                            $distinct_pos = strpos($match_zero , "distinct");
+                            $match_zero = suite_strtolower($matches[0]);
+                            $distinct_pos = suite_strpos($match_zero , "distinct");
                             //get position of where
-                            $where_pos = strpos($match_zero, "where");
+                            $where_pos = suite_strpos($match_zero, "where");
                             //parse through string
-                            $beg = substr($matches[0], 0, $distinct_pos+9 );
-                            $mid = substr($matches[0], strlen($beg), ($where_pos+5) - (strlen($beg)));
-                            $end = substr($matches[0], strlen($beg) + strlen($mid) );
+                            $beg = suite_substr($matches[0], 0, $distinct_pos+9 );
+                            $mid = suite_substr($matches[0], suite_strlen($beg), ($where_pos+5) - (suite_strlen($beg)));
+                            $end = suite_substr($matches[0], suite_strlen($beg) + suite_strlen($mid) );
                             //repopulate matches array
                             $matches[1] = $beg; $matches[2] = $mid; $matches[3] = $end;
 
@@ -499,21 +499,21 @@ class MssqlManager extends DBManager
                     //if there is a distinct clause, parse sql string as we will have to insert the rownumber
                     //for paging, AFTER the distinct clause
                     $grpByStr = '';
-                    $hasDistinct = strpos(strtolower($matches[0]), "distinct");
+                    $hasDistinct = suite_strpos(suite_strtolower($matches[0]), "distinct");
 
                     require_once('include/php-sql-parser.php');
                     $parser = new PHPSQLParser();
                     $sqlArray = $parser->parse($sql);
 
                     if ($hasDistinct) {
-                        $matches_sql = strtolower($matches[0]);
+                        $matches_sql = suite_strtolower($matches[0]);
                         //remove reference to distinct and select keywords, as we will use a group by instead
                         //we need to use group by because we are introducing rownumber column which would make every row unique
 
                         //take out the select and distinct from string so we can reuse in group by
                         $dist_str = 'distinct';
                         preg_match('/\b' . $dist_str . '\b/simU', $matches_sql, $matchesPartSQL, PREG_OFFSET_CAPTURE);
-                        $matches_sql = trim(substr($matches_sql,$matchesPartSQL[0][1] + strlen($dist_str)));
+                        $matches_sql = trim(suite_substr($matches_sql,$matchesPartSQL[0][1] + suite_strlen($dist_str)));
                         //get the position of where and from for further processing
                         preg_match('/\bfrom\b/simU', $matches_sql, $matchesPartSQL, PREG_OFFSET_CAPTURE);
                         $from_pos = $matchesPartSQL[0][1];
@@ -522,12 +522,12 @@ class MssqlManager extends DBManager
                         //split the sql into a string before and after the from clause
                         //we will use the columns being selected to construct the group by clause
                         if ($from_pos>0 ) {
-                            $distinctSQLARRAY[0] = substr($matches_sql, 0, $from_pos);
-                            $distinctSQLARRAY[1] = substr($matches_sql, $from_pos);
+                            $distinctSQLARRAY[0] = suite_substr($matches_sql, 0, $from_pos);
+                            $distinctSQLARRAY[1] = suite_substr($matches_sql, $from_pos);
                             //get position of order by (if it exists) so we can strip it from the string
-                            $ob_pos = strpos($distinctSQLARRAY[1], "order by");
+                            $ob_pos = suite_strpos($distinctSQLARRAY[1], "order by");
                             if ($ob_pos) {
-                                $distinctSQLARRAY[1] = substr($distinctSQLARRAY[1],0,$ob_pos);
+                                $distinctSQLARRAY[1] = suite_substr($distinctSQLARRAY[1],0,$ob_pos);
                             }
 
                             // strip off last closing parentheses from the where clause
@@ -623,31 +623,31 @@ class MssqlManager extends DBManager
         $i=0;
         $offset = 0;
         $strip_array = array();
-        while ($i<$count && $offset<strlen($p_sql)) {
-            if ($offset > strlen($p_sql))
+        while ($i<$count && $offset<suite_strlen($p_sql)) {
+            if ($offset > suite_strlen($p_sql))
             {
 				break;
             }
 
-            $beg_sin = strpos($p_sql, $strip_beg, $offset);
+            $beg_sin = suite_strpos($p_sql, $strip_beg, $offset);
             if (!$beg_sin)
             {
                 break;
             }
-            $sec_sin = strpos($p_sql, $strip_end, $beg_sin+1);
-            $strip_array[$patt.$i] = substr($p_sql, $beg_sin, $sec_sin - $beg_sin +1);
+            $sec_sin = suite_strpos($p_sql, $strip_end, $beg_sin+1);
+            $strip_array[$patt.$i] = suite_substr($p_sql, $beg_sin, $sec_sin - $beg_sin +1);
             if ($increment > 1) {
                 //we are in here because beginning and end patterns are not identical, so search for nesting
-                $exists = strpos($strip_array[$patt.$i], $strip_beg );
+                $exists = suite_strpos($strip_array[$patt.$i], $strip_beg );
                 if ($exists>=0) {
-                    $nested_pos = (strrpos($strip_array[$patt.$i], $strip_beg ));
-                    $strip_array[$patt.$i] = substr($p_sql,$nested_pos+$beg_sin,$sec_sin - ($nested_pos+$beg_sin)+1);
-                    $p_sql = substr($p_sql, 0, $nested_pos+$beg_sin) . " ##". $patt.$i."## " . substr($p_sql, $sec_sin+1);
+                    $nested_pos = (suite_strrpos($strip_array[$patt.$i], $strip_beg ));
+                    $strip_array[$patt.$i] = suite_substr($p_sql,$nested_pos+$beg_sin,$sec_sin - ($nested_pos+$beg_sin)+1);
+                    $p_sql = suite_substr($p_sql, 0, $nested_pos+$beg_sin) . " ##". $patt.$i."## " . suite_substr($p_sql, $sec_sin+1);
                     $i = $i + 1;
                     continue;
                 }
             }
-            $p_sql = substr($p_sql, 0, $beg_sin) . " ##". $patt.$i."## " . substr($p_sql, $sec_sin+1);
+            $p_sql = suite_substr($p_sql, 0, $beg_sin) . " ##". $patt.$i."## " . suite_substr($p_sql, $sec_sin+1);
             //move the marker up
             $offset = $sec_sin+1;
 
@@ -701,7 +701,7 @@ class MssqlManager extends DBManager
         //all functions should be removed now, so split the array on commas
         $mstr_sql_array = explode(",", $new_sql);
         foreach($mstr_sql_array as $token ) {
-            if (strpos($token, $alias)) {
+            if (suite_strpos($token, $alias)) {
                 //found token, add back comments
                 $token = $this->addPatternToSQL($token, $paren_array);
                 $token = $this->addPatternToSQL($token, $dub_array);
@@ -725,7 +725,7 @@ class MssqlManager extends DBManager
     private function findColumnByAlias($sql, $orderMatch)
     {
         //change case to lowercase
-        $sql = strtolower($sql);
+        $sql = suite_strtolower($sql);
         $patt = '/\s+'.trim($orderMatch).'\s*(,|from)/';
 
         //check for the alias, it should contain comma, may contain space, \n, or \t
@@ -743,16 +743,16 @@ class MssqlManager extends DBManager
             $found_count = substr_count($sql, $orderMatch);
             $i = 0;
             $first_ = 0;
-            $len = strlen($orderMatch);
+            $len = suite_strlen($orderMatch);
             //loop through string as many times as there is a match
             while ($found_count > $i) {
                 //get the first match
-                $found_in_sql = strpos($sql, $orderMatch,$first_);
+                $found_in_sql = suite_strpos($sql, $orderMatch,$first_);
                 //make sure there was a match
                 if($found_in_sql){
                     //grab the next 2 individual characters
-                    $str_plusone = substr($sql,$found_in_sql + $len,1);
-                    $str_plustwo = substr($sql,$found_in_sql + $len+1,1);
+                    $str_plusone = suite_substr($sql,$found_in_sql + $len,1);
+                    $str_plustwo = suite_substr($sql,$found_in_sql + $len+1,1);
                     //if one of those characters is a comma, then we have our alias
                     if ($str_plusone === "," || $str_plustwo === ","){
                         //keep track of this position
@@ -778,23 +778,23 @@ class MssqlManager extends DBManager
      */
     private function returnOrderBy($sql, $orig_order_match)
     {
-        $sql = strtolower($sql);
+        $sql = suite_strtolower($sql);
         $orig_order_match = trim($orig_order_match);
-        if (strpos($orig_order_match, ".") != 0)
+        if (suite_strpos($orig_order_match, ".") != 0)
             //this has a tablename defined, pass in the order match
             return $orig_order_match;
 
         // If there is no ordering direction (ASC/DESC), use ASC by default
-        if (strpos($orig_order_match, " ") === false) {
+        if (suite_strpos($orig_order_match, " ") === false) {
         	$orig_order_match .= " ASC";
         }
 
         //grab first space in order by
-        $firstSpace = strpos($orig_order_match, " ");
+        $firstSpace = suite_strpos($orig_order_match, " ");
 
         //split order by into column name and ascending/descending
-        $orderMatch = " " . strtolower(substr($orig_order_match, 0, $firstSpace));
-        $asc_desc = trim(substr($orig_order_match,$firstSpace));
+        $orderMatch = " " . suite_strtolower(suite_substr($orig_order_match, 0, $firstSpace));
+        $asc_desc = trim(suite_substr($orig_order_match,$firstSpace));
 
         //look for column name as an alias in sql string
         $found_in_sql = $this->findColumnByAlias($sql, $orderMatch);
@@ -802,18 +802,18 @@ class MssqlManager extends DBManager
         if (!$found_in_sql) {
             //check if this column needs the tablename prefixed to it
             $orderMatch = ".".trim($orderMatch);
-            $colMatchPos = strpos($sql, $orderMatch);
+            $colMatchPos = suite_strpos($sql, $orderMatch);
             if ($colMatchPos !== false) {
                 //grab sub string up to column name
-                $containsColStr = substr($sql,0, $colMatchPos);
+                $containsColStr = suite_substr($sql,0, $colMatchPos);
                 //get position of first space, so we can grab table name
-                $lastSpacePos = strrpos($containsColStr, " ");
+                $lastSpacePos = suite_strrpos($containsColStr, " ");
                 //use positions of column name, space before name, and length of column to find the correct column name
-                $col_name = substr($sql, $lastSpacePos, $colMatchPos-$lastSpacePos+strlen($orderMatch));
+                $col_name = suite_substr($sql, $lastSpacePos, $colMatchPos-$lastSpacePos+suite_strlen($orderMatch));
 				//bug 25485. When sorting by a custom field in Account List and then pressing NEXT >, system gives an error
-				$containsCommaPos = strpos($col_name, ",");
+				$containsCommaPos = suite_strpos($col_name, ",");
 				if($containsCommaPos !== false) {
-					$col_name = substr($col_name, $containsCommaPos+1);
+					$col_name = suite_substr($col_name, $containsCommaPos+1);
 				}
                 //add the "asc/desc" order back
                 $col_name = $col_name. " ". $asc_desc;
@@ -832,29 +832,29 @@ class MssqlManager extends DBManager
 
             $psql = (trim($this->getAliasFromSQL($sql, $orderMatch )));
             if (empty($psql))
-                $psql = trim(substr($sql, 0, $found_in_sql));
+                $psql = trim(suite_substr($sql, 0, $found_in_sql));
 
             //grab the last comma before the alias
             preg_match('/\s+' . trim($orderMatch). '/', $psql, $match, PREG_OFFSET_CAPTURE);
             $comma_pos = $match[0][1];
             //substring between the comma and the alias to find the joined_table alias and column name
-            $col_name = substr($psql,0, $comma_pos);
+            $col_name = suite_substr($psql,0, $comma_pos);
 
             //make sure the string does not have an end parenthesis
             //and is not part of a function (i.e. "ISNULL(leads.last_name,'') as name"  )
             //this is especially true for unified search from home screen
 
             $alias_beg_pos = 0;
-            if(strpos($psql, " as "))
-                $alias_beg_pos = strpos($psql, " as ");
+            if(suite_strpos($psql, " as "))
+                $alias_beg_pos = suite_strpos($psql, " as ");
 
             // Bug # 44923 - This breaks the query and does not properly filter isnull
             // as there are other functions such as ltrim and rtrim.
             /* else if (strncasecmp($psql, 'isnull', 6) != 0)
-                $alias_beg_pos = strpos($psql, " "); */
+                $alias_beg_pos = suite_strpos($psql, " "); */
 
             if ($alias_beg_pos > 0) {
-                $col_name = substr($psql,0, $alias_beg_pos );
+                $col_name = suite_substr($psql,0, $alias_beg_pos );
             }
             //add the "asc/desc" order back
             $col_name = $col_name. " ". $asc_desc;
@@ -903,26 +903,26 @@ class MssqlManager extends DBManager
             //and grab the table name from the passed in sql
             $GLOBALS['log']->debug("Could not find table name from module in request, retrieve from passed in sql");
             $tbl_name = $module_str;
-            $sql = strtolower($sql);
+            $sql = suite_strtolower($sql);
 
             // Bug #45625 : Getting Multi-part identifier (reports.id) could not be bound error when navigating to next page in reprots in mssql
             // there is cases when sql string is multiline string and it we cannot find " from " string in it
             $sql = str_replace(array("\n", "\r"), " ", $sql);
 
             //look for the location of the "from" in sql string
-            $fromLoc = strpos($sql," from " );
+            $fromLoc = suite_strpos($sql," from " );
             if ($fromLoc>0){
                 //found from, substring from the " FROM " string in sql to end
-                $tableEnd = substr($sql, $fromLoc+6);
+                $tableEnd = suite_substr($sql, $fromLoc+6);
                 //We know that tablename will be next parameter after from, so
                 //grab the next space after table name.
                 // MFH BUG #14009: Also check to see if there are any carriage returns before the next space so that we don't grab any arbitrary joins or other tables.
-                $carriage_ret = strpos($tableEnd,"\n");
-                $next_space = strpos($tableEnd," " );
+                $carriage_ret = suite_strpos($tableEnd,"\n");
+                $next_space = suite_strpos($tableEnd," " );
                 if ($carriage_ret < $next_space)
                     $next_space = $carriage_ret;
                 if ($next_space > 0) {
-                    $tbl_name= substr($tableEnd,0, $next_space);
+                    $tbl_name= suite_substr($tableEnd,0, $next_space);
                     if(empty($tbl_name)){
                         $GLOBALS['log']->debug("Could not find table name sql either, return $module_str. ");
                         $tbl_name = $module_str;
@@ -930,11 +930,11 @@ class MssqlManager extends DBManager
                 }
 
                 //grab the table, to see if it is aliased
-                $aliasTableEnd = trim(substr($tableEnd, $next_space));
-                $alias_space = strpos ($aliasTableEnd, " " );
+                $aliasTableEnd = trim(suite_substr($tableEnd, $next_space));
+                $alias_space = suite_strpos ($aliasTableEnd, " " );
                 if ($alias_space > 0){
-                    $alias_tbl_name= substr($aliasTableEnd,0, $alias_space);
-                    strtolower($alias_tbl_name);
+                    $alias_tbl_name= suite_substr($aliasTableEnd,0, $alias_space);
+                    suite_strtolower($alias_tbl_name);
                     if(empty($alias_tbl_name)
                         || $alias_tbl_name == "where"
                         || $alias_tbl_name == "inner"
@@ -946,10 +946,10 @@ class MssqlManager extends DBManager
                     }
                     elseif ($alias_tbl_name == "as") {
                             //the next word is the table name
-                            $aliasTableEnd = trim(substr($aliasTableEnd, $alias_space));
-                            $alias_space = strpos ($aliasTableEnd, " " );
+                            $aliasTableEnd = trim(suite_substr($aliasTableEnd, $alias_space));
+                            $alias_space = suite_strpos ($aliasTableEnd, " " );
                             if ($alias_space > 0) {
-                                $alias_tbl_name= trim(substr($aliasTableEnd,0, $alias_space));
+                                $alias_tbl_name= trim(suite_substr($aliasTableEnd,0, $alias_space));
                                 if (!empty($alias_tbl_name))
                                     $tbl_name = $alias_tbl_name;
                             }
@@ -983,7 +983,7 @@ class MssqlManager extends DBManager
             if (!$meta)
                 return 0;
             if($make_lower_case==true)
-                $meta->name = strtolower($meta->name);
+                $meta->name = suite_strtolower($meta->name);
 
             $field_array[] = $meta->name;
 
@@ -1182,7 +1182,7 @@ class MssqlManager extends DBManager
             array_unshift($all_parameters, $string);
         }
 
-        switch (strtolower($type)) {
+        switch (suite_strtolower($type)) {
             case 'today':
                 return "GETDATE()";
             case 'left':
@@ -1234,9 +1234,9 @@ class MssqlManager extends DBManager
     {
         switch($type) {
             case 'datetimecombo':
-            case 'datetime': return substr($string, 0,19);
-            case 'date': return substr($string, 0, 10);
-            case 'time': return substr($string, 11);
+            case 'datetime': return suite_substr($string, 0,19);
+            case 'date': return suite_substr($string, 0, 10);
+            case 'time': return suite_substr($string, 11);
 		}
 		return $string;
     }
@@ -1262,7 +1262,7 @@ class MssqlManager extends DBManager
      */
     public function isTextType($type)
     {
-        $type = strtolower($type);
+        $type = suite_strtolower($type);
         if(!isset($this->type_map[$type])) return false;
         return in_array($this->type_map[$type], array('ntext','text','image', 'nvarchar(max)'));
     }
@@ -1432,10 +1432,10 @@ EOSQL;
                 $index_type = 'primary';
             elseif ($row['is_unique'] == 1 )
                 $index_type = 'unique';
-            $name = strtolower($row['index_name']);
+            $name = suite_strtolower($row['index_name']);
             $indices[$name]['name']     = $name;
             $indices[$name]['type']     = $index_type;
-            $indices[$name]['fields'][] = strtolower($row['column_name']);
+            $indices[$name]['fields'][] = suite_strtolower($row['column_name']);
         }
         return $indices;
     }
@@ -1450,27 +1450,27 @@ EOSQL;
 
         $columns = array();
         while (($row=$this->fetchByAssoc($result)) !=null) {
-            $column_name = strtolower($row['COLUMN_NAME']);
+            $column_name = suite_strtolower($row['COLUMN_NAME']);
             $columns[$column_name]['name']=$column_name;
-            $columns[$column_name]['type']=strtolower($row['TYPE_NAME']);
+            $columns[$column_name]['type']=suite_strtolower($row['TYPE_NAME']);
             if ( $row['TYPE_NAME'] == 'decimal' ) {
-                $columns[$column_name]['len']=strtolower($row['PRECISION']);
-                $columns[$column_name]['len'].=','.strtolower($row['SCALE']);
+                $columns[$column_name]['len']=suite_strtolower($row['PRECISION']);
+                $columns[$column_name]['len'].=','.suite_strtolower($row['SCALE']);
             }
 			elseif ( in_array($row['TYPE_NAME'],array('nchar','nvarchar')) )
-				$columns[$column_name]['len']=strtolower($row['PRECISION']);
+				$columns[$column_name]['len']=suite_strtolower($row['PRECISION']);
             elseif ( !in_array($row['TYPE_NAME'],array('datetime','text')) )
-                $columns[$column_name]['len']=strtolower($row['LENGTH']);
+                $columns[$column_name]['len']=suite_strtolower($row['LENGTH']);
             if ( stristr($row['TYPE_NAME'],'identity') ) {
                 $columns[$column_name]['auto_increment'] = '1';
-                $columns[$column_name]['type']=str_replace(' identity','',strtolower($row['TYPE_NAME']));
+                $columns[$column_name]['type']=str_replace(' identity','',suite_strtolower($row['TYPE_NAME']));
             }
 
             if (!empty($row['IS_NULLABLE']) && $row['IS_NULLABLE'] == 'NO' && (empty($row['KEY']) || !stristr($row['KEY'],'PRI')))
-                $columns[strtolower($row['COLUMN_NAME'])]['required'] = 'true';
+                $columns[suite_strtolower($row['COLUMN_NAME'])]['required'] = 'true';
 
             $column_def = 1;
-            if ( strtolower($tablename) == 'relationships' ) {
+            if ( suite_strtolower($tablename) == 'relationships' ) {
                 $column_def = $this->getOne("select cdefault from syscolumns where id = object_id('relationships') and name = '$column_name'");
             }
             if ( $column_def != 0 && ($row['COLUMN_DEF'] != null)) {	// NOTE Not using !empty as an empty string may be a viable default value.
@@ -1699,7 +1699,7 @@ EOQ;
         }
         if($fieldDef['type'] == 'decimal'
            && empty($fieldDef['precision'])
-           && !strpos($fieldDef['len'], ','))
+           && !suite_strpos($fieldDef['len'], ','))
         {
              $fieldDef['len'] .= ',0'; // Adding 0 precision if it is not specified
         }
@@ -1820,9 +1820,9 @@ EOQ;
 		    return false;
         }
 
-        $sqlpos = strpos($sqlmsg, 'Changed database context to');
-        $sqlpos2 = strpos($sqlmsg, 'Warning:');
-        $sqlpos3 = strpos($sqlmsg, 'Checking identity information:');
+        $sqlpos = suite_strpos($sqlmsg, 'Changed database context to');
+        $sqlpos2 = suite_strpos($sqlmsg, 'Warning:');
+        $sqlpos3 = suite_strpos($sqlmsg, 'Checking identity information:');
         if ( $sqlpos !== false || $sqlpos2 !== false || $sqlpos3 !== false ) {
             return false;
         } else {
@@ -1835,13 +1835,13 @@ EOQ;
                 return false;
             }
             else {
-                $sqlpos = strpos($sqlmsg, $app_strings['ERR_MSSQL_DB_CONTEXT']);
+                $sqlpos = suite_strpos($sqlmsg, $app_strings['ERR_MSSQL_DB_CONTEXT']);
                 if ( $sqlpos !== false )
                     return false;
             }
         }
 
-        if ( strlen($sqlmsg) > 2 ) {
+        if ( suite_strlen($sqlmsg) > 2 ) {
         	return "SQL Server error: " . $sqlmsg;
         }
 
@@ -1882,7 +1882,7 @@ EOQ;
     protected function _appendN($sql)
     {
         // If there are no single quotes, don't bother, will just assume there is no character data
-        if (strpos($sql, "'") === false)
+        if (suite_strpos($sql, "'") === false)
             return $sql;
 
         // Flag if there are odd number of single quotes, just continue without trying to append N
@@ -1928,7 +1928,7 @@ EOQ;
         if (!empty($pairs))
             $sql = str_replace(array_keys($pairs), $pairs, $sql);
 
-        if(strpos($sql, "<@#@#@PAIR@#@#@>"))
+        if(suite_strpos($sql, "<@#@#@PAIR@#@#@>"))
             $sql = str_replace(array('<@#@#@PAIR@#@#@>'), array("''"), $sql);
 
         return $sql;

--- a/include/database/MysqlManager.php
+++ b/include/database/MysqlManager.php
@@ -289,7 +289,7 @@ class MysqlManager extends DBManager
 			if (empty($row['table']))
 				continue;
 			$badQuery[$row['table']] = '';
-			if (strtoupper($row['type']) == 'ALL')
+			if (suite_strtoupper($row['type']) == 'ALL')
 				$badQuery[$row['table']]  .=  ' Full Table Scan;';
 			if (empty($row['key']))
 				$badQuery[$row['table']] .= ' No Index Key Used;';
@@ -328,13 +328,13 @@ class MysqlManager extends DBManager
 
 		$columns = array();
 		while (($row=$this->fetchByAssoc($result)) !=null) {
-			$name = strtolower($row['Field']);
+			$name = suite_strtolower($row['Field']);
 			$columns[$name]['name']=$name;
 			$matches = array();
 			preg_match_all('/(\w+)(?:\(([0-9]+,?[0-9]*)\)|)( unsigned)?/i', $row['Type'], $matches);
-			$columns[$name]['type']=strtolower($matches[1][0]);
-			if ( isset($matches[2][0]) && in_array(strtolower($matches[1][0]),array('varchar','char','varchar2','int','decimal','float')) )
-				$columns[$name]['len']=strtolower($matches[2][0]);
+			$columns[$name]['type']=suite_strtolower($matches[1][0]);
+			if ( isset($matches[2][0]) && in_array(suite_strtolower($matches[1][0]),array('varchar','char','varchar2','int','decimal','float')) )
+				$columns[$name]['len']=suite_strtolower($matches[2][0]);
 			if ( stristr($row['Extra'],'auto_increment') )
 				$columns[$name]['auto_increment'] = '1';
 			if ($row['Null'] == 'NO' && !stristr($row['Key'],'PRI'))
@@ -362,7 +362,7 @@ class MysqlManager extends DBManager
 				return array();
 
 			if($make_lower_case == true)
-				$meta->name = strtolower($meta->name);
+				$meta->name = suite_strtolower($meta->name);
 
 			$field_array[] = $meta->name;
 		}
@@ -569,7 +569,7 @@ class MysqlManager extends DBManager
 		$sql = preg_replace("!alter table $tablename!is",', ', $sql);
 
 		// re-add it at the beginning
-		$sql = substr_replace($sql,'',strpos($sql,','),1);
+		$sql = substr_replace($sql,'',suite_strpos($sql,','),1);
 		$sql = str_replace(";","",$sql);
 		$sql = str_replace("\n","",$sql);
 		$sql = "ALTER TABLE $tablename $sql";
@@ -596,7 +596,7 @@ class MysqlManager extends DBManager
 		}
 		$all_strings = implode(',', $all_parameters);
 
-		switch (strtolower($type)) {
+		switch (suite_strtolower($type)) {
 			case 'today':
 				return "CURDATE()";
 			case 'left':
@@ -674,12 +674,12 @@ class MysqlManager extends DBManager
 	{
 		if(!is_string($engine)) return false;
 
-		$engine = strtoupper($engine);
+		$engine = suite_strtoupper($engine);
 
 		$r = $this->query("SHOW ENGINES");
 
 		while ( $row = $this->fetchByAssoc($r) )
-			if ( strtoupper($row['Engine']) == $engine )
+			if ( suite_strtoupper($row['Engine']) == $engine )
 				return ($row['Support']=='YES' || $row['Support']=='DEFAULT');
 
 		return false;
@@ -740,7 +740,7 @@ class MysqlManager extends DBManager
      */
     public function isTextType($type)
     {
-        $type = $this->getColumnType(strtolower($type));
+        $type = $this->getColumnType(suite_strtolower($type));
         return in_array($type, array('blob','text','longblob', 'longtext'));
     }
 
@@ -915,10 +915,10 @@ class MysqlManager extends DBManager
 			elseif ( $row['Non_unique'] == '0' ) {
 				$index_type='unique';
 			}
-			$name = strtolower($row['Key_name']);
+			$name = suite_strtolower($row['Key_name']);
 			$indices[$name]['name']=$name;
 			$indices[$name]['type']=$index_type;
-			$indices[$name]['fields'][]=strtolower($row['Column_name']);
+			$indices[$name]['fields'][]=suite_strtolower($row['Column_name']);
 		}
 		return $indices;
 	}
@@ -1141,7 +1141,7 @@ class MysqlManager extends DBManager
 	 */
 	protected function quoteTerm($term)
 	{
-		if(strpos($term, ' ') !== false) {
+		if(suite_strpos($term, ' ') !== false) {
 			return '"'.$term.'"';
 		}
 		return $term;
@@ -1243,7 +1243,7 @@ class MysqlManager extends DBManager
 		$this->log->debug("verifying ALTER TABLE");
 		// Skipping ALTER TABLE [table] DROP PRIMARY KEY because primary keys are not being copied
 		// over to the temp tables
-		if(strpos(strtoupper($query), 'DROP PRIMARY KEY') !== false) {
+		if(suite_strpos(suite_strtoupper($query), 'DROP PRIMARY KEY') !== false) {
 			$this->log->debug("Skipping DROP PRIMARY KEY");
 			return '';
 		}
@@ -1254,8 +1254,8 @@ class MysqlManager extends DBManager
 		// test the query on the test table
 		$this->log->debug('testing query: ['.$query.']');
 		$tempTableTestQuery = str_replace("ALTER TABLE `{$table}`", "ALTER TABLE `{$table}__uw_temp`", $query);
-		if (strpos($tempTableTestQuery, 'idx') === false) {
-			if(strpos($tempTableTestQuery, '__uw_temp') === false) {
+		if (suite_strpos($tempTableTestQuery, 'idx') === false) {
+			if(suite_strpos($tempTableTestQuery, '__uw_temp') === false) {
 				return 'Could not use a temp table to test query!';
 			}
 
@@ -1286,7 +1286,7 @@ class MysqlManager extends DBManager
 		// test the query on the test table
 		$this->log->debug('testing query: ['.$query.']');
 		$tempTableTestQuery = str_replace("$querytype `{$table}`", "$querytype `{$table}__uw_temp`", $query);
-		if(strpos($tempTableTestQuery, '__uw_temp') === false) {
+		if(suite_strpos($tempTableTestQuery, '__uw_temp') === false) {
 			return 'Could not use a temp table to test query!';
 		}
 

--- a/include/database/MysqliManager.php
+++ b/include/database/MysqliManager.php
@@ -145,7 +145,7 @@ class MysqliManager extends MysqlManager
 		/*
 		$bt = debug_backtrace();
 		for ( $i = count($bt) ; $i-- ; $i > 0 ) {
-			if ( strpos('MysqliManager.php',$bt[$i]['file']) === false ) {
+			if ( suite_strpos('MysqliManager.php',$bt[$i]['file']) === false ) {
 				$line = $bt[$i];
 			}
 		}
@@ -227,7 +227,7 @@ class MysqliManager extends MysqlManager
 				return 0;
 
 			if($make_lower_case == true)
-				$meta->name = strtolower($meta->name);
+				$meta->name = suite_strtolower($meta->name);
 
 			$field_array[] = $meta->name;
 
@@ -273,10 +273,10 @@ class MysqliManager extends MysqlManager
 			$dbhost=$configOptions['db_host_name'];
             $dbport=$configOptions['db_port'] == '' ? null : $configOptions['db_port'];
 			
-			$pos=strpos($configOptions['db_host_name'],':');
+			$pos=suite_strpos($configOptions['db_host_name'],':');
 			if ($pos !== false) {
-				$dbhost=substr($configOptions['db_host_name'],0,$pos);
-				$dbport=substr($configOptions['db_host_name'],$pos+1);
+				$dbhost=suite_substr($configOptions['db_host_name'],0,$pos);
+				$dbport=suite_substr($configOptions['db_host_name'],$pos+1);
 			}
 
 			$this->database = mysqli_connect($dbhost,$configOptions['db_user_name'],$configOptions['db_password'],isset($configOptions['db_name'])?$configOptions['db_name']:'',$dbport);

--- a/include/database/SqlsrvManager.php
+++ b/include/database/SqlsrvManager.php
@@ -246,7 +246,7 @@ class SqlsrvManager extends MssqlManager
         foreach ( sqlsrv_field_metadata($result) as $fieldMetadata ) {
             $key = $fieldMetadata['Name'];
             if($make_lower_case==true)
-                $key = strtolower($key);
+                $key = suite_strtolower($key);
 
             $field_array[] = $key;
         }
@@ -371,32 +371,32 @@ class SqlsrvManager extends MssqlManager
 
         $columns = array();
         while (($row=$this->fetchByAssoc($result)) !=null) {
-            $column_name = strtolower($row['COLUMN_NAME']);
+            $column_name = suite_strtolower($row['COLUMN_NAME']);
             $columns[$column_name]['name']=$column_name;
-            $columns[$column_name]['type']=strtolower($row['TYPE_NAME']);
+            $columns[$column_name]['type']=suite_strtolower($row['TYPE_NAME']);
             if ( $row['TYPE_NAME'] == 'decimal' ) {
-                $columns[$column_name]['len']=strtolower($row['PRECISION']);
-                $columns[$column_name]['len'].=','.strtolower($row['SCALE']);
+                $columns[$column_name]['len']=suite_strtolower($row['PRECISION']);
+                $columns[$column_name]['len'].=','.suite_strtolower($row['SCALE']);
             }
 			elseif ( in_array($row['TYPE_NAME'],array('nchar','nvarchar')) ) {
-				$columns[$column_name]['len']=strtolower($row['PRECISION']);
+				$columns[$column_name]['len']=suite_strtolower($row['PRECISION']);
 				if ( $row['TYPE_NAME'] == 'nvarchar' && $row['PRECISION'] == '0' ) {
 				    $columns[$column_name]['len']='max';
 				}
 			}
             elseif ( !in_array($row['TYPE_NAME'],array('datetime','text')) ) {
-                $columns[$column_name]['len']=strtolower($row['LENGTH']);
+                $columns[$column_name]['len']=suite_strtolower($row['LENGTH']);
             }
             if ( stristr($row['TYPE_NAME'],'identity') ) {
                 $columns[$column_name]['auto_increment'] = '1';
-                $columns[$column_name]['type']=str_replace(' identity','',strtolower($row['TYPE_NAME']));
+                $columns[$column_name]['type']=str_replace(' identity','',suite_strtolower($row['TYPE_NAME']));
             }
 
             if (!empty($row['IS_NULLABLE']) && $row['IS_NULLABLE'] == 'NO' && (empty($row['KEY']) || !stristr($row['KEY'],'PRI')))
-                $columns[strtolower($row['COLUMN_NAME'])]['required'] = 'true';
+                $columns[suite_strtolower($row['COLUMN_NAME'])]['required'] = 'true';
 
             $column_def = 1;
-            if ( strtolower($tablename) == 'relationships' ) {
+            if ( suite_strtolower($tablename) == 'relationships' ) {
                 $column_def = $this->getOne("select cdefault from syscolumns where id = object_id('relationships') and name = '$column_name'");
             }
             if ( $column_def != 0 && ($row['COLUMN_DEF'] != null)) {	// NOTE Not using !empty as an empty string may be a viable default value.
@@ -507,14 +507,14 @@ EOSQL;
         $messages = array();
         foreach($errors as $error) {
             $sqlmsg = $error['message'];
-            $sqlpos = strpos($sqlmsg, 'Changed database context to');
-            $sqlpos2 = strpos($sqlmsg, 'Warning:');
-            $sqlpos3 = strpos($sqlmsg, 'Checking identity information:');
+            $sqlpos = suite_strpos($sqlmsg, 'Changed database context to');
+            $sqlpos2 = suite_strpos($sqlmsg, 'Warning:');
+            $sqlpos3 = suite_strpos($sqlmsg, 'Checking identity information:');
             if ( $sqlpos !== false || $sqlpos2 !== false || $sqlpos3 !== false ) {
                 continue;
             }
-            $sqlpos = strpos($sqlmsg, $app_strings['ERR_MSSQL_DB_CONTEXT']);
-            $sqlpos2 = strpos($sqlmsg, $app_strings['ERR_MSSQL_WARNING']);
+            $sqlpos = suite_strpos($sqlmsg, $app_strings['ERR_MSSQL_DB_CONTEXT']);
+            $sqlpos2 = suite_strpos($sqlmsg, $app_strings['ERR_MSSQL_WARNING']);
     		if ( $sqlpos !== false || $sqlpos2 !== false) {
                     continue;
             }

--- a/include/utils.php
+++ b/include/utils.php
@@ -5129,3 +5129,4 @@ function suite_strrpos($haystack,$needle,$offset=0,$encoding = DEFAULT_UTIL_SUIT
 	else
 		return strrpos($haystack,$needle,$offset);
 }
+

--- a/include/utils.php
+++ b/include/utils.php
@@ -5081,3 +5081,51 @@ function assignConcatenatedValue(SugarBean $bean, $fieldDef, $value)
     }
 }
 
+define("DEFAULT_UTIL_SUITE_ENCODING","UTF-8");
+
+function suite_strlen($input, $encoding = DEFAULT_UTIL_SUITE_ENCODING)
+{
+	if(function_exists('mb_strlen'))
+		return mb_strlen($input,$encoding);
+	else
+		return strlen($input);
+}
+
+function suite_substr($input, $start, $length = null,$encoding = DEFAULT_UTIL_SUITE_ENCODING)
+{
+	if(function_exists('mb_substr'))
+		return mb_substr($input,$start,$length,$encoding);
+	else
+		return substr($input,$start,$length);
+}
+
+function suite_strtoupper($input,$encoding = DEFAULT_UTIL_SUITE_ENCODING)
+{
+	if(function_exists('mb_strtoupper'))
+		return mb_strtoupper($input,$encoding);
+	else
+		return strtoupper($input);
+}
+function suite_strtolower($input,$encoding = DEFAULT_UTIL_SUITE_ENCODING)
+{
+	if(function_exists('mb_strtolower'))
+		return mb_strtolower($input,$encoding);
+	else
+		return strtolower($input);
+}
+
+function suite_strpos($haystack,$needle,$offset=0,$encoding = DEFAULT_UTIL_SUITE_ENCODING)
+{
+	if(function_exists('mb_strpos'))
+		return mb_strpos($haystack,$needle,$offset,$encoding);
+	else
+		return strpos($haystack,$needle,$offset);
+}
+
+function suite_strrpos($haystack,$needle,$offset=0,$encoding = DEFAULT_UTIL_SUITE_ENCODING)
+{
+	if(function_exists('mb_strrpos'))
+		return mb_strrpos($haystack,$needle,$offset,$encoding);
+	else
+		return strrpos($haystack,$needle,$offset);
+}


### PR DESCRIPTION
 As per bug #130, this adds a generic function for strlen, substr, strtoupper, strtolower, strpos, strrpos which will call the mb_* equivalent when available, else it will default back to the general version. This has updated all of the references to either the generic or mb_* calls to the new version in utils.php.