### PR TITLE
Fix "Close" button still showing

### DIFF
--- a/modules/Tasks/metadata/detailviewdefs.php
+++ b/modules/Tasks/metadata/detailviewdefs.php
@@ -83,6 +83,7 @@ array (
                 'name' => 'button1',
                 'id' => 'close_button',
               ),
+                'template' => '{if $fields.status.value != "Completed"}[CONTENT]{/if}'
             ),
           ),
         ),


### PR DESCRIPTION
In Tasks Module there's a bug, even if the task is completed the button "close" is still showing up in the options in detail view, this is a fix for it.