### PR TITLE
 closes #655 - all textarea fields were being escaped causing apostro…

### DIFF
--- a/include/Smarty/plugins/function.sugarvar.php
+++ b/include/Smarty/plugins/function.sugarvar.php
@@ -91,11 +91,11 @@ function smarty_function_sugarvar($params, &$smarty)
     $_contents =  '$'. $object . '.' . $member . '.' . $params['key'];
 	if(empty($params['stringFormat']) && empty($params['string'])) {
 		$_contents = '{' . $_contents;
-		if(!empty($params['htmlentitydecode'])){
-		    $_contents .= '|escape:\'htmlentitydecode\'';
-		}
 		if(!empty($displayParams['htmlescape'])){
-		    $_contents .= '|escape:\'html\'';
+			$_contents .= '|escape:\'html\'';
+		}
+		if(!empty($params['htmlentitydecode'])){
+			$_contents .= '|escape:\'html_entity_decode\'';
 		}
 		if(!empty($displayParams['strip_tags'])){
 			$_contents .= '|strip_tags';

--- a/include/Smarty/plugins/modifier.escape.php
+++ b/include/Smarty/plugins/modifier.escape.php
@@ -25,6 +25,9 @@ function smarty_modifier_escape($string, $esc_type = 'html', $char_set = 'ISO-88
         case 'html':
             return htmlspecialchars($string, ENT_QUOTES, $char_set);
 
+        case 'html_entity_decode':
+            return html_entity_decode($string, ENT_QUOTES, $char_set);
+
         case 'htmlall':
             return htmlentities($string, ENT_QUOTES, $char_set);
 


### PR DESCRIPTION
closes #655 - all textarea fields were being escaped causing apostrophes to show as escaped but not decoded via the smarty template due to missing function