### PR TITLE
PDF Template shows the key of the radio enum instead of the value

### DIFF
--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -33,7 +33,7 @@ class templateParser{
                 if($field_def['type'] == 'currency'){
                     $repl_arr[$key."_".$field_def['name']] = currency_format_number($focus->$field_def['name'],$params = array('currency_symbol' => false));
                 }
-				else if($field_def['type'] == 'enum' && isset($field_def['options'])) {
+				else if(($field_def['type'] == 'radioenum' || $field_def['type'] == 'enum') && isset($field_def['options'])) {
                     $repl_arr[$key."_".$field_def['name']] = translate($field_def['options'],$focus->module_dir,$focus->$field_def['name']);
 				}
                 else if($field_def['type'] == 'multienum' && isset($field_def['options'])) {


### PR DESCRIPTION
The parse_template_bean method call only checks for enum and multi-enum. This causes the pdf template to show the enum key instead of value from the language . Added check for radio enum to translate the enum key.