### PR TITLE
Patch to fix a Warning "Creating default object from empty value"

### DIFF
--- a/modules/ModuleBuilder/views/view.modulefield.php
+++ b/modules/ModuleBuilder/views/view.modulefield.php
@@ -151,6 +151,9 @@ class ViewModulefield extends SugarView
 
             VardefManager::loadVardef($moduleName, $objectName,true);
             global $dictionary;
+            if(!isset($module->mbvardefs) || is_null($module->mbvardefs)) {
+            	$module->mbvardefs = new stdClass();
+            }
             $module->mbvardefs->vardefs =  $dictionary[$objectName];
 			
             $module->name = $moduleName;


### PR DESCRIPTION
Warning: Creating default object from empty value occured in /srv/example/trunk/modules/ModuleBuilder/views/view.modulefield.php on line 154

Replicating solution suggested by isleshocky77 on https://github.com/sugarcrm/sugarcrm_dev/pull/143