### PR TITLE
Stay on Tab when going from DetailView to EditView

### DIFF
--- a/include/EditView/EditView.tpl
+++ b/include/EditView/EditView.tpl
@@ -53,9 +53,9 @@ class="yui-navset"
     {{counter name="tabCount" start=-1 print=false assign="tabCount"}}
     <ul class="yui-nav">
     {{foreach name=section from=$sectionPanels key=label item=panel}}
-        {{counter name="tabCount" print=false}}
         {{capture name=label_upper assign=label_upper}}{{$label|upper}}{{/capture}}
         {{if (isset($tabDefs[$label_upper].newTab) && $tabDefs[$label_upper].newTab == true)}}
+        {{counter name="tabCount" print=false}}
         <li class="selected"><a id="tab{{$tabCount}}" href="javascript:void({{$tabCount}})"><em>{sugar_translate label='{{$label}}' module='{{$module}}'}</em></a></li>
         {{/if}}
     {{/foreach}}

--- a/include/EditView/EditView.tpl
+++ b/include/EditView/EditView.tpl
@@ -278,4 +278,7 @@ $(document).ready(function() {ldelim}
     $(".collapseLink,.expandLink").click(function (e) {ldelim} e.preventDefault(); {rdelim});
   {rdelim});
 {rdelim}
+    opened_tab="{{literal}}{$opened_tab}{{/literal}}";
+    if(opened_tab!="")
+        {{$form_name}}_tabs.selectTab(opened_tab.substr(3,4));
 </script>

--- a/include/EditView/EditView2.php
+++ b/include/EditView/EditView2.php
@@ -591,7 +591,9 @@ class EditView
                 $this->th->ss->assign('scriptBlocks', $this->defs['templateMeta']['javascript']);
             }
         }
-
+        if(isset($_REQUEST['opened_tab'])){
+            $this->th->ss->assign('opened_tab', $_REQUEST['opened_tab']);
+        }
         $this->th->ss->assign('id', $this->fieldDefs['id']['value']);
         $this->th->ss->assign('offset', $this->offset + 1);
         $this->th->ss->assign('APP', $app_strings);

--- a/include/Smarty/plugins/function.sugar_button.php
+++ b/include/Smarty/plugins/function.sugar_button.php
@@ -325,7 +325,8 @@ function smarty_function_sugar_button($params, &$smarty)
             break;
 
 			case "EDIT";
-			    $output = '{if $bean->aclAccess("edit")}<input title="{$APP.LBL_EDIT_BUTTON_TITLE}" accessKey="{$APP.LBL_EDIT_BUTTON_KEY}" class="button primary" onclick="'.$js_form.' _form.return_module.value=\'' . $module . '\'; _form.return_action.value=\'DetailView\'; _form.return_id.value=\'{$id}\'; _form.action.value=\'EditView\';SUGAR.ajaxUI.submitForm(_form);" type="button" name="Edit" id="edit_button" value="{$APP.LBL_EDIT_BUTTON_LABEL}">{/if} ';
+			    $myonclick="{literal}$('<input>').attr({ type: 'hidden', id: 'opened_tab', name: 'opened_tab', value: $('.detailview_tabs .selected a').attr('id')}).appendTo('#formDetailView');{/literal}";
+			    $output = '{if $bean->aclAccess("edit")}<input title="{$APP.LBL_EDIT_BUTTON_TITLE}" accessKey="{$APP.LBL_EDIT_BUTTON_KEY}" class="button primary" onclick="'.$js_form.' _form.return_module.value=\'' . $module . '\'; _form.return_action.value=\'DetailView\'; _form.return_id.value=\'{$id}\'; _form.action.value=\'EditView\';' . $myonclick . 'SUGAR.ajaxUI.submitForm(_form);" type="button" name="Edit" id="edit_button" value="{$APP.LBL_EDIT_BUTTON_LABEL}">{/if} ';
             break;
 
 			case "FIND_DUPLICATES":


### PR DESCRIPTION
When on a Tab on Detailview and going to EditView, always the first Tab is open again.
This Patch stays on the Tab that was open on DetailView.
One Commit of the patch is a minor Bugfix, but is needed for the Complete Patch.
The other three patches are the ones that add the enhancement.

Invalidates pull request #93 that did only work in development mode because of template caching.
