### PR TITLE
closes #722 - On Popup the form name for the call back parameters sho…

### DIFF
--- a/include/SugarFields/Fields/Relate/SugarFieldRelate.php
+++ b/include/SugarFields/Fields/Relate/SugarFieldRelate.php
@@ -161,6 +161,7 @@ class SugarFieldRelate extends SugarFieldBase {
     }
 
     function getPopupViewSmarty($parentFieldArray, $vardef, $displayParams, $tabindex){
+        $displayParams['formName'] = 'popup_query_form'; // Bug Fix #722
     	return $this->getSearchViewSmarty($parentFieldArray, $vardef, $displayParams, $tabindex);
     }
 


### PR DESCRIPTION
…uld be the popup_query_form instead of search_form - thus why it was not populating the relate field's values.