### PR TITLE
closes bug 774

### DIFF
--- a/include/Dashlets/DashletGenericAutoRefresh.tpl
+++ b/include/Dashlets/DashletGenericAutoRefresh.tpl
@@ -53,7 +53,7 @@ if (document.getElementById("{$dashletId}_interval").value > 0) {ldelim}
 function refreshDashlet{$strippedDashletId}() 
 {ldelim}
     //refresh only if offset is 0
-    if ( SUGAR.mySugar && document.getElementById("{$dashletId}_offset").value == '0' ) {ldelim}
+    if ( SUGAR.mySugar && document.getElementById("{$dashletId}_offset") !== null && document.getElementById("{$dashletId}_offset").value == '0' ) {ldelim}
         SUGAR.mySugar.retrieveDashlet("{$dashletId}","{$url}");
     {rdelim}
 {rdelim}

--- a/include/Dashlets/DashletGenericAutoRefreshDynamic.tpl
+++ b/include/Dashlets/DashletGenericAutoRefreshDynamic.tpl
@@ -56,7 +56,7 @@ if(document.getElementById("{$dashletId}_interval").value > 0) {ldelim}
         function refreshDashlet{$strippedDashletId}() 
         {ldelim}
             //refresh only if offset is 0
-            if (SUGAR.mySugar && document.getElementById("{$dashletId}_offset").value == '0' ) {ldelim}
+            if (SUGAR.mySugar && document.getElementById("{$dashletId}_offset") !== null && document.getElementById("{$dashletId}_offset").value == '0' ) {ldelim}
                 SUGAR.mySugar.retrieveDashlet("{$dashletId}","{$url}");
             {rdelim}
         {rdelim}


### PR DESCRIPTION
This fix adds a check for a null item before calling ".value".  This closes bug #774.