### PR TITLE
Schedulers - global key - Fix issue #748

### DIFF
--- a/modules/Schedulers/language/en_us.lang.php
+++ b/modules/Schedulers/language/en_us.lang.php
@@ -45,7 +45,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  * All Rights Reserved.
  * Contributor(s): ______________________________________..
  ********************************************************************************/
-global $sugar_config;
+
 
 $mod_strings = array (
 // OOTB Scheduler Job Names:
@@ -170,4 +170,6 @@ $mod_strings = array (
 'LBL_CLEANJOBQUEUE' => 'Cleanup Job Queue',
 'LBL_REMOVEDOCUMENTSFROMFS' => 'Removal of documents from filesystem',
 );
+
+global $sugar_config;
 ?>


### PR DESCRIPTION
global $sugar_config key moved to the end. This fix issue 748
Schedulers language file - global $sugar_config key removal · Issue #748 · salesagility/SuiteCRM - https://github.com/salesagility/SuiteCRM/issues/748