### PR TITLE
Fixed email template parsing and refactored handleCreateCase()

### DIFF
--- a/custom/modules/InboundEmail/AOPInboundEmail.php
+++ b/custom/modules/InboundEmail/AOPInboundEmail.php
@@ -193,11 +193,6 @@ class AOPInboundEmail extends InboundEmail {
                 $caseBean->contacts->add($contactBean);
             }
 
-            // relate contact to case
-            if(!empty($contactBean)) {
-                $caseBean->contacts->add($contactIds);
-            }
-
             // Relate the email with the case
             if($caseBean->load_relationship('emails')) {
                 $caseBean->emails->add($email->id);


### PR DESCRIPTION
Changes:
* Fix: parses email template correctly
* Code is refactored to make it easier to understand. 
* Related lines are group together where possible.
* Redundant code removed. (improving performance)
* Relates the contact to the case.
* Relates case to a default account (if configure in config.php) when an account doesn't exist. eg $sugar_config['inbound_email_default_account_id'] = '0000000-0000-0000-0000-00000000000';
