### PR TITLE
fixed Connectors: Modify Mapping and Connectors to work across all themes

### DIFF
--- a/custom/modules/Connectors/controller.php
+++ b/custom/modules/Connectors/controller.php
@@ -39,8 +39,9 @@ if (!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 require_once('include/connectors/sources/SourceFactory.php');
 require_once('include/connectors/ConnectorFactory.php');
 require_once('include/MVC/Controller/SugarController.php');
+require_once('modules/Connectors/controller.php');
 
-class ConnectorsController extends SugarController
+class CustomConnectorsController extends ConnectorsController
 {
 
     var $admin_actions = array('ConnectorSettings', 'DisplayProperties', 'MappingProperties', 'ModifyMapping', 'ModifyDisplay', 'ModifyProperties',

--- a/include/connectors/formatters/default/company_detail.js
+++ b/include/connectors/formatters/default/company_detail.js
@@ -39,6 +39,6 @@ function header(header)
 function footer(footer)
 {this.footer=footer;}
 function display()
-{if(typeof(dialog)!='undefined')
+{if(typeof(dialog) != 'undefined' && dialog.destroy && typeof(dialog.destroy) == 'function')
 dialog.destroy();dialog=new YAHOO.widget.SimpleDialog(this.div_id,{width:this.width,visible:true,draggable:true,close:true,text:this.text,constraintoviewport:true,x:this.x,y:this.y});dialog.setHeader(this.header);dialog.setBody(this.text);dialog.setFooter(this.footer);dialog.render(document.body);dialog.show();}
 CompanyDetailsDialog.prototype.setHeader=header;CompanyDetailsDialog.prototype.setFooter=footer;CompanyDetailsDialog.prototype.display=display;

--- a/jssource/src_files/include/connectors/formatters/default/company_detail.js
+++ b/jssource/src_files/include/connectors/formatters/default/company_detail.js
@@ -60,7 +60,7 @@ function footer(footer)
 
 function display()
 {
-    if(typeof(dialog) != 'undefined')
+    if(typeof(dialog) != 'undefined' && dialog.destroy && typeof(dialog.destroy) == 'function')
         dialog.destroy();
 
     dialog = new YAHOO.widget.SimpleDialog(this.div_id,


### PR DESCRIPTION
Correctly extended the custom Connectors controller to include functions from original controller. Fixed Connectors to display properly on all themes by adding a check for the destroy function on the display object (necessary because theme SuiteR return a display object of html code causing js error)