### PR TITLE
Corrects wrong Content-Length - Fix for issue #825 - CSV export creates partial file

### DIFF
--- a/export.php
+++ b/export.php
@@ -89,10 +89,10 @@ header("Content-transfer-encoding: binary");
 header("Expires: Mon, 26 Jul 1997 05:00:00 GMT" );
 header("Last-Modified: " . TimeDate::httpTime() );
 header("Cache-Control: post-check=0, pre-check=0", false );
-header("Content-Length: ".mb_strlen($transContent, '8bit'));
 if (!empty($sugar_config['export_excel_compatible'])) {
     $transContent=chr(255) . chr(254) . mb_convert_encoding($transContent, 'UTF-16LE', 'UTF-8');
 }
+header("Content-Length: ".mb_strlen($transContent, '8bit'));
 print $transContent;
 
 sugar_cleanup(true);


### PR DESCRIPTION
This one fixes salesagility/SuiteCRM #825 - CSV export creates partial file when export_excel_compatible is set.

Content-Length was calculated before converting the encoding of the content to UTF-16LE. It should be calculated after conversion of encoding because conversion changes content size.
