### PR TITLE
Closes #834.

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -3977,7 +3977,7 @@ class SugarBean
             }
             if(!empty($rows_found) && (empty($limit) || $limit == -1))
             {
-                $limit = $sugar_config['list_max_entries_per_subpanel'];
+                $limit = $max_per_page;
             }
             if( $toEnd)
             {


### PR DESCRIPTION
Fall back to the max_per_page value. These two values differing would cause broken pagination. 