### PR TITLE
Closes  #805 by upping the limit the url limit from 255 to 2000

### DIFF
--- a/modules/Home/Dashlets/iFrameDashlet/configure.tpl
+++ b/modules/Home/Dashlets/iFrameDashlet/configure.tpl
@@ -70,7 +70,7 @@
 <tr>
     <td scope='row'>{$urlLBL}</td>
     <td>
-    	<input class="text" name="url" size='20' maxlength='255' value='{$url}'>
+    	<input class="text" name="url" size='20' maxlength='2000' value='{$url}'>
     </td>
 </tr>
 <tr>


### PR DESCRIPTION
As per http://stackoverflow.com/a/417184/3894683, setting to 2000 characters is a sensible upper bound.  I have tested this and it saves / loads the url at this length.