### PR TITLE
If empty($fieldDef['name']) dont use it in UPDATE SQL

### DIFF
--- a/include/database/DBManager.php
+++ b/include/database/DBManager.php
@@ -1929,7 +1929,7 @@ protected function checkQuery($sql, $object_name = false)
 			if (isset($fieldDef['source']) && $fieldDef['source'] != 'db')  continue;
 			// Do not write out the id field on the update statement.
     		// We are not allowed to change ids.
-    		if ($fieldDef['name'] == $primaryField['name']) continue;
+    		if (empty($fieldDef['name']) || $fieldDef['name'] == $primaryField['name']) continue;
 
     		// If the field is an auto_increment field, then we shouldn't be setting it.  This was added
     		// specially for Bugs and Cases which have a number associated with them.


### PR DESCRIPTION
I installed Suite 7.5.1 copied my modules from production server, copied my database (Old Sugar 6.5 installation, its time  to update ;) ), repair etc..
After that i was not able to save accounts or contacts. Tracked it down to jjw_maps fields. Dont know the exact reason why this happens (copying my old db can have to do with it, or wrong definitions in jjw_maps, or a combination of both).
When saving accounts following statement was in the logs:
<pre>
UPDATE accounts
SET `name`='Dummy GmbH',`date_modified`='2016-01-28 08:19:52',`modified_user_id`='1',`created_by`='6325aa79-fe07-4de9-f84a-55c07ad44482',`description`=NULL,`assigned_user_id`='',`account_type`=NULL,`industry`=NULL,`annual_revenue`=NULL,`phone_fax`=NULL,`billing_address_street`=NULL,`billing_address_city`=NULL,`billing_address_state`=NULL,`billing_address_postalcode`=NULL,`billing_address_country`=NULL,`rating`=NULL,`phone_office`='+99 99 99 - 99 99 0 ',`phone_alternate`=NULL,`website`='http://',`ownership`=NULL,`employees`=NULL,`ticker_symbol`=NULL,`shipping_address_street`=NULL,`shipping_address_city`=NULL,`shipping_address_state`=NULL,`shipping_address_postalcode`=NULL,`shipping_address_country`=NULL,`parent_id`='',`sic_code`=NULL,`campaign_id`='',``=NULL,``=NULL,``=NULL,``=NULL
WHERE  accounts.id = 'e6678a6e-2d5e-b388-6444-5668654302a' AND deleted=0: MySQL error 1054: Unknown column '' in 'field list'
</pre>
I tracked these empty fields down with following debug in include/database/DBManager.php, around line 1965 
Debug Code:
<pre>
$columnName = $this->quoteIdentifier($fieldDef['name']);
$this->log->fatal($field . " / " . $columnName ." - " . print_r($fieldDef,1)); // added this
</pre>

Gives me following:
<pre>
Thu Jan 28 09:19:52 2016 [23007][1][FATAL] jjwg_maps_lat_c / `` - Array
(
    [inline_edit] => 1
)
</pre>
and the same for the other jjwg_maps fields: jjwg_maps_address_c, jjwg_maps_lng_c, jjwg_maps_geocode_status_c

Dont know if we should fix the thing at jjwg, too, or where exactly this happens.