### PR TITLE
Fixed #739, #903, #928

### DIFF
--- a/modules/Administration/language/en_us.lang.php
+++ b/modules/Administration/language/en_us.lang.php
@@ -1185,6 +1185,7 @@ $mod_strings = array(
     'LBL_COLOUR_ADMIN_BTNLNK' => 'Button link colour: ',
     'LBL_COLOUR_ADMIN_BTNLNKHOVER' => 'Button link hover colour: ',
     'LBL_COLOUR_ADMIN_DASHHEAD' => 'Dashlet header colour: ',
+    'LBL_COLOUR_ADMIN_DASHHEADTEXT' => 'Dashlet header text colour: ',
     'LBL_COLOUR_ADMIN_ICON' => 'Icon colour: ',
     'LBL_COLOUR_ADMIN_TABS' => 'Menu contents config',
     'LBL_SUGGESTION_POPUP_FROM' => 'Suggestion & Pop-up gradient (from):',

--- a/modules/Schedulers/_AddJobsHere.php
+++ b/modules/Schedulers/_AddJobsHere.php
@@ -532,7 +532,7 @@ function cleanJobQueue($job)
 
 function pollMonitoredInboxesAOP()
 {
-    require_once 'custom/modules/InboundEmail/AOPInboundEmail.php';
+    require_once 'modules/InboundEmail/AOPInboundEmail.php';
     $GLOBALS['log']->info('----->Scheduler fired job of type pollMonitoredInboxesAOP()');
     global $dictionary;
     global $app_strings;

--- a/themes/SuiteR/css/colourSelector.php
+++ b/themes/SuiteR/css/colourSelector.php
@@ -37,7 +37,7 @@ background: #<?php echo $sugar_config['theme_settings']['SuiteR']['dashlet']; ?>
 }
 
 .dashletPanel .h3Row .dashletToolSet .icon{
-fill: #<?php echo $sugar_config['theme_settings']['SuiteR']['page_link']; ?>;	
+fill: #<?php echo $sugar_config['theme_settings']['SuiteR']['page_link']; ?> !important;
 }
 
 /* Top navigation bar CSS */
@@ -66,13 +66,13 @@ color:#<?php echo $sugar_config['theme_settings']['SuiteR']['navbar_link_hover']
 }
 
 #desktop_notifications .btn {
-background: #<?php echo $sugar_config['theme_settings']['SuiteR']['navbar']; ?>;	
+background: #<?php echo $sugar_config['theme_settings']['SuiteR']['navbar']; ?> !important;
 }
 
 #searchform .btn
 {
-background:#<?php echo $sugar_config['theme_settings']['SuiteR']['navbar'];?>;
-color: #<?php echo $sugar_config['theme_settings']['SuiteR']['icon']; ?>;
+background:#<?php echo $sugar_config['theme_settings']['SuiteR']['navbar'];?> !important;
+color: #<?php echo $sugar_config['theme_settings']['SuiteR']['icon']; !important?>;
 }
 
 /* Drop down menu CSS */

--- a/themes/SuiteR/css/colourSelector.php
+++ b/themes/SuiteR/css/colourSelector.php
@@ -26,18 +26,22 @@ color: #<?php echo $sugar_config['theme_settings']['SuiteR']['page_header']; ?>;
 
 /* Pagelink CSS */
 
-a, a:link, a:visited, .dashletPanel .h3Row h3, #dashletbuttons, .detail tr td a:link, .detail tr td a:visited, .detail tr td a:hover{
+a, a:link, a:visited, #dashletbuttons, .detail tr td a:link, .detail tr td a:visited, .detail tr td a:hover{
 color: #<?php echo $sugar_config['theme_settings']['SuiteR']['page_link']; ?>;
 }
 
 /* Dashlet CSS */
 
 .dashletPanel .h3Row{
-background: #<?php echo $sugar_config['theme_settings']['SuiteR']['dashlet']; ?>;
+background: #<?php echo $sugar_config['theme_settings']['SuiteR']['dashlet'];?>;
+}
+
+.dashletPanel .h3Row h3{
+color: #<?php echo $sugar_config['theme_settings']['SuiteR']['dashlet_headertext'];?> !important;
 }
 
 .dashletPanel .h3Row .dashletToolSet .icon{
-fill: #<?php echo $sugar_config['theme_settings']['SuiteR']['page_link']; ?> !important;
+fill: #<?php echo $sugar_config['theme_settings']['SuiteR']['dashlet_headertext'];?> !important;
 }
 
 /* Top navigation bar CSS */

--- a/themes/SuiteR/themedef.php
+++ b/themes/SuiteR/themedef.php
@@ -142,6 +142,11 @@ $themedef = array(
             'type' => 'colour',
             'default' => '#ffffff'
         ),
+        'dashlet_headertext' => array(
+            'vname' => 'LBL_COLOUR_ADMIN_DASHHEADTEXT',
+            'type' => 'colour',
+            'default' => '#3C8DBC'
+        ),        
         'icon' => array(
             'vname' => 'LBL_COLOUR_ADMIN_ICON',
             'type' => 'colour',


### PR DESCRIPTION
- This should fix the notification & search btn background, and the dashlet icons color.
- This removes the references to "custom" for #903
- Added the option "dashlet header text" to theme settings for #928 