### PR TITLE
ProspectList: Related field fix

### DIFF
--- a/modules/ProspectLists/ProspectList.php
+++ b/modules/ProspectLists/ProspectList.php
@@ -175,7 +175,8 @@ class ProspectList extends SugarBean {
 
 		// query all custom fields in the fields_meta_data table for the modules which are being exported 
 		$db = DBManagerFactory::getInstance();
-		$result = $db->query("select name, custom_module from fields_meta_data where custom_module in ('" . 
+		$result = $db->query("select (case when (type = 'relate') then ext3 else name end) as name,
+					custom_module from fields_meta_data where custom_module in ('" .
 					implode("', '", array_keys($members)) . "')",
 					true,
 					"ProspectList::create_export_members_query() : error querying custom fields");


### PR DESCRIPTION
If you add a custom field to either Accounts, Contacts, Users, Prospects or Leads which it is of type: _relate_ then the Export query for ProspectList is broken. That means that the user gets an error about an SQL error and not CSV is output.

It insists on using name field as its table value while it should use the ext3 field instead.

TODO: Check if other type of fields need similar workarounds or not.