### PR TITLE
On AJAX enabled modules make sure quicksearch gets initialized

### DIFF
--- a/include/SugarFields/Fields/Parent/EditView.tpl
+++ b/include/SugarFields/Fields/Parent/EditView.tpl
@@ -95,11 +95,13 @@ function changeParentQS(field) {
     }
     enableQS(false);
 }}
+</script>
+{{$displayParams.disabled_parent_types}}
+{{$quickSearchCode}}
+<script>
 //change this in case it wasn't the default on editing existing items.
 $(document).ready(function(){
 	changeParentQS("parent_name")
 });
 </script>
-{{$displayParams.disabled_parent_types}}
-{{$quickSearchCode}}
 {/literal}


### PR DESCRIPTION
On AJAX enabled modules the relate field does not get initialized. By changing the sequence it gets initialized correctly again.
Bug was: Select box showed a module "AModule", but quicksearch textbox searched in "Accounts". (Only in AJAX modules)