### PR TITLE
Closes #951.  This will select the appropriate report module on edit page load.

### DIFF
--- a/modules/AOR_Reports/tpls/EditViewFooter.tpl
+++ b/modules/AOR_Reports/tpls/EditViewFooter.tpl
@@ -212,6 +212,11 @@
                 node.loaded = true;
                 $('#fieldTree').tree('openNode', node);
             }
+            else
+            {
+                if($('#fieldTree a:first').length)
+                    $('#fieldTree a:first').click();
+            }
 
         }
 


### PR DESCRIPTION
This will list the fields for the selected report module on edit page load.  This will always selected the first tree item (which is always the selected report module as per the getModuleTreeData method of aow_utils.php