### PR TITLE
Fix for #967 

### DIFF
--- a/themes/SuiteR/css/style.css
+++ b/themes/SuiteR/css/style.css
@@ -3071,6 +3071,20 @@ li#usermenu:hover {
 }
 
 /* Custom styles fore 'More' list item on top navigation */
+@media screen and (max-width: 991px){
+    .All{
+        height: 200px;
+        overflow:scroll;
+        }
+    }
+
+@media screen and (min-width: 992px){
+    .All{
+        -moz-column-count:2;
+        -webkit-column-count:2;
+        column-count: 2;
+    }
+}
 
 .moremenu a{
     color:#ffffff !important;

--- a/themes/SuiteR/tpls/_headerModuleList.tpl
+++ b/themes/SuiteR/tpls/_headerModuleList.tpl
@@ -154,7 +154,7 @@
                             <span class="notCurrentTabLeft">&nbsp;</span><span class="notCurrentTab">
                             <a href="#" id="grouptab_{$smarty.foreach.groupList.index}" class="dropdown-toggle" data-toggle="dropdown">{$group}</a>
                             <span class="notCurrentTabRight">&nbsp;</span>
-                            <ul class="dropdown-menu" role="menu" {if $smarty.foreach.groupList.last} class="All"{/if}>
+                            <ul {if $smarty.foreach.groupList.last} class="All dropdown-menu"{else} class="dropdown-menu"{/if} role="menu">
                                 {foreach from=$modules.modules item=module key=modulekey}
                                     <li>
                                         {capture name=moduleTabId assign=moduleTabId}moduleTab_{$smarty.foreach.moduleList.index}_{$module}{/capture}


### PR DESCRIPTION
This is a possible solution to bring back "the Suite7 more menu" in the responsive theme.

## Changelog

- [x] Added class "All" to the stylesheet for SuiteR
- [x] Fixed the bug that duplicated  class="" for "All"

## Todo 
- [ ]  customize the dropdown-menu for "All menu"