### PR TITLE
Fix user time zone issue with reminder datetime. Fix for #766.

### DIFF
--- a/modules/Reminders/Reminder.php
+++ b/modules/Reminders/Reminder.php
@@ -279,12 +279,14 @@ class Reminder extends Basic
             return;
         }
 
-        //Create separate variable to hold timedate value
-        $alertDateTimeNow = $timedate->nowDb();
+        // Create separate variable to hold timedate value
+        // These timedates need to be in the user time zone as the
+        // datetime returned by the Bean below is in the user time zone
+        $alertDateTimeNow = $timedate->getNow(true)->asDb(false);
 
         // cn: get a boundary limiter
-        $dateTimeMax = $timedate->getNow()->modify("+{$app_list_strings['reminder_max_time']} seconds")->asDb();
-        $dateTimeNow = $timedate->nowDb();
+        $dateTimeMax = $timedate->getNow(true)->modify("+{$app_list_strings['reminder_max_time']} seconds")->asDb(false);
+        $dateTimeNow = $timedate->getNow(true)->asDb(false);
 
         $dateTimeNow = $db->convert($db->quoted($dateTimeNow), 'datetime');
         $dateTimeMax = $db->convert($db->quoted($dateTimeMax), 'datetime');


### PR DESCRIPTION
Reminders for Calls and Meetings do not work correctly unless the user’s time zone is set to UTC. If the user’s time zone is set to say Europe (UTC+1) the reminder will trigger 1 hour later.

This was introduced as part of the Reminder enhancements for 7.4.3. It looks like code was copied from include/javascript/jsAlerts.php to modules/Reminders/Reminder.php, however the code in jsAlerts queried Call reminder datetime directly from the database using a query and thus the datetime returned was in UTC, whereas in Reminder.php the query was changed to use the Bean which returns time in the user’s time zone.

The checks performed against the current time were using nowDb() which returns UTC times. This fix changes to check against current time in the user’s time zone.
Originally found this issue in 7.4.3 and then upgraded to 7.5.1 and it was still present. It is also still present in the hotfix branch. This fix will work both releases and the hotfix branch. I am currently running 7.4.3 and have verified that it works. I have also testing in 7.5.1 and hotfix.

This also addresses #811 and #822.
