### PR TITLE
Closes #409 by removing the hard-coding of the labels

### DIFF
--- a/modules/Calendar/CalendarDisplay.php
+++ b/modules/Calendar/CalendarDisplay.php
@@ -506,15 +506,15 @@ class CalendarDisplay {
 			echo "<div class='custom_module_title moduleTitle'><h2>". $mod_strings['LBL_MODULE_TITLE'] ."</h2></div>";
 			echo "<div style='float:right;' class='moduleTitle'>";
 
-            echo '<div class="btn-group">
-                    <button type="button" class="btn button dropdown-toggle" data-toggle="dropdown">Add Item <span class="caret"></span></button>
+			echo '<div class="btn-group">
+                    <button type="button" class="btn button dropdown-toggle" data-toggle="dropdown">'.$mod_strings["LBL_ADD_ITEM"].'<span class="caret"></span></button>
                        <ul class="dropdown-menu pull-left" style="right: 0; left: auto;">';
 
-                        foreach($buttons as $module){
-                            echo '<li><a href="index.php?return_module=Calendar&return_action=index&module=' . $module .'s&action=EditView">Add ' . $module .'</a></li>';
-                        }
+			foreach($buttons as $module){
+				echo '<li><a href="index.php?return_module=Calendar&return_action=index&module=' . $module .'s&action=EditView">'.$mod_strings["LBL_ADD_".strtoupper($module)].'</a></li>';
+			}
 
-            echo '</ul></div></div>';
+			echo '</ul></div></div>';
 
 		}else{
 			echo "<div class='moduleTitle'><h2>". $mod_strings['LBL_MODULE_TITLE'] ."</h2></div>";

--- a/modules/Calendar/language/en_us.lang.php
+++ b/modules/Calendar/language/en_us.lang.php
@@ -160,6 +160,11 @@ $mod_strings = array(
     'LBL_NO_ITEMS_MOBILE' => 'Your calendar is clear for the week.',
     'LBL_SECURITYGROUPS' => 'Filter user list by Security Group',
 
+    'LBL_ADD_ITEM' => 'Add Item',
+    'LBL_ADD_MEETING' => 'Add Meeting',
+    'LBL_ADD_TASK' => 'Add Task',
+    'LBL_ADD_CALL' => 'Add Call',
+
 );
 
 $mod_list_strings = array(


### PR DESCRIPTION
This closes #409 as per the OP's suggestion of replacing the hard-coded values with the mod_strings value.