### PR TITLE
For long usernames search box will be partly hidden by alert-nav

### DIFF
--- a/themes/Suite7/css/style.css
+++ b/themes/Suite7/css/style.css
@@ -4898,6 +4898,7 @@ ul#quick-nav ul li:hover {
     z-index:55;
     padding:0;
     margin-bottom:2px;
+    margin-right:1px;
 }
 
 #alert-nav #alerts {


### PR DESCRIPTION
When the text field resizes when clicking in the field, it resizes and hides the beginning unter the alert-nav. With margin the resize stops just behind the alert notification.