### PR TITLE
Fixes #517 Check box field do not Export value in module Reports

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -840,10 +840,21 @@ class AOR_Report extends Basic {
             $csv .= "\r\n";
             foreach($fields as $name => $att){
                 if($att['display']){
-                    if($att['function'] != '' )
+                    if($att['function'] != '' ){
                         $csv .= $this->encloseForCSV($row[$name]);
-                    else
-                        $csv .= $this->encloseForCSV(trim(strip_tags(getModuleField($att['module'], $att['field'], $att['field'], 'DetailView',$row[$name]))));
+                    }
+                    else{
+                        $field_temp = getModuleField($att['module'], $att['field'], $att['field'], 'DetailView',$row[$name]);
+                        if(strpos($field_temp, 'type="checkbox"') !== false){
+                            if(strpos($field_temp, 'CHECKED')){
+                                $field_temp = '1';
+                            }
+                            else {
+                                $field_temp = '0';
+                            }
+                        }
+                        $csv .= $this->encloseForCSV(trim(strip_tags($field_temp)));
+                    }
                     $csv .= $delimiter;
                 }
             }


### PR DESCRIPTION
More specifically when getModuleField returns the field in most cases it returns a value enclosed in span tags so when strip_tags is run it strips off the span tags and leaves the value but in the case of a check box field getModuleField just returns the input html tag with its value checked so therefore strip_tags removes everything,  thus leaving it blank.

There does not seem to be an easy way to fix this without altering aow_utils.php since AOR_Fields doesn’t store the field type. So I have added code to check if it is a checkbox directly in the returned string and whether its been checked or not.
(cherry picked from commit b56044c)