### PR TITLE
Closes #998.  Adds a fix to limit the y-axis labels for the "pipeline…

### DIFF
--- a/modules/AOR_Charts/AOR_Chart.php
+++ b/modules/AOR_Charts/AOR_Chart.php
@@ -529,6 +529,7 @@ EOF;
                 tickmarks:'encircle',
                 textSize:10,
                 titleSize:10,
+                gutterLeft:70,
                 //title: '$chartName',
                 labels: $chartLabelValues,
 

--- a/modules/Charts/Dashlets/PipelineBySalesStageDashlet/PipelineBySalesStageDashlet.php
+++ b/modules/Charts/Dashlets/PipelineBySalesStageDashlet/PipelineBySalesStageDashlet.php
@@ -50,6 +50,8 @@ class PipelineBySalesStageDashlet extends DashletGenericChart
     public $pbss_date_end;
     public $pbss_sales_stages = array();
 
+    public $maxLabelSizeBeforeTotal = 18;
+    public $labelReplacementString = '...';
     /**
      * @see DashletGenericChart::$_seedName
      */
@@ -333,7 +335,7 @@ EOD;
         foreach($data as $i)
         {
             //$chart['labelsAndValues'][]=$i['key'].' ('.$currency.(int)$i['total'].')';
-            $chart['labelsAndValues'][]=$i['key'].' ('.$currency_symbol.(int)$i['total'].$thousands_symbol.')';
+            $chart['labelsAndValues'][]=$this->resizeLabel($i['key']).' ('.$currency_symbol.(int)$i['total'].$thousands_symbol.')';
             $chart['labels'][]=$i['key'];
             $chart['data'][]=(int)$i['total'];
             $total+=(int)$i['total'];
@@ -343,6 +345,16 @@ EOD;
         $chart['total']=$total;
         return $chart;
     }
+
+    protected function resizeLabel($label)
+    {
+        if(strlen($label) < $this->maxLabelSizeBeforeTotal)
+            return $label;
+        else
+            return substr($label,0,$this->maxLabelSizeBeforeTotal).$this->labelReplacementString;
+
+    }
+
 
 
 }


### PR DESCRIPTION
… by sales stage" report and for all line charts (the others already have this in place).