### PR TITLE
Browser title not correct for custom modules - from gunnicom

### DIFF
--- a/themes/Suite7/tpls/_head.tpl
+++ b/themes/Suite7/tpls/_head.tpl
@@ -45,7 +45,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset={$APP.LBL_CHARSET}">
     <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
     <meta http-equiv="X-UA-Compatible" content="IE=9"/>
-    <title>{$APP.LBL_BROWSER_TITLE}</title>
+    <title>{$SYSTEM_NAME}</title>
     {$SUGAR_JS}
     {literal}
     <script type="text/javascript">


### PR DESCRIPTION
In stock modules the title shows the object you are watching, not in custom modules. This fixes this.
Reference: http://forums.sugarcrm.com/f3/module-name-record-name-browser-title-87820/