### PR TITLE
Closes #1040.  Updates the documentation url and removes the knowledge base item to stop 404.

### DIFF
--- a/modules/Users/tpls/wizard.tpl
+++ b/modules/Users/tpls/wizard.tpl
@@ -358,9 +358,7 @@
                                     {else}
                                         <tr><td><img src=include/images/university2.png style="margin-right: 5px;"></td><td><a href="http://www.suitecrm.com/forum/index" target="_blank"><b> {$MOD.LBL_WIZARD_FINISH11} </b></a></b><br>{$MOD.LBL_WIZARD_FINISH12}</td></tr>
                                         <tr><td colspan=2><hr style="margin: 5px 0px;"></td></tr>
-                                        <tr><td><img src=include/images/docs.png style="margin-right: 5px;"></td><td><a href="http://suitecrm.com/suitecrm-the-sugarcrm-fork" target="_blank"><b> {$MOD.LBL_WIZARD_FINISH14} </b></a></b><br>{$MOD.LBL_WIZARD_FINISH15}</td></tr>
-                                        <tr><td colspan=2><hr style="margin: 5px 0px;"></td></tr>
-                                        <tr><td><img src=include/images/kb.png style="margin-right: 5px;"></td><td><a href="http://suitecrm.com/suitecrm-the-sugarcrm-fork" target="_blank"><b> {$MOD.LBL_WIZARD_FINISH16} </b></a></b><br>{$MOD.LBL_WIZARD_FINISH17}</td></tr>
+                                        <tr><td><img src=include/images/docs.png style="margin-right: 5px;"></td><td><a href="https://suitecrm.com/wiki/index.php/Userguide" target="_blank"><b> {$MOD.LBL_WIZARD_FINISH14} </b></a></b><br>{$MOD.LBL_WIZARD_FINISH15}</td></tr>
                                         <tr><td colspan=2><hr style="margin: 5px 0px;"></td></tr>
                                         <tr><td><img src=include/images/forums.png style="margin-right: 5px;"></td><td><a href="http://www.suitecrm.com/forum/index" target="_blank"><b> {$MOD.LBL_WIZARD_FINISH18} </b></a></b><br>{$MOD.LBL_WIZARD_FINISH19}</td></tr>
                                         <tr><td colspan=2><hr style="margin: 5px 0px;"></td></tr>


### PR DESCRIPTION
This update changes the documentation link in the wizard to point to the SuiteCRM userguides and it removes the Knowledge Base item.  These were both previously 404'ing by pointing to https://suitecrm.com/suitecrm-the-sugarcrm-fork.