### PR TITLE
substituted 'die()' in sugar_die method with \Exception

### DIFF
--- a/include/utils.php
+++ b/include/utils.php
@@ -1606,13 +1606,12 @@ function get_select_options_with_id_separate_key ($label_list, $key_list, $selec
  * Call this method instead of die().
  * We print the error message and then die with an appropriate
  * exit code.
+ * @throws \Exception
  */
 function sugar_die($error_message, $exit_code = 1)
 {
-	global $focus;
 	sugar_cleanup();
-	echo $error_message;
-	die($exit_code);
+    throw new \Exception($error_message, $exit_code);
 }
 
 
@@ -5023,7 +5022,7 @@ function getDuplicateRelationListWithTitle($def, $var_def, $module)
             }
             $select_array[$temp_key] = $temp_value;
         }
-        
+
         // Add the relationship name for easier recognition
         foreach ($select_array as $key => $value)
         {
@@ -5036,7 +5035,7 @@ function getDuplicateRelationListWithTitle($def, $var_def, $module)
 
 /**
  * Gets the list of "*type_display*".
- * 
+ *
  * @return array
  */
 function getTypeDisplayList()
@@ -5046,7 +5045,7 @@ function getTypeDisplayList()
 
 /**
  * Breaks given string into substring according
- * to 'db_concat_fields' from field definition 
+ * to 'db_concat_fields' from field definition
  * and assigns values to corresponding properties
  * of bean.
  *


### PR DESCRIPTION
It is very difficult to check for errors and react to them - especially when working on tests - when application is killed.
Is there any reason why this shoul not be a valid alternative?
