### PR TITLE
Closes #1010. The mobile calendar was 500'ing due to the $start_time variable not being created from DateTime::createFromFormat.

### DIFF
--- a/modules/Calendar/CalendarGrid.php
+++ b/modules/Calendar/CalendarGrid.php
@@ -281,9 +281,9 @@ class CalendarGrid {
 	}
 
 	function mobile_get_end_time($day_item){
-		$start_time = DateTime::createFromFormat("h:ia",$day_item['time_start']);
+		$start_time = DateTime::createFromFormat("H:i",$day_item['time_start']);
 		$start_time->modify('+' . $day_item['duration_minutes'] .'minutes');
-		return $start_time->format("h:ia");
+		return $start_time->format("H:i");
 	}
 
 


### PR DESCRIPTION
Closes #1010.  This error was because it was expecting the time in h:ia format (e.g. 10:50am) but it was getting passed through as simply "10:50".  I have also modified the returned format to match that of the start time.