### PR TITLE
Fixes #1050.  This allows for enter to move the carriage return rather than activating the form for textareas within the search form

### DIFF
--- a/include/SearchForm/tpls/header.tpl
+++ b/include/SearchForm/tpls/header.tpl
@@ -52,8 +52,7 @@
 function submitOnEnter(e)
 {
     var characterCode = (e && e.which) ? e.which : event.keyCode;
-
-    if (characterCode == 13) {
+    if (characterCode == 13 && event.target.type !== "textarea") {
         document.getElementById('search_form').submit();
         return false;
     } else {


### PR DESCRIPTION
Fixes #1050.  This allows for the enter key to cause a carriage return rather than posting the form for textareas within the search screen.