### PR TITLE
Fix undefined index for Facebook and Twittter issue#1080

### DIFF
--- a/modules/SugarFeed/views/view.adminsettings.php
+++ b/modules/SugarFeed/views/view.adminsettings.php
@@ -161,14 +161,12 @@ class ViewAdminsettings extends SugarView
                 // Fake module, need to handle specially
                 $userFeedEnabled = $currModule['enabled'];
                 continue;
-            } else {
-                $currModule['label'] = $GLOBALS['app_list_strings']['moduleList'][$module];
-            }
-
-            if ($module == 'Facebook' || $module == 'Twitter') {
+            } elseif ($module == 'Facebook' || $module == 'Twitter') {
 
                 $currModule['label'] = $module;
 
+            } else {
+                $currModule['label'] = $GLOBALS['app_list_strings']['moduleList'][$module];
             }
 
             $module_list[] = $currModule;


### PR DESCRIPTION
$currModule['label'] = $module was being overridden if $module is Facebook or Twitter.

Re-arranged the conditional to ensure it was set earlier if condition is met and avoid the Undefined Index in $currModule['label'] = $GLOBALS['app_list_strings']['moduleList'][$module];