### PR TITLE
Convert value to unescape ampersand and comparision for audit works

### DIFF
--- a/include/database/DBManager.php
+++ b/include/database/DBManager.php
@@ -2866,7 +2866,7 @@ protected function checkQuery($sql, $object_name = false)
 
             foreach ($field_defs as $field => $properties) {
                 $before_value = $fetched_row[$field];
-                $after_value=$bean->$field;
+                $after_value=from_html($bean->$field);
                 if (isset($properties['type'])) {
                     $field_type=$properties['type'];
                 } else {


### PR DESCRIPTION
If you have a audited field that contains ampersands, they always get written to audit log because ampersands are not escaped in $after_value
Example:
$before_value = "Company GmbH & Co. KG"
$after_value = "Company GmbH & amp; Co. KG"   // space only to show the amp here correctly
So it seems unequal for audit log, but is saved equal because from_html is calles before update query.
Calling from_html like it is done before the update query fixes this.