### PR TITLE
Allow NULL values to be inserted on new record

### DIFF
--- a/include/database/DBManager.php
+++ b/include/database/DBManager.php
@@ -514,7 +514,7 @@ protected function checkQuery($sql, $object_name = false)
 			//custom fields handle there save seperatley
 			if(!empty($field_map) && !empty($field_map[$field]['custom_type'])) continue;
 
-			if(isset($data[$field])) {
+			if(isset($data[$field]) && strlen($data[$field])>0) {
 				// clean the incoming value..
 				$val = from_html($data[$field]);
 			} else {


### PR DESCRIPTION
If you create a record, and the field type is numeric, empty fields get saved as "0" or "0.00".
If you update them and delete the 0 you can get NULL, but you should also be able to save NULLs on create.
By only cleaning values that are longer than 0 chars, you are able to save them as NULL or the default value for that field.