### PR TITLE
SugarFeed content cut results in invalid characters

### DIFF
--- a/modules/SugarFeed/SugarFeed.php
+++ b/modules/SugarFeed/SugarFeed.php
@@ -253,9 +253,9 @@ class SugarFeed extends Basic {
         }
         $text = strip_tags(from_html($text));
 		$text = '<b>{this.CREATED_BY}</b> ' . $text;
-		$feed->name = substr($text, 0, 255);
-		if(strlen($text) > 255){
-			$feed->description = substr($text, 255, 510);
+		$feed->name = mb_substr($text, 0, 255, 'UTF-8');	
+		if(mb_strlen($text, 'UTF-8') > 255){
+			$feed->description = mb_substr($text, 255, 510, 'UTF-8');
 		}
 
 		if ( $record_assigned_user_id === false ) {


### PR DESCRIPTION
Consider the following scenario:
You want to save an Opportunity with a name exactly 28 bytes long and the Account name is exactly 35 bytes long. The default currency is Euro with it's sign (€) in the config and the amount of the opportunity is 2016,03.

With the text of the SugarFeed, this will be more than 255 bytes long (since the € sign takes 3 bytes) so Suite gonna try to cut it after 255 bytes. Since this is at the "middle" of the 3 byte € sign, it will cut it half which results in two invalid characters, which can give the database a hard time.

If we count the UTF-8 characters instead of the bytes of the string, and cut the string as UTF-8, then the problem disappears.
