### PR TITLE
Avoid creating img tag if there is no product image

### DIFF
--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -70,8 +70,8 @@ class templateParser{
 						$value='';
 					}
 				}
-				if ($name === 'aos_products_product_image'){
-				$value = '<img src="'.$value.'"width="50" height="50"/>';
+				if ($name === 'aos_products_product_image' && !empty($value)){
+					$value = '<img src="'.$value.'"width="50" height="50"/>';
 				}
 				if ($name === 'aos_products_quotes_product_qty'){
 					$sep = get_number_seperators();


### PR DESCRIPTION
If you use a quote or invoice templates that included the product image you have to have a product image for every product otherwise it will show an image load error since the URL in the img-tag is invalid.

This code change checks if there is an image for the product before creating the img-tag.