### PR TITLE
Issue #1065: Hotfix

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -51,6 +51,7 @@ class AOR_Report extends Basic {
 		parent::Basic();
         $this->load_report_beans();
         require_once('modules/AOW_WorkFlow/aow_utils.php');
+        require_once('modules/AOR_Reports/aor_utils.php');
 	}
 
 	function bean_implements($interface){

--- a/suitecrm_version.php
+++ b/suitecrm_version.php
@@ -1,5 +1,5 @@
 <?php
  if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 
-$suitecrm_version      = '7.5.2';
-$suitecrm_timestamp    = '2016-03-07 17:00';
+$suitecrm_version      = '7.5.3';
+$suitecrm_timestamp    = '2016-03-15 17:00';


### PR DESCRIPTION
Issue #1065

Adding require_once reference "modules/AOR_Reports/aor_utils.php" into the constructor of AOR_Report()

After testing, There seems to have no signification implications as AOR_Report depends on this util package and there are no naming collisions.