### PR TITLE
Fixed #682 Theme settings for supbanels menu + icons

### DIFF
--- a/modules/Administration/language/en_us.lang.php
+++ b/modules/Administration/language/en_us.lang.php
@@ -1171,6 +1171,7 @@ $mod_strings = array(
     'LBL_COLOUR_ADMIN_DDLINK' => 'Drop down link colour: ',
     'LBL_COLOUR_ADMIN_DDMENU' => 'Drop down menu colour: ',
     'LBL_COLOUR_ADMIN_DDLINK_HOVER' => 'Drop down menu link hover colour: ',
+    'LBL_ACTION_MENU_BUTTON' => 'Action Menu button colour',
     'LBL_ACTION_MENU_BACKGROUND' => 'Action Menu background colour',
     'LBL_ACTION_MENU_BACKGROUND_HOVER' => 'Action Menu hover colour',
     'LBL_COLOUR_ADMIN_MENUFONT' => 'Menu link colour',

--- a/themes/SuiteR/css/colourSelector.php
+++ b/themes/SuiteR/css/colourSelector.php
@@ -111,16 +111,14 @@ color:#<?php echo $sugar_config['theme_settings']['SuiteR']['dropdown_menu_link_
     color:#<?php echo $sugar_config['theme_settings']['SuiteR']['dropdown_menu_link_hover']; ?> !important;
 }
 
-/* Action Menu CSS */
-
-ul.clickMenu li ul.subnav, ul.clickMenu ul.subnav-sub, ul.SugarActionMenuIESub, ul.clickMenu li ul.subnav li a, ul.clickMenu li ul.subnav li input, ul.subnav-sub li a, ul.SugarActionMenuIESub li a, ul.clickMenu li ul.subnav li a, ul.clickMenu li ul.subnav li input, ul.subnav-sub li a, ul.SugarActionMenuIESub li a, ul.clickMenu li ul.subnav, ul.clickMenu ul.subnav-sub, ul.SugarActionMenuIESub, ul.clickMenu li ul.subnav li a, ul.clickMenu li ul.subnav li input, ul.subnav-sub li a, ul.SugarActionMenuIESub li a{
-color: #<?php echo $sugar_config['theme_settings']['SuiteR']['page_link']; ?> !important;
-background:#<?php echo $sugar_config['theme_settings']['SuiteR']['action_menu_background']; ?> !important;
+#mobilegloballinks ul li a {
+color:#<?php echo $sugar_config['theme_settings']['SuiteR']['dropdown_menu_link']; ?> !important;
 }
 
-ul.clickMenu li ul.subnav li a:hover,ul.clickMenu li ul.subnav li input:hover, ul.clickMenu.subpanel.records li ul.subnav li a:hover, ul.clickMenu ul.subnav-sub li a:hover, ul.clickMenu ul.subnav-sub li a:hover{
-background:#<?php echo $sugar_config['theme_settings']['SuiteR']['action_menu_background_hover']; ?> !important;
+#mobilegloballinks ul li a:hover {
+color:#<?php echo $sugar_config['theme_settings']['SuiteR']['button_link_hover']; ?> !important;
 }
+
 
 /* Icon CSS */
 
@@ -130,19 +128,46 @@ background:#<?php echo $sugar_config['theme_settings']['SuiteR']['action_menu_ba
 
 /* Button and action menu CSS */
 
-button, .button, input[type="button"], input[type="reset"], input[type="submit"], a#create_link.utilsLink, .btn, .btn-success, .btn-primary, .button, input[type=submit], input[type=button], a#create_link.utilsLink, .btn-group a, ul.clickMenu>li, ul.SugarActionMenuIESub li, ul.SugarActionMenuIESub li a,
-ul.clickMenu li a, .list tr.pagination td.buttons ul.clickMenu > li > a:link, .list tr.pagination td.buttons ul.clickMenu > li > a {
+button, .button, input[type="button"], input[type="reset"], input[type="submit"], a#create_link.utilsLink, .btn, .btn-success, .btn-primary, .button, input[type=submit], input[type=button], a#create_link.utilsLink, .btn-group a {
 background:#<?php echo $sugar_config['theme_settings']['SuiteR']['button']; ?> !important;
 color:#<?php echo $sugar_config['theme_settings']['SuiteR']['button_link']; ?> !important;
 }
 
 .btn:hover, .btn-success:hover, .btn-primary:hover, .button:hover, input[type=submit]:hover, input[type=button]:hover, a#create_link.utilsLink:hover, .btn-group a:hover, #globalLinksModule ul.clickMenu.SugarActionMenu li a:hover,
-#globalLinksModule ul.clickMenu li:hover span,
-ul.SugarActionMenuIESub li a:hover, ul.clickMenu.SugarActionMenu li a:hover, ul.clickMenu.SugarActionMenu li span.subhover:hover,
-ul#globalLinksSubnav li a:hover, ul#quickCreateULSubnav li a:hover {
+#globalLinksModule ul.clickMenu li:hover span, ul#globalLinksSubnav li a:hover, ul#quickCreateULSubnav li a:hover {
 background:#<?php echo $sugar_config['theme_settings']['SuiteR']['button_hover']; ?> !important;
 color:#<?php echo $sugar_config['theme_settings']['SuiteR']['button_link_hover']; ?> !important;
 }
+
+/* Action Menu CSS */
+
+ul.clickMenu li ul.subnav, ul.clickMenu ul.subnav-sub, ul.SugarActionMenuIESub, ul.clickMenu li ul.subnav li a, ul.clickMenu li ul.subnav li input, ul.subnav-sub li a, ul.SugarActionMenuIESub li a, ul.clickMenu li ul.subnav li a, ul.clickMenu li ul.subnav li input, ul.subnav-sub li a, ul.SugarActionMenuIESub li a, ul.clickMenu li ul.subnav, ul.clickMenu ul.subnav-sub, ul.SugarActionMenuIESub, ul.clickMenu li ul.subnav li a, ul.clickMenu li ul.subnav li input, ul.subnav-sub li a, ul.SugarActionMenuIESub li a{
+color: #<?php echo $sugar_config['theme_settings']['SuiteR']['page_link']; ?> !important;
+background:#<?php echo $sugar_config['theme_settings']['SuiteR']['action_menu_background']; ?> !important;
+}
+
+ul.clickMenu li ul.subnav li a:hover,ul.clickMenu li ul.subnav li input:hover, ul.clickMenu.subpanel.records li ul.subnav li a:hover, ul.clickMenu ul.subnav-sub li a:hover, ul.clickMenu ul.subnav-sub li a:hover{
+background:#<?php echo $sugar_config['theme_settings']['SuiteR']['action_menu_background_hover']; ?> !important;
+color:#<?php echo $sugar_config['theme_settings']['SuiteR']['button_link']; ?> !important;
+}
+
+ul.clickMenu>li, ul.SugarActionMenuIESub li, ul.SugarActionMenuIESub li a,
+ul.clickMenu li a, .list tr.pagination td.buttons ul.clickMenu > li > a:link, .list tr.pagination td.buttons ul.clickMenu > li > a {
+background:#<?php echo $sugar_config['theme_settings']['SuiteR']['action_menu_button']; ?> !important;
+}
+
+ul.SugarActionMenuIESub li a:hover, ul.clickMenu.SugarActionMenu li a:hover, ul.clickMenu.SugarActionMenu li span.subhover:hover {
+    /*Leave Blank */
+}
+
+ul.clickMenu.SugarActionMenu li a:hover {
+color:#<?php echo $sugar_config['theme_settings']['SuiteR']['button_link_hover']; ?> !important;
+}
+
+ul.clickMenu li span.subhover:hover {
+background-position: 6px 0;
+}
+
 
 /* popup colors */
 

--- a/themes/SuiteR/themedef.php
+++ b/themes/SuiteR/themedef.php
@@ -93,6 +93,12 @@ $themedef = array(
             'default' => '#ffffff'
         ),
 
+        'action_menu_button' => array(
+            'vname' => 'LBL_ACTION_MENU_BUTTON',
+            'type' => 'colour',
+            'default' => '#eeeeee'
+        ),
+
         'action_menu_background' => array(
             'vname' => 'LBL_ACTION_MENU_BACKGROUND',
             'type' => 'colour',


### PR DESCRIPTION
The Action menu buttons and the icons should actually be two separate issues. This fixes the action menu drop colour selection issues. Suggest opening a separate bug for the icon colour issues.  