### PR TITLE
fix for #1200: changing emails parent relation leads to email be rela…

### DIFF
--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -1060,24 +1060,26 @@ class Email extends SugarBean {
                  }
 			}
 
-			parent::save($check_notify);
-
-			if(!empty($this->parent_type) && !empty($this->parent_id)) {
-                if(!empty($this->fetched_row) && !empty($this->fetched_row['parent_id']) && !empty($this->fetched_row['parent_type'])) {
-                    if($this->fetched_row['parent_id'] != $this->parent_id || $this->fetched_row['parent_type'] != $this->parent_type) {
+            // croessler: has the parent-bean or its id been modified? compare via fetched-row...
+            // if so, delete the old relation and add the new one. one email can only be related to one parent, not multiple parents.
+            if (!empty($this->parent_type) && !empty($this->parent_id)) {
+                if (!empty($this->fetched_row) && !empty($this->fetched_row['parent_id']) && !empty($this->fetched_row['parent_type'])) {
+                    if ($this->fetched_row['parent_id'] != $this->parent_id || $this->fetched_row['parent_type'] != $this->parent_type) {
                         $mod = strtolower($this->fetched_row['parent_type']);
                         $rel = array_key_exists($mod, $this->field_defs) ? $mod : $mod . "_activities_emails"; //Custom modules rel name
-                        if($this->load_relationship($rel) ) {
+                        if ($this->load_relationship($rel)) {
                             $this->$rel->delete($this->id, $this->fetched_row['parent_id']);
                         }
                     }
                 }
                 $mod = strtolower($this->parent_type);
                 $rel = array_key_exists($mod, $this->field_defs) ? $mod : $mod . "_activities_emails"; //Custom modules rel name
-                if($this->load_relationship($rel) ) {
+                if ($this->load_relationship($rel)) {
                     $this->$rel->add($this->parent_id);
                 }
-			}
+            }
+
+            parent::save($check_notify);
 		}
 		$GLOBALS['log']->debug('-------------------------------> Email save() done');
 	}


### PR DESCRIPTION
…ted to both parent beans, not only one.

- updated save() method, fixed logical error when accessing bean->fetched_row AFTER parent::save(). Doing so leads to bean->fetched_row not to contain the fields before modifying and thus the email is in state "nothing has been modified". 
- new: save checks the fetched_row contents correctly. modifications to the parent type/id are being recognized, the old parent-relation is deleted, the new one is added.
- a bit of code styling applied so one can read that stuff.

CLA has been signed.
Fixes #1200 