### PR TITLE
Fixed #817 - Inline Editing: Relationship always displayed as link after inline editing

### DIFF
--- a/include/InlineEditing/InlineEditing.php
+++ b/include/InlineEditing/InlineEditing.php
@@ -446,7 +446,12 @@ function formatDisplayValue($bean, $value, $vardef, $method = "save")
         }
         $record = $bean->$vardef['id_name'];
 
-        $value = "<a class=\"listViewTdLinkS1\" href=\"index.php?action=DetailView&module=".$vardef['module']."&record=$record\">";
+        if($vardef['name'] != "assigned_user_name") {
+            $value = "<a class=\"listViewTdLinkS1\" href=\"index.php?action=DetailView&module=".$vardef['module']."&record=$record\">";
+        } else {
+            $value = "";
+        }
+
 
         //To fix github bug 880 (the rname was null and was causing a 500 error in the getFieldValueFromModule call to $fieldname
         $fieldName = 'name';//$vardef['name'];
@@ -455,13 +460,17 @@ function formatDisplayValue($bean, $value, $vardef, $method = "save")
 
         if($vardef['ext2']){
 
-            $value .= getFieldValueFromModule($fieldName,$vardef['ext2'],$record) . "</a>";
+            $value .= getFieldValueFromModule($fieldName,$vardef['ext2'],$record);
 
         }else if(!empty($vardef['rname'])){
-            $value .= getFieldValueFromModule($fieldName,$vardef['module'],$record) . "</a>";
+            $value .= getFieldValueFromModule($fieldName,$vardef['module'],$record);
 
         } else {
-            $value .= $name . "</a>";
+            $value .= $name;
+        }
+
+        if($vardef['name'] != "assigned_user_name") {
+            $value .= "</a>";
         }
     }
 


### PR DESCRIPTION
This checks if the vardef name is "assigned_user_name", if that is the case, it does not create a link for it.