### PR TITLE
Fixed #706 - Inline Editing Display Error in Documents Module

### DIFF
--- a/include/InlineEditing/InlineEditing.php
+++ b/include/InlineEditing/InlineEditing.php
@@ -457,7 +457,7 @@ function formatDisplayValue($bean, $value, $vardef, $method = "save")
 
             $value .= getFieldValueFromModule($fieldName,$vardef['ext2'],$record) . "</a>";
 
-        }else if(!empty($vardef['rname'])){
+        } else if(!empty($vardef['rname']) || $vardef['name'] == "related_doc_name") {
             $value .= getFieldValueFromModule($fieldName,$vardef['module'],$record) . "</a>";
 
         } else {


### PR DESCRIPTION
This checks if the vardef name is 'related_doc_name', then gets the value of the field using the 'getFieldValueFromModule' function and displays it to the user.