### PR TITLE
Fixed #1160: Translatable strings in Inline Editing

### DIFF
--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -216,7 +216,7 @@ function clickedawayclose(field,id,module, type){
             // Fix for issue #373 strip HTML tags for correct comparison
             var output_value_compare = $(output_value).text();
             if(user_value != output_value_compare) {
-                var r = confirm("You have clicked away from the field you were editing without saving it. Click ok if you're happy to lose your change, or cancel if you would like to continue editing " + message_field);
+                var r = confirm( SUGAR.language.translate('app_strings', 'LBL_CONFIRM_CANCEL_INLINE_EDITING') + message_field);
                 if(r == true) {
                     var output = setValueClose(output_value);
                     $(document).off('click');
@@ -482,7 +482,7 @@ function getValidationRules(field,module,id){
     try {
         var validation = JSON.parse(result.responseText);
     } catch(e) {
-        alert("There was an error loading the field. Your session may have timed out. Please log in again to fix this");
+        alert(SUGAR.language.translate('app_strings', 'LBL_LOADING_ERROR_INLINE_EDITING'));
         return false;
     }
 

--- a/include/language/en_us.lang.php
+++ b/include/language/en_us.lang.php
@@ -3896,3 +3896,6 @@ $app_strings['LBL_RENAME_DASHBOARD_PAGE'] = 'Rename Dashboard Page';
 $app_strings['LBL_DISCOVER_SUITECRM'] = 'Discover SuiteCRM';
 
 $app_list_strings['collection_temp_list'] = array('Tasks' => 'Tasks', 'Meetings' => 'Meetings', 'Calls' => 'Calls', 'Notes' => 'Notes', 'Emails' => 'Emails');
+
+$app_strings['LBL_CONFIRM_CANCEL_INLINE_EDITING'] = "You have clicked away from the field you were editing without saving it. Click ok if you're happy to lose your change, or cancel if you would like to continue editing";
+$app_strings['LBL_LOADING_ERROR_INLINE_EDITING'] = "There was an error loading the field. Your session may have timed out. Please log in again to fix this";


### PR DESCRIPTION
In relation to issue #1160. Making alert and confirm strings in inlineEditing.js translatable.

Added two labels:
* LBL_CONFIRM_CANCEL_INLINE_EDITING
* LBL_LOADING_ERROR_INLINE_EDITING
 