### PR TITLE
Fixed #123 Checkbox not displayed when exported to PDF

### DIFF
--- a/include/SugarFields/Fields/Bool/DetailView.tpl
+++ b/include/SugarFields/Fields/Bool/DetailView.tpl
@@ -39,7 +39,7 @@
 
 *}
 {if strval({{sugarvar key='value' stringFormat='false'}}) == "1" || strval({{sugarvar key='value' stringFormat='false'}}) == "yes" || strval({{sugarvar key='value' stringFormat='false'}}) == "on"} 
-{assign var="checked" value="CHECKED"}
+{assign var="checked" value='checked="checked"'}
 {else}
 {assign var="checked" value=""}
 {/if}

--- a/include/SugarFields/Fields/Bool/EditView.tpl
+++ b/include/SugarFields/Fields/Bool/EditView.tpl
@@ -39,7 +39,7 @@
 
 *}
 {if strval({{sugarvar key='value' stringFormat='false'}}) == "1" || strval({{sugarvar key='value' stringFormat='false'}}) == "yes" || strval({{sugarvar key='value' stringFormat='false'}}) == "on"} 
-{assign var="checked" value="CHECKED"}
+{assign var="checked" value='checked="checked"'}
 {else}
 {assign var="checked" value=""}
 {/if}

--- a/include/SugarFields/Fields/Bool/InlineEdit.tpl
+++ b/include/SugarFields/Fields/Bool/InlineEdit.tpl
@@ -40,7 +40,7 @@
 *}
 {{assign var=fieldName value=$vardef.name}}
 {{if strval($parentFieldArray->$fieldName) == "1"}}
-{{assign var="checked" value="CHECKED"}}
+{{assign var="checked" value='checked="checked"'}}
 {{else}}
 {{assign var="checked" value=""}}
 {{/if}}

--- a/include/SugarFields/Fields/Bool/InlineEditView.tpl
+++ b/include/SugarFields/Fields/Bool/InlineEditView.tpl
@@ -40,7 +40,7 @@
 *}
 {{assign var=fieldName value=$vardef.name}}
 {{if strval($parentFieldArray->$fieldName) == "1"}}
-{{assign var="checked" value="CHECKED"}}
+{{assign var="checked" value='checked="checked"'}}
 {{else}}
 {{assign var="checked" value=""}}
 {{/if}}

--- a/include/SugarFields/Fields/Bool/ListView.tpl
+++ b/include/SugarFields/Fields/Bool/ListView.tpl
@@ -40,7 +40,7 @@
 *}
 
     {if strval($parentFieldArray.$col) == "1" || strval($parentFieldArray.$col) == "yes" || strval($parentFieldArray.$col) == "on"}
-{assign var="checked" value="CHECKED"}
+{assign var="checked" value='checked="checked"'}
 {else}
 {assign var="checked" value=""}
 {/if}


### PR DESCRIPTION
The root cause of this is in the core sugarfield Bool. Where it sets the value="CHECKED" where as it should be: checked="checked". Tested it in a few random places and does not seem to have any negative effects on checkbox fields. 