### PR TITLE
Fixed #1170 - replaced htmlentities with htmlspecialchars.

### DIFF
--- a/modules/DynamicFields/templates/Fields/TemplateField.php
+++ b/modules/DynamicFields/templates/Fields/TemplateField.php
@@ -497,7 +497,10 @@ class TemplateField{
                 if($field == 'help' && !empty($this->$vardef))
                 {
                     $help = htmlspecialchars_decode($this->$vardef, ENT_QUOTES);
-                    $this->$vardef = htmlentities(remove_xss($help));
+
+					// Fix for issue #1170 - text in studio can't accept the special language characters.
+					//$this->$vardef = htmlentities(remove_xss($help));
+					$this->$vardef = htmlspecialchars(remove_xss($help));
                 }
 
 


### PR DESCRIPTION
Fixed #1170 - replaced htmlentities with htmlspecialchars in order to allow users to enter special language characters. 