### PR TITLE
substituted deprecated preg_match 'e' modifier usage

### DIFF
--- a/include/utils.php
+++ b/include/utils.php
@@ -4360,8 +4360,14 @@ function html_entity_decode_utf8($string)
     static $trans_tbl;
     // replace numeric entities
     //php will have issues with numbers with leading zeros, so do not include them in what we send to code2utf.
-    $string = preg_replace('~&#x0*([0-9a-f]+);~ei', 'code2utf(hexdec("\\1"))', $string);
-    $string = preg_replace('~&#0*([0-9]+);~e', 'code2utf(\\1)', $string);
+    $string = preg_replace_callback('~&#x0*([0-9a-f]+);~i', function($m) {
+        return 'code2utf(hexdec("'.$m[1].'"))';
+    }, $string);
+
+    $string = preg_replace_callback('~&#0*([0-9]+);~', function($m) {
+        return 'code2utf('.$m[1].')';
+    }, $string);
+
     // replace literal entities
     if (!isset($trans_tbl)) {
         $trans_tbl = array();

--- a/tests/tests/include/utilsTest.php
+++ b/tests/tests/include/utilsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+require_once 'include/utils.php';
+
+/**
+ * Class utilsTest
+ */
+class utilsTest extends PHPUnit_Framework_TestCase
+{
+    public function test_html_entity_decode_utf8()
+    {
+        $testString = 'aaabbbccc';
+        $expectedString = 'aaabbbccc';
+        $this->assertSame($expectedString, html_entity_decode_utf8($testString));
+
+        $testString = 'aaa&#x0123456789ABCDEF;bbb';
+        $expectedString = 'aaacode2utf(hexdec("123456789ABCDEF"))bbb';
+        $this->assertSame($expectedString, html_entity_decode_utf8($testString));
+
+        $testString = 'aaa&#0123456789;bbb';
+        $expectedString = 'aaacode2utf(123456789)bbb';
+        $this->assertSame($expectedString, html_entity_decode_utf8($testString));
+
+        $testString = 'aaa&#x0123456789ABCDEF;bbb_aaa&#0123456789;bbb';
+        $expectedString = 'aaacode2utf(hexdec("123456789ABCDEF"))bbb_aaacode2utf(123456789)bbb';
+        $this->assertSame($expectedString, html_entity_decode_utf8($testString));
+
+        //add some moer on "replace literal entities"
+    }
+
+
+}


### PR DESCRIPTION
substituted deprecated preg_match 'e' modifier usage
I found this when creating a report condition on a datetime field with operator: EqualTo + Type:Date

Warning: preg_replace(): The /e modifier is no longer supported, use preg_replace_callback instead in /home/jack/domains/suitecrm.bradipo/httpdocs/include/utils.php on line 4363

In fact, the value like: Now +1 Day before fix is not saved
