### PR TITLE
Fix for #1289

### DIFF
--- a/include/database/MysqliManager.php
+++ b/include/database/MysqliManager.php
@@ -160,6 +160,14 @@ class MysqliManager extends MysqlManager
 
 		return $result;
 	}
+	
+	/**
+	 * Commits all uncommitted queries
+	 */
+	public function commit()
+	{
+		$this->database->commit();
+	}
 
 	/**
 	 * Returns the number of rows affected by the last query

--- a/include/database/MysqliManager.php
+++ b/include/database/MysqliManager.php
@@ -119,12 +119,21 @@ class MysqliManager extends MysqlManager
 	/**
 	 * @see MysqlManager::query()
 	 */
-	public function query($sql, $dieOnError = false, $msg = '', $suppress = false, $keepResult = false)
+	public function query($sql, $dieOnError = false, $msg = '', $suppress = false, $keepResult = false, $autoCommit = true)
 	{
 		if(is_array($sql)) {
 			return $this->queryArray($sql, $dieOnError, $msg, $suppress);
         }
-
+		
+		$this->database->autocommit($autoCommit);
+		
+		if($sugar_config['logger']['level'] == 'debug') {
+			$autoCommitResult = $this->database->query("SELECT @@AUTOCOMMIT");
+			$autoCommit = $autoCommitResult->fetch_row()[0];
+			$autoCommitResult->free();
+			$GLOBALS['log']->debug("Auto commit state:" . (($autoCommit) ? "on" : "off"));
+		}
+		
 		static $queryMD5 = array();
 
 		parent::countQuery($sql);

--- a/include/database/MysqliManager.php
+++ b/include/database/MysqliManager.php
@@ -176,7 +176,7 @@ class MysqliManager extends MysqlManager
 	 */
 	public function getAffectedRowCount($result)
 	{
-		return mysqli_affected_rows($this->getDatabase());
+		return $this->database->affected_rows;
 	}
 
 	/**

--- a/modules/EmailMan/EmailManDelivery.php
+++ b/modules/EmailMan/EmailManDelivery.php
@@ -187,8 +187,11 @@ do {
 		$lock_query.=" AND (in_queue ='0' OR in_queue IS NULL OR ( in_queue ='1' AND in_queue_date <= " .$db->convert($db->quoted($timedate->fromString("-1 day")->asDb()),"datetime")."))";
 
  		//if the query fails to execute.. terminate campaign email process.
- 		$lock_result=$db->query($lock_query,true,'Error acquiring a lock for emailman entry.');
+ 		$lock_result=$db->query($lock_query,true,'Error acquiring a lock for emailman entry.',false,false,false);
 		$lock_count=$db->getAffectedRowCount($lock_result);
+		if($db->dbtype == "mysql" && $db->variant == "mysqli") {
+			$db->commit();
+		}
 
 		//do not process the message if unable to acquire lock.
 		if (!$test && $lock_count!= 1) {


### PR DESCRIPTION
This fixes https://github.com/salesagility/SuiteCRM/issues/1289

The MysqliManager::query function got a new optional parameter to control whether a query is auto-committed or not.
Then, EmailManDelivery calls with that parameter set to false, and commits the query after the count of rows affected is gotten.