### PR TITLE
Add missing return

### DIFF
--- a/modules/Schedulers/_AddJobsHere.php
+++ b/modules/Schedulers/_AddJobsHere.php
@@ -739,6 +739,7 @@ function aorRunScheduledReports()
             $jq->submitJob($job);
         }
     }
+    return true;  
 }
 
 function processAOW_Workflow()


### PR DESCRIPTION
According to the docs at the top of the file (and proven by how no scheduling works *at all* at the moment) you have to return a boolean indicating success or failure.  Since this function had no return, it was returning null which the caller tests and treats as false.  Hence, no report schedules.  "return true" might not be the brightest thing to do here, but it beats "return null" until someone smarter than me can sort it out.

(Resubmitted to hotfix as requested)