### PR TITLE
Fix Additional Details in Calendar for Tasks

### DIFF
--- a/modules/Tasks/metadata/additionalDetails.php
+++ b/modules/Tasks/metadata/additionalDetails.php
@@ -55,8 +55,10 @@ function additionalDetailsTask($fields) {
 
     if(!empty($fields['DATE_START'])) $overlib_string .= '<b>'. $mod_strings['LBL_START_DATE_AND_TIME'] . '</b> ' . $fields['DATE_START'] .  '<br>';
 	if(!empty($fields['DATE_DUE'])) $overlib_string .= '<b>'. $mod_strings['LBL_DUE_DATE_AND_TIME'] . '</b> ' . $fields['DATE_DUE'] .  '<br>';
-	if(!empty($fields['PRIORITY'])) $overlib_string .= '<b>'. $mod_strings['LBL_PRIORITY'] . '</b> ' . 
-$app_list_strings['task_priority_dom'][$fields['PRIORITY']] . '<br>';
+	if(!empty($fields['PRIORITY'])) {
+      	$overlib_string .= '<b>'. $mod_strings['LBL_PRIORITY'] . '</b> ' . $fields['PRIORITY'];
+      	$overlib_string .= '<br>';
+      }
     if (!empty($fields['PARENT_ID']))
     {
             $overlib_string .= "<b>". $mod_strings['LBL_RELATED_TO'] . "</b> ".
@@ -64,7 +66,10 @@ $app_list_strings['task_priority_dom'][$fields['PRIORITY']] . '<br>';
                     $fields['PARENT_NAME'] . "</a>";
             $overlib_string .= '<br>';
     }
-    if(!empty($fields['STATUS'])) $overlib_string .= '<b>'. $mod_strings['LBL_STATUS'] . '</b> ' . $app_list_strings['task_status_dom'][$fields['STATUS']] . '<br>';
+    if(!empty($fields['STATUS'])) {
+      	$overlib_string .= '<b>'. $mod_strings['LBL_STATUS'] . '</b> ' . $fields['STATUS'];
+      	$overlib_string .= '<br>';
+      }
 		
 	if(!empty($fields['DESCRIPTION'])) { 
 		$overlib_string .= '<b>'. $mod_strings['LBL_DESCRIPTION'] . '</b> ' . substr($fields['DESCRIPTION'], 0, 300);


### PR DESCRIPTION
This fixes my reported bug for not translating the dropdown for Priority and Status for Tasks Module in Calendar when clicking the Additional Details button
