### PR TITLE
Fix for unchmodabble file systems

### DIFF
--- a/include/utils/sugar_file_utils.php
+++ b/include/utils/sugar_file_utils.php
@@ -69,7 +69,7 @@ function sugar_mkdir($pathname, $mode=null, $recursive=false, $context='') {
 	}
 
 	if($result){
-		if(!sugar_chmod($pathname, $mode)){
+        if(!sugar_chmod($pathname, $mode) && !is_writable($pathname)){
 			return false;
 		}
 		if(!empty($GLOBALS['sugar_config']['default_permissions']['user'])){


### PR DESCRIPTION
When you are on an hybrid filesystem, for instance, a Windows NTFS mounted on a Linux host, your filesystem may not be chmoddable, but the folder may be still writable. In those cases we get an error while trying to install a module. This fix prevents it to happen.

Fix for https://github.com/salesagility/SuiteCRM/issues/1406
