### PR TITLE
Fixed #1420.

### DIFF
--- a/modules/SugarFeed/metadata/dashletviewdefs.php
+++ b/modules/SugarFeed/metadata/dashletviewdefs.php
@@ -49,19 +49,10 @@ $dashletData['SugarFeedDashlet']['searchFields'] = array(
     'assigned_user_id' =>
         array(
             'type' => 'assigned_user_name',
-            'default' => 'Administrator',
+            'default' => $current_user->name
         ),
 );
 $dashletData['SugarFeedDashlet']['columns'] = array(
-    'created_by_name' =>
-        array(
-            'type' => 'relate',
-            'link' => true,
-            'label' => 'LBL_CREATED',
-            'id' => 'CREATED_BY',
-            'width' => '10%',
-            'default' => true,
-        ),
     'name' =>
         array(
             'width' => '40%',


### PR DESCRIPTION
Fixed #1420.  As per OP's suggestion, the created_by_name has been removed.  As per Matt's comment, the assigned_user_id has been set to $current_user->name.