### PR TITLE
Fixed #1489 duplicating a report with a chart removes the chart from the original report

### DIFF
--- a/modules/AOR_Charts/AOR_Chart.php
+++ b/modules/AOR_Charts/AOR_Chart.php
@@ -71,11 +71,12 @@ class AOR_Chart extends Basic {
     }
 
 
-    function save_lines(array $post,AOR_Report $bean,$postKey){
+    function save_lines(array $post,AOR_Report $bean,$postKey,$duplicate){
         $seenIds = array();
         if(isset($post[$postKey.'id'])) {
             foreach ($post[$postKey . 'id'] as $key => $id) {
-                if ($id) {
+                // if we're duplicating a report we need to create a new chart as a chart can only be related to one report
+                if ($id && !$duplicate) {
                     $aorChart = BeanFactory::getBean('AOR_Charts', $id);
                 } else {
                     $aorChart = BeanFactory::newBean('AOR_Charts');

--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -80,10 +80,12 @@ class AOR_Report extends Basic {
 
         // TODO: process of saveing the fields and conditions is too long so we will have to make some optimization on save_lines functions
         set_time_limit(3600);
-
+        
+        $duplicate = false;
         if (empty($this->id)){
             unset($_POST['aor_conditions_id']);
             unset($_POST['aor_fields_id']);
+            $duplicate = true;
         }
 
         parent::save($check_notify);
@@ -98,7 +100,7 @@ class AOR_Report extends Basic {
 
         require_once('modules/AOR_Charts/AOR_Chart.php');
         $chart = new AOR_Chart();
-        $chart->save_lines($_POST, $this, 'aor_chart_');
+        $chart->save_lines($_POST, $this, 'aor_chart_', $duplicate);
     }
 
     function load_report_beans(){


### PR DESCRIPTION
Fixes issue #1489. Previously code checked if we had chart id and edited existing chart. This caused an issue as a chart can only be related to one report. Added check so if a report is being duplicated we create a new chart object.
