### PR TITLE
Fixed #1506 - IE11 cannot display generic 'application/octet-stream'.

### DIFF
--- a/download.php
+++ b/download.php
@@ -170,7 +170,12 @@ else {
             $doQuery = false;
         }
 
-        $mime_type = 'application/octet-stream';
+        // Fix for issue 1506: IE11 cannot display generic 'application/octet-stream' (which is defined as "arbitrary binary data" in RFC 2046).
+        $mime_type = mime_content_type($local_location);
+        if($mime_type == null || $mime_type == '') {
+            $mime_type = 'application/octet-stream';
+        }
+
         if($doQuery && isset($query)) {
             $rs = $GLOBALS['db']->query($query);
             $row = $GLOBALS['db']->fetchByAssoc($rs);

--- a/modules/Contacts/views/view.detail.php
+++ b/modules/Contacts/views/view.detail.php
@@ -53,6 +53,17 @@ class ContactsViewDetail extends ViewDetail
 	public function display(){
 		global $sugar_config;
 
+		// Fix for issue 1506: removed picture is still cached in the Detail View.
+		$js=<<<EOQ
+		<script type='text/javascript'>
+			if(!window.location.hash) {
+				window.location = window.location + '#loaded';
+				window.location.reload();
+			}
+		</script>
+EOQ;
+		echo $js;
+
 		$aop_portal_enabled = !empty($sugar_config['aop']['enable_portal']) && !empty($sugar_config['aop']['enable_aop']);
 
 		$this->ss->assign("AOP_PORTAL_ENABLED", $aop_portal_enabled);


### PR DESCRIPTION
Fixed #1506 - IE11 cannot display generic 'application/octet-stream' (which is defined as "arbitrary binary data" in RFC 2046).