### PR TITLE
Fixed #1512.  This removes "en_us" from the body of the label.

### DIFF
--- a/modules/Leads/language/en_us.lang.php
+++ b/modules/Leads/language/en_us.lang.php
@@ -55,7 +55,7 @@ $mod_strings = array(
     'db_email2' => 'LBL_LIST_EMAIL_ADDRESS',
 
     //END DON'T CONVERT
-    'ERR_DELETE_RECORD' => 'en_us A record number must be specified to delete the lead.',
+    'ERR_DELETE_RECORD' => 'A record number must be specified to delete the lead.',
     'LBL_ACCOUNT_DESCRIPTION' => 'Account Description',
     'LBL_ACCOUNT_ID' => 'Account ID',
     'LBL_ACCOUNT_NAME' => 'Account Name:',


### PR DESCRIPTION
Fixed #1512.  This removes "en_us" from the body of the label.