### PR TITLE
AOR_Chart: Make bar colors stay same if label is same

### DIFF
--- a/modules/AOR_Charts/AOR_Chart.php
+++ b/modules/AOR_Charts/AOR_Chart.php
@@ -409,6 +409,16 @@ EOF;
         {
             return "<h3>$this->noDataMessage</h3>";
         }
+        $labels=json_decode($chartLabelValues);
+        foreach($labels AS $onelabel){
+                $hash = md5($onelabel);
+                $color[]= "#" . substr($hash,0,6);
+        }
+        if(!empty($color)){
+            $colorstring="['" . implode($color,"','") . "']";
+        }else{
+            $colorstring=$this->colours;	
+        }
         $html = '';
         $html .= "<canvas id='$chartId' width='$chartWidth' height='$chartHeight' class='resizableCanvas'></canvas>";
         $html .= <<<EOF
@@ -433,7 +443,7 @@ EOF;
                 tooltipsCssClass: 'rgraph_chart_tooltips_css',
                 tooltipsEvent:'onmousemove',
 
-                colors: $this->colours,
+                colors: $colorstring,
                 ymax:calculateMaxYForSmallNumbers($chartDataValues)
             }
         }).draw();


### PR DESCRIPTION
To make it easier to identify the bar for a specific label it would be nice if the color stays same for same label.
So for example if you have different reports on the dashboard but with same labels you can identify the bars for one label easy.
Another thing is easier, if you remember "your" color, you can faster spot your bar.
If you like it it can be applied to other charts as well.
