### PR TITLE
Give focus to search field saves one click on mobile

### DIFF
--- a/themes/SuiteR/js/style.js
+++ b/themes/SuiteR/js/style.js
@@ -290,6 +290,7 @@ var checkContents = setInterval(function(){
         });
         $('#userlinks_togglemobilesearch').click(function() {
             $('#searchmobile').toggle('slide', {direction: 'left'}, '350');
+            $('#query_string').focus();
         });
 
         clearInterval(checkContents);


### PR DESCRIPTION
Like this you can start typing right after touching the search symbol. Otherwise you will need one more click in the search field.