### PR TITLE
Fixed: #1249 - Hiding Reminders for the navigation but keep them in the moduleList

### DIFF
--- a/include/modules.php
+++ b/include/modules.php
@@ -312,12 +312,14 @@ $moduleList[] = 'AOK_KnowledgeBase';
 
 $beanList['Reminders'] = 'Reminder';
 $beanFiles['Reminder'] = 'modules/Reminders/Reminder.php';
-$moduleList[] = 'Reminders';
+// Issue #1249 - Reminders should be hidden from the navigation
+//$moduleList[] = 'Reminders';
 $modInvisList[] = 'Reminders';
 
 $beanList['Reminders_Invitees'] = 'Reminder_Invitee';
 $beanFiles['Reminder_Invitee'] = 'modules/Reminders_Invitees/Reminder_Invitee.php';
-$moduleList[] = 'Reminders_Invitees';
+// Issue #1249 - Reminders should be hidden from the navigation
+//$moduleList[] = 'Reminders_Invitees';
 $modInvisList[] = 'Reminders_Invitees';
 
 $beanList['FP_events'] = 'FP_events';

--- a/include/modules.php
+++ b/include/modules.php
@@ -229,6 +229,8 @@ $adminOnlyList = array(
     'UpgradeWizard' => array('all' => 1),
     'Studio' => array('all' => 1),
     'Schedulers' => array('all' => 1),
+    'Reminders' => array('all' => '1'),
+    'Reminders_Invitees' => array('all' => '1'),
 );
 
 $modInvisList[] = 'ACL';
@@ -313,13 +315,13 @@ $moduleList[] = 'AOK_KnowledgeBase';
 $beanList['Reminders'] = 'Reminder';
 $beanFiles['Reminder'] = 'modules/Reminders/Reminder.php';
 // Issue #1249 - Reminders should be hidden from the navigation
-//$moduleList[] = 'Reminders';
+$moduleList[] = 'Reminders';
 $modInvisList[] = 'Reminders';
 
 $beanList['Reminders_Invitees'] = 'Reminder_Invitee';
 $beanFiles['Reminder_Invitee'] = 'modules/Reminders_Invitees/Reminder_Invitee.php';
 // Issue #1249 - Reminders should be hidden from the navigation
-//$moduleList[] = 'Reminders_Invitees';
+$moduleList[] = 'Reminders_Invitees';
 $modInvisList[] = 'Reminders_Invitees';
 
 $beanList['FP_events'] = 'FP_events';


### PR DESCRIPTION
Related to issue #1249. Hiding Reminders for the navigation. 