### PR TITLE
Fix #1472 - strip HTML tags from notification e-mail Subjects

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -2765,7 +2765,7 @@ class SugarBean
         $xtpl->parse($template_name . "_Subject");
 
         $notify_mail->Body = from_html(trim($xtpl->text($template_name)));
-        $notify_mail->Subject = from_html($xtpl->text($template_name . "_Subject"));
+        $notify_mail->Subject = strip_tags(from_html($xtpl->text($template_name . "_Subject")));
 
         // cn: bug 8568 encode notify email in User's outbound email encoding
         $notify_mail->prepForOutbound();


### PR DESCRIPTION
Email subjects should never include HTML. 
Since there is a difficulty with translated email templates that is causing HTML tags in email "Subjects" to be visible to end-users, and we couldn't find any way to fix it in Crowdin, this change solves the problem. 
At the same time, it's follows a good general principle - HTML tags don't belong there.