### PR TITLE
Fixed #1679 - Emails module broken

### DIFF
--- a/modules/Emails/EmailUI.php
+++ b/modules/Emails/EmailUI.php
@@ -441,6 +441,7 @@ eoq;
 		$lang = "var app_strings = new Object();\n";
 		foreach($app_strings as $k => $v) {
 			if(strpos($k, 'LBL_EMAIL_') !== false) {
+				$v = str_replace("'", "\'", $v);
 				$lang .= "app_strings.{$k} = '{$v}';\n";
 			}
 		}


### PR DESCRIPTION
Escape single quotes when creating translation strings for JavaScript.
#1679
