### PR TITLE
notify_template.html - include proper html tags to allow translation

### DIFF
--- a/include/language/en_us.notify_template.html
+++ b/include/language/en_us.notify_template.html
@@ -48,9 +48,9 @@
 <!-- BEGIN: Quote -->
 <p>{ASSIGNER} has assigned a Quote to {ASSIGNED_USER}.</p>
 
-<p>Subject: {QUOTE_SUBJECT}</br>
-Status: {QUOTE_STATUS}</br>
-Expected Close Date: {QUOTE_CLOSEDATE}</br>
+<p>Subject: {QUOTE_SUBJECT}<br />
+Status: {QUOTE_STATUS}<br />
+Expected Close Date: {QUOTE_CLOSEDATE}<br />
 Description: {QUOTE_DESCRIPTION}</p>
 
 <p>You may review this Quote at:</p>
@@ -64,8 +64,8 @@ Description: {QUOTE_DESCRIPTION}</p>
 <!-- BEGIN: Account -->
 <p>{ASSIGNER} has assigned an Account to {ASSIGNED_USER}.</p>
 
-<p>Name: {ACCOUNT_NAME}</br>
-Type: {ACCOUNT_TYPE}</br>
+<p>Name: {ACCOUNT_NAME}<br />
+Type: {ACCOUNT_TYPE}<br />
 Description: {ACCOUNT_DESCRIPTION}</p>
 
 <p>You may review this Account at:</p>
@@ -79,9 +79,9 @@ Description: {ACCOUNT_DESCRIPTION}</p>
 <!-- BEGIN: Case -->
 <p>{ASSIGNER} has assigned a Case to {ASSIGNED_USER}.</p>
 
-<p>Subject: {CASE_SUBJECT}</br>
-Priority: {CASE_PRIORITY}</br>
-Status: {CASE_STATUS}</br>
+<p>Subject: {CASE_SUBJECT}<br />
+Priority: {CASE_PRIORITY}<br />
+Status: {CASE_STATUS}<br />
 Description: {CASE_DESCRIPTION}</p>
 
 <p>You may review this Case at:</p>
@@ -95,10 +95,10 @@ Description: {CASE_DESCRIPTION}</p>
 <!-- BEGIN: Task -->
 <p>{ASSIGNER} has assigned a Task to {ASSIGNED_USER}.</p>
 
-<p>Subject: {TASK_SUBJECT}</br>
-Priority: {TASK_PRIORITY}</br>
-Due Date: {TASK_DUEDATE}</br>
-Status: {TASK_STATUS}</br>
+<p>Subject: {TASK_SUBJECT}<br />
+Priority: {TASK_PRIORITY}<br />
+Due Date: {TASK_DUEDATE}<br />
+Status: {TASK_STATUS}<br />
 Description: {TASK_DESCRIPTION}</p>
 
 <p>You may review this Task at:</p>
@@ -114,8 +114,8 @@ Description: {TASK_DESCRIPTION}</p>
 
 <p>{ASSIGNER} has invited you to a Meeting</p>
 
-<p>Subject: {MEETING_SUBJECT}</br>
-Start Date: {MEETING_STARTDATE}</br>
+<p>Subject: {MEETING_SUBJECT}<br />
+Start Date: {MEETING_STARTDATE}<br />
 End Date: {MEETING_ENDDATE}</p>
 <p><!-- BEGIN: Meeting_External_API -->
 Meeting URL: {MEETING_URL}</p>
@@ -139,10 +139,10 @@ Meeting URL: {MEETING_URL}</p>
 <!-- BEGIN: MeetingSpecial -->
 <p>{ASSIGNER} has assigned a Meeting to {ASSIGNED_USER}.</p>
 
-<p>Subject: {MEETING_SUBJECT}</br>
-Status: {MEETING_STATUS}</br>
-Start Date: {MEETING_STARTDATE}</br>
-End Date: {MEETING_ENDDATE}</br>
+<p>Subject: {MEETING_SUBJECT}<br />
+Status: {MEETING_STATUS}<br />
+Start Date: {MEETING_STARTDATE}<br />
+End Date: {MEETING_ENDDATE}<br />
 Description: {MEETING_DESCRIPTION}</p>
 
 <p>You may review this Meeting at:</p>
@@ -156,7 +156,7 @@ Description: {MEETING_DESCRIPTION}</p>
 <!-- BEGIN: Email -->
 <p>{ASSIGNER} has assigned an Email to {ASSIGNED_USER}.</p>
 
-<p>Subject: {EMAIL_SUBJECT}</br>
+<p>Subject: {EMAIL_SUBJECT}<br />
 Date Sent: {EMAIL_DATESENT}</p>
 
 <p>You may review this Email at:</p>
@@ -174,7 +174,7 @@ Date Sent: {EMAIL_DATESENT}</p>
 <!-- BEGIN: Contact -->
 <p>{ASSIGNER} has assigned a Contact to {ASSIGNED_USER}.</p>
 
-<p>Name: {CONTACT_NAME}</br>
+<p>Name: {CONTACT_NAME}<br />
 Description: {CONTACT_DESCRIPTION}</p>
 
 <p>You may review this Contact at:</p>
@@ -188,9 +188,9 @@ Description: {CONTACT_DESCRIPTION}</p>
 <!-- BEGIN: Lead -->
 <p>{ASSIGNER} has assigned a Lead to {ASSIGNED_USER}.</p>
 
-<p>Name: {LEAD_NAME}</br>
-Lead Source: {LEAD_SOURCE}</br>
-Status: {LEAD_STATUS}</br>
+<p>Name: {LEAD_NAME}<br />
+Lead Source: {LEAD_SOURCE}<br />
+Status: {LEAD_STATUS}<br />
 Description: {LEAD_DESCRIPTION}</p>
 
 <p>You may review this Lead at:</p>
@@ -204,10 +204,10 @@ Description: {LEAD_DESCRIPTION}</p>
 <!-- BEGIN: Opportunity -->
 <p>{ASSIGNER} has assigned an Opportunity to {ASSIGNED_USER}.</p>
 
-<p>Name: {OPPORTUNITY_NAME}</br>
-Amount: {OPPORTUNITY_AMOUNT}</br>
-Expected Close Date: {OPPORTUNITY_CLOSEDATE}</br>
-Sales Stage: {OPPORTUNITY_STAGE}</br>
+<p>Name: {OPPORTUNITY_NAME}<br />
+Amount: {OPPORTUNITY_AMOUNT}<br />
+Expected Close Date: {OPPORTUNITY_CLOSEDATE}<br />
+Sales Stage: {OPPORTUNITY_STAGE}<br />
 Description: {OPPORTUNITY_DESCRIPTION}</p>
 
 <p>You may review this Opportunity at:</p>
@@ -221,14 +221,14 @@ Description: {OPPORTUNITY_DESCRIPTION}</p>
 <!-- BEGIN: Bug -->
 <p>{ASSIGNER} has assigned a Bug to {ASSIGNED_USER}.</p>
 
-<p>Bug Number: {BUG_BUG_NUMBER}</br>
-Subject: {BUG_SUBJECT}</br>
-Type: {BUG_TYPE}</br>
-Priority: {BUG_PRIORITY}</br>
-Status: {BUG_STATUS}</br>
-Resolution: {BUG_RESOLUTION}</br>
-Release: {BUG_RELEASE}</br>
-Description: {BUG_DESCRIPTION}</br>
+<p>Bug Number: {BUG_BUG_NUMBER}<br />
+Subject: {BUG_SUBJECT}<br />
+Type: {BUG_TYPE}<br />
+Priority: {BUG_PRIORITY}<br />
+Status: {BUG_STATUS}<br />
+Resolution: {BUG_RESOLUTION}<br />
+Release: {BUG_RELEASE}<br />
+Description: {BUG_DESCRIPTION}<br />
 Work Log: {BUG_WORK_LOG}</p>
 
 <p>You may review this Bug at:</p>
@@ -252,10 +252,10 @@ Work Log: {BUG_WORK_LOG}</p>
 <!-- BEGIN: Call -->
 <p>To: {CALL_TO}</p>
 <p>{ASSIGNER} has invited you to a Call</p>
-<p>Subject: {CALL_SUBJECT}</br>
-Status: {CALL_STATUS}</br>
-Start Date: {CALL_STARTDATE}</br>
-Duration: {CALL_HOURS}h, {CALL_MINUTES}m</br>
+<p>Subject: {CALL_SUBJECT}<br />
+Status: {CALL_STATUS}<br />
+Start Date: {CALL_STARTDATE}<br />
+Duration: {CALL_HOURS}h, {CALL_MINUTES}m<br />
 Description: {CALL_DESCRIPTION}</p>
 
 <p>Accept this call:</p>
@@ -275,10 +275,10 @@ Description: {CALL_DESCRIPTION}</p>
 <!-- BEGIN: CallSpecial -->
 <p>{ASSIGNER} has assigned a Call to {ASSIGNED_USER}.</p>
 
-<p>Subject: {CALL_SUBJECT}</br>
-Status: {CALL_STATUS}</br>
-Start Date: {CALL_STARTDATE}</br>
-Duration: {CALL_HOURS}h, {CALL_MINUTES}m</br>
+<p>Subject: {CALL_SUBJECT}<br />
+Status: {CALL_STATUS}<br />
+Start Date: {CALL_STARTDATE}<br />
+Duration: {CALL_HOURS}h, {CALL_MINUTES}m<br />
 Description: {CALL_DESCRIPTION}</p>
 
 <p>You may review this Call at:</p>
@@ -291,10 +291,10 @@ Description: {CALL_DESCRIPTION}</p>
 <!-- BEGIN: Campaign -->
 <p>{ASSIGNER} has assigned a Campaign to {ASSIGNED_USER}.</p>
 
-<p>Subject: {CAMPAIGN_NAME}</br>
-Amount: {CAMPAIGN_AMOUNT}</br>
-Close Date: {CAMPAIGN_CLOSEDATE}</br>
-Status: {CAMPAIGN_STATUS}</br>
+<p>Subject: {CAMPAIGN_NAME}<br />
+Amount: {CAMPAIGN_AMOUNT}<br />
+Close Date: {CAMPAIGN_CLOSEDATE}<br />
+Status: {CAMPAIGN_STATUS}<br />
 Description: {CAMPAIGN_DESCRIPTION}</p>
 
 <p>You may review this Campaign at:</p>
@@ -307,7 +307,7 @@ Description: {CAMPAIGN_DESCRIPTION}</p>
 <!-- BEGIN: Quota -->
 <p>{ASSIGNER} has assigned a Quota to {ASSIGNED_USER}.</p>
 
-<p>Amount: {QUOTA_AMOUNT}</br>
+<p>Amount: {QUOTA_AMOUNT}<br />
 Timeperiod: {QUOTA_TIMEPERIOD}</p>
 
 <p>You may review this Quota assignment at:</p>
@@ -321,10 +321,10 @@ Timeperiod: {QUOTA_TIMEPERIOD}</p>
 
 {NOTIFICATION_MESSAGE}
 
-<p>Name: {KBDOCUMENT_NAME}</br>
-Created Date: {KBDOCUMENT_DATE_CREATED}</br>
-Created By: {KBDOCUMENT_CREATED_BY}</br>
-Status: {KBDOCUMENT_STATUS}</br>
+<p>Name: {KBDOCUMENT_NAME}<br />
+Created Date: {KBDOCUMENT_DATE_CREATED}<br />
+Created By: {KBDOCUMENT_CREATED_BY}<br />
+Status: {KBDOCUMENT_STATUS}<br />
 Description: {KBDOCUMENT_DESCRIPTION}</p>
 
 <p>You may review this Document at:</p>
@@ -357,9 +357,9 @@ Description: {KBDOCUMENT_DESCRIPTION}</p>
 <p>Meeting Reminder - {MEETING_SUBJECT}</p>
 <!-- END: MeetingSpecial_Subject -->
 <!-- BEGIN: MeetingReminder -->
-<p>Title: {MEETING_SUBJECT}</br>
-When: {MEETING_STARTDATE}</br>
-Location: {MEETING_LOCATION}</br>
+<p>Title: {MEETING_SUBJECT}<br />
+When: {MEETING_STARTDATE}<br />
+Location: {MEETING_LOCATION}<br />
 Created By: {MEETING_CREATED_BY}</p>
 <!-- END: MeetingReminder -->
 
@@ -367,7 +367,7 @@ Created By: {MEETING_CREATED_BY}</p>
 <p>Call Reminder - {CALL_SUBJECT}</p>
 <!-- END: CallReminder_Subject -->
 <!-- BEGIN: CallReminder -->
-<p>Title: {CALL_SUBJECT}</br>
-When: {CALL_STARTDATE}</br>
+<p>Title: {CALL_SUBJECT}<br />
+When: {CALL_STARTDATE}<br />
 Created By: {CALL_CREATED_BY}</p>
 <!-- END: CallReminder -->

--- a/include/language/en_us.notify_template.html
+++ b/include/language/en_us.notify_template.html
@@ -43,123 +43,123 @@
 -->
 
 <!-- BEGIN: Quote_Subject -->
-SuiteCRM Quote - {QUOTE_SUBJECT}
+<p>SuiteCRM Quote - {QUOTE_SUBJECT}</p>
 <!-- END: Quote_Subject -->
 <!-- BEGIN: Quote -->
-{ASSIGNER} has assigned a Quote to {ASSIGNED_USER}.
+<p>{ASSIGNER} has assigned a Quote to {ASSIGNED_USER}.</p>
 
-Subject: {QUOTE_SUBJECT}
-Status: {QUOTE_STATUS}
-Expected Close Date: {QUOTE_CLOSEDATE}
-Description: {QUOTE_DESCRIPTION}
+<p>Subject: {QUOTE_SUBJECT}</br>
+Status: {QUOTE_STATUS}</br>
+Expected Close Date: {QUOTE_CLOSEDATE}</br>
+Description: {QUOTE_DESCRIPTION}</p>
 
-You may review this Quote at:
+<p>You may review this Quote at:</p>
 <{URL}>
 <!-- END: Quote -->
 
 
 <!-- BEGIN: Account_Subject -->
-SuiteCRM Account - {ACCOUNT_NAME}
+<p>SuiteCRM Account - {ACCOUNT_NAME}</p>
 <!-- END: Account_Subject -->
 <!-- BEGIN: Account -->
-{ASSIGNER} has assigned an Account to {ASSIGNED_USER}.
+<p>{ASSIGNER} has assigned an Account to {ASSIGNED_USER}.</p>
 
-Name: {ACCOUNT_NAME}
-Type: {ACCOUNT_TYPE}
-Description: {ACCOUNT_DESCRIPTION}
+<p>Name: {ACCOUNT_NAME}</br>
+Type: {ACCOUNT_TYPE}</br>
+Description: {ACCOUNT_DESCRIPTION}</p>
 
-You may review this Account at:
+<p>You may review this Account at:</p>
 <{URL}>
 <!-- END: Account -->
 
 
 <!-- BEGIN: Case_Subject -->
-SuiteCRM Case - {CASE_SUBJECT}
+<p>SuiteCRM Case - {CASE_SUBJECT}</p>
 <!-- END: Case_Subject -->
 <!-- BEGIN: Case -->
-{ASSIGNER} has assigned a Case to {ASSIGNED_USER}.
+<p>{ASSIGNER} has assigned a Case to {ASSIGNED_USER}.</p>
 
-Subject: {CASE_SUBJECT}
-Priority: {CASE_PRIORITY}
-Status: {CASE_STATUS}
-Description: {CASE_DESCRIPTION}
+<p>Subject: {CASE_SUBJECT}</br>
+Priority: {CASE_PRIORITY}</br>
+Status: {CASE_STATUS}</br>
+Description: {CASE_DESCRIPTION}</br>
 
-You may review this Case at:
+<p>You may review this Case at:</p>
 <{URL}>
 <!-- END: Case -->
 
 
 <!-- BEGIN: Task_Subject -->
-SuiteCRM Task - {TASK_SUBJECT}
+<p>SuiteCRM Task - {TASK_SUBJECT}</p>
 <!-- END: Task_Subject -->
 <!-- BEGIN: Task -->
-{ASSIGNER} has assigned a Task to {ASSIGNED_USER}.
+<p>{ASSIGNER} has assigned a Task to {ASSIGNED_USER}.</p>
 
-Subject: {TASK_SUBJECT}
-Priority: {TASK_PRIORITY}
-Due Date: {TASK_DUEDATE}
-Status: {TASK_STATUS}
-Description: {TASK_DESCRIPTION}
+<p>Subject: {TASK_SUBJECT}</br>
+Priority: {TASK_PRIORITY}</br>
+Due Date: {TASK_DUEDATE}</br>
+Status: {TASK_STATUS}</br>
+Description: {TASK_DESCRIPTION}</p>
 
-You may review this Task at:
+<p>You may review this Task at:</p>
 <{URL}>
 <!-- END: Task -->
 
 
 <!-- BEGIN: Meeting_Subject -->
-SuiteCRM Meeting - {MEETING_SUBJECT}
+<p>SuiteCRM Meeting - {MEETING_SUBJECT}</p>
 <!-- END: Meeting_Subject -->
 <!-- BEGIN: Meeting -->
-To: {MEETING_TO}
+<p>To: {MEETING_TO}</p>
 
-{ASSIGNER} has invited you to a Meeting
+<p>{ASSIGNER} has invited you to a Meeting</p>
 
-Subject: {MEETING_SUBJECT}
-Start Date: {MEETING_STARTDATE}
-End Date: {MEETING_ENDDATE}
-<!-- BEGIN: Meeting_External_API -->
-Meeting URL: {MEETING_URL}
+<p>Subject: {MEETING_SUBJECT}</br>
+Start Date: {MEETING_STARTDATE}</br>
+End Date: {MEETING_ENDDATE}</p>
+<p><!-- BEGIN: Meeting_External_API -->
+Meeting URL: {MEETING_URL}</p>
 <!-- END: Meeting_External_API -->
-Description: {MEETING_DESCRIPTION}
+<p>Description: {MEETING_DESCRIPTION}</p>
 
-Accept this meeting:
+<p>Accept this meeting:</p>
 <{ACCEPT_URL}&accept_status=accept>
 
-Tentatively Accept this meeting
+<p>Tentatively Accept this meeting</p>
 <{ACCEPT_URL}&accept_status=tentative>
 
-Decline this meeting
+<p>Decline this meeting</p>
 <{ACCEPT_URL}&accept_status=decline>
 
 <!-- END: Meeting -->
 
 <!-- BEGIN: MeetingSpecial_Subject -->
-SuiteCRM Meeting - {MEETING_SUBJECT}
+<p>SuiteCRM Meeting - {MEETING_SUBJECT}</p>
 <!-- END: MeetingSpecial_Subject -->
 <!-- BEGIN: MeetingSpecial -->
-{ASSIGNER} has assigned a Meeting to {ASSIGNED_USER}.
+<p>{ASSIGNER} has assigned a Meeting to {ASSIGNED_USER}.</p>
 
-Subject: {MEETING_SUBJECT}
-Status: {MEETING_STATUS}
-Start Date: {MEETING_STARTDATE}
-End Date: {MEETING_ENDDATE}
-Description: {MEETING_DESCRIPTION}
+<p>Subject: {MEETING_SUBJECT}</br>
+Status: {MEETING_STATUS}</br>
+Start Date: {MEETING_STARTDATE}</br>
+End Date: {MEETING_ENDDATE}</br>
+Description: {MEETING_DESCRIPTION}</p>
 
-You may review this Meeting at:
+<p>You may review this Meeting at:</p>
 <{URL}>
 <!-- END: MeetingSpecial -->
 
 
 <!-- BEGIN: Email_Subject -->
-SuiteCRM Email - {EMAIL_SUBJECT}
+<p>SuiteCRM Email - {EMAIL_SUBJECT}</p>
 <!-- END: Email_Subject -->
 <!-- BEGIN: Email -->
-{ASSIGNER} has assigned an Email to {ASSIGNED_USER}.
+<p>{ASSIGNER} has assigned an Email to {ASSIGNED_USER}.</p>
 
-Subject: {EMAIL_SUBJECT}
-Date Sent: {EMAIL_DATESENT}
+<p>Subject: {EMAIL_SUBJECT}</br>
+Date Sent: {EMAIL_DATESENT}</p>
 
-You may review this Email at:
+<p>You may review this Email at:</p>
 <{URL}>
 <!-- END: Email -->
 
@@ -169,205 +169,205 @@ You may review this Email at:
 
 
 <!-- BEGIN: Contact_Subject -->
-SuiteCRM Contact - {CONTACT_NAME}
+<p>SuiteCRM Contact - {CONTACT_NAME}</p>
 <!-- END: Contact_Subject -->
 <!-- BEGIN: Contact -->
-{ASSIGNER} has assigned a Contact to {ASSIGNED_USER}.
+<p>{ASSIGNER} has assigned a Contact to {ASSIGNED_USER}.</p>
 
-Name: {CONTACT_NAME}
-Description: {CONTACT_DESCRIPTION}
+<p>Name: {CONTACT_NAME}</br>
+Description: {CONTACT_DESCRIPTION}</p>
 
-You may review this Contact at:
+<p>You may review this Contact at:</p>
 <{URL}>
 <!-- END: Contact -->
 
 
 <!-- BEGIN: Lead_Subject -->
-SuiteCRM Lead - {LEAD_NAME}
+<p>SuiteCRM Lead - {LEAD_NAME}</p>
 <!-- END: Lead_Subject -->
 <!-- BEGIN: Lead -->
-{ASSIGNER} has assigned a Lead to {ASSIGNED_USER}.
+<p>{ASSIGNER} has assigned a Lead to {ASSIGNED_USER}.</p>
 
-Name: {LEAD_NAME}
-Lead Source: {LEAD_SOURCE}
-Status: {LEAD_STATUS}
-Description: {LEAD_DESCRIPTION}
+<p>Name: {LEAD_NAME}</br>
+Lead Source: {LEAD_SOURCE}</br>
+Status: {LEAD_STATUS}</br>
+Description: {LEAD_DESCRIPTION}</p>
 
-You may review this Lead at:
+<p>You may review this Lead at:</p>
 <{URL}>
 <!-- END: Lead -->
 
 
 <!-- BEGIN: Opportunity_Subject -->
-SuiteCRM Opportunity - {OPPORTUNITY_NAME}
+<p>SuiteCRM Opportunity - {OPPORTUNITY_NAME}</p>
 <!-- END: Opportunity_Subject -->
 <!-- BEGIN: Opportunity -->
-{ASSIGNER} has assigned an Opportunity to {ASSIGNED_USER}.
+<p>{ASSIGNER} has assigned an Opportunity to {ASSIGNED_USER}.</p>
 
-Name: {OPPORTUNITY_NAME}
-Amount: {OPPORTUNITY_AMOUNT}
-Expected Close Date: {OPPORTUNITY_CLOSEDATE}
-Sales Stage: {OPPORTUNITY_STAGE}
-Description: {OPPORTUNITY_DESCRIPTION}
+<p>Name: {OPPORTUNITY_NAME}</br>
+Amount: {OPPORTUNITY_AMOUNT}</br>
+Expected Close Date: {OPPORTUNITY_CLOSEDATE}</br>
+Sales Stage: {OPPORTUNITY_STAGE}</br>
+Description: {OPPORTUNITY_DESCRIPTION}</p>
 
-You may review this Opportunity at:
+<p>You may review this Opportunity at:</p>
 <{URL}>
 <!-- END: Opportunity -->
 
 
 <!-- BEGIN: Bug_Subject -->
-SuiteCRM Bug - {BUG_SUBJECT}
+<p>SuiteCRM Bug - {BUG_SUBJECT}</p>
 <!-- END: Bug_Subject -->
 <!-- BEGIN: Bug -->
-{ASSIGNER} has assigned a Bug to {ASSIGNED_USER}.
+<p>{ASSIGNER} has assigned a Bug to {ASSIGNED_USER}.</p>
 
-Bug Number: {BUG_BUG_NUMBER}
-Subject: {BUG_SUBJECT}
-Type: {BUG_TYPE}
-Priority: {BUG_PRIORITY}
-Status: {BUG_STATUS}
-Resolution: {BUG_RESOLUTION}
-Release: {BUG_RELEASE}
-Description: {BUG_DESCRIPTION}
-Work Log: {BUG_WORK_LOG}
+<p>Bug Number: {BUG_BUG_NUMBER}</br>
+Subject: {BUG_SUBJECT}</br>
+Type: {BUG_TYPE}</br>
+Priority: {BUG_PRIORITY}</br>
+Status: {BUG_STATUS}</br>
+Resolution: {BUG_RESOLUTION}</br>
+Release: {BUG_RELEASE}</br>
+Description: {BUG_DESCRIPTION}</br>
+Work Log: {BUG_WORK_LOG}</p>
 
-You may review this Bug at:
+<p>You may review this Bug at:</p>
 <{URL}>
 <!-- END: Bug -->
 
 
 <!-- BEGIN: Default_Subject -->
-SuiteCRM - Assigned {OBJECT}
+<p>SuiteCRM - Assigned {OBJECT}</p>
 <!-- END: Default_Subject -->
 <!-- BEGIN: Default -->
-{ASSIGNER} has assigned a(n) {OBJECT} to {ASSIGNED_USER}.
+<p>{ASSIGNER} has assigned a(n) {OBJECT} to {ASSIGNED_USER}.</p>
 
-You may review this {OBJECT} at:
+<p>You may review this {OBJECT} at:</p>
 <{URL}>
 <!-- END: Default -->
 
 <!-- BEGIN: Call_Subject -->
-SuiteCRM Call - {CALL_SUBJECT}
+<p>SuiteCRM Call - {CALL_SUBJECT}</p>
 <!-- END: Call_Subject -->
 <!-- BEGIN: Call -->
-To: {CALL_TO}
- {ASSIGNER} has invited you to a Call
-Subject: {CALL_SUBJECT}
-Status: {CALL_STATUS}
-Start Date: {CALL_STARTDATE}
-Duration: {CALL_HOURS}h, {CALL_MINUTES}m
-Description: {CALL_DESCRIPTION}
+<p>To: {CALL_TO}<p>
+<p>{ASSIGNER} has invited you to a Call</p>
+<p>Subject: {CALL_SUBJECT}</br>
+Status: {CALL_STATUS}</br>
+Start Date: {CALL_STARTDATE}</br>
+Duration: {CALL_HOURS}h, {CALL_MINUTES}m</br>
+Description: {CALL_DESCRIPTION}</p>
 
-Accept this call:
+<p>Accept this call:</p>
 <{ACCEPT_URL}&accept_status=accept>
 
-Tentatively Accept this call
+<p>Tentatively Accept this call</p>
 <{ACCEPT_URL}&accept_status=tentative>
 
-Decline this call
+<p>Decline this call</p>
 <{ACCEPT_URL}&accept_status=decline>
 
 <!-- END: Call -->
 
 <!-- BEGIN: CallSpecial_Subject -->
-SuiteCRM Call - {CALL_SUBJECT}
+<p>SuiteCRM Call - {CALL_SUBJECT}</p>
 <!-- END: CallSpecial_Subject -->
 <!-- BEGIN: CallSpecial -->
-{ASSIGNER} has assigned a Call to {ASSIGNED_USER}.
+<p>{ASSIGNER} has assigned a Call to {ASSIGNED_USER}.</p>
 
-Subject: {CALL_SUBJECT}
-Status: {CALL_STATUS}
-Start Date: {CALL_STARTDATE}
-Duration: {CALL_HOURS}h, {CALL_MINUTES}m
-Description: {CALL_DESCRIPTION}
+<p>Subject: {CALL_SUBJECT}</br>
+Status: {CALL_STATUS}</br>
+Start Date: {CALL_STARTDATE}</br>
+Duration: {CALL_HOURS}h, {CALL_MINUTES}m</br>
+Description: {CALL_DESCRIPTION}</p>
 
-You may review this Call at:
+<p>You may review this Call at:</p>
 <{URL}>
 <!-- END: CallSpecial -->
 
 <!-- BEGIN: Campaign_Subject -->
-SuiteCRM Campaign - {CAMPAIGN_NAME}
+<p>SuiteCRM Campaign - {CAMPAIGN_NAME}</p>
 <!-- END: Campaign_Subject -->
 <!-- BEGIN: Campaign -->
-{ASSIGNER} has assigned a Campaign to {ASSIGNED_USER}.
+<p>{ASSIGNER} has assigned a Campaign to {ASSIGNED_USER}.</p>
 
-Subject: {CAMPAIGN_NAME}
-Amount: {CAMPAIGN_AMOUNT}
-Close Date: {CAMPAIGN_CLOSEDATE}
-Status: {CAMPAIGN_STATUS}
-Description: {CAMPAIGN_DESCRIPTION}
+<p>Subject: {CAMPAIGN_NAME}</br>
+Amount: {CAMPAIGN_AMOUNT}</br>
+Close Date: {CAMPAIGN_CLOSEDATE}</br>
+Status: {CAMPAIGN_STATUS}</br>
+Description: {CAMPAIGN_DESCRIPTION}</p>
 
-You may review this Campaign at:
+<p>You may review this Campaign at:</p>
 <{URL}>
 <!-- END: Campaign -->
 
 <!-- BEGIN: Quota_Subject -->
-SuiteCRM Quotas - Your Quota for {QUOTA_TIMEPERIOD}
+<p>SuiteCRM Quotas - Your Quota for {QUOTA_TIMEPERIOD}</p>
 <!-- END: Quota_Subject -->
 <!-- BEGIN: Quota -->
-{ASSIGNER} has assigned a Quota to {ASSIGNED_USER}.
+<p>{ASSIGNER} has assigned a Quota to {ASSIGNED_USER}.</p>
 
-Amount: {QUOTA_AMOUNT}
-Timeperiod: {QUOTA_TIMEPERIOD}
+<p>Amount: {QUOTA_AMOUNT}</br>
+Timeperiod: {QUOTA_TIMEPERIOD}</p>
 
-You may review this Quota assignment at:
+<p>You may review this Quota assignment at:</p>
 <{QUOTA_URL}>
 <!-- END: Quota -->
 
 <!-- BEGIN: KBDocument_Subject -->
-SuiteCRM Document - {KBDOCUMENT_NAME}
+<p>SuiteCRM Document - {KBDOCUMENT_NAME}</p>
 <!-- END: KBDocument_Subject -->
 <!-- BEGIN: KBDocument -->
 
 {NOTIFICATION_MESSAGE}
 
-Name: {KBDOCUMENT_NAME}
-Created Date: {KBDOCUMENT_DATE_CREATED}
-Created By: {KBDOCUMENT_CREATED_BY}
-Status: {KBDOCUMENT_STATUS}
-Description: {KBDOCUMENT_DESCRIPTION}
+<p>Name: {KBDOCUMENT_NAME}</br>
+Created Date: {KBDOCUMENT_DATE_CREATED}</br>
+Created By: {KBDOCUMENT_CREATED_BY}</br>
+Status: {KBDOCUMENT_STATUS}</br>
+Description: {KBDOCUMENT_DESCRIPTION}</p>
 
-You may review this Document at:
+<p>You may review this Document at:</p>
 <{URL}>
 <!-- END: KBDocument -->
 
 <!-- BEGIN: Contract_Subject -->
-SuiteCRM Contract - {CONTRACT_NAME}
+<p>SuiteCRM Contract - {CONTRACT_NAME}</p>
 <!-- END: Contract_Subject -->
 <!-- BEGIN: Contract-->
 
-{ASSIGNER} has assigned a Contract to {ASSIGNED_USER}.
+<p>{ASSIGNER} has assigned a Contract to {ASSIGNED_USER}.</p>
 
-You may review this Contract at:
+<p>You may review this Contract at:</p>
 <{URL}>
 <!-- END:Contract-->
 
 <!-- BEGIN: ContractSpecial_Subject -->
-SuiteCRM Contract - {CONTRACT_NAME}
+<p>SuiteCRM Contract - {CONTRACT_NAME}</p>
 <!-- END: ContractSpecial_Subject -->
 <!-- BEGIN: ContractSpecial -->
 
-Your Contract: {CONTRACT_NAME} will be out of date at {CONTRACT_END_DATE}.
+<p>Your Contract: {CONTRACT_NAME} will be out of date at {CONTRACT_END_DATE}.</p>
 
-You may review this Contract at:
+<p>You may review this Contract at:</p>
 <{URL}>
 <!-- END:ContractSpecial-->
 
 <!-- BEGIN: MeetingReminder_Subject -->
-Meeting Reminder - {MEETING_SUBJECT}
+<p>Meeting Reminder - {MEETING_SUBJECT}</p>
 <!-- END: MeetingSpecial_Subject -->
 <!-- BEGIN: MeetingReminder -->
-Title: {MEETING_SUBJECT}
-When: {MEETING_STARTDATE}
-Location: {MEETING_LOCATION}
-Created By: {MEETING_CREATED_BY}
+<p>Title: {MEETING_SUBJECT}</br>
+When: {MEETING_STARTDATE}</br>
+Location: {MEETING_LOCATION}</br>
+Created By: {MEETING_CREATED_BY}</p>
 <!-- END: MeetingReminder -->
 
 <!-- BEGIN: CallReminder_Subject -->
-Call Reminder - {CALL_SUBJECT}
+<p>Call Reminder - {CALL_SUBJECT}</p>
 <!-- END: CallReminder_Subject -->
 <!-- BEGIN: CallReminder -->
-Title: {CALL_SUBJECT}
-When: {CALL_STARTDATE}
-Created By: {CALL_CREATED_BY}
+<p>Title: {CALL_SUBJECT}</br>
+When: {CALL_STARTDATE}</br>
+Created By: {CALL_CREATED_BY}</p>
 <!-- END: CallReminder -->

--- a/include/language/en_us.notify_template.html
+++ b/include/language/en_us.notify_template.html
@@ -82,7 +82,7 @@ Description: {ACCOUNT_DESCRIPTION}</p>
 <p>Subject: {CASE_SUBJECT}</br>
 Priority: {CASE_PRIORITY}</br>
 Status: {CASE_STATUS}</br>
-Description: {CASE_DESCRIPTION}</br>
+Description: {CASE_DESCRIPTION}</p>
 
 <p>You may review this Case at:</p>
 <{URL}>
@@ -250,7 +250,7 @@ Work Log: {BUG_WORK_LOG}</p>
 <p>SuiteCRM Call - {CALL_SUBJECT}</p>
 <!-- END: Call_Subject -->
 <!-- BEGIN: Call -->
-<p>To: {CALL_TO}<p>
+<p>To: {CALL_TO}</p>
 <p>{ASSIGNER} has invited you to a Call</p>
 <p>Subject: {CALL_SUBJECT}</br>
 Status: {CALL_STATUS}</br>


### PR DESCRIPTION
Formating include/language/en_us.notify_template.html
with html tags to allow translation on Crowdin.

This cause an issue on email subject filed but its solved by a related PR #1472 and #1654 that should be implemented at same time.

This PR is a recreation from #867 because I had to delete my repo.