### PR TITLE
Strip HTML tags from notification e-mail Subjects

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -2762,7 +2762,7 @@ class SugarBean
         $xtpl->parse($template_name . "_Subject");
 
         $notify_mail->Body = from_html(trim($xtpl->text($template_name)));
-        $notify_mail->Subject = from_html($xtpl->text($template_name . "_Subject"));
+        $notify_mail->Subject = strip_tags(from_html($xtpl->text($template_name . "_Subject")));
 
         // cn: bug 8568 encode notify email in User's outbound email encoding
         $notify_mail->prepForOutbound();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is in reference to a PR (https://github.com/salesagility/SuiteCRM/pull/1654) that was made by @pgorod which needed to be merge via git itself.

## Motivation and Context
Email subjects should never include HTML. 
Since there is a difficulty with translated email templates that is causing HTML tags in email "Subjects" to be visible to end-users, and we couldn't find any way to fix it in Crowdin, this change solves the problem. 
At the same time, it's follows a good general principle - HTML tags don't belong there.

## How To Test This
First - pull down horus68 PR (https://github.com/salesagility/SuiteCRM/pull/1698) to have HTML tags within Assigned To notification emails.  Then Assigned a record whch actives this email.  The received email should not receive HTML within the subject.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
