### PR TITLE
Fixed #1662 - Reports empty if conditions strings for aor_sql_operato…

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -1399,9 +1399,7 @@ class AOR_Report extends Basic {
                             break;
                     }
 
-                    // Dealing with language translations
-
-                    //handle like conditions
+                    //handle like conditions and dealing with language translations
                     Switch($condition->operator) {
                         case 'Contains':
                             $value = "CONCAT('%', ".$value." ,'%')";

--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -1248,6 +1248,7 @@ class AOR_Report extends Basic {
                 }
                 if(isset($app_list_strings['aor_sql_operator_list'][$condition->operator])) {
                     $where_set = false;
+                    $where_operator = $app_list_strings['aor_sql_operator_list'][$condition->operator];
 
                     $data = $condition_module->field_defs[$condition->field];
 
@@ -1373,7 +1374,7 @@ class AOR_Report extends Basic {
                                 $value = '(';
                                 foreach ($multi_values as $multi_value) {
                                     if ($value != '(') $value .= $sep;
-                                    $value .= $field . ' ' . $app_list_strings['aor_sql_operator_list'][$condition->operator] . " '" . $multi_value . "'";
+                                    $value .= $field . ' ' . $where_operator . " '" . $multi_value . "'";
                                 }
                                 $value .= ')';
                             }
@@ -1398,16 +1399,21 @@ class AOR_Report extends Basic {
                             break;
                     }
 
+                    // Dealing with language translations
+
                     //handle like conditions
                     Switch($condition->operator) {
                         case 'Contains':
                             $value = "CONCAT('%', ".$value." ,'%')";
+                            $where_operator = 'LIKE';
                             break;
                         case 'Starts_With':
                             $value = "CONCAT(".$value." ,'%')";
+                            $where_operator = 'LIKE';
                             break;
                         case 'Ends_With':
                             $value = "CONCAT('%', ".$value.")";
+                            $where_operator = 'LIKE';
                             break;
                     }
 
@@ -1428,7 +1434,7 @@ class AOR_Report extends Basic {
                             $query['where'][] = ($tiltLogicOp ? '' : ($condition->logic_op ? $condition->logic_op . ' ': 'AND '));
                             $tiltLogicOp = false;
 
-                            switch ($app_list_strings['aor_sql_operator_list'][$condition->operator]) {
+                            switch ($where_operator) {
                                 case "=":
                                     $query['where'][] = $field . ' BETWEEN ' . $value .  ' AND ' . '"' . $date . '"';
                                     break;
@@ -1439,11 +1445,11 @@ class AOR_Report extends Basic {
                                 case "<":
                                 case ">=":
                                 case "<=":
-                                    $query['where'][] = $field . ' ' . $app_list_strings['aor_sql_operator_list'][$condition->operator] . ' ' . $value;
+                                    $query['where'][] = $field . ' ' . $where_operator . ' ' . $value;
                                     break;
                             }
                         } else {
-                            if (!$where_set) $query['where'][] = ($tiltLogicOp ? '' : ($condition->logic_op ? $condition->logic_op . ' ': 'AND ')) . $field . ' ' . $app_list_strings['aor_sql_operator_list'][$condition->operator] . ' ' . $value;
+                            if (!$where_set) $query['where'][] = ($tiltLogicOp ? '' : ($condition->logic_op ? $condition->logic_op . ' ': 'AND ')) . $field . ' ' . $where_operator . ' ' . $value;
                         }
                     }
                     $tiltLogicOp = false;


### PR DESCRIPTION
…r_list are translated

## Description
This resolves the issue with translated aor_sql_operator_list values when running reports with a 'LIKE' condition operator.

## Motivation and Context
This allows language packs to use the 'LIKE' operator in the Reports module - previously it would break the sql query.

Issue raised by horus68 - https://github.com/salesagility/SuiteCRM/issues/1662
Issue raised by gunnicom - https://github.com/salesagility/SuiteCRM/issues/1451

## How To Test This
Following the instructions via this issue thread
https://github.com/salesagility/SuiteCRM/issues/1662
- change the aor_sql_operator_list via include/language/whatever_language.php
- create a report with the three 'LIKE' operators (contains, starts with and ends with) and the report will return with expected results.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
