### PR TITLE
Remove function getDisplayForField() thats nearly identical by small change

### DIFF
--- a/modules/AOR_Reports/aor_utils.php
+++ b/modules/AOR_Reports/aor_utils.php
@@ -59,6 +59,7 @@ function getDisplayForField($modulePath, $field, $reportModule)
             $modulePathDisplay[] = $currentBean->module_name;
         }
     }
+    $fieldType = $currentBean->field_name_map[$field]['type'];
     $fieldDisplay = $currentBean->field_name_map[$field]['vname'];
     $fieldDisplay = translate($fieldDisplay, $currentBean->module_dir);
     $fieldDisplay = trim($fieldDisplay, ':');
@@ -67,7 +68,7 @@ function getDisplayForField($modulePath, $field, $reportModule)
             isset($app_list_strings['moduleList'][$module]) ? $app_list_strings['moduleList'][$module] : $module
         );
     }
-    return array('field' => $fieldDisplay, 'module' => str_replace(' ', '&nbsp;', implode(' : ', $modulePathDisplay)));
+    return array('field' => $fieldDisplay, 'type'=>$fieldType, 'module' => str_replace(' ', '&nbsp;', implode(' : ', $modulePathDisplay)));
 }
 
 function requestToUserParameters()

--- a/modules/AOR_Reports/views/view.edit.php
+++ b/modules/AOR_Reports/views/view.edit.php
@@ -116,9 +116,9 @@ class AOR_ReportsViewEdit extends ViewEdit {
             $field_name->module_path = implode(":",unserialize(base64_decode($field_name->module_path)));
             $arr = $field_name->toArray();
 
-            $arr['field_type'] = $this->getDisplayForField($field_name->module_path, $field_name->field  , $this->bean->report_module);
 
             $display = getDisplayForField($field_name->module_path, $field_name->field, $this->bean->report_module);
+            $arr['field_type'] = $display['type'];
 
             $arr['module_path_display'] = $display['module'];
             $arr['field_label'] = $display['field'];
@@ -136,38 +136,6 @@ class AOR_ReportsViewEdit extends ViewEdit {
             $charts[] = $chart->toArray();
         }
         return $charts;
-    }
-
-    public function getDisplayForField($modulePath, $field, $reportModule){
-        $modulePathDisplay = array();
-        $currentBean = BeanFactory::getBean($reportModule);
-        $modulePathDisplay[] = $currentBean->module_name;
-        if(is_array($modulePath)) {
-            $split = $modulePath;
-        }else{
-            $split = explode(':', $modulePath);
-        }
-        if ($split && $split[0] == $currentBean->module_dir) {
-            array_shift($split);
-        }
-        foreach($split as $relName){
-            if(empty($relName)){
-                continue;
-            }
-            if(!empty($currentBean->field_name_map[$relName]['vname'])){
-                $moduleLabel = trim(translate($currentBean->field_name_map[$relName]['vname'],$currentBean->module_dir),':');
-            }
-            $thisModule = getRelatedModule($currentBean->module_dir, $relName);
-            $currentBean = BeanFactory::getBean($thisModule);
-
-            if(!empty($moduleLabel)){
-                $modulePathDisplay[] = $moduleLabel;
-            }else {
-                $modulePathDisplay[] = $currentBean->module_name;
-            }
-        }
-        $fieldDisplay = $currentBean->field_name_map[$field]['type'];
-        return $fieldDisplay;
     }
 
 }


### PR DESCRIPTION
## Description
The two functions getDisplayForField() are almost identical, so i merged them.

## Motivation and Context
Code duplication is bad.

## How To Test This
There should be no effect of the code.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.
