### PR TITLE
Parameter order wrong in Dashlet Parameters

### DIFF
--- a/modules/AOR_Reports/aor_utils.php
+++ b/modules/AOR_Reports/aor_utils.php
@@ -134,7 +134,7 @@ function getConditionsAsParameters($report, $override = array())
         $value = isset($override[$condition->id]['value']) ? $override[$condition->id]['value'] : $value = $condition->value;
 
 
-        $field = getModuleField($field_module, $condition->field, "parameter_value[$key]", 'EditView', $value);
+        $field = getModuleField($field_module, $condition->field, "parameter_value[]", 'EditView', $value);
         $disp = getDisplayForField($path, $condition->field, $report->report_module);
         $conditions[] = array(
             'id' => $condition->id,


### PR DESCRIPTION
## Description

If you got parameters in a dashlet the parameter ids would be numbered in the html source like "parameter_value[1]" "parameter_value[2]".
The Problem is that the parameters should be unnumbered like "parameter_value[]" so the count begins with 0 not with 1.
If you now save changed parameters the wrong parameter gets changed, you change the first(Index 1, but should be index 0), but the second parameter gets changed.
## Motivation and Context

Bug.
## How To Test This

Add Report dashlet with at least two changeable parameters, try to change a parameter.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
### Final checklist
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.
