### PR TITLE
Fixed #1727 - Invalid foreach argument warning in AOP admin under php…

### DIFF
--- a/modules/Administration/AOPAdmin.php
+++ b/modules/Administration/AOPAdmin.php
@@ -154,11 +154,15 @@ $sugar_smarty->assign('error', $errors);
 $cBean = BeanFactory::getBean('Cases');
 $statusDropdown = get_select_options($app_list_strings[$cBean->field_name_map['status']['options']], '');
 $currentStatuses = '';
-foreach (json_decode($cfg->config['aop']['case_status_changes'], true) as $if => $then) {
-    $ifDropdown = get_select_options($app_list_strings[$cBean->field_name_map['status']['options']], $if);
-    $thenDropdown = get_select_options($app_list_strings[$cBean->field_name_map['status']['options']], $then);
-    $currentStatuses .= getStatusRowTemplate($mod_strings, $ifDropdown, $thenDropdown) . "\n";
+
+if($cfg->config['aop']['case_status_changes']) {
+    foreach (json_decode($cfg->config['aop']['case_status_changes'], true) as $if => $then) {
+        $ifDropdown = get_select_options($app_list_strings[$cBean->field_name_map['status']['options']], $if);
+        $thenDropdown = get_select_options($app_list_strings[$cBean->field_name_map['status']['options']], $then);
+        $currentStatuses .= getStatusRowTemplate($mod_strings, $ifDropdown, $thenDropdown) . "\n";
+    }
 }
+
 
 $sugar_smarty->assign('currentStatuses', $currentStatuses);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Added a check before the foreach loop to make there is some data inside it.

Relates to #1727 

<!--- Describe your changes in detail -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here unless your commit contains the issue number -->
## Motivation and Context

This is to avoid the warning created from the foreach look. The will prevent the warning from happening also prevents foreach loop from running if there is no data.

<!--- Why is this change required? What problem does it solve? -->
## How To Test This

Set the Log Level to "Warn" and look for errors when navigating to AOP settings.

<!--- Please describe in detail how to test your changes. -->
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
### Final checklist

<!--- Go over all the following points and check all the boxes that apply. --->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->

… 7 with 7.7 beta2
