### PR TITLE
Subpanels Templates

### DIFF
--- a/include/SubPanel/SubPanelTiles.php
+++ b/include/SubPanel/SubPanelTiles.php
@@ -206,6 +206,7 @@ class SubPanelTiles
         $template_footer = "";
 
         $tabs = array();
+        $tabs_properties = array();
         $tab_names = array();
 
         $default_div_display = 'inline';
@@ -238,8 +239,9 @@ class SubPanelTiles
             {
                 $availableTabs = $tabs ;
                 $tabs = array_intersect ( $usersLayout , $availableTabs ) ; // remove any tabs that have been removed since the user's layout was saved
-                foreach (array_diff ( $availableTabs , $usersLayout ) as $tab)
-                    $tabs [] = $tab ;
+                foreach (array_diff ( $availableTabs , $usersLayout ) as $tab) {
+                    $tabs [] = $tab;
+                }
             }
         }
         else
@@ -350,33 +352,35 @@ class SubPanelTiles
 
             if (empty($this->show_tabs))
             {
+                ///
+                /// Legacy Support for subpanels
                 $show_icon_html = SugarThemeRegistry::current()->getImage('advanced_search', 'border="0" align="absmiddle"', null, null, '.gif', translate('LBL_SHOW'));
                 $hide_icon_html = SugarThemeRegistry::current()->getImage('basic_search', 'border="0" align="absmiddle"', null, null, '.gif', translate('LBL_HIDE'));
 
-                $tabs[$t]['show_icon_html'] = $show_icon_html;
-                $tabs[$t]['hide_icon_html'] = $hide_icon_html;
+                $tabs_properties[$t]['show_icon_html'] = $show_icon_html;
+                $tabs_properties[$t]['hide_icon_html'] = $hide_icon_html;
 
                 $max_min = "<a name=\"$tab\"> </a><span id=\"show_link_".$tab."\" style=\"display: $opp_display\"><a href='#' class='utilsLink' onclick=\"current_child_field = '".$tab."';showSubPanel('".$tab."',null,null,'".$layout_def_key."');document.getElementById('show_link_".$tab."').style.display='none';document.getElementById('hide_link_".$tab."').style.display='';return false;\">"
                     . "" . $show_icon_html . "</a></span>";
                 $max_min .= "<span id=\"hide_link_".$tab."\" style=\"display: $div_display\"><a href='#' class='utilsLink' onclick=\"hideSubPanel('".$tab."');document.getElementById('hide_link_".$tab."').style.display='none';document.getElementById('show_link_".$tab."').style.display='';return false;\">"
                     . "" . $hide_icon_html . "</a></span>";
-                $tabs[$t]['title'] = $thisPanel->get_title();
-                $tabs[$t]['get_form_header']  = get_form_header( $thisPanel->get_title(), $max_min, false, false);
+                $tabs_properties[$t]['title'] = $thisPanel->get_title();
+                $tabs_properties[$t]['get_form_header']  = get_form_header( $thisPanel->get_title(), $max_min, false, false);
             }
 
-            $tabs[$t]['cookie_name'] = $cookie_name;
-            $tabs[$t]['div_display'] = $div_display;
-            $tabs[$t]['opp_display'] = $opp_display;
+            $tabs_properties[$t]['cookie_name'] = $cookie_name;
+            $tabs_properties[$t]['div_display'] = $div_display;
+            $tabs_properties[$t]['opp_display'] = $opp_display;
 
             $display_spd = '';
             if($div_display != 'none') {
-//                include_once('include/SubPanel/SubPanel.php');
-//                $subpanel_object = new SubPanel($this->module, $_REQUEST['record'], $tab, $thisPanel, $layout_def_key);
-////                $subpanel_data = $subpanel_object->fetch('include/SubPanel/SubPanelDynamic.html');
-//
-////                echo $this->get_buttons($thisPanel,$subpanel_object->subpanel_query);
-//
-//                $tabs[$t]['display_spd'] = $subpanel_data;
+                include_once('include/SubPanel/SubPanel.php');
+                $subpanel_object = new SubPanel($this->module, $_REQUEST['record'], $tab, $thisPanel, $layout_def_key);
+                $subpanel_data = $subpanel_object->fetch('include/SubPanel/SubPanelDynamic.html');
+
+                echo $this->get_buttons($thisPanel,$subpanel_object->subpanel_query);
+
+                $tabs_properties[$t]['subpanel_body'] = $subpanel_data;
             }
             array_push($tab_names, $tab);
         }
@@ -384,6 +388,7 @@ class SubPanelTiles
         $template->assign('layout_def_key', $this->layout_def_key);
         $template->assign('show_subpanel_tabs', $this->show_tabs);
         $template->assign('subpanel_tabs', $tabs);
+        $template->assign('subpanel_tabs_properties', $tabs_properties);
         $template->assign('module_sub_panels', $module_sub_panels);
         $template->assign('sugar_config', $sugar_config);
         $template->assign('REQUEST', $_REQUEST);

--- a/include/SubPanel/SubPanelTiles.php
+++ b/include/SubPanel/SubPanelTiles.php
@@ -184,61 +184,41 @@ class SubPanelTiles
 
                foreach($tabs as $tab){
     	           $displayTabs []= array('key'=>$tab, 'label'=>translate($this->subpanel_definitions->layout_defs['subpanel_setup'][$tab]['title_key']));
-    	           //echo '<td nowrap="nowrap"><a class="subTabLink" href="#' . $tab . '">' .  translate($this->subpanel_definitions->layout_defs['subpanel_setup'][$tab]['title_key']) .  '</a></td><td> | </td>';
     	       }
                $sugarTab->setup(array(),array(),$displayTabs);
                $sugarTab->display();
             }
-            //echo '<td width="100%">&nbsp;</td></tr></table>';
         }
 	    return $tabs;
 
 	}
 	function display($showContainer = true, $forceTabless = false)
 	{
-		global $layout_edit_mode, $sugar_version, $sugar_config, $current_user, $app_strings;
+		global $layout_edit_mode, $sugar_version, $sugar_config, $current_user, $app_strings, $modListHeader;
+
 		if(isset($layout_edit_mode) && $layout_edit_mode){
 			return;
 		}
 
-		global $modListHeader;
+        $template = new Sugar_Smarty();
+        $template_header = "";
+        $template_body = "";
+        $template_footer = "";
 
-		ob_start();
-    echo '<script type="text/javascript" src="'. getJSPath('include/SubPanel/SubPanelTiles.js') . '"></script>';
-?>
-<script>
-if(document.DetailView != null &&
-   document.DetailView.elements != null &&
-   document.DetailView.elements.layout_def_key != null &&
-   typeof document.DetailView.elements['layout_def_key'] != 'undefined'){
-    document.DetailView.elements['layout_def_key'].value = '<?php echo $this->layout_def_key; ?>';
-}
-</script>
-<?php
+        $tabs = array();
+        $tab_names = array();
 
-		$tabs = array();
-		$default_div_display = 'inline';
-		if(!empty($sugar_config['hide_subpanels_on_login'])){
-			if(!isset($_SESSION['visited_details'][$this->focus->module_dir])){
-				setcookie($this->focus->module_dir . '_divs', '',0,null,null,false,true);
-				unset($_COOKIE[$this->focus->module_dir . '_divs']);
-				$_SESSION['visited_details'][$this->focus->module_dir] = true;
+        $default_div_display = 'inline';
+        if(!empty($sugar_config['hide_subpanels_on_login'])){
+            if(!isset($_SESSION['visited_details'][$this->focus->module_dir])){
+                setcookie($this->focus->module_dir . '_divs', '',0,null,null,false,true);
+                unset($_COOKIE[$this->focus->module_dir . '_divs']);
+                $_SESSION['visited_details'][$this->focus->module_dir] = true;
+            }
+            $default_div_display = 'none';
+        }
+        $div_cookies = get_sub_cookies($this->focus->module_dir . '_divs');
 
-			}
-			$default_div_display = 'none';
-		}
-		$div_cookies = get_sub_cookies($this->focus->module_dir . '_divs');
-
-
-		//Display the group header. this section is executed only if the tabbed interface is being used.
-		$current_key = '';
-		if (! empty($this->show_tabs))
-		{
-			require_once('include/tabs.php');
-    		$tab_panel = new SugarWidgetTabs($tabs, $current_key, 'showSubPanel');
-			echo get_form_header('Related', '', false);
-			echo "<br />" . $tab_panel->display();
-		}
 
         if(empty($_REQUEST['subpanels']))
         {
@@ -264,56 +244,56 @@ if(document.DetailView != null &&
         }
         else
         {
-        	$tabs = explode(',', $_REQUEST['subpanels']);
+            $tabs = explode(',', $_REQUEST['subpanels']);
         }
 
-        $tab_names = array();
-
-        if($showContainer)
+        // Display the group header. this section is executed only if the tabbed interface is being used.
+        $current_key = '';
+        if (! empty($this->show_tabs))
         {
-            echo '<ul class="noBullet" id="subpanel_list">';
+            require_once('include/tabs.php');
+            $tab_panel = new SugarWidgetTabs($tabs, $current_key, 'showSubPanel');
+            $template_header .= get_form_header('Related', '', false);
+            $template_header .= $tab_panel->display();
         }
-        //echo "<li id='hidden_0' style='height: 5px' class='noBullet'>&nbsp;&nbsp;&nbsp;</li>";
+
         if (empty($GLOBALS['relationships'])) {
-        	if (!class_exists('Relationship')) {
-        		require('modules/Relationships/Relationship.php');
-        	}
-        	$rel= new Relationship();
-	        $rel->load_relationship_meta();
+            if (!class_exists('Relationship')) {
+                require('modules/Relationships/Relationship.php');
+            }
+            $rel= new Relationship();
+            $rel->load_relationship_meta();
         }
 
-        // this array will store names of sub-panels that can contain items
-        // of each module
-        $module_sub_panels = array();
-
-        foreach ($tabs as $tab)
-		{
-			//load meta definition of the sub-panel.
-			$thisPanel=$this->subpanel_definitions->load_subpanel($tab);
-            if ($thisPanel === false)
+        foreach ($tabs as $t => $tab)
+        {
+            // load meta definition of the sub-panel.
+            $thisPanel = $this->subpanel_definitions->load_subpanel($tab);
+            if ($thisPanel === false) {
                 continue;
-			//this if-block will try to skip over ophaned subpanels. Studio/MB are being delete unloaded modules completely.
-			//this check will ignore subpanels that are collections (activities, history, etc)
-			if (!isset($thisPanel->_instance_properties['collection_list']) and isset($thisPanel->_instance_properties['get_subpanel_data']) ) {
-				//ignore when data source is a function
+            }
+            // this if-block will try to skip over ophaned subpanels. Studio/MB are being delete unloaded modules completely.
+            // this check will ignore subpanels that are collections (activities, history, etc)
+            if (!isset($thisPanel->_instance_properties['collection_list']) and isset($thisPanel->_instance_properties['get_subpanel_data']) ) {
+                // ignore when data source is a function
 
-				if (!isset($this->focus->field_defs[$thisPanel->_instance_properties['get_subpanel_data']])) {
-					if (stripos($thisPanel->_instance_properties['get_subpanel_data'],'function:') === false) {
-						$GLOBALS['log']->fatal("Bad subpanel definition, it has incorrect value for get_subpanel_data property " .$tab);
-						continue;
-					}
-				} else {
-					$rel_name='';
-					if (isset($this->focus->field_defs[$thisPanel->_instance_properties['get_subpanel_data']]['relationship'])) {
-						$rel_name=$this->focus->field_defs[$thisPanel->_instance_properties['get_subpanel_data']]['relationship'];
-					}
+                if (!isset($this->focus->field_defs[$thisPanel->_instance_properties['get_subpanel_data']])) {
+                    if (stripos($thisPanel->_instance_properties['get_subpanel_data'],'function:') === false) {
+                        $GLOBALS['log']->fatal("Bad subpanel definition, it has incorrect value for get_subpanel_data property " .$tab);
+                        continue;
+                    }
+                } else {
+                    $rel_name='';
+                    if (isset($this->focus->field_defs[$thisPanel->_instance_properties['get_subpanel_data']]['relationship'])) {
+                        $rel_name=$this->focus->field_defs[$thisPanel->_instance_properties['get_subpanel_data']]['relationship'];
+                    }
 
-					if (empty($rel_name) or !isset($GLOBALS['relationships'][$rel_name])) {
-						$GLOBALS['log']->fatal("Missing relationship definition " .$rel_name. ". skipping " .$tab ." subpanel");
-						continue;
-					}
-				}
-			}
+                    if (empty($rel_name) or !isset($GLOBALS['relationships'][$rel_name])) {
+                        $GLOBALS['log']->fatal("Missing relationship definition " .$rel_name. ". skipping " .$tab ." subpanel");
+                        continue;
+                    }
+                }
+            }
 
             if ($thisPanel->isCollection()) {
                 // collect names of sub-panels that may contain items of each module
@@ -332,34 +312,35 @@ if(document.DetailView != null &&
                 }
             }
 
-			echo '<li class="noBullet" id="whole_subpanel_' . $tab . '">';
+            $display = 'none';
+            $div_display = $default_div_display;
+            $cookie_name =   $tab . '_v';
 
-			$display= 'none';
-			$div_display = $default_div_display;
-			$cookie_name =   $tab . '_v';
+            if (isset($thisPanel->_instance_properties['collapsed']) && $thisPanel->_instance_properties['collapsed'])
+            {
+                $div_display = 'none';
+            }
 
-			if (isset($thisPanel->_instance_properties['collapsed']) && $thisPanel->_instance_properties['collapsed'])
-			{
-				$div_display = 'none';
-			}
+            if(isset($div_cookies[$cookie_name])){
+                // If defaultSubPanelExpandCollapse is set, ignore the cookie that remembers whether the panel is expanded or collapsed.
+                // To be used with the above 'collapsed' metadata setting so they will always be set the same when the page is loaded.
+                if(!isset($sugar_config['defaultSubPanelExpandCollapse']) || $sugar_config['defaultSubPanelExpandCollapse'] == false)
+                    $div_display = 	$div_cookies[$cookie_name];
+            }
 
-			if(isset($div_cookies[$cookie_name])){
-				//If defaultSubPanelExpandCollapse is set, ignore the cookie that remembers whether the panel is expanded or collapsed.
-				//To be used with the above 'collapsed' metadata setting so they will always be set the same when the page is loaded.
-				if(!isset($sugar_config['defaultSubPanelExpandCollapse']) || $sugar_config['defaultSubPanelExpandCollapse'] == false)
-					$div_display = 	$div_cookies[$cookie_name];
-			}
-			if(!empty($sugar_config['hide_subpanels'])){
-				$div_display = 'none';
-			}
+            if(!empty($sugar_config['hide_subpanels'])){
+                $div_display = 'none';
+            }
+
             if($thisPanel->isDefaultHidden()) {
                 $div_display = 'none';
             }
-			if($div_display == 'none'){
-				$opp_display  = 'inline';
-			}else{
-				$opp_display  = 'none';
-			}
+
+            if($div_display == 'none'){
+                $opp_display  = 'inline';
+            }else{
+                $opp_display  = 'none';
+            }
 
             if (!empty($this->layout_def_key) ) {
                 $layout_def_key = $this->layout_def_key;
@@ -367,110 +348,50 @@ if(document.DetailView != null &&
                 $layout_def_key = '';
             }
 
-			if (empty($this->show_tabs))
-			{
-				$show_icon_html = SugarThemeRegistry::current()->getImage( 'advanced_search', 'border="0" align="absmiddle"',null,null,'.gif',translate('LBL_SHOW'));
-				$hide_icon_html = SugarThemeRegistry::current()->getImage( 'basic_search', 'border="0" align="absmiddle"',null,null,'.gif',translate('LBL_HIDE'));
-
- 		 		$max_min = "<a name=\"$tab\"> </a><span id=\"show_link_".$tab."\" style=\"display: $opp_display\"><a href='#' class='utilsLink' onclick=\"current_child_field = '".$tab."';showSubPanel('".$tab."',null,null,'".$layout_def_key."');document.getElementById('show_link_".$tab."').style.display='none';document.getElementById('hide_link_".$tab."').style.display='';return false;\">"
- 		 			. "" . $show_icon_html . "</a></span>";
-				$max_min .= "<span id=\"hide_link_".$tab."\" style=\"display: $div_display\"><a href='#' class='utilsLink' onclick=\"hideSubPanel('".$tab."');document.getElementById('hide_link_".$tab."').style.display='none';document.getElementById('show_link_".$tab."').style.display='';return false;\">"
-				 . "" . $hide_icon_html . "</a></span>";
-				echo '<div id="subpanel_title_' . $tab . '"';
-                if(empty($sugar_config['lock_subpanels']) || $sugar_config['lock_subpanels'] == false) echo ' onmouseover="this.style.cursor = \'move\';"';
-                echo '>' . get_form_header( $thisPanel->get_title(), $max_min, false) . '</div>';
-			}
-
-            echo <<<EOQ
-<div cookie_name="$cookie_name" id="subpanel_$tab" style="display:$div_display">
-    <script>document.getElementById("subpanel_$tab" ).cookie_name="$cookie_name";</script>
-EOQ;
-            $display_spd = '';
-            if($div_display != 'none'){
-            	echo "<script>SUGAR.util.doWhen(\"typeof(markSubPanelLoaded) != 'undefined'\", function() {markSubPanelLoaded('$tab');});</script>";
-            	$old_contents = ob_get_contents();
-            	@ob_end_clean();
-
-            	ob_start();
-            	include_once('include/SubPanel/SubPanel.php');
-            	$subpanel_object = new SubPanel($this->module, $_REQUEST['record'], $tab,$thisPanel,$layout_def_key);
-            	$subpanel_object->setTemplateFile('include/SubPanel/SubPanelDynamic.html');
-            	$subpanel_object->display();
-            	$subpanel_data = ob_get_contents();
-            	@ob_end_clean();
-
-            	ob_start();
-            	echo $this->get_buttons($thisPanel,$subpanel_object->subpanel_query);
-            	$buttons = ob_get_contents();
-            	@ob_end_clean();
-
-            	ob_start();
-            	echo $old_contents;
-            	//echo $buttons;
-                $display_spd = $subpanel_data;
-            }
-            echo <<<EOQ
-    <div id="list_subpanel_$tab">$display_spd</div>
-</div>
-EOQ;
-        	array_push($tab_names, $tab);
-        	echo '</li>';
-        } // end $tabs foreach
-        if($showContainer)
-        {
-        	echo '</ul>';
-
-
-            if(!empty($selected_group))
+            if (empty($this->show_tabs))
             {
-                // closing table from tpls/singletabmenu.tpl
-                echo '</td></tr></table>';
+                $show_icon_html = SugarThemeRegistry::current()->getImage('advanced_search', 'border="0" align="absmiddle"', null, null, '.gif', translate('LBL_SHOW'));
+                $hide_icon_html = SugarThemeRegistry::current()->getImage('basic_search', 'border="0" align="absmiddle"', null, null, '.gif', translate('LBL_HIDE'));
+
+                $tabs[$t]['show_icon_html'] = $show_icon_html;
+                $tabs[$t]['hide_icon_html'] = $hide_icon_html;
+
+                $max_min = "<a name=\"$tab\"> </a><span id=\"show_link_".$tab."\" style=\"display: $opp_display\"><a href='#' class='utilsLink' onclick=\"current_child_field = '".$tab."';showSubPanel('".$tab."',null,null,'".$layout_def_key."');document.getElementById('show_link_".$tab."').style.display='none';document.getElementById('hide_link_".$tab."').style.display='';return false;\">"
+                    . "" . $show_icon_html . "</a></span>";
+                $max_min .= "<span id=\"hide_link_".$tab."\" style=\"display: $div_display\"><a href='#' class='utilsLink' onclick=\"hideSubPanel('".$tab."');document.getElementById('hide_link_".$tab."').style.display='none';document.getElementById('show_link_".$tab."').style.display='';return false;\">"
+                    . "" . $hide_icon_html . "</a></span>";
+                $tabs[$t]['title'] = $thisPanel->get_title();
+                $tabs[$t]['get_form_header']  = get_form_header( $thisPanel->get_title(), $max_min, false, false);
             }
-        }
-        // drag/drop code
-        $tab_names = '["' . join($tab_names, '","') . '"]';
-        global $sugar_config;
 
-        if(empty($sugar_config['lock_subpanels']) || $sugar_config['lock_subpanels'] == false) {
-            echo <<<EOQ
-    <script>
-    	var SubpanelInit = function() {
-    		SubpanelInitTabNames({$tab_names});
-    	}
-        var SubpanelInitTabNames = function(tabNames) {
-    		subpanel_dd = new Array();
-    		j = 0;
-    		for(i in tabNames) {
-    			subpanel_dd[j] = new ygDDList('whole_subpanel_' + tabNames[i]);
-    			subpanel_dd[j].setHandleElId('subpanel_title_' + tabNames[i]);
-    			subpanel_dd[j].onMouseDown = SUGAR.subpanelUtils.onDrag;
-    			subpanel_dd[j].afterEndDrag = SUGAR.subpanelUtils.onDrop;
-    			j++;
-    		}
+            $tabs[$t]['cookie_name'] = $cookie_name;
+            $tabs[$t]['div_display'] = $div_display;
+            $tabs[$t]['opp_display'] = $opp_display;
 
-    		YAHOO.util.DDM.mode = 1;
-    	}
-    	currentModule = '{$this->module}';
-    	SUGAR.util.doWhen(
-    	    "typeof(SUGAR.subpanelUtils) == 'object' && typeof(SUGAR.subpanelUtils.onDrag) == 'function'" +
-    	        " && document.getElementById('subpanel_list')",
-    	    SubpanelInit
-    	);
-    </script>
-EOQ;
+            $display_spd = '';
+            if($div_display != 'none') {
+//                include_once('include/SubPanel/SubPanel.php');
+//                $subpanel_object = new SubPanel($this->module, $_REQUEST['record'], $tab, $thisPanel, $layout_def_key);
+////                $subpanel_data = $subpanel_object->fetch('include/SubPanel/SubPanelDynamic.html');
+//
+////                echo $this->get_buttons($thisPanel,$subpanel_object->subpanel_query);
+//
+//                $tabs[$t]['display_spd'] = $subpanel_data;
+            }
+            array_push($tab_names, $tab);
         }
 
-        $module_sub_panels = array_map('array_keys', $module_sub_panels);
-        $module_sub_panels = json_encode($module_sub_panels);
-        echo <<<EOQ
-<script>
-var ModuleSubPanels = $module_sub_panels;
-</script>
-EOQ;
+        $template->assign('layout_def_key', $this->layout_def_key);
+        $template->assign('show_subpanel_tabs', $this->show_tabs);
+        $template->assign('subpanel_tabs', $tabs);
+        $template->assign('module_sub_panels', $module_sub_panels);
+        $template->assign('sugar_config', $sugar_config);
+        $template->assign('REQUEST', $_REQUEST);
+        $template->assign('GLOBALS', $GLOBALS);
 
-		$ob_contents = ob_get_contents();
-		ob_end_clean();
-		return $ob_contents;
+        $template_body = $template->fetch('include/SubPanel/tpls/SubPanelTiles.tpl');
+
+        return $template_header . $template_body . $template_footer;
 	}
 
 

--- a/include/SubPanel/SubPanelTiles.php
+++ b/include/SubPanel/SubPanelTiles.php
@@ -370,31 +370,21 @@ class SubPanelTiles
             $tabs_properties[$t]['div_display'] = $div_display;
             $tabs_properties[$t]['opp_display'] = $opp_display;
 
-            $tabs_properties[$t]['subpanel_body'] = '';
-            $tabs_properties[$t]['buttons'] = '';
-//            if($div_display != 'none') {
-                ob_start();
-                    include_once('include/SubPanel/SubPanel.php');
-                    $subpanel_object = new SubPanel($this->module, $_REQUEST['record'], $tab, $thisPanel, $layout_def_key);
-                    $subpanel_object->setTemplateFile('include/SubPanel/SubPanelDynamic.html');
-                    $subpanel_object->display();
-                    $subpanel_data = ob_get_contents();
-                @ob_end_clean();
-                ob_start();
-                    $this->get_buttons($thisPanel,$subpanel_object->subpanel_query);
-                    $tabs_properties[$t]['buttons'] = ob_get_contents();
-                @ob_end_clean();
+            // Get Subpanel
+            include_once('include/SubPanel/SubPanel.php');
+            $subpanel_object = new SubPanel($this->module, $_REQUEST['record'], $tab, $thisPanel, $layout_def_key);
 
-                $tabs_properties[$t]['subpanel_body'] = $subpanel_data;
-//            }
+            $arr = array();
+            // TODO: Remove x-template:
+            $tabs_properties[$t]['subpanel_body'] = $subpanel_object->ProcessSubPanelListView('include/SubPanel/SubPanelDynamic.html', $arr);
+
+            // Get subpanel buttons
+            $tabs_properties[$t]['buttons'] = $this->get_buttons($thisPanel,$subpanel_object->subpanel_query);
+
             array_push($tab_names, $tab);
         }
 
         $tab_names = '["' . join($tab_names, '","') . '"]';
-
-        if(empty($sugar_config['lock_subpanels']) || $sugar_config['lock_subpanels'] == false) {
-
-        }
 
         $module_sub_panels = array_map('array_keys', $module_sub_panels);
         $module_sub_panels = json_encode($module_sub_panels);

--- a/include/SubPanel/tpls/SubPanelTiles.tpl
+++ b/include/SubPanel/tpls/SubPanelTiles.tpl
@@ -26,9 +26,8 @@
 
                         {if $tabs_properties.$i.div_display != 'none'}
                             <script>SUGAR.util.doWhen("typeof(markSubPanelLoaded) != 'undefined'", function() {literal}{ markSubPanelLoaded('{/literal}{$subpanel_tab}{literal}');}{/literal});</script>
+                            {*{$subpanel_tabs_properties.$i.buttons}*}
                         {/if}
-
-                        {$subpanel_tabs_properties.$i.get_buttons}
 
                         <div id="list_subpanel_{$subpanel_tab}">{$subpanel_tabs_properties.$i.subpanel_body}</div>
                     </div>

--- a/include/SubPanel/tpls/SubPanelTiles.tpl
+++ b/include/SubPanel/tpls/SubPanelTiles.tpl
@@ -10,7 +10,7 @@ SubPanelTiles.tpl:<br>
     }
         {/literal}
     </script>
-    {if $show_subpanel_tabs}
+    {*{if $show_subpanel_tabs}*}
         <ul class="noBullet" id="subpanel_list">
             {foreach from=$sub_panel_tabs item=subpanel_tab}
                 <li class="noBullet" id="whole_subpanel_{$subpanel_tab}">
@@ -41,6 +41,6 @@ SubPanelTiles.tpl:<br>
                 </li>
             {/foreach}
         </ul>
-    {/if}
+    {*{/if}*}
 
 /SubPanelTiles.tpl:

--- a/include/SubPanel/tpls/SubPanelTiles.tpl
+++ b/include/SubPanel/tpls/SubPanelTiles.tpl
@@ -1,4 +1,4 @@
-SubPanelTiles.tpl:<br>
+<br>
     <script type="text/javascript" src="{sugar_getjspath file='include/SubPanel/SubPanelTiles.js'}"></script>
     <script>
         {literal}
@@ -12,35 +12,19 @@ SubPanelTiles.tpl:<br>
     </script>
     {*{if $show_subpanel_tabs}*}
         <ul class="noBullet" id="subpanel_list">
-            {foreach from=$sub_panel_tabs item=subpanel_tab}
+            {foreach from=$subpanel_tabs key=i item=subpanel_tab}
                 <li class="noBullet" id="whole_subpanel_{$subpanel_tab}">
-                    <div cookie_name="{$subpanel_tab.cookie_name}" id="subpanel_{$subpanel_tab}" style="display:{$subpanel_tab.div_display}">
+                    <!--subpanel-title -->
+                    <div id="subpanel_title_{$subpanel_tab}" {if empty($sugar_config.lock_subpanels) || $sugar_config.lock_subpanels == false} onmouseover="this.style.cursor = 'move';" {/if}>
+                        {$subpanel_tabs_properties.$i.get_form_header}
+                    </div>
+
+                    <!--subpanel-body -->
+                    <div cookie_name="{$subpanel_tabs_properties.$i.cookie_name}" id="subpanel_{$subpanel_tab}" style="display:{$subpanel_tabs_properties.$i.div_display}">
                         <script>document.getElementById("subpanel_{$subpanel_tab}" ).cookie_name="{$subpanel_tab.cookie_name}";</script>
-
-                    {if empty($show_tabs)}
-                        <a name="{$subpanel_tab}"> </a>
-                        <span id="show_link_{$subpanel_tab}" style="display: {$subpanel_tab.opp_display}">
-                            <a href='#' class='utilsLink' onclick="current_child_field = '{$subpanel_tab}'; showSubPanel('{$subpanel_tab}',null,null,'{$layout_def_key}');document.getElementById('show_link_{$subpanel_tab}').style.display='none';document.getElementById('hide_link_".$tab."').style.display='';return false;">
-                                {$subpanel_tab.show_icon_html}
-                            </a>
-                        </span>
-
-                        <span id="hide_link_{$subpanel_tab}" style="display: {$subpanel_tab.div_display}">
-                            <a href='#' class='utilsLink' onclick="hideSubPanel('{$subpanel_tab}');document.getElementById('hide_link_{$subpanel_tab}').style.display='none';document.getElementById('show_link_{$subpanel_tab}').style.display='';return false;">
-                                {$subpanel_tab.hide_icon_html}
-                            </a>
-                        </span>
-                        <div id="subpanel_title_{$subpanel_tab}" {if empty($sugar_config.lock_subpanels) || $sugar_config.lock_subpanels == false} onmouseover="this.style.cursor = 'move';" {/if}>
-                                {$subpanel_tab.get_form_header}
-                        </div>
-                    {/if}
-
-                        <script>SUGAR.util.doWhen("typeof(markSubPanelLoaded) != 'undefined'\", function() {literal}{markSubPanelLoaded('{/literal}{$subpanel_tab}{literal}');}{/literal});</script>
-                        <div id="list_subpanel_{$subpanel_tab}">{$subpanel_tab.display_spd}</div>
+                        <div id="list_subpanel_{$subpanel_tab}">{$subpanel_tabs_properties.$i.display_spd}</div>
                     </div>
                 </li>
             {/foreach}
         </ul>
     {*{/if}*}
-
-/SubPanelTiles.tpl:

--- a/include/SubPanel/tpls/SubPanelTiles.tpl
+++ b/include/SubPanel/tpls/SubPanelTiles.tpl
@@ -21,10 +21,59 @@
 
                     <!--subpanel-body -->
                     <div cookie_name="{$subpanel_tabs_properties.$i.cookie_name}" id="subpanel_{$subpanel_tab}" style="display:{$subpanel_tabs_properties.$i.div_display}">
+
                         <script>document.getElementById("subpanel_{$subpanel_tab}" ).cookie_name="{$subpanel_tab.cookie_name}";</script>
-                        <div id="list_subpanel_{$subpanel_tab}">{$subpanel_tabs_properties.$i.display_spd}</div>
+
+                        {if $tabs_properties.$i.div_display != 'none'}
+                            <script>SUGAR.util.doWhen("typeof(markSubPanelLoaded) != 'undefined'", function() {literal}{ markSubPanelLoaded('{/literal}{$subpanel_tab}{literal}');}{/literal});</script>
+                        {/if}
+
+                        {$subpanel_tabs_properties.$i.get_buttons}
+
+                        <div id="list_subpanel_{$subpanel_tab}">{$subpanel_tabs_properties.$i.subpanel_body}</div>
                     </div>
                 </li>
             {/foreach}
         </ul>
+
+{if $show_container}
+    </ul>
+    {if !empty($selected_group)}
+        {*closing table from tpls/singletabmenu.tpl*}
+        </td></tr></table>
+    {/if}
+{/if}
+
+{if empty($sugar_config.lock_subpanels) || $sugar_config.lock_subpanels == false}
+    {*drag and drop code*}
+    <script>
+        {literal}
+        var SubpanelInit = function() {
+            SubpanelInitTabNames({/literal}{$tab_names}{literal});
+        }
+        var SubpanelInitTabNames = function(tabNames) {
+            subpanel_dd = new Array();
+            j = 0;
+            for(i in tabNames) {
+                subpanel_dd[j] = new ygDDList('whole_subpanel_' + tabNames[i]);
+                subpanel_dd[j].setHandleElId('subpanel_title_' + tabNames[i]);
+                subpanel_dd[j].onMouseDown = SUGAR.subpanelUtils.onDrag;
+                subpanel_dd[j].afterEndDrag = SUGAR.subpanelUtils.onDrop;
+                j++;
+            }
+            YAHOO.util.DDM.mode = 1;
+        }
+        currentModule = '{/literal}{$module}{literal}';
+        SUGAR.util.doWhen(
+                "typeof(SUGAR.subpanelUtils) == 'object' && typeof(SUGAR.subpanelUtils.onDrag) == 'function'" +
+                " && document.getElementById('subpanel_list')",
+                SubpanelInit
+        );
+        {/literal}
+    </script>
+{/if}
+<script>
+    var ModuleSubPanels = {$module_sub_panels};
+</script>
+
     {*{/if}*}

--- a/include/SubPanel/tpls/SubPanelTiles.tpl
+++ b/include/SubPanel/tpls/SubPanelTiles.tpl
@@ -1,0 +1,46 @@
+SubPanelTiles.tpl:<br>
+    <script type="text/javascript" src="{sugar_getjspath file='include/SubPanel/SubPanelTiles.js'}"></script>
+    <script>
+        {literal}
+    if(document.DetailView != null &&
+        document.DetailView.elements != null &&
+        document.DetailView.elements.layout_def_key != null &&
+        typeof document.DetailView.elements['layout_def_key'] != 'undefined'){
+            document.DetailView.elements['layout_def_key'].value = '{/literal}{$layout_def_key}{literal}';
+    }
+        {/literal}
+    </script>
+    {if $show_subpanel_tabs}
+        <ul class="noBullet" id="subpanel_list">
+            {foreach from=$sub_panel_tabs item=subpanel_tab}
+                <li class="noBullet" id="whole_subpanel_{$subpanel_tab}">
+                    <div cookie_name="{$subpanel_tab.cookie_name}" id="subpanel_{$subpanel_tab}" style="display:{$subpanel_tab.div_display}">
+                        <script>document.getElementById("subpanel_{$subpanel_tab}" ).cookie_name="{$subpanel_tab.cookie_name}";</script>
+
+                    {if empty($show_tabs)}
+                        <a name="{$subpanel_tab}"> </a>
+                        <span id="show_link_{$subpanel_tab}" style="display: {$subpanel_tab.opp_display}">
+                            <a href='#' class='utilsLink' onclick="current_child_field = '{$subpanel_tab}'; showSubPanel('{$subpanel_tab}',null,null,'{$layout_def_key}');document.getElementById('show_link_{$subpanel_tab}').style.display='none';document.getElementById('hide_link_".$tab."').style.display='';return false;">
+                                {$subpanel_tab.show_icon_html}
+                            </a>
+                        </span>
+
+                        <span id="hide_link_{$subpanel_tab}" style="display: {$subpanel_tab.div_display}">
+                            <a href='#' class='utilsLink' onclick="hideSubPanel('{$subpanel_tab}');document.getElementById('hide_link_{$subpanel_tab}').style.display='none';document.getElementById('show_link_{$subpanel_tab}').style.display='';return false;">
+                                {$subpanel_tab.hide_icon_html}
+                            </a>
+                        </span>
+                        <div id="subpanel_title_{$subpanel_tab}" {if empty($sugar_config.lock_subpanels) || $sugar_config.lock_subpanels == false} onmouseover="this.style.cursor = 'move';" {/if}>
+                                {$subpanel_tab.get_form_header}
+                        </div>
+                    {/if}
+
+                        <script>SUGAR.util.doWhen("typeof(markSubPanelLoaded) != 'undefined'\", function() {literal}{markSubPanelLoaded('{/literal}{$subpanel_tab}{literal}');}{/literal});</script>
+                        <div id="list_subpanel_{$subpanel_tab}">{$subpanel_tab.display_spd}</div>
+                    </div>
+                </li>
+            {/foreach}
+        </ul>
+    {/if}
+
+/SubPanelTiles.tpl:

--- a/include/get_form_header.tpl
+++ b/include/get_form_header.tpl
@@ -19,40 +19,38 @@
             {/if}
         {/foreach}
 
-        {if $other_text && $match}
+        {if $other_text && $match == true}
                 <td colspan="10" width="100%"><IMG height="1" width="1" src="{$blankImageURL}" alt=""></td>
             </tr>
                 <tr>
-                    <td width="100%" align="left" valign="middle" nowrap style="padding-bottom: 2px;">$other_text</td>
-
-                {if $show_help}
+                    <td width="100%" align="left" valign="middle" nowrap style="padding-bottom: 2px;">{$other_text}</td>
+                    {if $show_help}
                         <td align="right" nowrap>
-                    {if ($REQUEST.action != "EditView")}
-                        <a href="index.php?{$GLOBALS.request_string}" class="utilsLink">
-                            <img src="{$printImageURL}" alt="{$app_strings.LBL_PRINT}" border="0" align="absmiddle">
-                        </a>&nbsp;
-                        <a href="index.php?{$GLOBALS.request_string}" class="utilsLink">
-                            {$app_strings.LNK_PRINT}
-                        </a>
-                    {/if}
-                        &nbsp;
-                        <a href="index.php?module=Administration&action=SupportPortal&view=documentation&version={$sugar_version}&edition={$sugar_flavor}&lang={$current_language}&help_module={$current_module}&help_action={$current_action}&key={$server_unique_key}"
-                           class="utilsLink" target="_blank">
-                            <img src="{$helpImageURL}" alt="Help" border="0" align="absmiddle">
-                        </a>&nbsp;
-                        <a href="index.php?module=Administration&action=SupportPortal&view=documentation&version={$sugar_version}&edition={$sugar_flavor}&lang={$current_language}&help_module={$current_module}&help_action={$current_action}&key={$server_unique_key}"
-                           class="utilsLink" target="_blank">
-                            {$app_strings.LNK_HELP}
-                        </a>
-                    </td>
+                            {if $REQUEST.action != "EditView"}
+                                <a href="index.php?{$GLOBALS.request_string}" class="utilsLink">
+                                    <img src="{$printImageURL}" alt="{$app_strings.LBL_PRINT}" border="0" align="absmiddle">
+                                </a>&nbsp;
+                                <a href="index.php?{$GLOBALS.request_string}" class="utilsLink">
+                                    {$app_strings.LNK_PRINT}
+                                </a>
+                            {/if}
+                            &nbsp;
+                            <a href="index.php?module=Administration&action=SupportPortal&view=documentation&version={$sugar_version}&edition={$sugar_flavor}&lang={$current_language}&help_module={$current_module}&help_action={$current_action}&key={$server_unique_key}"
+                               class="utilsLink" target="_blank">
+                                <img src="{$helpImageURL}" alt="Help" border="0" align="absmiddle">
+                            </a>&nbsp;
+                            <a href="index.php?module=Administration&action=SupportPortal&view=documentation&version={$sugar_version}&edition={$sugar_flavor}&lang={$current_language}&help_module={$current_module}&help_action={$current_action}&key={$server_unique_key}"
+                               class="utilsLink" target="_blank">
+                                {$app_strings.LNK_HELP}
+                            </a>
+                        </td>
+                {/if}
+        {else}
+                {if $other_text && $is_min_max == false}
+                    <td width="20"><img height="1" width="20" src="{$blankImageURL}" alt=""></td>
+                    <td valign="middle" nowrap width="100%">{$other_text}</td>
                 {else}
-                    {if $other_text && $is_min_max == false}
-                        <td width="20"><img height="1" width="20" src="$blankImageURL" alt=""></td>
-                        <td valign="middle" nowrap width="100%">$other_text</td>
-                    }
-                    {else}
-                        <td width="100%"><img height="1" width="1" src="$blankImageURL" alt=""></td>
-                    {/if}
+                    <td width="100%"><img height="1" width="1" src="{$blankImageURL}" alt=""></td>
                 {/if}
                 {if $show_help}
                     <td align="right" nowrap>

--- a/include/get_form_header.tpl
+++ b/include/get_form_header.tpl
@@ -1,0 +1,79 @@
+{assign var=is_min_max value=$other_text|strpos:"_search.gif"}
+{if $is_min_max !== false}
+    {assign var=form_title value="$other_text $form_title"}
+{/if}
+
+<table width="100%" cellpadding="0" cellspacing="0" border="0" class="formHeader h3Row">
+    <tr>
+        <td nowrap>
+            <h3><span>{$form_title}</span></h3>
+        </td>
+
+        {assign var=keywords expr="array('class=\"button\"', 'class=\"button\"', 'class=button', '</form>')"}
+        {assign var=match value=false}
+
+        {foreach from=$keywords  item=left}
+            {assign var=found_match value=$left|strpos:$other_text}
+            {if $found_match !== false}
+                {assign var=match value=true}
+            {/if}
+        {/foreach}
+
+        {if $other_text && $match}
+                <td colspan="10" width="100%"><IMG height="1" width="1" src="$blankImageURL" alt=""></td>
+            </tr>
+                <tr>
+                    <td width="100%" align="left" valign="middle" nowrap style="padding-bottom: 2px;">$other_text</td>
+
+                {if $show_help}
+                        <td align="right" nowrap>
+                    {if ($REQUEST.action != "EditView")}
+                        <a href="index.php?{$GLOBALS.request_string}" class="utilsLink">
+                            <img src="{$printImageURL}" alt="{$app_strings.LBL_PRINT}" border="0" align="absmiddle">
+                        </a>&nbsp;
+                        <a href="index.php?{$GLOBALS.request_string}" class="utilsLink">
+                            {$app_strings.LNK_PRINT}
+                        </a>
+                    {/if}
+                        &nbsp;
+                        <a href="index.php?module=Administration&action=SupportPortal&view=documentation&version={$sugar_version}&edition={$sugar_flavor}&lang={$current_language}&help_module={$current_module}&help_action={$current_action}&key={$server_unique_key}"
+                           class="utilsLink" target="_blank">
+                            <img src="{$helpImageURL}" alt="Help" border="0" align="absmiddle">
+                        </a>&nbsp;
+                        <a href="index.php?module=Administration&action=SupportPortal&view=documentation&version={$sugar_version}&edition={$sugar_flavor}&lang={$current_language}&help_module={$current_module}&help_action={$current_action}&key={$server_unique_key}"
+                           class="utilsLink" target="_blank">
+                            {$app_strings.LNK_HELP}
+                        </a>
+                    </td>
+                {else}
+                    {if $other_text && $is_min_max == false}
+                        <td width="20"><img height="1" width="20" src="$blankImageURL" alt=""></td>
+                        <td valign="middle" nowrap width="100%">$other_text</td>
+                    }
+                    {else}
+                        <td width="100%"><img height="1" width="1" src="$blankImageURL" alt=""></td>
+                    {/if}
+                {/if}
+                {if $show_help}
+                    <td align="right" nowrap>
+                        {if $REQUEST.action != "EditView"}
+                        <a href="index.php?{$GLOBALS.request_string}" class="utilsLink">
+                            <img src="{$printImageURL}" alt="{$app_strings.LBL_PRINT}" border="0" align="absmiddle">
+                        </a>
+                        &nbsp;
+                        <a href="index.php?{$GLOBALS.request_string}" class="utilsLink">
+                            {$app_strings.LNK_PRINT}</a>
+                        {/if}
+                        &nbsp;
+                        <a href="index.php?module=Administration&action=SupportPortal&view=documentation&version={$sugar_version}&edition={$sugar_flavor}&lang={$current_language}&help_module={$current_module}&help_action={$current_action}&key={$server_unique_key}"
+                           class="utilsLink" target="_blank">
+                            <img src="{$helpImageURL}" alt="{$app_strings.LBL_HELP}" border="0" align="absmiddle">
+                        </a>&nbsp;
+                        <a href="index.php?module=Administration&action=SupportPortal&view=documentation&version={$sugar_version}&edition={$sugar_flavor}&lang={$current_language}&help_module={$current_module}&help_action={$current_action}&key={$server_unique_key}"
+                           class="utilsLink" target="_blank">{$app_strings.LNK_HELP}</a>
+                    </td>
+                {/if}
+        {/if}
+    </tr>
+</table>
+

--- a/include/get_form_header.tpl
+++ b/include/get_form_header.tpl
@@ -20,7 +20,7 @@
         {/foreach}
 
         {if $other_text && $match}
-                <td colspan="10" width="100%"><IMG height="1" width="1" src="$blankImageURL" alt=""></td>
+                <td colspan="10" width="100%"><IMG height="1" width="1" src="{$blankImageURL}" alt=""></td>
             </tr>
                 <tr>
                     <td width="100%" align="left" valign="middle" nowrap style="padding-bottom: 2px;">$other_text</td>

--- a/include/tabs.php
+++ b/include/tabs.php
@@ -38,29 +38,30 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  * display the words  "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  ********************************************************************************/
 
+    /**
+     * Class SugarWidgetTabs
+     *
+     * Displays users subpanels in tabs
+     */
+class SugarWidgetTabs {
 
+    var $tabs;
+    var $current_key;
 
+    function __construct(&$tabs, $current_key, $jscallback) {
 
-
-
-class SugarWidgetTabs
-{
- var $tabs;
- var $current_key;
-
- function __construct(&$tabs,$current_key,$jscallback)
- {
-   $this->tabs = $tabs;
-   $this->current_key = $current_key;
-   $this->jscallback = $jscallback;
- }
+        $this->tabs = $tabs;
+        $this->current_key = $current_key;
+        $this->jscallback = $jscallback;
+    }
 
     /**
      * @deprecated deprecated since version 7.6, PHP4 Style Constructors are deprecated and will be remove in 7.8, please update your code, use __construct instead
      */
-    function SugarWidgetTabs(&$tabs,$current_key,$jscallback){
+    function SugarWidgetTabs(&$tabs, $current_key, $jscallback) {
+
         $deprecatedMessage = 'PHP4 Style Constructors are deprecated and will be remove in 7.8, please update your code';
-        if(isset($GLOBALS['log'])) {
+        if (isset($GLOBALS['log'])) {
             $GLOBALS['log']->deprecated($deprecatedMessage);
         }
         else {
@@ -70,79 +71,14 @@ class SugarWidgetTabs
     }
 
 
- function display()
- {
-	ob_start();
-?>
-<script>
-var keys = [ <?php
-$tabs_count = count($this->tabs);
-for($i=0; $i < $tabs_count;$i++)
-{
- $tab = $this->tabs[$i];
- echo "\"".$tab['key']."\"";
- if ($tabs_count > ($i + 1))
- {
-   echo ",";
- }
+    function display() {
+
+        $template = new Sugar_Smarty();
+        $template->assign('subpanel_tabs', $this->tabs);
+        $template->assign('subpanel_tabs_count', count($this->tabs));
+        $template->assign('jscallback', $this->jscallback);
+        $template->assign('subpanel_current_key', $this->current_key);
+
+        return $template->display('include/tabs.tpl');
+    }
 }
-?>];
-tabPreviousKey = '';
-
-function selectTabCSS(key)
-{
-
-
-  for( var i=0; i<keys.length;i++)
-  {
-   var liclass = '';
-   var linkclass = '';
-
- if ( key == keys[i])
- {
-   var liclass = 'active';
-   var linkclass = 'current';
- }
-  	document.getElementById('tab_li_'+keys[i]).className = liclass;
-
-  	document.getElementById('tab_link_'+keys[i]).className = linkclass;
-  }
-    <?php echo $this->jscallback;?>(key, tabPreviousKey);
-    tabPreviousKey = key;
-}
-</script>
-
-<ul id="searchTabs" class="tablist">
-<?php
-	foreach ($this->tabs as $tab)
-	{
-		$TITLE = $tab['title'];
-		$LI_ID = "";
-		$A_ID = "";
-
-	  if ( ! empty($tab['hidden']) && $tab['hidden'] == true)
-		{
-			  $LI_ID = "style=\"display: none\"";
-			  $A_ID = "style=\"display: none\"";
-
-		} else if ( $this->current_key == $tab['key'])
-		{
-			  $LI_ID = "class=\"active\"";
-			  $A_ID = "class=\"current\"";
-		}
-
-		$LINK = "<li $LI_ID id=\"tab_li_".$tab['link']."\"><a $A_ID id=\"tab_link_".$tab['link']."\" href=\"javascript:selectTabCSS('{$tab['link']}');\">$TITLE</a></li>";
-
-?>
-<?php echo $LINK; ?>
-<?php
-	}
-?>
-</ul>
-<?php
-	$ob_contents = ob_get_contents();
-        ob_end_clean();
-        return $ob_contents;
-	}
-}
-?>

--- a/include/tabs.tpl
+++ b/include/tabs.tpl
@@ -1,0 +1,59 @@
+<br>
+<script>
+    {literal}
+        var keys = [
+    {/literal}
+            {foreach from=$subpanel_tabs key=subpanel_tab_count item=subpanel_tab}
+                {$subpanel_tab},
+            {/foreach}
+    {literal}
+        ];
+    {/literal}
+
+    tabPreviousKey = '';
+    {literal}
+    function selectTabCSS(key)
+    {
+        for( var i=0; i<keys.length;i++)
+        {
+            var liclass = '';
+            var linkclass = '';
+
+            if ( key == keys[i])
+            {
+                var liclass = 'active';
+                var linkclass = 'current';
+            }
+            document.getElementById('tab_li_'+keys[i]).className = liclass;
+            document.getElementById('tab_link_'+keys[i]).className = linkclass;
+        }
+        {/literal}
+
+        {$jscallback}(key, tabPreviousKey);
+
+        {literal}
+        tabPreviousKey = key;
+    }
+    {/literal}
+</script>
+
+
+<ul id="searchTabs" class="tablist">
+    {foreach from=$subpanel_tabs key=subpanel_tab_count item=subpanel_tab}
+
+        {assign var="subpanel_title" value=$subpanel_tab.title}
+        {assign var="li_id" value=""}
+        {assign var="a_id" value=""}
+
+        {if !empty($subpanel_tab.hidden) &&  $subpanel_tab.hidden == true}
+            {assign var="li_id" value="style=\"display: none\";"}
+            {assign var="a_id" value="style=\"display: none\";"}
+        {elseif $subpanel_current_key == $subpanel_tab.key }
+            {assign var="li_id" value="class=\"active\";"}
+            {assign var="a_id" value="class=\"current: none\";"}
+        {/if}
+        {*<li>{$subpanel_title}</li>*}
+        <li {$li_id} id="tab_li_{$subpanel_tab.link}"><a {$a_id} id="tab_link_{$subpanel_tab.link}" href="javascript:selectTabCSS('{$subpanel_tab.link}_sp_tab');">{$subpanel_title}</a></li>
+
+    {/foreach}
+</ul>

--- a/include/utils/layout_utils.php
+++ b/include/utils/layout_utils.php
@@ -67,7 +67,21 @@ function get_form_header(
     $printImageURL = SugarThemeRegistry::current()->getImageURL("print.gif");
     $helpImageURL  = SugarThemeRegistry::current()->getImageURL("help.gif");
 
+    $keywords = array("/class=\"button\"/","/class='button'/","/class=button/","/<\/form>/");
+    $match = false;
+    foreach ($keywords as $left) {
+        if (preg_match($left,$other_text)) {
+            $match = true;
+        }
+    }
+
+    $other_text_and_match = false;
+    if ($other_text && $match) {
+        $other_text_and_match = true;
+    }
+
     $template = new Sugar_Smarty();
+
     $template->assign('sugar_version', $sugar_version);
     $template->assign('sugar_flavor', $sugar_flavor);
     $template->assign('server_unique_key', $server_unique_key);
@@ -76,6 +90,8 @@ function get_form_header(
     $template->assign('current_action', $current_action);
     $template->assign('app_strings', $app_strings);
 
+    $template->assign('match', $match);
+    $template->assign('other_text_and_match', other_text_and_match);
     $template->assign('blankImageURL', $blankImageURL);
     $template->assign('printImageURL', $printImageURL);
     $template->assign('helpImageURL', $helpImageURL);

--- a/include/utils/layout_utils.php
+++ b/include/utils/layout_utils.php
@@ -51,113 +51,44 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  * @param  $form_title string to display as the title in the header
  * @param  $other_text string to next to the title.  Typically used for form buttons.
  * @param  $show_help  boolean which determines if the print and help links are shown.
+ * @param  $print_out  boolean which determines if the print/echo out code
  * @return string HTML
  */
 function get_form_header(
     $form_title,
     $other_text,
-    $show_help
+    $show_help,
+    $print_out = false
     )
 {
-    global $sugar_version, $sugar_flavor, $server_unique_key, $current_language, $current_module, $current_action;
-    global $app_strings;
+    global $sugar_version, $sugar_flavor, $server_unique_key, $current_language, $current_module, $current_action, $app_strings;
 
     $blankImageURL = SugarThemeRegistry::current()->getImageURL('blank.gif');
     $printImageURL = SugarThemeRegistry::current()->getImageURL("print.gif");
     $helpImageURL  = SugarThemeRegistry::current()->getImageURL("help.gif");
 
-    $is_min_max = strpos($other_text,"_search.gif");
-    if($is_min_max !== false)
-        $form_title = "{$other_text}&nbsp;{$form_title}";
+    $template = new Sugar_Smarty();
+    $template->assign('sugar_version', $sugar_version);
+    $template->assign('sugar_flavor', $sugar_flavor);
+    $template->assign('server_unique_key', $server_unique_key);
+    $template->assign('current_language', $current_language);
+    $template->assign('current_module', $current_module);
+    $template->assign('current_action', $current_action);
+    $template->assign('app_strings', $app_strings);
 
-    $the_form = <<<EOHTML
-<table width="100%" cellpadding="0" cellspacing="0" border="0" class="formHeader h3Row">
-<tr>
-<td nowrap><h3><span>{$form_title}</span></h3></td>
-EOHTML;
+    $template->assign('blankImageURL', $blankImageURL);
+    $template->assign('printImageURL', $printImageURL);
+    $template->assign('helpImageURL', $helpImageURL);
+    $template->assign('show_help', $show_help);
+    $template->assign('other_text', $other_text);
+    $template->assign('form_title', $form_title);
 
-    $keywords = array("/class=\"button\"/","/class='button'/","/class=button/","/<\/form>/");
-    $match="";
-    foreach ($keywords as $left)
-        if (preg_match($left,$other_text))
-            $match = true;
-
-    if ($other_text && $match) {
-        $the_form .= <<<EOHTML
-<td colspan='10' width='100%'><IMG height='1' width='1' src='$blankImageURL' alt=''></td>
-</tr>
-<tr>
-<td width='100%' align='left' valign='middle' nowrap style='padding-bottom: 2px;'>$other_text</td>
-EOHTML;
-        if ($show_help) {
-            $the_form .= "<td align='right' nowrap>";
-            if ($_REQUEST['action'] != "EditView") {
-                $the_form .= <<<EOHTML
-    <a href='index.php?{$GLOBALS['request_string']}' class='utilsLink'>
-    <img src='{$printImageURL}' alt='{$app_strings["LBL_PRINT"]}' border='0' align='absmiddle'>
-    </a>&nbsp;
-    <a href='index.php?{$GLOBALS['request_string']}' class='utilsLink'>
-    {$app_strings['LNK_PRINT']}
-    </a>
-EOHTML;
-            }
-            $the_form .= <<<EOHTML
-&nbsp;
-    <a href='index.php?module=Administration&action=SupportPortal&view=documentation&version={$sugar_version}&edition={$sugar_flavor}&lang={$current_language}&help_module={$current_module}&help_action={$current_action}&key={$server_unique_key}'
-       class='utilsLink' target='_blank'>
-    <img src='{$helpImageURL}' alt='Help' border='0' align='absmiddle'>
-    </a>&nbsp;
-    <a href='index.php?module=Administration&action=SupportPortal&view=documentation&version={$sugar_version}&edition={$sugar_flavor}&lang={$current_language}&help_module={$current_module}&help_action={$current_action}&key={$server_unique_key}'
-        class='utilsLink' target='_blank'>
-    {$app_strings['LNK_HELP']}
-    </a>
-</td>
-EOHTML;
-        }
-    } 
-    else {
-        if ($other_text && $is_min_max === false) {
-            $the_form .= <<<EOHTML
-<td width='20'><img height='1' width='20' src='$blankImageURL' alt=''></td>
-<td valign='middle' nowrap width='100%'>$other_text</td>
-EOHTML;
-        }
-        else {
-            $the_form .= <<<EOHTML
-<td width='100%'><IMG height='1' width='1' src='$blankImageURL' alt=''></td>
-EOHTML;
-        }
-
-        if ($show_help) {
-            $the_form .= "<td align='right' nowrap>";
-            if ($_REQUEST['action'] != "EditView") {
-                $the_form .= <<<EOHTML
-    <a href='index.php?{$GLOBALS['request_string']}' class='utilsLink'>
-    <img src='{$printImageURL}' alt='{$app_strings['LBL_PRINT']}' border='0' align='absmiddle'>
-    </a>&nbsp;
-    <a href='index.php?{$GLOBALS['request_string']}' class='utilsLink'>
-    {$app_strings['LNK_PRINT']}</a>
-EOHTML;
-            }
-            $the_form .= <<<EOHTML
-    &nbsp;
-    <a href='index.php?module=Administration&action=SupportPortal&view=documentation&version={$sugar_version}&edition={$sugar_flavor}&lang={$current_language}&help_module={$current_module}&help_action={$current_action}&key={$server_unique_key}'
-       class='utilsLink' target='_blank'>
-    <img src='{$helpImageURL}' alt='{$app_strings['LBL_HELP']}' border='0' align='absmiddle'>
-    </a>&nbsp;
-    <a href='index.php?module=Administration&action=SupportPortal&view=documentation&version={$sugar_version}&edition={$sugar_flavor}&lang={$current_language}&help_module={$current_module}&help_action={$current_action}&key={$server_unique_key}'
-        class='utilsLink' target='_blank'>{$app_strings['LNK_HELP']}</a>
-</td>
-EOHTML;
-        }
+    $template_output = $template->fetch('include/get_form_header.tpl');
+    if($print_out) {
+        echo $template_output;
     }
 
-    $the_form .= <<<EOHTML
-</tr>
-</table>
-EOHTML;
-
-    return $the_form;
+    return $template_output;
 }
 
 /**

--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -3875,7 +3875,8 @@ fieldset[disabled] .btn-primary.active {
 #EditView_tabs .id-ff-remove,
 #EditView_tabs .edit [type="button"],
 #conditionLines [type="button"],
-#actionLines [type="button"] {
+#actionLines [type="button"],
+#deleteGroup img {
     margin-right: 4px;
     padding: 0px;
     background-color: #F08377;
@@ -3896,6 +3897,12 @@ fieldset[disabled] .btn-primary.active {
 #conditionLines [type="button"] img,
 #actionLines [type="button"] img {
     content: url('../../../../index.php?entryPoint=getImage&themeName=SuiteP&imageName=id-ff-remove-nobg.png');
+    height: 32px;
+    width: 32px;
+}
+
+#deleteGroup img {
+    content: url('../../../../index.php?entryPoint=getImage&themeName=SuiteP&imageName=id-ff-clear.png');
     height: 32px;
     width: 32px;
 }
@@ -4964,15 +4971,26 @@ span#quickcreateplus {
     border-radius: 50%;
 }
 
-#conditionLines_head, #fieldLines_head {
+#conditionLines_head,
+#fieldLines_head, #lineItems,
+table#lineItems,
+#lineItems table,
+#lineItems thead,
+#lineItems tr,
+#lineItems td {
     background: none !important;
 }
 
-#actionLines, #actionLines table, #actionLines tr, #actionLines td {
+#actionLines,
+#actionLines table,
+#actionLines tr,
+#actionLines td {
     border: 1px solid transparent !important;
 }
 
-#actionLines, #actionLines table {
+#actionLines,
+#actionLines table,
+#line_items table {
     clear: both;
     border-radius: 4px;
     width: 100%;
@@ -4987,7 +5005,7 @@ table#actionLines > tr > td > table td:first-of-type {
 }
 
 
-table#actionLines > tr > td > table {
+table#actionLines > tr > td > table, #line_items table > tr > td > table {
     background: #F5F5F5;
     margin: 16px 0 0 0 !important;
     clear: both;
@@ -4996,6 +5014,11 @@ table#actionLines > tr > td > table {
 
 #conditionLines td,  #fieldLines td {
     padding: 8px;
+}
+
+
+#lineItems table > thead:nth-child(1) > tr > td:nth-child(1) [type="text"] {
+    width: 50% !important;
 }
 
 li.moremenu {


### PR DESCRIPTION
Moving sub panel hard coded content to tpls.

## Description
This effects:
- elements that use the get_form_header() function (include/utils/layout_utils.php)
- elements that use the SugarWidgetTabs class  (include/tabs.php)
- elements that use the SubPanelTiles class (include/SubPanel/SubPanelTiles.php)
- Dashboard
- Dashlets
- Subpanels

## Motivation and Context
In order to customise the the html per theme, we need to have a tpl we can override. My intention is to move to using the new bootstrap panels that are in the detail and edit views.

## How To Test This
- Check any page that has subpanels or dashlets.
- Test each theme to ensure they behave the same way.

## Types of changes
- Feature

### Final checklist
- [] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.
