### PR TITLE
Fixed #1029 - prevent user from adding or editing field if the filds name already exists.

### DIFF
--- a/modules/DynamicFields/templates/Fields/Forms/enum.tpl
+++ b/modules/DynamicFields/templates/Fields/Forms/enum.tpl
@@ -49,7 +49,7 @@
 	<td class='mbLBL'>{sugar_translate module="DynamicFields" label="LBL_DROP_DOWN_LIST"}:</td>
 	<td>
 	{if $hideLevel < 5 && empty($vardef.function)}
-		{html_options name="options" id="options" selected=$selected_dropdown values=$dropdowns output=$dropdowns onChange="ModuleBuilder.dropdownChanged(this.value);"}{if !$uneditable}<br><input type='button' value='{sugar_translate module="DynamicFields" label="LBL_BTN_EDIT"}' class='button' onclick="ModuleBuilder.moduleDropDown(this.form.options.value, this.form.options.value);">&nbsp;<input type='button' value='{sugar_translate module="DynamicFields" label="LBL_BTN_ADD"}' class='button' onclick="ModuleBuilder.moduleDropDown('', this.form.name.value);">{/if}
+		{html_options name="options" id="options" selected=$selected_dropdown values=$dropdowns output=$dropdowns onChange="ModuleBuilder.dropdownChanged(this.value);"}{if !$uneditable}<br><input type='button' value='{sugar_translate module="DynamicFields" label="LBL_BTN_EDIT"}' class='button' onclick="{literal}if(check_form('popup_form')) { ModuleBuilder.moduleDropDown(this.form.options.value, this.form.options.value); }{/literal}">&nbsp;<input type='button' value='{sugar_translate module="DynamicFields" label="LBL_BTN_ADD"}' class='button' onclick="{literal}if(check_form('popup_form')) { ModuleBuilder.moduleDropDown('', this.form.name.value); }{/literal}">{/if}
 	{else}
 		<input type='hidden' name='options' value='{$selected_dropdown}'>{$selected_dropdown}
 	{/if}


### PR DESCRIPTION
Original problem:

An issue occurs when a user adds a new drop down field with a new drop down list for the field. For example, if a user adds a new 'employees' field with a drop down list 'employees_list' and saves this, the existing core 'employees' field is modified, instead of a new 'employees_c' field being generated. This could have further implications on existing functionality/data.

Solution:
added some JavaScript to prevent user from adding or editing field if the filds name already exists.