### PR TITLE
Fixed #1309 - Reports export to csv correctly when date parameter is …

### DIFF
--- a/modules/AOR_Reports/AOR_Report.js
+++ b/modules/AOR_Reports/AOR_Report.js
@@ -38,6 +38,21 @@ $(document).ready(function() {
             var fieldType = $('#aor_conditions_value_type\\['+ln+'\\]').val();
             _form.append('<input type="hidden" name="parameter_type[]" value="'+fieldType+'">');
             var fieldInput = $('#aor_conditions_value\\['+ln+'\\]').val();
+            if($('#aor_conditions_value\\['+ln+'\\]\\[0\\]').length){
+                var fieldValue = $('#aor_conditions_value\\['+ln+'\\]\\[0\\]').val();
+                var fieldSign = $('#aor_conditions_value\\['+ln+'\\]\\[1\\]').val();
+                var fieldNumber = $('#aor_conditions_value\\['+ln+'\\]\\[2\\]').val();
+                var fieldTime = $('#aor_conditions_value\\['+ln+'\\]\\[3\\]').val();
+                _form.append('<input type="hidden" name="parameter_value[]" value="'+fieldValue+'">');
+                _form.append('<input type="hidden" name="parameter_value[]" value="'+fieldSign+'">');
+                _form.append('<input type="hidden" name="parameter_value[]" value="'+fieldNumber+'">');
+                _form.append('<input type="hidden" name="parameter_value[]" value="'+fieldTime+'">');
+            }
+            if($('#aor_conditions_value\\['+index+'\\]').hasClass('date_input')) { // only change to DB format if its a date
+                if ($('#aor_conditions_value\\[' + ln + '\\]').hasClass('date_input')) {
+                    fieldInput = $.datepicker.formatDate('yy-mm-dd', new Date(fieldInput));
+                }
+            }
             _form.append('<input type="hidden" name="parameter_value[]" value="'+fieldInput+'">');
         });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixed #1309 - Reports export to csv correctly when date parameter is selected.
## Description

<!--- Describe your changes in detail -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here unless your commit contains the issue number -->

Added the same code from the report.tpl that retrieves each variable and appends them into the parameter_value array to the download_csv_button_old function in AOR_Report.js. Was previously only grabbing a single field.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Allows the user to export a csv file when a date field parameter is in use.
## How To Test This

<!--- Please describe in detail how to test your changes. -->

Create a report that uses date type condition and set it to become a parameter. Check to make sure that the report is displaying the correct results, and then select the export option. If working, it should have the same data as on the report detail view.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
### Final checklist

<!--- Go over all the following points and check all the boxes that apply. --->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->

…selected
