### PR TITLE
External Meeting Response URL

### DIFF
--- a/modules/Administration/AOPAdmin.php
+++ b/modules/Administration/AOPAdmin.php
@@ -104,6 +104,7 @@ if (isset($_REQUEST['do']) && $_REQUEST['do'] == 'save') {
     $cfg->config['aop']['joomla_account_creation_email_template_id'] = $_REQUEST['joomla_account_creation_email_template_id'];
     $cfg->config['aop']['support_from_address'] = $_REQUEST['support_from_address'];
     $cfg->config['aop']['support_from_name'] = $_REQUEST['support_from_name'];
+    $cfg->config['aop']['meeting_response_url'] = $_REQUEST['meeting_response_url'];
     /*
      * We save the case_status_changes array as json since the way config changes are persisted to config.php
      * means that removing entries is tricky. json simplifies this.

--- a/modules/Administration/AOPAdmin.tpl
+++ b/modules/Administration/AOPAdmin.tpl
@@ -70,6 +70,13 @@
             </td>
 
         </tr>
+	<tr id="meeting_response_url_row">
+	    <td  scope="row" width="200">{$MOD.LBL_AOP_MEETING_RESPONSE_URL}: </td>
+	    <td  >
+	        <input type='text' id='meeting_response_url' name='meeting_response_url' value='{$config.meeting_response_url}' />
+	    </td>
+	</tr>
+
         <!--<tr>
             <td  scope="row" width="200">{$MOD.LBL_AOP_JOOMLA_ACCESS_KEY}: </td>
             <td  >

--- a/modules/Administration/language/en_us.lang.php
+++ b/modules/Administration/language/en_us.lang.php
@@ -1208,6 +1208,8 @@ $mod_strings = array(
     'LBL_AOP_CASE_REMINDER_EMAIL_TEMPLATE' => 'Case Reminder Email Template',
     'LBL_AOP_JOOMLA_ACCOUNT_CREATION_EMAIL_TEMPLATE' => 'Joomla Support Portal Account Creation Template',
 
+    'LBL_AOP_MEETING_RESPONSE_URL' => 'Meeting Response URL',
+
     'LBL_AOP_BUSINESS_HOURS_SETTINGS' => 'Business Hours',
     'LBL_AOP_OPENING_DAYS' => 'Opening Days',
     'LBL_AOP_OPENING_HOURS' => 'Opening Hours',

--- a/modules/Contacts/AcceptDecline.php
+++ b/modules/Contacts/AcceptDecline.php
@@ -95,7 +95,9 @@ if (!empty($responseUrl)) {
         $description = $result->description;
         $name = $result->name;
         $location = $result->location;
-        $start = preg_replace('/[0-9][0-9]:[0-9][0-9]/', $result->time_start, $result->date_start).' '.date('T');
+	$datetime = new DateTime($result->date_start.' UTC');
+        $datetime->setTimezone(new DateTimeZone(date('T')));
+        $start = $datetime->format('l m/d/Y - g:i A T');
 
         $append = "meeting_accept_status=".urlencode($status);
         $append .= "&meeting_name=".urlencode($name);
@@ -104,10 +106,11 @@ if (!empty($responseUrl)) {
         $append .= "&meeting_start=".urlencode($start);
 
 
-        if (strpos($responseUrl, '?') === false)
+        if (strpos($responseUrl, '?') === false) {
                 $responseUrl .= '?';
-        else
+	} else {
                 $responseUrl .= '&';
+	}
 
         $responseUrl .= $append;
 

--- a/modules/Contacts/AcceptDecline.php
+++ b/modules/Contacts/AcceptDecline.php
@@ -88,6 +88,32 @@ if($result == null) {
 
 $focus->set_accept_status($current_entity,$_REQUEST['accept_status']);
 
+$responseUrl = trim($sugar_config['aop']['meeting_response_url']);
+
+if (!empty($responseUrl)) {
+        $status = $_REQUEST['accept_status'];
+        $description = $result->description;
+        $name = $result->name;
+        $location = $result->location;
+        $start = preg_replace('/[0-9][0-9]:[0-9][0-9]/', $result->time_start, $result->date_start).' '.date('T');
+
+        $append = "meeting_accept_status=".urlencode($status);
+        $append .= "&meeting_name=".urlencode($name);
+        $append .= "&meeting_description=".urlencode($description);
+        $append .= "&meeting_location=".urlencode($location);
+        $append .= "&meeting_start=".urlencode($start);
+
+
+        if (strpos($responseUrl, '?') === false)
+                $responseUrl .= '?';
+        else
+                $responseUrl .= '&';
+
+        $responseUrl .= $append;
+
+        header('Location: '.$responseUrl);
+}
+
 print $app_strings['LBL_STATUS_UPDATED']."<BR><BR>";
 print $app_strings['LBL_STATUS']. " ". $app_list_strings['dom_meeting_accept_status'][$_REQUEST['accept_status']];
 print "<BR><BR>";


### PR DESCRIPTION
This is a new feature that allows users to define a custom URL that users who click on a response link within a meeting invitation get redirected to instead of seeing the standard meeting response page.
## Description

If the user defines a meeting response URL under Admin > AOP Settings. The meeting response page will forward to the set URL instead of displaying the standard meeting response page. If there is no URL set nothing change. Therefore this will only affect users that actively provide a value. In addition it will append some variables to the URL to allow the response page to display some details about the meeting.
## Motivation and Context

When SuiteCRM sends out meeting invitations the user is supposed to use the links to accept or decline the invitation. So far the response page has been very simple and there was no way to customize it either. In addition it displayed a link to the meeting record in sugar which customers usually can't access. In my case this kept me from using the meetings module altogether. 
## How To Test This
1. Go under Admin > AOP Settings and set a Meeting Response URL
2. Create a new meeting and send our invites. 
3. Click on one of the response links in the invitation email 
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
### Final checklist

<!--- Go over all the following points and check all the boxes that apply. --->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
