### PR TITLE
Reports with NULL value conditions fixed

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -1412,7 +1412,8 @@ class AOR_Report extends Basic {
                     }
 
                     if($condition->value_type == 'Value' && !$condition->value && $condition->operator == 'Equal_To') {
-                        $value = "{$value} OR {$field} IS NULL";
+                        $value = "{$value} OR {$field} IS NULL)";
+                        $parenthesisForNull = true;
                     }
 
                     if(!$where_set) {
@@ -1443,7 +1444,10 @@ class AOR_Report extends Basic {
                                     break;
                             }
                         } else {
-                            if (!$where_set) $query['where'][] = ($tiltLogicOp ? '' : ($condition->logic_op ? $condition->logic_op . ' ': 'AND ')) . $field . ' ' . $app_list_strings['aor_sql_operator_list'][$condition->operator] . ' ' . $value;
+                            if (!$where_set) {
+                                $query['where'][] = ($tiltLogicOp ? '' : ($condition->logic_op ? $condition->logic_op . ' ': 'AND ')) . ($parenthesisForNull ? ' (' : '') . $field . ' ' . $app_list_strings['aor_sql_operator_list'][$condition->operator] . ' ' . $value;
+                                $parenthesisForNull = false;
+                            }
                         }
                     }
                     $tiltLogicOp = false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixed an issue in reports where conditions after a condition with it's value set to NULL would be ignored.
## Description

<!--- Describe your changes in detail -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here unless your commit contains the issue number -->

In AOR_Reports.php, the build_report_query_where function builds the query for the condition with an empty value in a certain way. However, originally it would not use parenthesis for this part of the query, meaning the OR operator would affect the rest of the query. The change places the brackets around the specific section of the query for the NULL value so that it is contained.  

Issue link: #1812
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Allows the user to build a report with multiple NULL value conditions and place them in any order.
## How To Test This

<!--- Please describe in detail how to test your changes. -->
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
### Final checklist

<!--- Go over all the following points and check all the boxes that apply. --->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
