### PR TITLE
Fixed  #99 Issue with apostrophes in search

### DIFF
--- a/modules/Home/UnifiedSearchAdvanced.php
+++ b/modules/Home/UnifiedSearchAdvanced.php
@@ -310,7 +310,7 @@ class UnifiedSearchAdvanced {
                 //add inner joins back into the where clause
                 $params = array('custom_select' => "");
                 foreach($innerJoins as $field=>$def) {
-                    if (isset ($def['db_field'])) {
+                    if (isset($def['db_field'])) {
                       foreach($def['db_field'] as $dbfield)
                           $where_clauses[] = $dbfield . " LIKE '" . $this->query_string . "%'";
                           $params['custom_select'] .= ", $dbfield";

--- a/modules/Home/UnifiedSearchAdvanced.php
+++ b/modules/Home/UnifiedSearchAdvanced.php
@@ -312,7 +312,7 @@ class UnifiedSearchAdvanced {
                 foreach($innerJoins as $field=>$def) {
                     if (isset($def['db_field'])) {
                       foreach($def['db_field'] as $dbfield)
-                          $where_clauses[] = $dbfield . " LIKE '" . $this->query_string . "%'";
+                          $where_clauses[] = $dbfield . " LIKE '" . $GLOBALS[db]->quote($this->query_string) . "%'";
                           $params['custom_select'] .= ", $dbfield";
                           $params['distinct'] = true;
                           //$filterFields[$dbfield] = $dbfield;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Couple changes in modules/Home/UnifiedSearchAdvanced.php
## Description
<!--- Describe your changes in detail -->
Modified $where_clauses[]
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
- create number of contacts
- open SuiteCRM
- in global search type some record with apostrophe
- click search
- the output displays searched record
- click on basic search
- after apostrophe apear "/" 
- after search again another 2 "/"
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Remove "/" appearience in record
## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
