### PR TITLE
Suitep inline edit

### DIFF
--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -204,7 +204,7 @@ function validateFormAndSave(field,id,module,type){
         var valid_form = check_form("EditView");
         if(valid_form){
             handleSave(field, id, module, type)
-            $(document).off('click');
+            clickListenerActive = false;
         }else{
             return false
         };
@@ -229,9 +229,11 @@ function validateFormAndSave(field,id,module,type){
  * @param module - the module we are editing
  */
 
+var ie_field, ie_id, ie_module, ie_type, ie_message_field;
+var clickListenerActive = false;
 function clickedawayclose(field,id,module, type){
     // Fix for issue #373 get name from system field name.
-    var message_field = 'LBL_' + field.toUpperCase();
+    message_field = 'LBL_' + field.toUpperCase();
     message_field = SUGAR.language.get(module, message_field);
 
     // Fix for issue #373 remove ':'
@@ -239,19 +241,30 @@ function clickedawayclose(field,id,module, type){
     if (':'.toUpperCase() === last_charachter.toUpperCase()) {
         message_field = message_field.substring(0, message_field.length - 1);
     }
-
-    $(document).on('click', function (e) {
-
-        if(!$(e.target).parents().is(".inlineEditActive, .cal_panel") && !$(e.target).hasClass("inlineEditActive")){
-            var output_value = loadFieldHTMLValue(field,id,module);
+    ie_field = field;
+    ie_id = id;
+    ie_module = module;
+    ie_type = type;
+    ie_message_field = message_field;
+    clickListenerActive = true;
+}
+$(document).on('click', function (e) {
+    if(clickListenerActive) {
+        var field = ie_field;
+        var id = ie_id;
+        var module = ie_module;
+        var type = ie_type;
+        var message_field = ie_message_field;
+        if (!$(e.target).parents().is(".inlineEditActive, .cal_panel") && !$(e.target).hasClass("inlineEditActive")) {
+            var output_value = loadFieldHTMLValue(field, id, module);
             var user_value = getInputValue(field, type);
             // Fix for issue #373 strip HTML tags for correct comparison
             var output_value_compare = $(output_value).text();
-            if(user_value != output_value_compare) {
-                var r = confirm( SUGAR.language.translate('app_strings', 'LBL_CONFIRM_CANCEL_INLINE_EDITING') + message_field);
-                if(r == true) {
+            if (user_value != output_value_compare) {
+                var r = confirm(SUGAR.language.translate('app_strings', 'LBL_CONFIRM_CANCEL_INLINE_EDITING') + message_field);
+                if (r == true) {
                     var output = setValueClose(output_value);
-                    $(document).off('click');
+                    clickListenerActive = false;
                 } else {
                     $("#" + field).focus();
                     e.preventDefault();
@@ -259,13 +272,11 @@ function clickedawayclose(field,id,module, type){
             } else {
                 // user hasn't changed value so can close field without warning them first
                 var output = setValueClose(output_value);
-                $(document).off('click');
+                clickListenerActive = false;
             }
         }
-
-    });
-}
-
+    }
+});
 
 /**
  * Depending on what type of field we are editing the parts of the field may differ and need different jquery to pickup the values

--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -97,12 +97,15 @@ function buildEditField(){
             }
         }
     });
-    $(".inlineEdit").dblclick(function(e) {
+
+
+    var onInlineEditDblClick = function(elem, e) {
+        var _this = elem;
         e.preventDefault();
-        //depending on what view you are using will find the id,module,type of field, and field name from the view
+        // depending on what view you are using will find the id,module,type of field, and field name from the view
         if(view == "DetailView"){
-            var field = $(this).attr( "field" );
-            var type = $(this).attr( "type" );
+            var field = $(_this).attr( "field" );
+            var type = $(_this).attr( "type" );
 
             if(currentModule){
                 var module = currentModule;
@@ -112,10 +115,10 @@ function buildEditField(){
 
             var id = $("input[name=record]").attr( "value" );
         }else{
-            var field = $(this).attr( "field" );
-            var type = $(this).attr( "type" );
+            var field = $(_this).attr( "field" );
+            var type = $(_this).attr( "type" );
             var module = $("#displayMassUpdate input[name=module]").val();
-            var id = $(this).closest('tr').find('[type=checkbox]').attr( "value" );
+            var id = $(_this).closest('tr').find('[type=checkbox]').attr( "value" );
         }
 
         //If we find all the required variables to do inline editing.
@@ -128,19 +131,19 @@ function buildEditField(){
 
             //If we have the field html append it to the div we clicked.
             if(html){
-                $(this).html(validation + "<form name='EditView' id='EditView'><div id='inline_edit_field'>" + html + "</div><a id='inlineEditSaveButton'></a></form>");
+                $(_this).html(validation + "<form name='EditView' id='EditView'><div id='inline_edit_field'>" + html + "</div><a id='inlineEditSaveButton'></a></form>");
                 $("#inlineEditSaveButton").load(inlineEditSaveButtonImg);
                 //If the field is a relate field we will need to retrieve the extra js required to make the field work.
                 if(type == "relate" || type == "parent") {
                     var relate_js = getRelateFieldJS(field, module, id);
-                    $(this).append(relate_js);
-                    SUGAR.util.evalScript($(this).html());
+                    $(_this).append(relate_js);
+                    SUGAR.util.evalScript($(_this).html());
                     //Needs to be called to enable quicksearch/typeahead functionality on the field.
                     enableQS(true);
                 }
 
                 //Add the active class so we know which td we are editing as they all have the inlineEdit class.
-                $(this).addClass("inlineEditActive");
+                $(_this).addClass("inlineEditActive");
 
                 //Put the cursor in the field if possible.
                 $("#" + field).focus();
@@ -151,6 +154,7 @@ function buildEditField(){
                 }
 
                 //We can only edit one field at a time currently so turn off the on dblclick event
+                $(".inlineEdit").off('click');
                 $(".inlineEdit").off('dblclick');
 
                 //Call the click away function to handle if the user has clicked off the field, if they have it will close the form.
@@ -161,8 +165,31 @@ function buildEditField(){
 
             }
         }
+    };
 
+    var touchtime = 0;
+    $('.inlineEdit').on('click', function(e) {
+        if(touchtime == 0) {
+            //set first click
+            touchtime = new Date().getTime();
+        } else {
+            //compare first click to this click and see if they occurred within double click threshold
+            if(((new Date().getTime())-touchtime) < 800) {
+                //double click occurred
+                //alert("double clicked");
+                touchtime = 0;
+                onInlineEditDblClick(this, e);
+            } else {
+                //not a double click so set as a new first click
+                touchtime = new Date().getTime();
+            }
+        }
     });
+
+    $(".inlineEdit").dblclick(function(e) {
+        onInlineEditDblClick(this, e);
+    });
+
 }
 
 /**


### PR DESCRIPTION
In-Line Editing Issues

## Description
"After Inline editing a Field, (And Saving changes), You are unable to expand the Action Menu.
Also, refreshing the page after inline editing redirects to the Homepage."

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->