### PR TITLE
Fixed #1783 Inline editing of date fields resets date to current date

### DIFF
--- a/include/InlineEditing/InlineEditing.php
+++ b/include/InlineEditing/InlineEditing.php
@@ -258,7 +258,8 @@ function getEditFieldHTML($module, $fieldname, $aow_field, $view = 'EditView', $
         $value = $focus->convertField($value, $fieldlist[$fieldname]);
         $fieldlist[$fieldname]['name'] = $aow_field;
         if (empty($value) == "") {
-            $value = str_replace("%", "", date($date_format));
+            $date_format_new = str_replace("%", "", $date_format);	
+			$value = date($date_format_new, strtotime($value));
         }
         $fieldlist[$fieldname]['value'] = $value;
     } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Changes done in include\InlineEditing\InlineEditing.php
## Description

<!--- Describe your changes in detail -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here unless your commit contains the issue number -->

relates to issue #1783 & #1042
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
## How To Test This

<!--- Please describe in detail how to test your changes. -->
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
### Final checklist

<!--- Go over all the following points and check all the boxes that apply. --->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
