### PR TITLE
Fixed if that was preventing date getting set properly. Fixed #1783

### DIFF
--- a/include/InlineEditing/InlineEditing.php
+++ b/include/InlineEditing/InlineEditing.php
@@ -257,7 +257,7 @@ function getEditFieldHTML($module, $fieldname, $aow_field, $view = 'EditView', $
     } else if (isset($fieldlist[$fieldname]['type']) && ($fieldlist[$fieldname]['type'] == 'date')) {
         $value = $focus->convertField($value, $fieldlist[$fieldname]);
         $fieldlist[$fieldname]['name'] = $aow_field;
-        if (empty($value) == "") {
+        if (empty($value)) {
             $value = str_replace("%", "", date($date_format));
         }
         $fieldlist[$fieldname]['value'] = $value;


### PR DESCRIPTION
Fixes issue #1783 with inline editing. This is also one of the 2 issues mentioned in #1042. 
## Description

Fixes the if statement in inline editing as before it was always setting date fields to the current date rather than the date that was previously set
## Motivation and Context

Stops date fields defaulting to the current date rather than the previous date set by the user when inline editing
## How To Test This

Set a date in any module then use inline editing to update it. The initial value shown should be the date that was previously set
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
### Final checklist

<!--- Go over all the following points and check all the boxes that apply. --->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
