### PR TITLE
Fixed #1867 - Making the quick create menu translatable.

### DIFF
--- a/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -466,7 +466,7 @@
             </form>
             <div id="quickcreatetop" class="create dropdown nav navbar-nav navbar-right">
                 <a class="dropdown-toggle" aria-expanded="false">
-                    Create
+                    {$APP.LBL_CREATE_BUTTON_LABEL}
                 </a>
                 <ul class="dropdown-menu" role="menu">
                     <li>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
I modified the SuiteP template to translate the label LBL_CREATE_BUTTON_LABEL for the quick create button on the global navigation

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows the label to be translated into other languages.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

- Install an other language pack.
- Check that the button to ensure that it has been translated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
