### PR TITLE
Fixed hide_subpanels config option with SuiteP

### DIFF
--- a/include/SubPanel/SubPanelTiles.php
+++ b/include/SubPanel/SubPanelTiles.php
@@ -337,10 +337,10 @@ class SubPanelTiles
 
             if($div_display == 'none'){
                 $opp_display  = 'inline';
-                $tabs_properties[$t]['expanded_subpanels'] = true;
+                $tabs_properties[$t]['expanded_subpanels'] = false;
             } else{
                 $opp_display  = 'none';
-                $tabs_properties[$t]['expanded_subpanels'] = false;
+                $tabs_properties[$t]['expanded_subpanels'] = true;
             }
 
             if (!empty($this->layout_def_key) ) {

--- a/include/SubPanel/SubPanelTiles.php
+++ b/include/SubPanel/SubPanelTiles.php
@@ -216,8 +216,7 @@ class SubPanelTiles
                 unset($_COOKIE[$this->focus->module_dir . '_divs']);
                 $_SESSION['visited_details'][$this->focus->module_dir] = true;
             }
-            $default_div_display = 'none';
-        }
+            $default_div_display = 'none';}
         $div_cookies = get_sub_cookies($this->focus->module_dir . '_divs');
 
 
@@ -338,8 +337,10 @@ class SubPanelTiles
 
             if($div_display == 'none'){
                 $opp_display  = 'inline';
+                $tabs_properties[$t]['expanded_subpanels'] = true;
             } else{
                 $opp_display  = 'none';
+                $tabs_properties[$t]['expanded_subpanels'] = false;
             }
 
             if (!empty($this->layout_def_key) ) {

--- a/themes/SuiteP/include/SubPanel/tpls/SubPanelTiles.tpl
+++ b/themes/SuiteP/include/SubPanel/tpls/SubPanelTiles.tpl
@@ -6,7 +6,7 @@
 <ul class="noBullet" id="subpanel_list">
 {foreach from=$subpanel_tabs key=i item=subpanel_tab}
     <li class="noBullet" id="whole_subpanel_{$subpanel_tab}">
-        {$subpanel_tabs_properties.$i.collapse_subpanels |var_dump}
+        {$subpanel_tabs_properties.$i.collapse_subpanels}
         <div class="panel panel-default sub-panel">
             <div class="panel-heading panel-heading-collapse">
 

--- a/themes/SuiteP/include/SubPanel/tpls/SubPanelTiles.tpl
+++ b/themes/SuiteP/include/SubPanel/tpls/SubPanelTiles.tpl
@@ -6,9 +6,15 @@
 <ul class="noBullet" id="subpanel_list">
 {foreach from=$subpanel_tabs key=i item=subpanel_tab}
     <li class="noBullet" id="whole_subpanel_{$subpanel_tab}">
+        {$subpanel_tabs_properties.$i.collapse_subpanels |var_dump}
         <div class="panel panel-default sub-panel">
             <div class="panel-heading panel-heading-collapse">
+
+            {if $subpanel_tabs_properties.$i.expanded_subpanels == true}
+                <a id="subpanel_title_{$subpanel_tab}" class="in" role="button" data-toggle="collapse" href="#subpanel_{$subpanel_tab}" aria-expanded="false">
+            {else}
                 <a id="subpanel_title_{$subpanel_tab}" class="collapsed" role="button" data-toggle="collapse" href="#subpanel_{$subpanel_tab}" aria-expanded="false">
+            {/if}
                     <div class="col-xs-10 col-sm-11 col-md-11">
                         <div>
                            <img src="{sugar_getimagepath directory='sub_panel' file_name=$subpanel_tabs_properties.$i.module_name file_extension='svg'}">
@@ -18,7 +24,12 @@
                 </a>
 
             </div>
-            <div class="panel-body panel-collapse collapse" id="subpanel_{$subpanel_tab}">
+
+            {if $subpanel_tabs_properties.$i.expanded_subpanels == true}
+                <div class="panel-body panel-collapse collapse in" id="subpanel_{$subpanel_tab}">
+            {else}
+                <div class="panel-body panel-collapse collapse" id="subpanel_{$subpanel_tab}">
+            {/if}
                     <div class="tab-content">
                         <div id="list_subpanel_{$subpanel_tab}">
                             {$subpanel_tabs_properties.$i.subpanel_body}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
config values 'hide_subpanels' and 'hide_subpanels_on_login' do not work, and it just defaults to hide_subpanels always in SuiteP. The defult should be to show the the subpanel, On install of a new install it should set the hide_subpanels to true if this should be the new default

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In some cases it is appropriate to display the subpanels as expanded. 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
You have to edit the config.php file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
