### PR TITLE
Fixed  Screen freezes add a Project Task via Projects (css issue)

### DIFF
--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -5813,7 +5813,7 @@ a[id^=grouptab]:visited, a[id^=grouptab]:active {
 
 
 /* fix schedule bar popup on calendar */
-.ui-front, .ui-dialog {
+.ui-dialog {
     z-index: 1100 !important;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
In Firefox 47 (and chrome) can not add project task to project via ghantt chart navigate to Project Add a Task via the Project detail view. Click Save - nothing happens Then Click Cancel - screen freezes.
I believe the issue is cause by the zindex of the dialog overlay being more than the dialog it self causing the page to appear to crash, as you can't select anything in the tab.

So I have change the z-index of the overlay

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This makes adding a project task in the ghantt chart impossible with  out this fix.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
navigate to Project Add a Task via the Project detail view. Open the task up again.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
