### PR TITLE
External Account page load fix on User EditView

### DIFF
--- a/include/SubPanel/SubPanel.php
+++ b/include/SubPanel/SubPanel.php
@@ -90,7 +90,7 @@ class SubPanel
 			sugar_die($app_strings['ERROR_NO_RECORD']);
 		}
 		$this->buildSearchQuery();
-		if (!empty($subpanelDef)) {
+		if (empty($subpanelDef)) {
 			//load the subpanel by name.
 			$panelsdef=new SubPanelDefinitions($result,$layout_def_key);
 			$subpanelDef=$panelsdef->load_subpanel($subpanel_id, false, false, $this->search_query,$collections);
@@ -406,8 +406,11 @@ class SubPanel
 		} else {
 			$module = $subpanel_defs['module'];
 		}
-		$seed = BeanFactory::getBean($module);
-
+		if($module) {
+			$seed = BeanFactory::getBean($module);
+		} else {
+			$seed = new Meeting();
+		}
 
 		$_REQUEST['searchFormTab'] = 'basic_search';
 		$searchForm = new SubPanelSearchForm($seed, $module, $this);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
bugfix for External Account page load.  first bad commit was 6bc114b978b050f6899505a1ef95fa93a840bd01 so it's may related for an other issue thereat

## Motivation and Context
External Accounts tab page contents didn't loaded on User EditView (profile page)

## How To Test This
External Accounts tab page contents didn't loaded on User EditView (profile page) so try to click on the "External Accounts" tab

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
