### PR TITLE
Hotfix user profile 196

### DIFF
--- a/themes/SuiteP/js/style.js
+++ b/themes/SuiteP/js/style.js
@@ -362,76 +362,148 @@ function changeFirstTab(src) {
 
 
 // fix for tab navigation on user profile for SuiteP theme
-var isUserProfileEditViewPage = function() {
-    function getParameterByName(name, url) {
-        if (!url) url = window.location.href;
-        name = name.replace(/[\[\]]/g, "\\$&");
-        var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
-          results = regex.exec(url);
-        if (!results) return null;
-        if (!results[2]) return '';
-        return decodeURIComponent(results[2].replace(/\+/g, " "));
-    }
+
+var getParameterByName = function(name, url) {
+    if (!url) url = window.location.href;
+    name = name.replace(/[\[\]]/g, "\\$&");
+    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+      results = regex.exec(url);
+    if (!results) return null;
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, " "));
+}
+var isUserProfilePage = function() {
     var module = getParameterByName('module');
-    var action = getParameterByName('action');
-    return module == 'Users' && action == 'EditView';
+    if(!module) {
+        module = $('#EditView_tabs').closest('form#EditView').find('input[name="module"]').val()
+    }
+    if(!module) {
+        module = module_sugar_grp1;
+    }
+    return module == 'Users';;
 };
 
-if(isUserProfileEditViewPage()) {
-    var tabsRefresh = function() {
-        var tabFrames = {
-            // User Profile
-            'tab1': [
-                // User Profile & Employee Information
-                'form#EditView div#EditView_tabs.yui-navset.yui-navset-top div.yui-content div div#EditView_tabs',
-                // Email Settings
-                '#email_options'
-            ],
-            // Password
-            'tab2': [
+var isEditViewPage = function() {
+    var action = getParameterByName('action');
+    if(!action) {
+        action = $('#EditView_tabs').closest('form#EditView').find('input[name="page"]').val()
+    }
+    return action == 'EditView';
+};
+
+var isDetailViewPage = function() {
+    var action = getParameterByName('action');
+    if(!action) {
+        action = action_sugar_grp1;
+    }
+    return action == 'DetailView';
+};
+
+$(function () {
+    if(isUserProfilePage()) {
+
+        var tabActiveSelector;
+        var tabFramesLength;
+        var tabFrames;
+
+        if (isEditViewPage()) {
+            tabActiveSelector = '#EditView_tabs.yui-navset.yui-navset-top ul.yui-nav li.selected a';
+            tabFramesLength = 5;
+            tabFrames = {
+                // User Profile
+                'tab1': [
+                    // User Profile & Employee Information
+                    'form#EditView div#EditView_tabs.yui-navset.yui-navset-top div.yui-content div div#EditView_tabs',
+                    // Email Settings
+                    '#email_options'
+                ],
                 // Password
-                '#generate_password'
-            ],
-            // Themes
-            'tab3': [
+                'tab2': [
+                    // Password
+                    '#generate_password'
+                ],
                 // Themes
-                '#themepicker'
-            ],
-            // Advanced
-            'tab4': [
-                // User Settings
-                '#settings',
-                // Layout Options
-                '#layout',
-                // Locale Settings
-                '#locale',
-                // Calendar Options
-                '#calendar_options'
-            ],
-            // External Account
-            'tab5': [
-                '#eapm_area'
-            ]
-        };
-        // hide all tabs..
-        for(var i=1; i<=5; i++) {
-            for(var j=0; j<tabFrames['tab'+i].length; j++) {
-                $(tabFrames['tab'+i][j]).hide();
+                'tab3': [
+                    // Themes
+                    '#themepicker'
+                ],
+                // Advanced
+                'tab4': [
+                    // User Settings
+                    '#settings',
+                    // Layout Options
+                    '#layout',
+                    // Locale Settings
+                    '#locale',
+                    // Calendar Options
+                    '#calendar_options'
+                ],
+                // External Account
+                'tab5': [
+                    '#eapm_area'
+                ]
+            };
+
+        }
+        if (isDetailViewPage()) {
+            tabActiveSelector = '#user_detailview_tabs.yui-navset.detailview_tabs.yui-navset-top ul.yui-nav li.selected a';
+            tabFramesLength = 3;
+            tabFrames = {
+                // User Profile
+                'tab1': [
+                    // User Profile & Employee Information
+                    'div#user_detailview_tabs.yui-navset.detailview_tabs.yui-navset-top div.yui-content',
+                    // Email Settings
+                    '#email_options',
+                    // Security Groups Management etc..
+                    '#subpanel_list'
+                ],
+                // Advanced
+                'tab2': [
+                    // User Settings
+                    '#settings',
+                    // Locale Settings
+                    '#locale',
+                    // Calendar Options
+                    '#calendar_options',
+                    // Layout Options
+                    '#edit_tabs',
+                    // Security Groups Management etc..
+                    '#subpanel_list'
+                ],
+                // Access
+                'tab3': [
+                    // Security Groups Management etc..
+                    '#subpanel_list'
+                ]
+            };
+        }
+
+        var tabsRefresh = function () {
+            // hide all tabs..
+            for (var i = 1; i <= tabFramesLength; i++) {
+                for (var j = 0; j < tabFrames['tab' + i].length; j++) {
+                    $(tabFrames['tab' + i][j]).hide();
+                }
+            }
+
+            // show the active only
+            var activeTab = $(tabActiveSelector).first().attr('id');
+            for (i = 0; i < tabFrames[activeTab].length; i++) {
+                $(tabFrames[activeTab][i]).show();
             }
         }
 
-        // show the active only
-        var activeTab = $('#EditView_tabs.yui-navset.yui-navset-top ul.yui-nav li.selected a').first().attr('id');
-        for(i=0; i<tabFrames[activeTab].length; i++) {
-            $(tabFrames[activeTab][i]).show();
-        }
-    }
-    $(function () {
-        for(var i=1; i<=5; i++) {
-            $('#tab'+i).click(function () {
-                setTimeout(function(){tabsRefresh();}, 300);
+        for (var i = 1; i <= tabFramesLength; i++) {
+            $('#tab' + i).click(function () {
+                setTimeout(function () {
+                    tabsRefresh();
+                }, 300);
             });
         }
-        setTimeout(function(){tabsRefresh();}, 300);
-    });
-}
+        setTimeout(function () {
+            tabsRefresh();
+        }, 300);
+
+    }
+});

--- a/themes/SuiteP/js/style.js
+++ b/themes/SuiteP/js/style.js
@@ -359,3 +359,79 @@ function changeFirstTab(src) {
     return true;
 }
 // End of custom jQuery
+
+
+// fix for tab navigation on user profile for SuiteP theme
+var isUserProfileEditViewPage = function() {
+    function getParameterByName(name, url) {
+        if (!url) url = window.location.href;
+        name = name.replace(/[\[\]]/g, "\\$&");
+        var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+          results = regex.exec(url);
+        if (!results) return null;
+        if (!results[2]) return '';
+        return decodeURIComponent(results[2].replace(/\+/g, " "));
+    }
+    var module = getParameterByName('module');
+    var action = getParameterByName('action');
+    return module == 'Users' && action == 'EditView';
+};
+
+if(isUserProfileEditViewPage()) {
+    var tabsRefresh = function() {
+        var tabFrames = {
+            // User Profile
+            'tab1': [
+                // User Profile & Employee Information
+                'form#EditView div#EditView_tabs.yui-navset.yui-navset-top div.yui-content div div#EditView_tabs',
+                // Email Settings
+                '#email_options'
+            ],
+            // Password
+            'tab2': [
+                // Password
+                '#generate_password'
+            ],
+            // Themes
+            'tab3': [
+                // Themes
+                '#themepicker'
+            ],
+            // Advanced
+            'tab4': [
+                // User Settings
+                '#settings',
+                // Layout Options
+                '#layout',
+                // Locale Settings
+                '#locale',
+                // Calendar Options
+                '#calendar_options'
+            ],
+            // External Account
+            'tab5': [
+                '#eapm_area'
+            ]
+        };
+        // hide all tabs..
+        for(var i=1; i<=5; i++) {
+            for(var j=0; j<tabFrames['tab'+i].length; j++) {
+                $(tabFrames['tab'+i][j]).hide();
+            }
+        }
+
+        // show the active only
+        var activeTab = $('#EditView_tabs.yui-navset.yui-navset-top ul.yui-nav li.selected a').first().attr('id');
+        for(i=0; i<tabFrames[activeTab].length; i++) {
+            $(tabFrames[activeTab][i]).show();
+        }
+    }
+    $(function () {
+        for(var i=1; i<=5; i++) {
+            $('#tab'+i).click(function () {
+                setTimeout(function(){tabsRefresh();}, 300);
+            });
+        }
+        setTimeout(function(){tabsRefresh();}, 300);
+    });
+}


### PR DESCRIPTION
SuiteP Theme – User Profile, All options on one screen (Regardless of Current Tab)

## Description
Edit user profile. (Can be done in SuiteP theme by hovering over Top-right and clicking “Profile”) All of the tab's Content is displayed in one long run-on page. This makes the tabs fairly redundant, and the page very long.

This can also be seen when on the Detailview for a user profile.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
Check tab contents on User Profile / EditView and DetailView

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
…reen (Regardless of Current Tab)