### PR TITLE
Fixed #1826 where cases wouldn't update with Suite P theme

### DIFF
--- a/themes/SuiteP/include/DetailView/DetailView.tpl
+++ b/themes/SuiteP/include/DetailView/DetailView.tpl
@@ -144,17 +144,21 @@
             {{assign var='collapseIcon' value="glyphicon glyphicon-minus"}}
             {{assign var='panelHeadingCollapse' value=""}}
         {{/if}}
-
+        {{if $label != "LBL_AOP_CASE_UPDATES"}}
+            {{assign var='panelId' value="top-panel-{{$panelCount}}"}}
+        {{else}}
+            {{assign var='panelId' value="LBL_AOP_CASE_UPDATES"}}
+        {{/if}}
         <div class="panel panel-default">
             <div class="panel-heading {{$panelHeadingCollapse}}">
-                <a class="{{$collapsed}}" role="button" data-toggle="collapse" href="#top-panel-{{$panelCount}}" aria-expanded="false">
+                <a class="{{$collapsed}}" role="button" data-toggle="collapse" href="#{{$panelId}}" aria-expanded="false">
                     <div class="col-xs-10 col-sm-11 col-md-11">
                          {sugar_translate label='{{$label}}' module='{{$module}}'}</div>
                     </div>
                 </a>
 
             </div>
-            <div class="panel-body {{$collapse}}" id="top-panel-{{$panelCount}}">
+            <div class="panel-body {{$collapse}}" id="{{$panelId}}">
                 <div class="tab-content">
                     {{include file='themes/SuiteP/include/DetailView/tab_panel_content.tpl'}}
                 </div>

--- a/themes/SuiteP/include/DetailView/DetailView.tpl
+++ b/themes/SuiteP/include/DetailView/DetailView.tpl
@@ -145,7 +145,7 @@
             {{assign var='panelHeadingCollapse' value=""}}
         {{/if}}
         {{if $label != "LBL_AOP_CASE_UPDATES"}}
-            {{assign var='panelId' value="top-panel-{{$panelCount}}"}}
+            {{assign var='panelId' value="top-panel-$panelCount"}}
         {{else}}
             {{assign var='panelId' value="LBL_AOP_CASE_UPDATES"}}
         {{/if}}


### PR DESCRIPTION

## Description
In SuiteP when you updated a case your update wouldn't appear as the javascript was looking for an ID in the HTML that no longer existed. I've updated Suite P's detailview template to fix this.

## Motivation and Context
Updating cases was broken in Suite P

## How To Test This
Set your theme to Suite P then try to update a case.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
