### PR TITLE
missing icons on the SuiteR theme's admin panel fixed (Task 204)

### DIFF
--- a/modules/Administration/index.php
+++ b/modules/Administration/index.php
@@ -78,6 +78,23 @@ $values_3_tab = array();
 $admin_group_header_tab = array();
 $j=0;
 
+
+// able to use same icons for different menu items when the theme doesn't contains it
+$adminImageOverrides = array(
+    'UserManagement' => 'Users',
+    'EmailCampaigns' => 'Campaigns',
+    'EmailInbound' => 'InboundEmail',
+    'EmailOutbound' => 'EmailMan',
+    'EmailQueue' => 'EmailMan',
+    'GeocodingTests' => 'CreateContacts',
+    'GeocodeAddresses' => 'CreateContacts',
+    'SecuritySuiteGroupManagement' => 'SecurityGroups',
+    'SecurityGroupsManagement' => 'SecurityGroups',
+    'AOD' => 'edit',
+    'AOP' => 'edit',
+    'BusinessHours' => 'edit',
+);
+
 foreach ($admin_group_header as $key=>$values) {
     $module_index = array_keys($values[3]);
     $addedHeaderGroups = array();
@@ -127,6 +144,16 @@ foreach ($admin_group_header as $key=>$values) {
                     '.svg',
                     translate($admin_option[1],'Administration')
                 );
+                if (!$header_image[$j][$i] && isset($adminImageOverrides[$admin_option[0]]) && $adminImageOverrides[$admin_option[0]]) {
+                   $header_image[$j][$i] = SugarThemeRegistry::current()->getImage(
+                       $adminImageOverrides[$admin_option[0]],
+                       'border="0" align="absmiddle"',
+                       null,
+                       null,
+                       '.svg',
+                       translate($admin_option[1],'Administration')
+                   );
+                }
                 $url[$j][$i] = $admin_option[3];
                 if(!empty($admin_option[5])) {
                 	$onclick[$j][$i] = $admin_option[5];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
missing icons on the SuiteR theme's admin panel fixed (Task 204) - This fix able to the developers to use same icons for different menu items when the theme doesn't contains it

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
Check icons on Admin page in all of the themes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
