### PR TITLE
Fixed #1029 - prevent user from adding or editing field if the fields name already exists. This fix also works for custom fields.

### DIFF
--- a/jssource/src_files/include/javascript/sugar_3.js
+++ b/jssource/src_files/include/javascript/sugar_3.js
@@ -1181,7 +1181,6 @@ function validate_form(formname, startsWith){
 								}
 							break;
 							case 'in_array':
-								arr = eval(validate[formname][i][arrIndex]);
 								operator = validate[formname][i][operatorIndex];
 								item1 = trim(form[validate[formname][i][nameIndex]].value);
 								if (operator.charAt(0) == 'u') {
@@ -1191,11 +1190,28 @@ function validate_form(formname, startsWith){
 									item1 = item1.toLowerCase();
 									operator = operator.substring(1);
 								}
-								for(j = 0; j < arr.length; j++){
-									val = arr[j];
-									if((operator == "==" && val == item1) || (operator == "!=" && val != item1)){
-										isError = true;
-										add_error_style(formname, validate[formname][i][nameIndex], invalidTxt + " " +	validate[formname][i][msgIndex]);
+								// Get all fields related to the selected module (including custom fields)
+								var current_fields = '';
+								var current_module = document.getElementsByName("view_module")[0].value;
+								$.ajax({
+									type: "GET",
+									url: "index.php?to_pdf=1&module=ModuleBuilder&action=getModuleFields&current_module=" + current_module,
+									async: false,
+									success: function(result) {
+										current_fields = JSON.parse(result);
+									},
+									error: function(xhr, status, error) {
+										var err = eval("(" + xhr.responseText + ")");
+									}
+								});
+
+								for (k = 0; k < current_fields.length; k++) {
+									if(isError != true) {
+										val = current_fields[k].toUpperCase();
+										if ((operator == "==" && val == item1) || (operator == "!=" && val != item1)) {
+											isError = true;
+											add_error_style(formname, validate[formname][i][nameIndex], 'Invalid Value: Field Name already exists');
+										}
 									}
 								}
 							break;

--- a/modules/ModuleBuilder/controller.php
+++ b/modules/ModuleBuilder/controller.php
@@ -915,5 +915,14 @@ class ModuleBuilderController extends SugarController
         }
     }
 
+    function action_getModuleFields ()
+    {
+        $bean = BeanFactory::getBean('Accounts');
+        $field_defs = $bean->getFieldDefinitions();
+        $keys = array_keys($field_defs);
+
+        echo json_encode($keys);
+    }
+
 }
 ?>


### PR DESCRIPTION
## Description
Fixed #1029 - prevent user from adding or editing field if the fields name already exists. This fix also works for custom fields.

## How To Test This
Go to admin -> Studio -> Add field -> change Data Type to dropdown, Radio or MultiSelect -> Edit -> if the field name already exists, then it should prevent you from editing and display an error message.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
