### PR TITLE
Quote MSSQL column names when creating tables

### DIFF
--- a/include/database/MssqlManager.php
+++ b/include/database/MssqlManager.php
@@ -1765,6 +1765,9 @@ EOQ;
 		// always return as array for post-processing
 		$ref = parent::oneColumnSQLRep($fieldDef, $ignoreRequired, $table, true);
 
+		// Quote the column name (fixes problems with names like 'open', as found in aobh_businesshours)
+		$ref['name'] = $this->quoteIdentifier($ref['name']);
+
 		// Bug 24307 - Don't add precision for float fields.
 		if ( stristr($ref['colType'],'float') )
 			$ref['colType'] = preg_replace('/(,\d+)/','',$ref['colType']);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When upgrading to 7.7.1 and using MS SQL Server (at least with version 2005), the upgrade fails in the last step. This is due to the column name 'open' in the 'aobh_businesshours' table. The identifier 'open' needs to be quoted with square brackets, since 'open' is a reserved word.

## Motivation and Context
The change fixes upgrades to current SuiteCRM versions with SQL Server. Presumably, the same problem exists during fresh installs, and if so, should likewise be fixed by this change.

Also, square-bracket-quoting identifier names in computer-generated SQL code is always good practice with MS SQL Server.

## How To Test This
In a SuiteCRM installation with MSSQL, delete the 'aobh_businesshours' table if it exists. Then upgrade to version 7.7.1 with the upgrade wizard, or if the system is already current, do a quick repair and rebuild. The upgrade/repair should work with this fix.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
Upgrading to SuiteCRM 7.7.1 fails in the last step with SQL Server, due to the unquoted aobh_businesshours column name 'open', which is a reserved word. Quoting all column names fixes the problem.