### PR TITLE
Fixed #1624 - convert parametarised dates correctly if the user date format changes. Also, only update user format after all condition line elements have been placed on the page. Also, made sure that fixUpFormatting() function does not roll back the dates.

### DIFF
--- a/modules/AOR_Reports/tpls/report.tpl
+++ b/modules/AOR_Reports/tpls/report.tpl
@@ -24,57 +24,65 @@
     <button id='updateParametersButton' class="panelContainer" type="button">{sugar_translate label='LBL_UPDATE_PARAMETERS' module='AOR_Reports'}</button>
         <script>
             {literal}
-            $.each(reportParameters,function(key,val){
-                loadConditionLine(val, 'EditView');
-            });
+                $.each(reportParameters,function(key,val){
+                    loadConditionLine(val, 'EditView');
+                });
 
-            $(document).ready(function() {
-                $('#updateParametersButton').click(function(){
-                    //Update the Detail view form to have the parameter info and reload the page
-                    var _form = $('#formDetailView');
-                    _form.find('input[name=action]').val('DetailView');
-                    //Add each parameter to the form in turn
-                    $('.aor_conditions_id').each(function(index, elem){
-                        $elem = $(elem);
-                        var ln = $elem.attr('id').substr(17);
-                        var id = $elem.val();
-                        _form.append('<input type="hidden" name="parameter_id[]" value="'+id+'">');
-                        var operator = $("#aor_conditions_operator\\["+ln+"\\]").val();
-                        _form.append('<input type="hidden" name="parameter_operator[]" value="'+operator+'">');
-                        var fieldType = $('#aor_conditions_value_type\\['+ln+'\\]').val();
-                        _form.append('<input type="hidden" name="parameter_type[]" value="'+fieldType+'">');
-                        var fieldInput = $('#aor_conditions_value\\['+ln+'\\]').val();
+                $(document).ready(function() {
+                    $('#updateParametersButton').click(function () {
+                        //Update the Detail view form to have the parameter info and reload the page
+                        var _form = $('#formDetailView');
+                        _form.find('input[name=action]').val('DetailView');
+                        //Add each parameter to the form in turn
+                        $('.aor_conditions_id').each(function (index, elem) {
+                            $elem = $(elem);
+                            var ln = $elem.attr('id').substr(17);
+                            var id = $elem.val();
+                            _form.append('<input type="hidden" name="parameter_id[]" value="' + id + '">');
+                            var operator = $("#aor_conditions_operator\\[" + ln + "\\]").val();
+                            _form.append('<input type="hidden" name="parameter_operator[]" value="' + operator + '">');
+                            var fieldType = $('#aor_conditions_value_type\\[' + ln + '\\]').val();
+                            _form.append('<input type="hidden" name="parameter_type[]" value="' + fieldType + '">');
+                            var fieldInput = $('#aor_conditions_value\\[' + ln + '\\]').val();
 
-                        // Fix for issue #1272 - AOR_Report module cannot update Date type parameter.
-                        if($('#aor_conditions_value\\['+ln+'\\]\\[0\\]').length){
-                            var fieldValue = $('#aor_conditions_value\\['+ln+'\\]\\[0\\]').val();
-                            var fieldSign = $('#aor_conditions_value\\['+ln+'\\]\\[1\\]').val();
-                            var fieldNumber = $('#aor_conditions_value\\['+ln+'\\]\\[2\\]').val();
-                            var fieldTime = $('#aor_conditions_value\\['+ln+'\\]\\[3\\]').val();                            _form.append('<input type="hidden" name="parameter_value[]" value="'+fieldValue+'">');
-                            _form.append('<input type="hidden" name="parameter_value[]" value="'+fieldSign+'">');
-                            _form.append('<input type="hidden" name="parameter_value[]" value="'+fieldNumber+'">');
-                            _form.append('<input type="hidden" name="parameter_value[]" value="'+fieldTime+'">');
-                        }
-                        // Fix for issue #1082 - change local date format to db date format
-                        if($('#aor_conditions_value\\['+index+'\\]').hasClass('date_input')) { // only change to DB format if its a date
-                            if ($('#aor_conditions_value\\[' + ln + '\\]').hasClass('date_input')) {
-                                fieldInput = $.datepicker.formatDate('yy-mm-dd', new Date(fieldInput));
+                            // Fix for issue #1272 - AOR_Report module cannot update Date type parameter.
+                            if ($('#aor_conditions_value\\[' + ln + '\\]\\[0\\]').length) {
+                                var fieldValue = $('#aor_conditions_value\\[' + ln + '\\]\\[0\\]').val();
+                                var fieldSign = $('#aor_conditions_value\\[' + ln + '\\]\\[1\\]').val();
+                                var fieldNumber = $('#aor_conditions_value\\[' + ln + '\\]\\[2\\]').val();
+                                var fieldTime = $('#aor_conditions_value\\[' + ln + '\\]\\[3\\]').val();
+
+                                _form.append('<input type="hidden" name="parameter_value[]" value="' + fieldValue + '">');
+                                _form.append('<input type="hidden" name="parameter_value[]" value="' + fieldSign + '">');
+                                _form.append('<input type="hidden" name="parameter_value[]" value="' + fieldNumber + '">');
+                                _form.append('<input type="hidden" name="parameter_value[]" value="' + fieldTime + '">');
                             }
-                        }
-                        _form.append('<input type="hidden" name="parameter_value[]" value="'+fieldInput+'">');
-                    });
-                    _form.submit();
-                });
 
-                // Make sure to change dates back to the user format
-                $('.aor_conditions_id').each(function(index, elem){
-                    if($('#aor_conditions_value\\['+index+'\\]').hasClass('date_input')) {
-                        var dateValue = new Date( $('#aor_conditions_value\\['+index+'\\]').val() );
-                        var dateValueinUserFormat = dateValue.toLocaleFormat(cal_date_format);
-                        $('#aor_conditions_value\\['+index+'\\]').val(dateValueinUserFormat)
-                    }
+                            // Fix for issue #1082 - change local date format to db date format
+                            if ($('#aor_conditions_value\\[' + index + '\\]').hasClass('date_input')) { // only change to DB format if its a date
+                                if (isDate(fieldInput)) {
+                                    var fieldInputObject = getDateObject(fieldInput);
+                                }
+                                fieldInput = $.datepicker.formatDate('yy-mm-dd', new Date(fieldInputObject));
+                            }
+
+                            _form.append('<input type="hidden" name="parameter_value[]" value="' + fieldInput + '">');
+                        });
+                        _form.submit();
+                    });
+
+                    // Need to wait to make sure that all the condition line elements have been added to the page.
+                    $(document).one("ajaxStop", function() {
+                        // Make sure to change dates back to the user format
+                        $('.aor_conditions_id').each(function(index, elem){
+                            if($('#aor_conditions_value\\['+index+'\\]').hasClass('date_input')) {
+                                var dateValue = new Date( $('#aor_conditions_value\\['+index+'\\]').val() );
+                                var dateValueinUserFormat = dateValue.toLocaleFormat(cal_date_format);
+                                $('#aor_conditions_value\\['+index+'\\]').val(dateValueinUserFormat);
+                            }
+                        });
+                    });
                 });
-            });
             {/literal}
         </script>
     <script type="text/javascript">SUGAR.util.doWhen("typeof initPanel == 'function'", function() {ldelim} initPanel('parameters', 'expanded'); {rdelim}); </script>

--- a/modules/AOW_WorkFlow/aow_utils.php
+++ b/modules/AOW_WorkFlow/aow_utils.php
@@ -759,8 +759,17 @@ function fixUpFormatting($module, $field, $value)
                 break;
             }
             if ( ! preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$/',$value) ) {
-                // This appears to be formatted in user date/time
-                $value = $timedate->to_db($value);
+                // If date string doesnt have time setup, dont change it to the previous date/future date
+                if (strpos($value, ':') === false) {
+                    global $current_user;
+                    $user_date_format = $timedate->get_date_format($current_user);
+
+                    $date = DateTime::createFromFormat($user_date_format, $value)->setTime(00, 00, 00);
+                    $value = $date->format('Y-m-d H:i:s');
+                } else {
+                    // This appears to be formatted in user date/time
+                    $value = $timedate->to_db($value);
+                }
             }
             break;
         case 'date':


### PR DESCRIPTION
## Description
Convert parametarised dates correctly if the user date format changes. 
Only update user format after all condition line elements have been placed on the page. 
Made sure that fixUpFormatting() function does not roll back the dates.

## How To Test This
Create a report which uses dates as parameters. Try to update this dates. 
Change the user date format. Try to update the dates again.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
