### PR TITLE
Fixed #1700 - convert parametarised dates correctly if the user date format changes. saveOptions() function from AORReportsDashlet.php needs to convert dates to the db format first in order for comparison to work.

### DIFF
--- a/modules/AOR_Reports/Dashlets/AORReportsDashlet/AORReportsDashlet.php
+++ b/modules/AOR_Reports/Dashlets/AORReportsDashlet/AORReportsDashlet.php
@@ -134,6 +134,21 @@ class AORReportsDashlet extends Dashlet {
 //            $req['parameter_value'][1] = $firstValue;
 //        }
         $allowedKeys = array_flip(array('aor_report_id','dashletTitle','charts','onlyCharts','parameter_id','parameter_value','parameter_type','parameter_operator'));
+
+        // Fix for issue #1700 - save value as db type
+        for($i = 0; $i < count($req['parameter_value']); $i++) {
+            if(isset($req['parameter_value'][$i]) && $req['parameter_value'][$i] != '') {
+                global $current_user, $timedate;
+                $user_date_format = $timedate->get_date_format($current_user);
+
+                if (DateTime::createFromFormat($user_date_format, $req['parameter_value'][$i]) !== FALSE) {
+                    $date = DateTime::createFromFormat($user_date_format, $req['parameter_value'][$i]);
+                    $date->setTime(00, 00, 00);
+                    $req['parameter_value'][$i] = $timedate->asDb($date);
+                }
+            }
+        }
+
         $intersected = array_intersect_key($req,$allowedKeys);
         return $intersected;
     }

--- a/modules/AOR_Reports/Dashlets/AORReportsDashlet/dashletConfigure.tpl
+++ b/modules/AOR_Reports/Dashlets/AORReportsDashlet/dashletConfigure.tpl
@@ -137,6 +137,18 @@
                 </td>
             </tr>
             {/foreach}
+            <script>
+                {literal}
+                // Make sure to change dates back to the user format
+                $(document).ready(function() {
+                    $('.date_input').each(function(index, elem) {
+                        var formatString = cal_date_format.replace(/%/g, '').toLowerCase().replace(/y/g, 'yy').replace(/m/g, 'mm').replace(/d/g, 'dd');
+                        var fieldInput = $.datepicker.formatDate(formatString, new Date($(this).val()) );
+                        $(this).val(fieldInput);
+                    });
+                });
+                {/literal}
+            </script>
             <tr>
                 <td scope='row'>
 


### PR DESCRIPTION
## Description
Convert parametarised dates correctly if the user date format changes. 
saveOptions() function from AORReportsDashlet.php needs to convert dates to the db format first in order for comparison to work.

## How To Test This
1. Home page -> add report dashlet -> change parametrised dates -> save -> check that it displays correct rows.
2. change the user date format.
3. Home page -> add report dashlet -> change parametrised dates -> save -> check that it still displays correct rows.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)