### PR TITLE
Fixed #1928 - restyling the email settings dialog box.

### DIFF
--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -6563,15 +6563,38 @@ td.inlineEditActive {
     overflow: auto !important;
 }
 
-#settingsDialog_c {
-    top: 0 !important;
-    left: 64px !important;
-}
 
 #settingsDialog .yui-content {
-    height: 384px;
     overflow-y: auto;
 }
+
+#settingsDialog_c {
+    position: fixed;
+    top: 120px !important;
+    z-index: 20000;
+}
+
+@media (max-width: 992px) {
+    #settingsDialog_c {
+        left: 1% !important;
+    }
+
+    #settingsDialog .yui-content {
+        height: 320px;
+    }
+}
+
+@media (min-width: 993px) {
+    #settingsDialog_c {
+        left: 30% !important;
+    }
+
+    #settingsDialog .yui-content {
+        height: 384px;
+    }
+}
+
+
 
 /* stop child elements of a hidden dialog from showing up above other elements */
 .yui-overlay-hidden * {

--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -6569,7 +6569,6 @@ td.inlineEditActive {
 }
 
 #settingsDialog_c {
-    position: fixed;
     top: 120px !important;
     z-index: 20000;
 }

--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -3367,6 +3367,10 @@ a.sugar-tab-close, .yui-navset .yui-nav a.sugar-tab-close, .yui-navset .yui-nav 
     background: transparent url('../../../../index.php?entryPoint=getImage&themeName=SuiteP&imageName=sugar-yui-sprites.png') no-repeat scroll 0 -70px;
 }
 
+.yui-nav {
+    overflow-y: hidden;
+}
+
 ul.yui-nav li.selected {
     background: #F08377;
 }
@@ -6559,12 +6563,21 @@ td.inlineEditActive {
     overflow: auto !important;
 }
 
-#settingsDialog_c, #settingsDialog {
-    width: 90% !important;
+#settingsDialog_c {
+    top: 0 !important;
+    left: 64px !important;
 }
 
-#formEmailSettingsGeneral {
-    overflow: scroll;
+#settingsDialog .yui-content {
+    height: 384px;
+    overflow-y: auto;
+}
+
+/* stop child elements of a hidden dialog from showing up above other elements */
+.yui-overlay-hidden * {
+    display: none;
+    visibility: collapse;
+    height: 0;
 }
 
 object {

--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -6586,7 +6586,7 @@ td.inlineEditActive {
 
 @media (min-width: 993px) {
     #settingsDialog_c {
-        left: 30% !important;
+        left: 22.5% !important;
     }
 
     #settingsDialog .yui-content {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Issue 1628 - Users are having trouble seeing the whole dialog and are not able to scroll through the form.
Relates to issue #1928 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows the user to fill in the email settings dialog.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
- Activities
- Emails
- Settings
- Ensure that you can scroll through the dialog.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
