### PR TITLE
Fixed #1938 - Calendar not showing time slots

### DIFF
--- a/modules/Calendar/Cal.js
+++ b/modules/Calendar/Cal.js
@@ -807,6 +807,8 @@ $(document).ready(function() {
 
 
     function get_cal(i, all_events){
+        console.log(global_view);
+        console.log(views);
         $('#calendar' + i).fullCalendar({
             header: {
                 left: '',

--- a/modules/Calendar/CalendarDisplay.php
+++ b/modules/Calendar/CalendarDisplay.php
@@ -159,9 +159,15 @@ class CalendarDisplay {
 		$ss->assign('a_str',json_encode($cal->items));
 
 		$start = $current_user->getPreference('day_start_time');
+		if(is_null($start)) {
+			$start = SugarConfig::getInstance()->get('calendar.default_day_start',"08:00");
+		}
 		$ss->assign('day_start_time',$start);
 
 		$end = $current_user->getPreference('day_end_time');
+		if(is_null($end)) {
+			$end = SugarConfig::getInstance()->get('calendar.default_day_end',"19:00");
+		}
 		$ss->assign('day_end_time',$end);
 
 		$ss->assign('sugar_body_only',(isset($_REQUEST['to_pdf']) && $_REQUEST['to_pdf'] || isset($_REQUEST['sugar_body_only']) && $_REQUEST['sugar_body_only']));

--- a/modules/Calendar/index.php
+++ b/modules/Calendar/index.php
@@ -59,7 +59,7 @@ if(empty($_REQUEST['view'])){
     }
     else
     {
-        $_REQUEST['view'] = SugarConfig::getInstance()->get('calendar.default_view','week');
+        $_REQUEST['view'] = SugarConfig::getInstance()->get('calendar.default_view','agendaWeek');
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Reference to issue #1938

Issues caused by start and end dates in the users preferences being undefined.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ensures that calendar displays correctly.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Open the calendar from for the first time by a user.
You should see the time slots in the calendar.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
