### PR TITLE
Fixed #1624 - convert parametarised dates correctly if the user date format changes. Also, only update user format after all condition line elements have been placed on the page. Also, made sure that fixUpFormatting() function does not roll back the dates.

### DIFF
--- a/modules/AOR_Reports/tpls/report.tpl
+++ b/modules/AOR_Reports/tpls/report.tpl
@@ -29,50 +29,76 @@
             });
 
             $(document).ready(function() {
-                $('#updateParametersButton').click(function(){
+                $('#updateParametersButton').click(function () {
                     //Update the Detail view form to have the parameter info and reload the page
                     var _form = $('#formDetailView');
                     _form.find('input[name=action]').val('DetailView');
                     //Add each parameter to the form in turn
-                    $('.aor_conditions_id').each(function(index, elem){
+                    $('.aor_conditions_id').each(function (index, elem) {
                         $elem = $(elem);
                         var ln = $elem.attr('id').substr(17);
                         var id = $elem.val();
-                        _form.append('<input type="hidden" name="parameter_id[]" value="'+id+'">');
-                        var operator = $("#aor_conditions_operator\\["+ln+"\\]").val();
-                        _form.append('<input type="hidden" name="parameter_operator[]" value="'+operator+'">');
-                        var fieldType = $('#aor_conditions_value_type\\['+ln+'\\]').val();
-                        _form.append('<input type="hidden" name="parameter_type[]" value="'+fieldType+'">');
-                        var fieldInput = $('#aor_conditions_value\\['+ln+'\\]').val();
+                        _form.append('<input type="hidden" name="parameter_id[]" value="' + id + '">');
+                        var operator = $("#aor_conditions_operator\\[" + ln + "\\]").val();
+                        _form.append('<input type="hidden" name="parameter_operator[]" value="' + operator + '">');
+                        var fieldType = $('#aor_conditions_value_type\\[' + ln + '\\]').val();
+                        _form.append('<input type="hidden" name="parameter_type[]" value="' + fieldType + '">');
+                        var fieldInput = $('#aor_conditions_value\\[' + ln + '\\]').val();
 
                         // Fix for issue #1272 - AOR_Report module cannot update Date type parameter.
-                        if($('#aor_conditions_value\\['+ln+'\\]\\[0\\]').length){
-                            var fieldValue = $('#aor_conditions_value\\['+ln+'\\]\\[0\\]').val();
-                            var fieldSign = $('#aor_conditions_value\\['+ln+'\\]\\[1\\]').val();
-                            var fieldNumber = $('#aor_conditions_value\\['+ln+'\\]\\[2\\]').val();
-                            var fieldTime = $('#aor_conditions_value\\['+ln+'\\]\\[3\\]').val();                            _form.append('<input type="hidden" name="parameter_value[]" value="'+fieldValue+'">');
-                            _form.append('<input type="hidden" name="parameter_value[]" value="'+fieldSign+'">');
-                            _form.append('<input type="hidden" name="parameter_value[]" value="'+fieldNumber+'">');
-                            _form.append('<input type="hidden" name="parameter_value[]" value="'+fieldTime+'">');
+                        if ($('#aor_conditions_value\\[' + ln + '\\]\\[0\\]').length) {
+                            var fieldValue = $('#aor_conditions_value\\[' + ln + '\\]\\[0\\]').val();
+                            var fieldSign = $('#aor_conditions_value\\[' + ln + '\\]\\[1\\]').val();
+                            var fieldNumber = $('#aor_conditions_value\\[' + ln + '\\]\\[2\\]').val();
+                            var fieldTime = $('#aor_conditions_value\\[' + ln + '\\]\\[3\\]').val();
+
+                            _form.append('<input type="hidden" name="parameter_value[]" value="' + fieldValue + '">');
+                            _form.append('<input type="hidden" name="parameter_value[]" value="' + fieldSign + '">');
+                            _form.append('<input type="hidden" name="parameter_value[]" value="' + fieldNumber + '">');
+                            _form.append('<input type="hidden" name="parameter_value[]" value="' + fieldTime + '">');
                         }
+
                         // Fix for issue #1082 - change local date format to db date format
-                        if($('#aor_conditions_value\\['+index+'\\]').hasClass('date_input')) { // only change to DB format if its a date
-                            if ($('#aor_conditions_value\\[' + ln + '\\]').hasClass('date_input')) {
-                                fieldInput = $.datepicker.formatDate('yy-mm-dd', new Date(fieldInput));
+                        if ($('#aor_conditions_value\\[' + index + '\\]').hasClass('date_input')) { // only change to DB format if its a date
+                            if (isDate(fieldInput)) {
+                                var dateObject = getDateObject(fieldInput);
                             }
+                            fieldInput = $.datepicker.formatDate('yy-mm-dd', dateObject);
                         }
-                        _form.append('<input type="hidden" name="parameter_value[]" value="'+fieldInput+'">');
+
+                        _form.append('<input type="hidden" name="parameter_value[]" value="' + fieldInput + '">');
                     });
                     _form.submit();
                 });
 
-                // Make sure to change dates back to the user format
-                $('.aor_conditions_id').each(function(index, elem){
-                    if($('#aor_conditions_value\\['+index+'\\]').hasClass('date_input')) {
-                        var dateValue = new Date( $('#aor_conditions_value\\['+index+'\\]').val() );
-                        var dateValueinUserFormat = dateValue.toLocaleFormat(cal_date_format);
-                        $('#aor_conditions_value\\['+index+'\\]').val(dateValueinUserFormat)
-                    }
+                // Need to wait to make sure that all the condition line elements have been added to the page.
+                $(document).one("ajaxStop", function() {
+                    // Make sure to change dates back to the user format
+                    $('.aor_conditions_id').each(function(index, elem){
+                        if($('#aor_conditions_value\\['+index+'\\]').hasClass('date_input')) {
+                            var value = $('#aor_conditions_value\\['+ index +'\\]').val();
+                            var formatString = cal_date_format.replace(/%/g, '').toLowerCase().replace(/y/g, 'yy').replace(/m/g, 'mm').replace(/d/g, 'dd');
+
+                            // From DB format
+                            var date_reg_format = '([0-9]{4})-([0-9]{1,2})-([0-9]{1,2})';
+                            myregexp = new RegExp(date_reg_format);
+                            if(myregexp.test(value)) {
+                                // Split timestamp into [ Y, M, D ]
+                                var t = value.split(/[- :]/);
+                                // Apply each element to the Date function
+                                var dateObject = new Date(Date.UTC(t[0], t[1]-1, t[2]));
+                                value = $.datepicker.formatDate(formatString, dateObject);
+                                // From user format
+                            } else {
+                                if (isDate(value)) {
+                                    var dateObject = getDateObject(value);
+                                }
+                                value = $.datepicker.formatDate(formatString, dateObject);
+                            }
+
+                            $('#aor_conditions_value\\['+index+'\\]').val(value);
+                        }
+                    });
                 });
             });
             {/literal}

--- a/modules/AOW_WorkFlow/aow_utils.php
+++ b/modules/AOW_WorkFlow/aow_utils.php
@@ -759,8 +759,20 @@ function fixUpFormatting($module, $field, $value)
                 break;
             }
             if ( ! preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$/',$value) ) {
-                // This appears to be formatted in user date/time
-                $value = $timedate->to_db($value);
+                // If date string doesnt have time setup, dont change it to the previous date/future date
+                if (strpos($value, ':') === false) {
+                    global $current_user;
+                    $user_date_format = $timedate->get_date_format($current_user);
+
+                    if (DateTime::createFromFormat($user_date_format, $value) !== FALSE) {
+                        $date = DateTime::createFromFormat($user_date_format, $value);
+                        $date->setTime(00, 00, 00);
+                        $value = $date->format('Y-m-d H:i:s');
+                    }
+                } else {
+                    // This appears to be formatted in user date/time
+                    $value = $timedate->to_db($value);
+                }
             }
             break;
         case 'date':


### PR DESCRIPTION
Convert parametarised dates correctly if the user date format changes. Also, only update user format after all condition line elements have been placed on the page. Also, made sure that fixUpFormatting() function does not roll back the dates.

relates to issue #1624 
