### PR TITLE
Fixed #1700 - convert parametarised dates correctly if the user date format changes. saveOptions() function from AORReportsDashlet.php needs to convert dates to the db format in order for comparison to work.

### DIFF
--- a/modules/AOR_Reports/Dashlets/AORReportsDashlet/AORReportsDashlet.php
+++ b/modules/AOR_Reports/Dashlets/AORReportsDashlet/AORReportsDashlet.php
@@ -134,6 +134,21 @@ class AORReportsDashlet extends Dashlet {
 //            $req['parameter_value'][1] = $firstValue;
 //        }
         $allowedKeys = array_flip(array('aor_report_id','dashletTitle','charts','onlyCharts','parameter_id','parameter_value','parameter_type','parameter_operator'));
+
+        // Fix for issue #1700 - save value as db type
+        for($i = 0; $i < count($req['parameter_value']); $i++) {
+            if(isset($req['parameter_value'][$i]) && $req['parameter_value'][$i] != '') {
+                global $current_user, $timedate;
+                $user_date_format = $timedate->get_date_format($current_user);
+
+                if (DateTime::createFromFormat($user_date_format, $req['parameter_value'][$i]) !== FALSE) {
+                    $date = DateTime::createFromFormat($user_date_format, $req['parameter_value'][$i]);
+                    $date->setTime(00, 00, 00);
+                    $req['parameter_value'][$i] = $timedate->asDb($date);
+                }
+            }
+        }
+
         $intersected = array_intersect_key($req,$allowedKeys);
         return $intersected;
     }

--- a/modules/AOR_Reports/Dashlets/AORReportsDashlet/dashletConfigure.tpl
+++ b/modules/AOR_Reports/Dashlets/AORReportsDashlet/dashletConfigure.tpl
@@ -137,6 +137,36 @@
                 </td>
             </tr>
             {/foreach}
+            <script>
+                {literal}
+                // Make sure to change dates back to the user format
+                $(document).ready(function() {
+                    $('.date_input').each(function(index, elem) {
+                        var value = $(this).val();
+                        var formatString = cal_date_format.replace(/%/g, '').toLowerCase().replace(/y/g, 'yy').replace(/m/g, 'mm').replace(/d/g, 'dd');
+
+                        // From DB format
+                        var date_reg_format = '([0-9]{4})-([0-9]{1,2})-([0-9]{1,2})';
+                        myregexp = new RegExp(date_reg_format);
+                        if(myregexp.test(value)) {
+                            // Split timestamp into [ Y, M, D ]
+                            var t = value.split(/[- :]/);
+                            // Apply each element to the Date function
+                            var dateObject = new Date(Date.UTC(t[0], t[1]-1, t[2]));
+                            value = $.datepicker.formatDate(formatString, dateObject);
+                            // From user format
+                        } else {
+                            if (isDate(value)) {
+                                var dateObject = getDateObject(value);
+                            }
+                            value = $.datepicker.formatDate(formatString, dateObject);
+                        }
+
+                        $(this).val(value);
+                    });
+                });
+                {/literal}
+            </script>
             <tr>
                 <td scope='row'>
 


### PR DESCRIPTION
Convert parametarised dates correctly if the user date format changes. saveOptions() function from AORReportsDashlet.php needs to convert dates to the db format in order for comparison to work.

relates to #1700
