### PR TITLE
Fixed #1903 - Unable to load Calendar in PHP5.3

### DIFF
--- a/modules/Calendar/CalendarDisplay.php
+++ b/modules/Calendar/CalendarDisplay.php
@@ -179,7 +179,8 @@ class CalendarDisplay {
 		foreach($this->views as $view){
 			$location_array[] = $view;
 		}
-		$ss->assign("langprefix", explode("_",$GLOBALS['current_language'])[0] );
+		$current_language = explode("_",$GLOBALS['current_language']);
+		$ss->assign("langprefix", $current_language[0]);
 
 		$ss->assign('custom_views',$location_array);
 		if($_REQUEST['module'] == "Calendar"){
@@ -576,7 +577,7 @@ class CalendarDisplay {
 
 	public function convertPHPToMomentFormat($format)
 	{
-		$replacements = [
+		$replacements = array(
 			'd' => 'DD',
 			'D' => 'ddd',
 			'j' => 'D',
@@ -614,7 +615,7 @@ class CalendarDisplay {
 			'c' => '', // no equivalent
 			'r' => '', // no equivalent
 			'U' => 'X',
-		];
+		);
 		$momentFormat = strtr($format, $replacements);
 		return $momentFormat;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A number of users in the forums have been unable to see the Calendar on php5.3 - this was due to a parsing error (works on PHP 5.4+)

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Made the code suitable for PHP5.3

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Unable to view Calendar in PHP 5.3 environments

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Be on a php5.3 environment
2. log in as any user
3. navigate to Calendar
4. you should now be able to use and navigate the calendar as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
