### PR TITLE
Fixed  #1849 - Quick edit sends AJAX request via GET

### DIFF
--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -413,7 +413,7 @@ function setValueClose(value){
 
 function saveFieldHTML(field,module,id,value, parent_type) {
     $.ajaxSetup({"async": false});
-    var result = $.getJSON('index.php',
+    var result = $.post('index.php',
         {
             'module': 'Home',
             'action': 'saveHTMLField',
@@ -424,7 +424,7 @@ function saveFieldHTML(field,module,id,value, parent_type) {
             'view' : view,
             'parent_type': parent_type,
             'to_pdf': true
-        }
+        }, null, "json"
     );
     $.ajaxSetup({"async": true});
     return(result.responseText);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I changed the GET request to a POST. To reproduce bug, inline edit description field and enter a large description.

## Motivation and Context
This change solves the problem of updating textboxes with a lot of text via inline editing.
#1849 


## How To Test This
Use a large description field and inline edit.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
