### PR TITLE
PHP5.3 code syntax for Spots module

### DIFF
--- a/modules/Spots/controller.php
+++ b/modules/Spots/controller.php
@@ -142,7 +142,7 @@ class SpotsController extends SugarController
     public function action_createAccountsSpotsData($filepath)
     {
         global $mod_strings;
-        $returnArray = [];
+        $returnArray = array();
         $db = DBManagerFactory::getInstance();
 
         $query = <<<EOF
@@ -198,7 +198,7 @@ EOF;
     public function action_createLeadsSpotsData($filepath)
     {
         global $mod_strings;
-        $returnArray = [];
+        $returnArray = array();
         $db = DBManagerFactory::getInstance();
 
         $mysqlSelect = <<<EOF
@@ -303,7 +303,7 @@ EOF;
     public function action_createSalesSpotsData($filepath)
     {
         global $mod_strings;
-        $returnArray = [];
+        $returnArray = array();
         $db = DBManagerFactory::getInstance();
 
         $mysqlSelect = <<<EOF
@@ -435,7 +435,7 @@ EOF;
     public function action_createServiceSpotsData($filepath)
     {
         global $mod_strings;
-        $returnArray = [];
+        $returnArray = array();
         $db = DBManagerFactory::getInstance();
 
         $mysqlSelect = <<<EOF
@@ -548,7 +548,7 @@ EOF;
     public function action_createActivitiesSpotsData($filepath)
     {
         global $mod_strings;
-        $returnArray = [];
+        $returnArray = array();
         $db = DBManagerFactory::getInstance();
 
         $mysqlQueryCalls = <<<EOF
@@ -688,7 +688,7 @@ EOF;
     public function action_createMarketingSpotsData($filepath)
     {
         global $mod_strings;
-        $returnArray = [];
+        $returnArray = array();
         $db = DBManagerFactory::getInstance();
 
         $mysqlSelect = <<<EOF
@@ -803,7 +803,7 @@ EOF;
     public function action_createMarketingActivitySpotsData($filepath)
     {
         global $mod_strings;
-        $returnArray = [];
+        $returnArray = array();
         $db = DBManagerFactory::getInstance();
 
         $query = <<<EOF
@@ -865,7 +865,7 @@ EOF;
     public function action_createQuotesSpotsData($filepath)
     {
         global $mod_strings;
-        $returnArray = [];
+        $returnArray = array();
         $db = DBManagerFactory::getInstance();
 
         $mysqlSelect = <<<EOF


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Error loading Spots module on PHP 5.3 due to array syntax

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Updated array syntax to suit older PHP versions

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Module is unusable for PHP 5.3 environments

## How To Test This
<!--- Please describe in detail how to test your changes. -->
On a PHP 5.3 environment test Spots module - should lead to fatal error
After fix, on PHP 5.3 should be able to navigate and create Spot records as expected on other supported PHP evironments

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
