### PR TITLE
Fixed #1138 AOW_WorkFlow - execution on 'New Records' fails when user…

### DIFF
--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -457,10 +457,11 @@ class AOW_WorkFlow extends Basic {
 
         if($this->flow_run_on){
 
-            // database time correction with the user's time-zoneqq
-            $beanDateEnteredTimestamp = strtotime($timedate->asUser(new DateTime($timedate->fromDb($bean->date_entered))));
-            $beanDateModifiedTimestamp = strtotime($timedate->asUser(new DateTime($timedate->fromDb($bean->date_modified))));
-            $thisDateEnteredTimestamp = strtotime($this->date_entered);
+            // database time correction with user's time-zone (using user's date format)
+            $userDateFormat = $timedate->get_date_time_format();
+            $beanDateEnteredTimestamp = date_create_from_format($userDateFormat,$timedate->asUser(new DateTime($timedate->fromDb($bean->date_entered))))->getTimestamp();
+            $beanDateModifiedTimestamp = date_create_from_format($userDateFormat,$timedate->asUser(new DateTime($timedate->fromDb($bean->date_modified))))->getTimestamp();
+            $thisDateEnteredTimestamp = date_create_from_format($userDateFormat,$this->date_entered)->getTimestamp();
 
             switch($this->flow_run_on){
                 case'New_Records':

--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -459,9 +459,20 @@ class AOW_WorkFlow extends Basic {
 
             // database time correction with user's time-zone (using user's date format)
             $userDateFormat = $timedate->get_date_time_format();
-            $beanDateEnteredTimestamp = date_create_from_format($userDateFormat,$timedate->asUser(new DateTime($timedate->fromDb($bean->date_entered))))->getTimestamp();
-            $beanDateModifiedTimestamp = date_create_from_format($userDateFormat,$timedate->asUser(new DateTime($timedate->fromDb($bean->date_modified))))->getTimestamp();
-            $thisDateEnteredTimestamp = date_create_from_format($userDateFormat,$this->date_entered)->getTimestamp();
+            $beanDateEnteredTimestampTemp = date_create_from_format($userDateFormat,$timedate->asUser(new DateTime($timedate->fromDb($bean->date_entered))));
+            if (($beanDateEnteredTimestampTemp instanceof DateTime) != null){
+                $beanDateEnteredTimestamp = $beanDateEnteredTimestampTemp->getTimestamp();
+            }
+
+            $beanDateModifiedTimestampTemp = date_create_from_format($userDateFormat,$timedate->asUser(new DateTime($timedate->fromDb($bean->date_modified))));
+            if (($beanDateModifiedTimestampTemp instanceof DateTime) != null){
+                $beanDateModifiedTimestamp = $beanDateModifiedTimestampTemp->getTimestamp();
+            }
+
+            $thisDateEnteredTimestampTemp = date_create_from_format($userDateFormat,$this->date_entered);
+            if (($thisDateEnteredTimestampTemp instanceof DateTime) != null){
+                $thisDateEnteredTimestamp = $thisDateEnteredTimestampTemp->getTimestamp();
+            }
 
             switch($this->flow_run_on){
                 case'New_Records':


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix #1138 AOW_WorkFlow - execution on 'New Records' fails when user's dateformat is not strtotime compatible
## Description

<!--- Describe your changes in detail -->

Using the proposition of @adamjakab ( https://github.com/salesagility/SuiteCRM/pull/1146/files ),
Thanks @adamjakab for contribution.

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
- Create WorkFlow with module:accounts, Run-on: New Records
   condytions: Module:Accounts, Field:Date Created, Operator: greater or equal then, Type: value,   value (some date)
- Create Account, watch is date fail
- Repeat for different time formats

References issue #1138

<!--- Please link to the issue here unless your commit contains the issue number -->
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
## How To Test This

<!--- Please describe in detail how to test your changes. -->

Repeat steps from replicate an issue
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
### Final checklist

<!--- Go over all the following points and check all the boxes that apply. --->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->

…'s dateformat is not strtotime compatible
