### PR TITLE
white space after primary object in detailview

### DIFF
--- a/themes/SuiteP/include/DetailView/DetailView.tpl
+++ b/themes/SuiteP/include/DetailView/DetailView.tpl
@@ -216,6 +216,10 @@
                 var tab = parseInt($(this).find('a').first().attr('id').match(/^tab(.)*$/)[1]);
                 selectTab(tab);
             });
+            $('#content ul.nav.nav-tabs li.active').each(function(e){
+                var tab = parseInt($(this).find('a').first().attr('id').match(/^tab(.)*$/)[1]);
+                selectTab(tab);
+            });
         });
 
     </script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
white space after primary object in detailview: seems to be a large block of white space between module and first subpanel

## Motivation and Context
related to task (251)

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
