### PR TITLE
Fixed - hide_subpanels default set on install

### DIFF
--- a/install/install_defaults.php
+++ b/install/install_defaults.php
@@ -97,7 +97,7 @@
             'setup_site_sugarbeet_anonymous_stats' => true,
             'siteConfig_submitted' => false,
             'dbUSRData' => 'same',
-
+            'hide_subpanels' => true,
         );
         
 ?>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This fix sets default state of the subpanels, so that they are collapsed/hidden.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

1. Looks nicer
2. It's better for mobile/tablet devices
 

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Install an instance of SuiteCRM (WIth this fix of couse)
2. Check that they subpanels in the detail view are collapsed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
