### PR TITLE
add 'collapsed subpanles' checkbox to system settings

### DIFF
--- a/include/ListView/ListViewSmarty.php
+++ b/include/ListView/ListViewSmarty.php
@@ -125,6 +125,10 @@ class ListViewSmarty extends ListViewDisplay{
             $this->ss->assign('inline_edit', true);
         }
 
+        if(!isset($sugar_config['hide_subpanels']) || $sugar_config['hide_subpanels']){
+            $this->ss->assign('hide_subpanels', true);
+        }
+
 		$this->ss->assign('sugarconfig', $this->displayColumns);
 		$this->ss->assign('displayColumns', $this->displayColumns);
 		$this->ss->assign('APP',$app_strings);

--- a/install/install_utils.php
+++ b/install/install_utils.php
@@ -790,6 +790,7 @@ function handleSugarConfig() {
     $sugar_config['log_file']                       = $setup_site_log_file;
     $sugar_config['enable_line_editing_detail']     = true;
     $sugar_config['enable_line_editing_list']       = true;
+    $sugar_config['hide_subpanels']       = true;
 
     // Setup FTS
     if (!empty($_SESSION['setup_fts_type'])) {

--- a/modules/Configurator/Configurator.php
+++ b/modules/Configurator/Configurator.php
@@ -45,7 +45,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 class Configurator {
 	var $config = '';
 	var $override = '';
-	var $allow_undefined = array ('stack_trace_errors', 'export_delimiter', 'use_real_names', 'developerMode', 'default_module_favicon', 'authenticationClass', 'SAML_loginurl', 'SAML_X509Cert', 'dashlet_auto_refresh_min', 'show_download_tab', 'enable_action_menu','enable_line_editing_list','enable_line_editing_detail');
+	var $allow_undefined = array ('stack_trace_errors', 'export_delimiter', 'use_real_names', 'developerMode', 'default_module_favicon', 'authenticationClass', 'SAML_loginurl', 'SAML_X509Cert', 'dashlet_auto_refresh_min', 'show_download_tab', 'enable_action_menu','enable_line_editing_list','enable_line_editing_detail', 'hide_subpanels');
 	var $errors = array ('main' => '');
 	var $logger = NULL;
 	var $previous_sugar_override_config_array = array();

--- a/modules/Configurator/language/en_us.lang.php
+++ b/modules/Configurator/language/en_us.lang.php
@@ -125,6 +125,7 @@ $mod_strings = array (
     'LBL_ENABLE_INLINE_EDITING_LIST_DESC' => 'Select to enable Inline Editing for fields on the list view. If unselected Inline Editing will be disabled on list view.',
     'LBL_ENABLE_INLINE_EDITING_DETAIL' => 'Enable inline editing on detail view',
     'LBL_ENABLE_INLINE_EDITING_DETAIL_DESC' => 'Select to enable Inline Editing for fields on the detail view. If unselected Inline Editing will be disabled on detail view.',
+	'LBL_HIDE_SUBPANELS' => 'Collapsed subpanels',
     'LIST_ENTRIES_PER_LISTVIEW'=>'Listview items per page',
 	'LIST_ENTRIES_PER_SUBPANEL'=>'Subpanel items per page',
 	'LOG_MEMORY_USAGE'=>'Log memory usage',

--- a/modules/Configurator/tpls/EditView.tpl
+++ b/modules/Configurator/tpls/EditView.tpl
@@ -214,7 +214,18 @@
     </tr>
 
 
-
+	<tr>
+		<td  scope="row" nowrap>{$MOD.LBL_HIDE_SUBPANELS}: &nbsp;{sugar_help text=$MOD.LBL_HIDE_SUBPANELS}</td>
+		{if isset($config.hide_subpanels) && $config.hide_subpanels != "true" }
+			{assign var='hide_subpanels' value=''}
+		{else}
+			{assign var='hide_subpanels' value='CHECKED'}
+		{/if}
+		<td>
+			<input type='hidden' name='hide_subpanels' value='false'>
+			<input name='hide_subpanels'  type="checkbox" value="true" {$hide_subpanels}>
+		</td>
+	</tr>
 
 </table>
 

--- a/modules/Configurator/tpls/EditView.tpl
+++ b/modules/Configurator/tpls/EditView.tpl
@@ -216,7 +216,7 @@
 
 	<tr>
 		<td  scope="row" nowrap>{$MOD.LBL_HIDE_SUBPANELS}: &nbsp;{sugar_help text=$MOD.LBL_HIDE_SUBPANELS}</td>
-		{if isset($config.hide_subpanels) && $config.hide_subpanels != "true" }
+		{if (isset($config.hide_subpanels) && $config.hide_subpanels != "true") || !isset($config.hide_subpanels)}
 			{assign var='hide_subpanels' value=''}
 		{else}
 			{assign var='hide_subpanels' value='CHECKED'}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
this PR able to users to set default collapsed/expanded settings for subpanels

## Motivation and Context
collapsed subpanels by default - we need that string in config_override (task 249)

## How To Test This
- quick repair and rebuild needed
- check/un-check the new one collapsed subpanels checkbox on system settings on admin panel
- you should see the different on edit view subpanels collapsed state by default

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
