### PR TITLE
SuiteP: Adding Support for No Module Filters

### DIFF
--- a/themes/SuiteP/css/bootstrap.min.css
+++ b/themes/SuiteP/css/bootstrap.min.css
@@ -1546,7 +1546,7 @@ pre code {
 }
 }
 
-@media (min-width:1200px) {
+@media (min-width:1130px) {
     .container {
     width: 1170px;
 }
@@ -2059,7 +2059,7 @@ pre code {
 }
 }
 
-@media (min-width:1200px) {
+@media (min-width:1130px) {
     .col-lg-1, .col-lg-10, .col-lg-11, .col-lg-12, .col-lg-2, .col-lg-3, .col-lg-4, .col-lg-5, .col-lg-6, .col-lg-7, .col-lg-8, .col-lg-9 {
     float: left;
 }
@@ -4178,7 +4178,7 @@ select[multiple].input-group-sm>.form-control, select[multiple].input-group-sm>.
     margin-top: 4px;
 }
 
-@media (min-width:1251px) {
+@media (min-width:1130px) {
     .navbar-toggle {
     display: none;
 }
@@ -6601,7 +6601,7 @@ td.visible-md, th.visible-md {
 }
 }
 
-@media (min-width:1200px) {
+@media (min-width:1130px) {
     .visible-lg {
     display: block!important;
 }
@@ -6619,19 +6619,19 @@ td.visible-lg, th.visible-lg {
 }
 }
 
-@media (min-width:1200px) {
+@media (min-width:1130px) {
     .visible-lg-block {
     display: block!important;
 }
 }
 
-@media (min-width:1200px) {
+@media (min-width:1130px) {
     .visible-lg-inline {
     display: inline!important;
 }
 }
 
-@media (min-width:1200px) {
+@media (min-width:1130px) {
     .visible-lg-inline-block {
     display: inline-block!important;
 }
@@ -6655,18 +6655,18 @@ td.visible-lg, th.visible-lg {
 
 }
 
-@media (max-width:1200px) {
+@media (max-width:1130px) {
     .hidden-md {
         display: none!important;
     }
 }
 
-@media (min-width:1201px) and (max-width:1250px) {
+@media (min-width:992px) and (max-width:1130px) {
     .hidden-mdlg {
         display: none !important;
 }
 
-@media (min-width:1200px) {
+@media (min-width:1130px) {
 .hidden-lg {
     display: none!important;
 }

--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -3566,6 +3566,33 @@ ul.nav-tabs > li:first-of-type > a {
     color: #ffffff;
 }
 
+
+#overflow-menu {
+    height: 300px;
+}
+
+#overflow-menu > li {
+    line-height: normal;
+    height: auto;
+}
+
+#overflow-menu > li a {
+    margin: 0;
+    padding: 12px 15px 12px 15px;
+    font-size: 14px;
+    font-weight: normal;
+    clear: both;
+}
+
+#overflow-menu > li > ul,
+#overflow-menu > li > ul > li {
+    display: none;
+    visibility: collapse;
+    height: 0;
+    padding: 0;
+    margin: 0;
+}
+
 a.first-tab-xs {
     /*TODO: fix long tabs*/
     background-color: #778591 !important;

--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -3577,6 +3577,11 @@ ul.nav-tabs > li:first-of-type > a {
     height: 300px;
 }
 
+#overflow-menu > li > span.notCurrentTabLeft, #overflow-menu > li > span.notCurrentTabRight {
+    visibility: collapse;
+    display: none;
+}
+
 #overflow-menu > li {
     line-height: normal;
     height: auto;

--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -5049,7 +5049,7 @@ li.topnav {
     height: 90px;
     letter-spacing: 2px;
     line-height: 90px;
-    padding: 0 10px 0 10px;
+    padding: 0 5px 0 5px;
     text-transform: uppercase;
 }
 
@@ -5319,6 +5319,12 @@ div.search_fields_basic label {
     }
 }
 /*lg-col-*/
+@media (min-width: 1260px) {
+    li.topnav {
+        padding: 0 10px 0 10px;
+    }
+}
+
 @media (min-width: 1200px) {
     div.search_name_basic, div.search_fields_basic, div.search_buttons_basic {
         width: auto;
@@ -8167,7 +8173,7 @@ div.list-view-rounded-corners > table th:last-of-type {
     }
 }
 
-@media (min-width: 1251px) {
+@media (min-width: 1131px) {
     #mobile_menu {
         position: absolute;
         overflow-y: scroll;
@@ -8190,7 +8196,7 @@ div.list-view-rounded-corners > table th:last-of-type {
         width: 1200px;
     }
 }
-@media (max-width: 1250px) {
+@media (max-width: 1130px) {
     #usermenu {
         display: none;
     }
@@ -8214,7 +8220,7 @@ div.list-view-rounded-corners > table th:last-of-type {
             float: left;
             text-align: left !important;
             margin: 0 auto 0 15px !important;
-            width: 8sc
+            width: 8px;
         }
 
     }

--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -5014,6 +5014,7 @@ textarea#description {
 }
 .recent_h3 {
     color: #ffffff;
+    line-height:42px;
 }
 
 .recent_h3 > strong {

--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -634,6 +634,10 @@ div.noBullet li, .nobullet
 }
 
 
+.with-actions > .dropdown-menu {
+    height: 292px;
+}
+
 #recentlyViewedSidebar {
     margin-bottom: 30px;
     float: left;
@@ -648,8 +652,10 @@ li.recentlinks_edit {
     background-color: yellow;
 }
 
-li.recentlinks {
-    width: 100%;}
+li.recentlinks, li.recentlinks a {
+    width: 100%;
+    clear: both;
+}
 
 li.recentlinks img {
     margin-right: 5px;
@@ -5009,6 +5015,11 @@ textarea#description {
 .recent_h3 {
     color: #ffffff;
 }
+
+.recent_h3 > strong {
+    text-transform: none;
+}
+
 
 ul.nav li.topnav a {
     border-top: 3px solid #534d64;

--- a/themes/SuiteP/js/style.js
+++ b/themes/SuiteP/js/style.js
@@ -278,8 +278,8 @@ jQuery(function($){
             "x-small": 480,
             "small": 768,
             "medium": 992,
-            "large": 1200,
-            "x-large": 1400
+            "large": 1130,
+            "x-large": 1250
         }
     });
 })

--- a/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -234,15 +234,85 @@
                         <span class="notCurrentTabLeft">&nbsp;</span>
                         <span class="modulename"><a href="{sugar_link module=$MODULE_TAB link_only=1 }">{sugar_translate module=$MODULE_TAB label='LBL_MODULE_NAME'}</a></span>
                         <span class="notCurrentTabRight">&nbsp;</span>
+                        {foreach from=$moduleTopMenu item=module key=name name=moduleList}
+                                {if $name == $MODULE_TAB}
+                                    <ul class="dropdown-menu" role="menu">
+                                        {if count($shortcutTopMenu.$name) > 0}
+                                            <h3 class="home_h3">{$APP.LBL_LINK_ACTIONS}</h3>
+                                            {foreach from=$shortcutTopMenu.$name item=item}
+                                                {if $item.URL == "-"}
+                                                    <li><a></a><span>&nbsp;</span></li>
+                                                {else}
+                                                    <li><a href="{$item.URL}">{$item.LABEL}</a></li>
+                                                {/if}
+                                            {/foreach}
+                                        {/if}
+                                        {*<h3 class="recent_h3">{$APP.LBL_LAST_VIEWED}</h3>*}
+                                        {*{foreach from=$recentRecords item=item name=lastViewed}*}
+                                            {*<div class="recently_viewed_link_container_sidebar">*}
+                                                {*<!--<li class="recentlinks_edit"><a*}
+                                            {*href="{sugar_link module=$item.module_name action='EditView' record=$item.item_id link_only=1}"*}
+                                            {*style="margin-left:10px;"><span class=" glyphicon glyphicon-pencil"*}
+                                                                            {*aria-hidden="true"></a></li>-->*}
+                                                {*<li class="topnav" role="presentation">*}
+                                                    {*<a title="{$item.module_name}"*}
+                                                       {*accessKey="{$smarty.foreach.lastViewed.iteration}"*}
+                                                       {*href="{sugar_link module=$item.module_name action='DetailView' record=$item.item_id link_only=1}">*}
+                                                        {*<img src="{sugar_getimagepath directory='sidebar/modules'  file_name=$item.module_name file_extension="svg" file='sidebar/modules/'.$item.module_name.".svg"}"/><span aria-hidden="true">{$item.item_summary_short}</span>*}
+                                                    {*</a>*}
+                                                {*</li>*}
+                                            {*</div>*}
+                                        {*{/foreach}*}
+                                        {*<h3 class="recent_h3">{$APP.LBL_FAVORITES}</h3>*}
+                                        {*{foreach from=$favoriteRecords item=item name=lastViewed}*}
+                                            {*<div class="recently_viewed_link_container_sidebar" id="{$item.id}_favorite">*}
+                                                {*<!--<li class="recentlinks_edit"><a*}
+                                            {*href="{sugar_link module=$item.module_name action='EditView' record=$item.id link_only=1}"*}
+                                            {*style="margin-left:10px;"><span class=" glyphicon glyphicon-pencil"*}
+                                                                            {*aria-hidden="true"></a></li>-->*}
+                                                {*<li class="recentlinks" role="presentation">*}
+                                                    {*<a title="{$item.module_name}"*}
+                                                       {*accessKey="{$smarty.foreach.lastViewed.iteration}"*}
+                                                       {*href="{sugar_link module=$item.module_name action='DetailView' record=$item.id link_only=1}">*}
+                                                        {*<img src="{sugar_getimagepath  directory='sidebar/modules' file_name=$item.module_name file_extension="svg" file='sidebar/modules/'.$item.module_name.".svg"}"/><span aria-hidden="true">{$item.item_summary_short}</span>*}
+                                                    {*</a>*}
+                                                {*</li>*}
+                                            {*</div>*}
+                                        {*{/foreach}*}
+                                    </ul>
+                                {/if}
+                            {/foreach}
                     </li>
                     {foreach from=$groupTabs item=modules key=group name=groupList}
                         {capture name=extraparams assign=extraparams}parentTab={$group}{/capture}
                     {/foreach}
+
+
+                    {foreach from=$modules.modules item=submodulename key=submodule}
+                        {if $submodule != "Home"}
+                            <li class="topnav">
+                                <span class="notCurrentTabLeft">&nbsp;</span>
+                                <span class="dropdown-toggle headerlinks notCurrentTab"> <a href="{sugar_link module=$submodule link_only=1 extraparams=$extraparams}">{$submodulename}</a> </span>
+                                <span class="notCurrentTabRight">&nbsp;</span>
+                                <ul class="dropdown-menu" role="menu">
+                                    {if count($shortcutTopMenu.$submodule) > 0}
+                                        <h3 class="home_h3">{$APP.LBL_LINK_ACTIONS}</h3>
+                                        {foreach from=$shortcutTopMenu.$submodule item=item}
+                                            {if $item.URL == "-"}
+                                                <li><a></a><span>&nbsp;</span></li>
+                                            {else}
+                                                <li><a href="{$item.URL}">{$item.LABEL}</a></li>
+                                            {/if}
+                                        {/foreach}
+                                    {/if}
+                                </ul>
+                            </li>
+                        {/if}
+                    {/foreach}
+
                     {foreach from=$modules.extra item=submodulename key=submodule}
                         <li class="topnav">
-                            <span class="notCurrentTabLeft">&nbsp;</span>
-                            <span class="dropdown-toggle headerlinks notCurrentTab"> <a href="{sugar_link module=$submodule link_only=1 extraparams=$extraparams}">{$submodulename}</a> </span>
-                            <span class="notCurrentTabRight">&nbsp;</span>
+                            <span class=" notCurrentTab"> <a href="{sugar_link module=$submodule link_only=1 extraparams=$extraparams}">{$submodulename}</a> </span>
                         </li>
                     {/foreach}
                     <li class="topnav overflow-toggle-menu">

--- a/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -298,10 +298,13 @@
                         var windowResize = function() {
                             // reset navbar
                             var $navCollapsedItems = $('ul#overflow-menu > li.with-actions');
-                            $($navCollapsedItems).each(function() {
-                                $(this).addClass('topnav');
-                                $(navItem).insertBefore('.overflow-menu');
-                            });
+                            if(typeof $navCollapsedItems !== "undefined") {
+                                $($navCollapsedItems).each(function() {
+                                    $(this).addClass('topnav');
+                                    $(this).insertBefore('.overflow-toggle-menu');
+                                });
+                            }
+
 
 
                             var $navItemMore = $('.navbar-horizontal-fluid > li.overflow-toggle-menu'),

--- a/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -230,73 +230,19 @@
             {else}
 
                 <ul class="nav navbar-nav navbar-horizontal-fluid">
-                    <li class="topnav">
-                        <span class="notCurrentTabLeft">&nbsp;</span>
-                        <span class="modulename"><a href="{sugar_link module=$MODULE_TAB link_only=1 }">{sugar_translate module=$MODULE_TAB label='LBL_MODULE_NAME'}</a></span>
-                        <span class="notCurrentTabRight">&nbsp;</span>
-                        {foreach from=$moduleTopMenu item=module key=name name=moduleList}
-                                {if $name == $MODULE_TAB}
-                                    <ul class="dropdown-menu" role="menu">
-                                        {if count($shortcutTopMenu.$name) > 0}
-                                            <h3 class="home_h3">{$APP.LBL_LINK_ACTIONS}</h3>
-                                            {foreach from=$shortcutTopMenu.$name item=item}
-                                                {if $item.URL == "-"}
-                                                    <li><a></a><span>&nbsp;</span></li>
-                                                {else}
-                                                    <li><a href="{$item.URL}">{$item.LABEL}</a></li>
-                                                {/if}
-                                            {/foreach}
-                                        {/if}
-                                        {*<h3 class="recent_h3">{$APP.LBL_LAST_VIEWED}</h3>*}
-                                        {*{foreach from=$recentRecords item=item name=lastViewed}*}
-                                            {*<div class="recently_viewed_link_container_sidebar">*}
-                                                {*<!--<li class="recentlinks_edit"><a*}
-                                            {*href="{sugar_link module=$item.module_name action='EditView' record=$item.item_id link_only=1}"*}
-                                            {*style="margin-left:10px;"><span class=" glyphicon glyphicon-pencil"*}
-                                                                            {*aria-hidden="true"></a></li>-->*}
-                                                {*<li class="topnav" role="presentation">*}
-                                                    {*<a title="{$item.module_name}"*}
-                                                       {*accessKey="{$smarty.foreach.lastViewed.iteration}"*}
-                                                       {*href="{sugar_link module=$item.module_name action='DetailView' record=$item.item_id link_only=1}">*}
-                                                        {*<img src="{sugar_getimagepath directory='sidebar/modules'  file_name=$item.module_name file_extension="svg" file='sidebar/modules/'.$item.module_name.".svg"}"/><span aria-hidden="true">{$item.item_summary_short}</span>*}
-                                                    {*</a>*}
-                                                {*</li>*}
-                                            {*</div>*}
-                                        {*{/foreach}*}
-                                        {*<h3 class="recent_h3">{$APP.LBL_FAVORITES}</h3>*}
-                                        {*{foreach from=$favoriteRecords item=item name=lastViewed}*}
-                                            {*<div class="recently_viewed_link_container_sidebar" id="{$item.id}_favorite">*}
-                                                {*<!--<li class="recentlinks_edit"><a*}
-                                            {*href="{sugar_link module=$item.module_name action='EditView' record=$item.id link_only=1}"*}
-                                            {*style="margin-left:10px;"><span class=" glyphicon glyphicon-pencil"*}
-                                                                            {*aria-hidden="true"></a></li>-->*}
-                                                {*<li class="recentlinks" role="presentation">*}
-                                                    {*<a title="{$item.module_name}"*}
-                                                       {*accessKey="{$smarty.foreach.lastViewed.iteration}"*}
-                                                       {*href="{sugar_link module=$item.module_name action='DetailView' record=$item.id link_only=1}">*}
-                                                        {*<img src="{sugar_getimagepath  directory='sidebar/modules' file_name=$item.module_name file_extension="svg" file='sidebar/modules/'.$item.module_name.".svg"}"/><span aria-hidden="true">{$item.item_summary_short}</span>*}
-                                                    {*</a>*}
-                                                {*</li>*}
-                                            {*</div>*}
-                                        {*{/foreach}*}
-                                    </ul>
-                                {/if}
-                            {/foreach}
-                    </li>
                     {foreach from=$groupTabs item=modules key=group name=groupList}
                         {capture name=extraparams assign=extraparams}parentTab={$group}{/capture}
                     {/foreach}
 
-
+                    <!--nav items with actions -->
                     {foreach from=$modules.modules item=submodulename key=submodule}
                         {if $submodule != "Home"}
-                            <li class="topnav">
+                            <li class="topnav with-actions">
                                 <span class="notCurrentTabLeft">&nbsp;</span>
                                 <span class="dropdown-toggle headerlinks notCurrentTab"> <a href="{sugar_link module=$submodule link_only=1 extraparams=$extraparams}">{$submodulename}</a> </span>
                                 <span class="notCurrentTabRight">&nbsp;</span>
                                 <ul class="dropdown-menu" role="menu">
                                     {if count($shortcutTopMenu.$submodule) > 0}
-                                        <h3 class="home_h3">{$APP.LBL_LINK_ACTIONS}</h3>
                                         {foreach from=$shortcutTopMenu.$submodule item=item}
                                             {if $item.URL == "-"}
                                                 <li><a></a><span>&nbsp;</span></li>
@@ -309,17 +255,18 @@
                             </li>
                         {/if}
                     {/foreach}
-
-                    {foreach from=$modules.extra item=submodulename key=submodule}
-                        <li class="topnav">
-                            <span class=" notCurrentTab"> <a href="{sugar_link module=$submodule link_only=1 extraparams=$extraparams}">{$submodulename}</a> </span>
-                        </li>
-                    {/foreach}
                     <li class="topnav overflow-toggle-menu">
                         <span class="notCurrentTabLeft">&nbsp;</span>
                         <span class="dropdown-toggle headerlinks notCurrentTab"><a href="#">{$APP.LBL_MORE}</a></span>
                         <span class="notCurrentTabRight">&nbsp;</span>
-                        <ul id="overflow-menu" class="dropdown-menu" role="menu"></ul>
+                        <ul id="overflow-menu" class="dropdown-menu" role="menu">
+                            <!--nav items without actions -->
+                            {foreach from=$modules.extra item=submodulename key=submodule}
+                                <li class="topnav without-actions">
+                                    <span class=" notCurrentTab"> <a href="{sugar_link module=$submodule link_only=1 extraparams=$extraparams}">{$submodulename}</a> </span>
+                                </li>
+                            {/foreach}
+                        </ul>
                     </li>
                 </ul>
 
@@ -329,18 +276,16 @@
                         var windowResize = function() {
 
                             var $navItemMore = $('.navbar-horizontal-fluid > li.overflow-toggle-menu'),
-                                    $navItems = $('.navbar-horizontal-fluid > li:not(.overflow-toggle-menu)'),
-                                    navItemMoreWidth = navItemWidth = $navItemMore.width(),
-                                    windowWidth = $(window).width(),
-                                    navItemMoreLeft, offset, navOverflowWidth;
+                            $navItems = $('.navbar-horizontal-fluid > li.with-actions'),
+                            navItemMoreWidth = navItemWidth = $navItemMore.width(),
+                            windowWidth = $(window).width() - ($(window).width()  * 0.55),
+                            navItemMoreLeft, offset, navOverflowWidth;
 
                             $navItems.each(function() {
                                 navItemWidth += $(this).width();
                             });
 
-//                            navItemWidth > (windowWidth - (windowWidth * 0.55)) ? $navItemMore.show() : $navItemMore.hide();
-
-                            while (navItemWidth > windowWidth - (windowWidth * 0.55)) {
+                            while (navItemWidth > windowWidth) {
                                 navItemWidth -= $navItems.last().width();
                                 $navItems.last().removeClass('topnav');
                                 $navItems.last().find('ul').remove();

--- a/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -228,143 +228,67 @@
                     {/foreach}
                 </ul>
             {else}
-                <ul class="nav navbar-nav">
-                    {foreach from=$moduleTopMenu item=module key=name name=moduleList}
-                        {if $name == $MODULE_TAB}
-                            <li class="topnav">
-                                {if $name !='Home'}
-                                    <span class="currentTabLeft">&nbsp;</span>
-                                    <span class="dropdown-toggle headerlinks currentTab">{sugar_link id="moduleTab_$name" module=$name data=$module}</span>
-                                    <span>&nbsp;</span>
-                                {/if}
-                                <ul class="dropdown-menu" role="menu">
-                                    {if count($shortcutTopMenu.$name) > 0}
-                                        <h3 class="home_h3">{$APP.LBL_LINK_ACTIONS}</h3>
-                                        {foreach from=$shortcutTopMenu.$name item=item}
-                                            {if $item.URL == "-"}
-                                                <li><a></a><span>&nbsp;</span></li>
-                                            {else}
-                                                <li><a href="{$item.URL}" class=""><span>{$item.LABEL}</span></a></li>
-                                            {/if}
-                                        {/foreach}
-                                    {/if}
-                                    <h3 class="recent_h3">{$APP.LBL_LAST_VIEWED}</h3>
-                                    {foreach from=$recentRecords item=item name=lastViewed}
-                                        {if $item.module_name == $name}
-                                            <div class="recently_viewed_link_container">
-                                                <li class="recentlinks_topedit"><a
-                                                            href="{sugar_link module=$item.module_name action='EditView' record=$item.item_id link_only=1}"
-                                                            style="margin-left:10px;"><span
-                                                                class=" glyphicon glyphicon-pencil" aria-hidden="true"></a>
-                                                </li>
-                                                <li class="recentlinks_top" role="presentation">
-                                                    <a title="{$item.module_name}"
-                                                       accessKey="{$smarty.foreach.lastViewed.iteration}"
-                                                       href="{sugar_link module=$item.module_name action='DetailView' record=$item.item_id link_only=1}">
-                                                        {$item.item_summary_short}
-                                                    </a>
-                                                </li>
-                                            </div>
-                                        {/if}
-                                        {foreachelse}
-                                        {$APP.NTC_NO_ITEMS_DISPLAY}
-                                    {/foreach}
-                                    <h3 class="recent_h3">{$APP.LBL_FAVORITES}</h3>
-                                    {foreach from=$favoriteRecords item=item name=lastViewed}
-                                        {if $item.module_name == $name}
-                                            <div class="recently_viewed_link_container">
-                                                <li class="recentlinks_topedit">
-                                                    <a href="{sugar_link module=$item.module_name action='EditView' record=$item.id link_only=1}"
-                                                       style="margin-left:10px;"><span
-                                                                class=" glyphicon glyphicon-pencil" aria-hidden="true"></a>
-                                                </li>
-                                                <li class="recentlinks_top" role="presentation">
-                                                    <a title="{$item.module_name}"
-                                                       accessKey="{$smarty.foreach.lastViewed.iteration}"
-                                                       href="{sugar_link module=$item.module action='DetailView' record=$item.id link_only=1}">{$item.item_summary_short}</a>
-                                                </li>
-                                            </div>
-                                        {/if}
-                                        {foreachelse}
-                                        {$APP.NTC_NO_ITEMS_DISPLAY}
-                                    {/foreach}
-                                </ul>
-                            </li>
-                        {else}
-                            <li class="topnav">
-                                {if $name != 'Home'}
-                                    <span class="notCurrentTabLeft">&nbsp;</span>
-                                    <span class="dropdown-toggle headerlinks notCurrentTab">{sugar_link id="moduleTab_$name" module=$name data=$module}</span>
-                                    <span class="notCurrentTabRight">&nbsp;</span>
-                                {/if}
-                                <ul class="dropdown-menu" role="menu">
-                                    {if count($shortcutTopMenu.$name) > 0}
-                                        <h3 class="home_h3">{$APP.LBL_LINK_ACTIONS}</h3>
-                                        {foreach from=$shortcutTopMenu.$name item=item}
-                                            {if $item.URL == "-"}
-                                                <li><a></a><span>&nbsp;</span></li>
-                                            {else}
-                                                <li><a href="{$item.URL}">{$item.LABEL}</a></li>
-                                            {/if}
-                                        {/foreach}
-                                    {/if}
-                                    <h3 class="recent_h3">{$APP.LBL_LAST_VIEWED}</h3>
-                                    {foreach from=$recentRecords item=item name=lastViewed}
-                                        {if $item.module_name == $name}
-                                            <div class="recently_viewed_link_container">
-                                                <li class="recentlinks_topedit"><a
-                                                            href="{sugar_link module=$item.module_name action='EditView' record=$item.item_id link_only=1}"
-                                                            style="margin-left:10px;"><span
-                                                                class=" glyphicon glyphicon-pencil" aria-hidden="true"></a>
-                                                </li>
-                                                <li class="recentlinks_top" role="presentation">
-                                                    <a title="{$item.module_name}"
-                                                       accessKey="{$smarty.foreach.lastViewed.iteration}"
-                                                       href="{sugar_link module=$item.module_name action='DetailView' record=$item.item_id link_only=1}">
-                                                        {$item.item_summary_short}
-                                                    </a>
-                                                </li>
-                                            </div>
-                                        {/if}
-                                        {foreachelse}
-                                        {$APP.NTC_NO_ITEMS_DISPLAY}
-                                    {/foreach}
-                                    <h3 class="recent_h3">{$APP.LBL_FAVORITES}</h3>
-                                    {foreach from=$favoriteRecords item=item name=lastViewed}
-                                        {if $item.module_name == $name}
-                                            <div class="recently_viewed_link_container">
-                                                <li class="recentlinks_topedit">
-                                                    <a href="{sugar_link module=$item.module_name action='EditView' record=$item.id link_only=1}"
-                                                       style="margin-left:10px;"><span
-                                                                class=" glyphicon glyphicon-pencil" aria-hidden="true"></a>
-                                                </li>
-                                                <li class="recentlinks_top" role="presentation">
-                                                    <a title="{$item.module_name}"
-                                                       accessKey="{$smarty.foreach.lastViewed.iteration}"
-                                                       href="{sugar_link module=$item.module_name action='DetailView' record=$item.id link_only=1}">{$item.item_summary_short}</a>
-                                                </li>
-                                            </div>
-                                        {/if}
-                                        {foreachelse}
-                                        {$APP.NTC_NO_ITEMS_DISPLAY}
-                                    {/foreach}
-                                </ul>
-                            </li>
-                        {/if}
+
+                <ul class="nav navbar-nav navbar-horizontal-fluid">
+                    <li class="topnav">
+                        <span class="notCurrentTabLeft">&nbsp;</span>
+                        <span class="modulename"><a href="{sugar_link module=$MODULE_TAB link_only=1 }">{sugar_translate module=$MODULE_TAB label='LBL_MODULE_NAME'}</a></span>
+                        <span class="notCurrentTabRight">&nbsp;</span>
+                    </li>
+                    {foreach from=$groupTabs item=modules key=group name=groupList}
+                        {capture name=extraparams assign=extraparams}parentTab={$group}{/capture}
                     {/foreach}
-                    {if count($moduleExtraMenu) > 0}
-                        <li class="dropdown-toggle moremenu ">
-                            <a class="dropdown-toggle" data-toggle="dropdown">{$APP.LBL_MORE} &raquo;</a>
-                            <ul class="dropdown-menu" role="menu">
-                                <div class="bigmenu">
-                                    {foreach from=$moduleExtraMenu item=module key=name name=moduleList}
-                                        <li>{sugar_link id="moduleTab_$name" module=$name data=$module}</li>
-                                    {/foreach}
-                                </div>
-                            </ul>
+                    {foreach from=$modules.extra item=submodulename key=submodule}
+                        <li class="topnav">
+                            <span class="notCurrentTabLeft">&nbsp;</span>
+                            <span class="dropdown-toggle headerlinks notCurrentTab"> <a href="{sugar_link module=$submodule link_only=1 extraparams=$extraparams}">{$submodulename}</a> </span>
+                            <span class="notCurrentTabRight">&nbsp;</span>
                         </li>
-                    {/if}
+                    {/foreach}
+                    <li class="topnav overflow-toggle-menu">
+                        <span class="notCurrentTabLeft">&nbsp;</span>
+                        <span class="dropdown-toggle headerlinks notCurrentTab"><a href="#">{$APP.LBL_MORE}</a></span>
+                        <span class="notCurrentTabRight">&nbsp;</span>
+                        <ul id="overflow-menu" class="dropdown-menu" role="menu"></ul>
+                    </li>
                 </ul>
+
+
+                {literal}
+                    <script>
+                        var windowResize = function() {
+
+                            var $navItemMore = $('.navbar-horizontal-fluid > li.overflow-toggle-menu'),
+                                    $navItems = $('.navbar-horizontal-fluid > li:not(.overflow-toggle-menu)'),
+                                    navItemMoreWidth = navItemWidth = $navItemMore.width(),
+                                    windowWidth = $(window).width(),
+                                    navItemMoreLeft, offset, navOverflowWidth;
+
+                            $navItems.each(function() {
+                                navItemWidth += $(this).width();
+                            });
+
+//                            navItemWidth > (windowWidth - (windowWidth * 0.55)) ? $navItemMore.show() : $navItemMore.hide();
+
+                            while (navItemWidth > windowWidth - (windowWidth * 0.55)) {
+                                navItemWidth -= $navItems.last().width();
+                                $navItems.last().removeClass('topnav');
+                                $navItems.last().find('ul').remove();
+                                $navItems.last().find('.notCurrentTabLeft').remove();
+                                $navItems.last().find('.notCurrentTabRight').remove();
+                                $navItems.last().prependTo('#overflow-menu');
+                                $navItems.splice(-1,1);
+                            }
+
+                            navItemMoreLeft = $('.navbar-horizontal-fluid .overflow-toggle-menu').offset().left;
+                            navOverflowWidth = $('#overflow-menu').width();
+                            offset = navItemMoreLeft + navItemMoreWidth - navOverflowWidth;
+                        };
+                        $(window).resize(windowResize);
+                        windowResize();
+                    </script>
+                {/literal}
+
             {/if}
             <div id="globalLinks" class="dropdown nav navbar-nav navbar-right globalLinks-desktop">
                 <li id="usermenu" class="user-dropdown" aria-expanded="false">

--- a/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -251,6 +251,28 @@
                                             {/if}
                                         {/foreach}
                                     {/if}
+
+                                    <li class="recent_h3"><strong>{$APP.LBL_LAST_VIEWED}</strong></li>
+                                    {foreach from=$recentRecords item=item name=lastViewed}
+                                            <li class="recentlinks" role="presentation">
+                                                <a title="{$item.module_name}"
+                                                   accessKey="{$smarty.foreach.lastViewed.iteration}"
+                                                   href="{sugar_link module=$item.module_name action='DetailView' record=$item.item_id link_only=1}">
+                                                    <img src="{sugar_getimagepath directory='sidebar/modules'  file_name=$item.module_name file_extension="svg" file='sidebar/modules/'.$item.module_name.".svg"}"/><span aria-hidden="true">{$item.item_summary_short}</span>
+                                                </a>
+                                            </li>
+                                    {/foreach}
+                                    <li class="recent_h3"><strong>{$APP.LBL_FAVORITES}</strong></li>
+                                    {foreach from=$favoriteRecords item=item name=lastViewed}
+                                            <li class="recentlinks" role="presentation">
+                                                <a title="{$item.module_name}"
+                                                   accessKey="{$smarty.foreach.lastViewed.iteration}"
+                                                   href="{sugar_link module=$item.module_name action='DetailView' record=$item.id link_only=1}">
+                                                    <img src="{sugar_getimagepath  directory='sidebar/modules' file_name=$item.module_name file_extension="svg" file='sidebar/modules/'.$item.module_name.".svg"}"/><span aria-hidden="true">{$item.item_summary_short}</span>
+                                                </a>
+                                            </li>
+                                    {/foreach}
+
                                 </ul>
                             </li>
                         {/if}

--- a/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -291,28 +291,33 @@
                         </ul>
                     </li>
                 </ul>
-
+                <div class="hidden hidden-actions">black cat</div>
 
                 {literal}
                     <script>
                         var windowResize = function() {
+                            // reset navbar
+                            var $navCollapsedItems = $('ul#overflow-menu > li.with-actions');
+                            $($navCollapsedItems).each(function() {
+                                $(this).addClass('topnav');
+                                $(navItem).insertBefore('.overflow-menu');
+                            });
+
 
                             var $navItemMore = $('.navbar-horizontal-fluid > li.overflow-toggle-menu'),
-                            $navItems = $('.navbar-horizontal-fluid > li.with-actions'),
-                            navItemMoreWidth = navItemWidth = $navItemMore.width(),
-                            windowWidth = $(window).width() - ($(window).width()  * 0.55),
-                            navItemMoreLeft, offset, navOverflowWidth;
+                                    $navItems = $('.navbar-horizontal-fluid > li.with-actions'),
+                                    navItemMoreWidth = navItemWidth = $navItemMore.width(),
+                                    windowWidth = $(window).width() - ($(window).width()  * 0.55),
+                                    navItemMoreLeft, offset, navOverflowWidth;
 
                             $navItems.each(function() {
                                 navItemWidth += $(this).width();
                             });
 
+                            // Remove nav items that are cause the right hand nav-bar items to wrap
                             while (navItemWidth > windowWidth) {
                                 navItemWidth -= $navItems.last().width();
                                 $navItems.last().removeClass('topnav');
-                                $navItems.last().find('ul').remove();
-                                $navItems.last().find('.notCurrentTabLeft').remove();
-                                $navItems.last().find('.notCurrentTabRight').remove();
                                 $navItems.last().prependTo('#overflow-menu');
                                 $navItems.splice(-1,1);
                             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
SuiteP: Adding Support for No Module Filters

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If a user doesn't use 'Module Menu Filters' the top menu on desktop doesn't display well.
## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Admin
2. Profile
3. Advance
4. check Module Menu Filters
5. Click save

Pass condition: if you are in the desktop view the right nav items should stay inline with the items.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->