### PR TITLE
Fixed #1559. Deleting a contact from a meeting doesn't call the logic hook

### DIFF
--- a/modules/Meetings/MeetingFormBase.php
+++ b/modules/Meetings/MeetingFormBase.php
@@ -342,14 +342,9 @@ function handleSave($prefix,$redirect=true, $useRequired=false) {
 	    	}
 
 	    	if(count($deleteContacts) > 0) {
-	    		$sql = '';
-	    		foreach($deleteContacts as $u) {
-	    		        $sql .= ",'" . $u . "'";
-	    		}
-	    		$sql = substr($sql, 1);
-	    		// We could run a delete SQL statement here, but will just mark as deleted instead
-	    		$sql = "UPDATE meetings_contacts set deleted = 1 where contact_id in ($sql) AND meeting_id = '". $focus->id . "'";
-	    		$focus->db->query($sql);
+				foreach($deleteContacts as $u) {
+					$focus->contacts->delete($focus->id, $u);
+				}
 	    	}
 	        if(!empty($_POST['lead_invitees'])) {
 	    	   $leadInvitees = explode(',', trim($_POST['lead_invitees'], ','));
@@ -371,14 +366,9 @@ function handleSave($prefix,$redirect=true, $useRequired=false) {
 	    	}
 
 	    	if(count($deleteLeads) > 0) {
-	    		$sql = '';
 	    		foreach($deleteLeads as $u) {
-	    		        $sql .= ",'" . $u . "'";
+					$focus->leads->delete($focus->id, $u);
 	    		}
-	    		$sql = substr($sql, 1);
-	    		// We could run a delete SQL statement here, but will just mark as deleted instead
-	    		$sql = "UPDATE meetings_leads set deleted = 1 where lead_id in ($sql) AND meeting_id = '". $focus->id . "'";
-	    		$focus->db->query($sql);
 	    	}
 	    	////	END REMOVE
 	    	///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description
Changed the code that deletes leads or contacts from a meeting to use the bean rather than SQL.
## Motivation and Context
After relationship delete logic hooks weren't getting called when you removed a lead or contact from a meeting using the link with the text rem on the meetings editview.

relates to issue #1559 
## How To Test This
Add an after relationship delete logic hook to the meetings module. Create a meeting and add contacts and leads to it. Edit meeting and use the link that says rem next to a contact/leads name to remove them and check if the logic hook gets called.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
