### PR TITLE
Fixed - Yellow background in side bar  favorites

### DIFF
--- a/modules/Favorites/Favorites.php
+++ b/modules/Favorites/Favorites.php
@@ -105,7 +105,15 @@ class Favorites extends Favorites_sugar
             $return_array[$i]['item_summary_short'] = to_html(getTrackerSubstring($bean->name));
             $return_array[$i]['id'] = $row['parent_id'];
             $return_array[$i]['module_name'] = $row['parent_type'];
-            $return_array[$i]['image'] = SugarThemeRegistry::current() ->getImage($row['parent_type'],'border="0" align="absmiddle"',null,null,'.gif',$bean->name);
+
+
+            // Change since 7.7 side bar icons can exist in images/sidebar.
+            $sidebarPath = 'themes/'.SugarThemeRegistry::current().'/images/sidebar/modules/';
+            if(file_exists($sidebarPath)) {
+                $return_array[$i]['image'] = SugarThemeRegistry::current()->getImage('sidebar/modules/'.$row['parent_type'],'border="0" align="absmiddle"',null,null,'.gif',$bean->name);
+            } else {
+                $return_array[$i]['image'] = SugarThemeRegistry::current()->getImage($row['parent_type'],'border="0" align="absmiddle"',null,null,'.gif',$bean->name);
+            }
 
             $i++;
         }

--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -6132,7 +6132,9 @@ a[id^=grouptab]:visited, a[id^=grouptab]:active {
 #fieldChoices .field-list input {
     height: 30px;
 }
-
+.recentlinks_edit {
+    visibility: collapse;
+}
 #fieldChoices .field {
 
 }

--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -648,10 +648,6 @@ div.noBullet li, .nobullet
     font-size: 13px;
 }
 
-li.recentlinks_edit {
-    background-color: yellow;
-}
-
 li.recentlinks {
     width: 100%;}
 

--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -6133,7 +6133,10 @@ a[id^=grouptab]:visited, a[id^=grouptab]:active {
     height: 30px;
 }
 .recentlinks_edit {
-    visibility: collapse;
+    visibility: collapse !important;
+    display: none !important;
+    height: 0 !important;
+    width: 0 !important;
 }
 #fieldChoices .field {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When a user marks a record as a favourite the background of said favorite becomes yellow. This change fixes the issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Mark a record as a favourite.
Passes if the background is not yellow.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
