### PR TITLE
fix calendar ignoring initial default values

### DIFF
--- a/modules/Calendar/Calendar.php
+++ b/modules/Calendar/Calendar.php
@@ -227,8 +227,12 @@ class Calendar {
 		$i = 0;
 		foreach($this->acts_arr as $user_id => $acts){
 			if(isset($acts) && empty($acts)){
+				$shared_calendar_separate = $GLOBALS['current_user']->getPreference('calendar_display_shared_separate');
+				if(is_null($shared_calendar_separate)) {
+					$shared_calendar_separate = SugarConfig::getInstance()->get('calendar.calendar_display_shared_separate', true);
+				}
 				//if no calendar items we add the user to the list.
-				if($GLOBALS['current_user']->getPreference('calendar_display_shared_separate')){
+				if($shared_calendar_separate){
 					//$this->items[ $item['user_id'] ][] = $item;
 					$this->items[ $user_id ][] = array();
 				}else{
@@ -301,7 +305,12 @@ class Calendar {
 					}
 
 
-				if($GLOBALS['current_user']->getPreference('calendar_display_shared_separate')){
+				$shared_calendar_separate = $GLOBALS['current_user']->getPreference('calendar_display_shared_separate');
+				if(is_null($shared_calendar_separate)) {
+					$shared_calendar_separate = SugarConfig::getInstance()->get('calendar.calendar_display_shared_separate', true);
+				}
+				//if no calendar items we add the user to the list.
+				if($shared_calendar_separate){
 					$this->items[ $item['user_id'] ][] = $item;
 				}else{
 					$this->items[ $GLOBALS['current_user']->id ][] = $item;

--- a/modules/Calendar/CalendarDisplay.php
+++ b/modules/Calendar/CalendarDisplay.php
@@ -48,34 +48,34 @@ class CalendarDisplay {
 	 */
 	public $activity_colors = array(
 		'Meetings' => array(
-			'border' => '#87719C',
-			'body' => '#6B5171',
-			'text' => '#E5E5E5'
+			'border' => '87719C',
+			'body' => '6B5171',
+			'text' => 'E5E5E5'
 		),
 		'Calls' => array(
-			'border' => '#487166',
-			'body' => '#72B3A1',
-			'text' => '#E5E5E5'
+			'border' => '487166',
+			'body' => '72B3A1',
+			'text' => 'E5E5E5'
 		),
 		'Tasks' => array(
-			'border' => '#515A71',
-			'body' => '#707C9C',
-			'text' => '#E5E5E5'
+			'border' => '515A71',
+			'body' => '707C9C',
+			'text' => 'E5E5E5'
 		),
 		'FP_events' => array(
-			'border' => '#C29B8A',
-			'body' => '#7D6459',
-			'text' => '#E5E5E5'
+			'border' => 'C29B8A',
+			'body' => '7D6459',
+			'text' => 'E5E5E5'
 		),
 		'Project' => array(
-			'border' => '#699DC9',
-			'body' => '#557FA3',
-			'text' => '#E5E5E5'
+			'border' => '699DC9',
+			'body' => '557FA3',
+			'text' => 'E5E5E5'
 		),
 		'ProjectTask' => array(
-			'border' => '#83C489',
-			'body' => '#659769',
-			'text' => '#E5E5E5'
+			'border' => '83C489',
+			'body' => '659769',
+			'text' => 'E5E5E5'
 		),
 	);
 	/**


### PR DESCRIPTION
## Description
Changed the hard coded array of colours in CalendarDisplay.php as Cal.js appends a # before them so the # before the hex color in the array was redundant and preventing it from using correct default colours. Related to Kanboard task 259

Also updated code so default shared calendar seperate setting is respected.
## Motivation and Context
The initial default calendar settings were being ignored

## How To Test This
If you go to view a shared calendar without setting any user preferences it should show a separate calendar for each user and use the default colours that are used in the settings menu.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
