### PR TITLE
fixed bug2097 

### DIFF
--- a/modules/AOP_Case_Updates/Case_Updates.php
+++ b/modules/AOP_Case_Updates/Case_Updates.php
@@ -311,7 +311,7 @@ function quick_edit_case_updates($case){
 
     <textarea id="update_text" name="update_text" cols="80" rows="4"></textarea>
 
-    <input id='internal' type='checkbox' name='$internalLabel' tabindex=0 title='' value='1' $internalChecked > $internalLabel</input>
+    <input id='internal' type='checkbox' name='internal' title='$internalLabel' tabindex=0 title='' value='1' $internalChecked > $internalLabel</input>
     </br>
     <input type='button' value='Save' onclick="caseUpdates('$record')" title="Save" name="button"> </input>
 

--- a/modules/AOP_Case_Updates/Case_Updates.php
+++ b/modules/AOP_Case_Updates/Case_Updates.php
@@ -302,13 +302,16 @@ function quick_edit_case_updates($case){
     if(isset($case->internal) && $case->internal){
         $internalChecked = "checked='checked'";
     }
+
+    require_once('include/utils.php');
+    $internalLabel = translate('LBL_INTERNAL', 'Cases');
     $html = <<< EOD
     <form id='case_updates' enctype="multipart/form-data">
 
 
     <textarea id="update_text" name="update_text" cols="80" rows="4"></textarea>
 
-    <input id='internal' type='checkbox' name='internal' tabindex=0 title='' value='1' $internalChecked > Internal</input>
+    <input id='internal' type='checkbox' name='$internalLabel' tabindex=0 title='' value='1' $internalChecked > $internalLabel</input>
     </br>
     <input type='button' value='Save' onclick="caseUpdates('$record')" title="Save" name="button"> </input>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix 2097 - Unable to rename checkbox name in case_updatesdates.
## Description
handle renaming checkbox name in more dynamic way.
e in more dynamic way.
References issue #2097 
<!--- Describe your changes in detail -->
handle renaming checkbox name in more dynamic way.
Using the same label as internal field on the EditView.
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Go to admin->studio->case module
Rename checkbox name in case_updates, this checkbox is named "Internal".
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Handle renaming checkbox name.
## How To Test This
<!--- Please describe in detail how to test your changes. -->
Repeat replication of the bug proces.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
