### PR TITLE
Fix appearance of Select All checkbox in Footer for SuiteP theme.

### DIFF
--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -1722,6 +1722,7 @@ table#mass_update_table td select {
 }
 
 #actionLinkTop li.sugar_action_button,
+#actionLinkBottom li.sugar_action_button,
 #selectLinkTop > .sugar_action_button > ul.subnav a:hover,
 #selectLinkBottom > .sugar_action_button > ul.subnav a:hover,
 #actionLinkBottom > .sugar_action_button > ul.subnav a:hover,
@@ -7594,6 +7595,7 @@ table.subpanel-table ul.subpanel > a,
 .single  a,
 .single > a,
 #actionLinkTop li.sugar_action_button,
+#actionLinkBottom li.sugar_action_button,
 table.subpanel-table li.sugar_action_button,
 #selectLinkTop li.sugar_action_button,
 #selectLinkBottom li.sugar_action_button,

--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -1634,6 +1634,7 @@ table#mass_update_table td select {
 
 
 #selectLinkTop,
+#selectLinkBottom,
 #actionLinkBottom {
     min-height: 16px;
     line-height: 16px;
@@ -1641,6 +1642,7 @@ table#mass_update_table td select {
     padding: 1px;
 }
 #selectLinkTop input[type=checkbox],
+#selectLinkBottom input[type=checkbox],
 #actionLinkBottom input[type=checkbox] {
     margin-top: 10px;
 }
@@ -1721,6 +1723,7 @@ table#mass_update_table td select {
 
 #actionLinkTop li.sugar_action_button,
 #selectLinkTop > .sugar_action_button > ul.subnav a:hover,
+#selectLinkBottom > .sugar_action_button > ul.subnav a:hover,
 #actionLinkBottom > .sugar_action_button > ul.subnav a:hover,
 #actionLinkTop .menuItemHilite,
 #actionLinkBottom .menuItemHilite {
@@ -3916,6 +3919,7 @@ ul.clickMenu > li > span {
 
 
 #selectLinkTop, #selectLinkTop .sugar_action_button,
+#selectLinkBottom, #selectLinkBottom .sugar_action_button,
 #selectLinkTop, #selectLinkTop .selectActionsDisabled {
     min-width: 32px;
 }
@@ -7592,6 +7596,7 @@ table.subpanel-table ul.subpanel > a,
 #actionLinkTop li.sugar_action_button,
 table.subpanel-table li.sugar_action_button,
 #selectLinkTop li.sugar_action_button,
+#selectLinkBottom li.sugar_action_button,
 table.subpanel-table .pagination .sugar_action_button,
 table.subpanel-table .pagination li.sugar_action_button > form > a,
 table.subpanel-table .pagination .sugar_action_button > form > a,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Made sure selectLinkBottom had the same styles applied to it as selectLinkTop so the select all checkbox at the bottom of list view looks the same as the one at the top of list view.

## Motivation and Context
Select all checkbox at bottom of list view looked broken in SuiteP.

## How To Test This
Check the checkbox at the top and bottom of any list view in SuiteP for selecting all items looks the same

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
