### PR TITLE
css fix for minimised subpanels so they aren't spaced out

### DIFF
--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -2484,7 +2484,7 @@ li.noBullet {
     list-style-type: none;
     padding: 0;
     margin: 0;
-    min-height: 100px;
+    min-height: initial;
 }
 
 #MorePanelHandle {


### PR DESCRIPTION
## Description
css fix for minimised subpanels so they aren't spaced out

## Motivation and Context
css fix for minimised subpanels so they aren't spaced out

## How To Test This
Go to detail view of any module, minimise the subpanels and make sure there aren't massive gaps between them.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
