### PR TITLE
Fixed #2128 - Footer Licence popups Missing in SuiteP

### DIFF
--- a/themes/SuiteP/js/style.js
+++ b/themes/SuiteP/js/style.js
@@ -233,8 +233,7 @@ $( "button" ).click(function() {
 
 });
 
-// Custom JavaScript for copyright pop-ups
-$(function() {
+var initFooterPopups = function() {
     $( "#dialog, #dialog2" ).dialog({
         autoOpen: false,
         show: {
@@ -253,6 +252,11 @@ $(function() {
     $( "#admin_options" ).click(function() {
         $( "#dialog2" ).dialog( "open" );
     });
+};
+
+// Custom JavaScript for copyright pop-ups
+$(function() {
+    initFooterPopups();
 });
 
 // Back to top animation
@@ -530,6 +534,7 @@ $(function () {
         var clazz = $('#bootstrap-container footer').attr('class');
         $('body').append('<footer class="' + clazz + '">' + $('#bootstrap-container footer').html() + '</footer>');
         $('#bootstrap-container footer').remove();
+        initFooterPopups();
     }
 
 });

--- a/themes/SuiteP/tpls/footer.tpl
+++ b/themes/SuiteP/tpls/footer.tpl
@@ -45,14 +45,6 @@
 {if $AUTHENTICATED}
     <!-- Start generic footer -->
     <footer>
-    	<div class="footer_left">
-    		<a id="admin_options">&copy; {$MOD.LBL_SUITE_SUPERCHARGED}</a>
-            <a id="powered_by">&copy; {$MOD.LBL_SUITE_POWERED_BY}</a>
-    	</div>
-    	<div class="footer_right">
-    		
-    		<a onclick="SUGAR.util.top();" href="javascript:void(0)">{$MOD.LBL_SUITE_TOP}</a>
-    	</div>
         <div id="copyright_data">
             <div id="dialog2" title="{$MOD.LBL_SUITE_SUPERCHARGED}">
                 <p>{$MOD.LBL_SUITE_DESC1}</p>
@@ -65,7 +57,15 @@
             <div id="dialog" title="&copy; {$MOD.LBL_SUITE_POWERED_BY}">
                 <p>{$COPYRIGHT}</p>
             </div>
+            <div id="copyrightbuttons" class="footer_left">
+                <a id="admin_options">&copy; {$MOD.LBL_SUITE_SUPERCHARGED}</a>
+                <a id="powered_by">&copy; {$MOD.LBL_SUITE_POWERED_BY}</a>
+            </div>
         </div>
+    	<div class="footer_right">
+    		
+    		<a onclick="SUGAR.util.top();" href="javascript:void(0)">{$MOD.LBL_SUITE_TOP}</a>
+    	</div>
     </footer>
     <!-- END Generic Footer -->
 {/if}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fix for issue #2128 

## Motivation and Context
task 264

## How To Test This
click on "© Supercharged by SuiteCRM" and "© Powered By SugarCRM " in footer area
(quick repair and rebuild needed)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
