### PR TITLE
Calendar day & week view shows an extra row

### DIFF
--- a/modules/Calendar/CalendarDisplay.php
+++ b/modules/Calendar/CalendarDisplay.php
@@ -130,16 +130,8 @@ class CalendarDisplay {
 		$ss->assign('CALENDAR_FDOW',$GLOBALS['current_user']->get_first_day_of_week());
 
 
-			switch($cal->view){
-				case "agendaDay":
-				case "agendaWeek":
-				case "sharedMonth":
-				case "sharedWeek":
-					$height = 650; break;
-				default:
-					$height = 650; break;
-			}
-		$ss->assign('basic_min_height',$height);
+
+		$ss->assign('basic_min_height',"'auto'");
 		
 		$ss->assign('isPrint', $this->cal->isPrint() ? 'true': 'false');
 


### PR DESCRIPTION
## Description
Changed calendar from being a fixed height to auto.

## Motivation and Context
Stops displaying an extra row at the bottom which made it look broken

## How To Test This
View calendar in either the day, week or shared week view and check it looks ok.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->