### PR TITLE
don't show favourites / Recent Items if there isn't any

### DIFF
--- a/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -149,56 +149,91 @@
                                     <span class="currentTab"
                                           style="color:#F08377 !important;">{sugar_link id="moduleTab_$name" module=$name data=$module}</span>
                                     <span>&nbsp;</span>
-                                    <ul class="dropdown-menu" role="menu">
-                                        {if count($shortcutTopMenu.$name) > 0}
-                                            <h3 class="home_h3">{$APP.LBL_LINK_ACTIONS}</h3>
-                                            {foreach from=$shortcutTopMenu.$name item=item}
-                                                {if $item.URL == "-"}
-                                                    <li><a></a><span>&nbsp;</span></li>
-                                                {else}
-                                                    <li><a href="{$item.URL}">{$item.LABEL}</a></li>
-                                                {/if}
-                                            {/foreach}
+
+
+
+                                    {* check, is there any recent items *}
+                                    {assign var=foundRecents value=false}
+                                    {foreach from=$recentRecords item=item name=lastViewed}
+                                        {if $item.module_name == $name}
+                                            {assign var=foundRecents value=true}
                                         {/if}
-                                        <h3 class="recent_h3">{$APP.LBL_LAST_VIEWED}</h3>
-                                        {foreach from=$recentRecords item=item name=lastViewed}
-                                            {if $item.module_name == $name}
-                                                <div class="recently_viewed_link_container">
-                                                    <li class="recentlinks_topedit">
-                                                        <a href="{sugar_link module=$item.module_name action='EditView' record=$item.item_id link_only=1}"
-                                                           style="margin-left:10px;"><span
-                                                                    class=" glyphicon glyphicon-pencil" aria-hidden="true"></a>
-                                                    </li>
-                                                    <li class="recentlinks_top" role="presentation">
-                                                        <a title="{$item.module_name}"
-                                                           accessKey="{$smarty.foreach.lastViewed.iteration}"
-                                                           href="{sugar_link module=$item.module_name action='DetailView' record=$item.item_id link_only=1}">{$item.item_summary_short}</a>
-                                                    </li>
-                                                </div>
+                                    {/foreach}
+
+
+                                    {* check, is there any favorit items *}
+                                    {assign var=foundFavorits value=false}
+                                    {foreach from=$favoriteRecords item=item name=lastViewed}
+                                        {if $item.module_name == $name}
+                                            {assign var=foundFavorits value=true}
+                                        {/if}
+                                    {/foreach}
+
+
+                                    {if $foundRecents || $foundFavorits || count($shortcutTopMenu.$name) > 0}
+
+                                        <ul class="dropdown-menu" role="menu">
+                                            {if count($shortcutTopMenu.$name) > 0}
+                                                <h3 class="home_h3">{$APP.LBL_LINK_ACTIONS}</h3>
+                                                {foreach from=$shortcutTopMenu.$name item=item}
+                                                    {if $item.URL == "-"}
+                                                        <li><a></a><span>&nbsp;</span></li>
+                                                    {else}
+                                                        <li><a href="{$item.URL}">{$item.LABEL}</a></li>
+                                                    {/if}
+                                                {/foreach}
                                             {/if}
-                                            {foreachelse}
-                                            {$APP.NTC_NO_ITEMS_DISPLAY}
-                                        {/foreach}
-                                        <h3 class="recent_h3">{$APP.LBL_FAVORITES}</h3>
-                                        {foreach from=$favoriteRecords item=item name=lastViewed}
-                                            {if $item.module_name == $name}
-                                                <div class="recently_viewed_link_container">
-                                                    <li class="recentlinks_topedit">
-                                                        <a href="{sugar_link module=$item.module_name action='EditView' record=$item.id link_only=1}"
-                                                           style="margin-left:10px;"><span
-                                                                    class=" glyphicon glyphicon-pencil" aria-hidden="true"></a>
-                                                    </li>
-                                                    <li class="recentlinks_top" role="presentation">
-                                                        <a title="{$item.module_name}"
-                                                           accessKey="{$smarty.foreach.lastViewed.iteration}"
-                                                           href="{sugar_link module=$item.module_name action='DetailView' record=$item.id link_only=1}">{$item.item_summary_short}</a>
-                                                    </li>
-                                                </div>
+
+                                            {if $foundRecents}
+                                                <h3 class="recent_h3">{$APP.LBL_LAST_VIEWED}</h3>
+                                                {foreach from=$recentRecords item=item name=lastViewed}
+                                                    {if $item.module_name == $name}
+                                                        <div class="recently_viewed_link_container">
+                                                            <li class="recentlinks_topedit">
+                                                                <a href="{sugar_link module=$item.module_name action='EditView' record=$item.item_id link_only=1}"
+                                                                   style="margin-left:10px;"><span
+                                                                            class=" glyphicon glyphicon-pencil" aria-hidden="true"></a>
+                                                            </li>
+                                                            <li class="recentlinks_top" role="presentation">
+                                                                <a title="{$item.module_name}"
+                                                                   accessKey="{$smarty.foreach.lastViewed.iteration}"
+                                                                   href="{sugar_link module=$item.module_name action='DetailView' record=$item.item_id link_only=1}">{$item.item_summary_short}</a>
+                                                            </li>
+                                                        </div>
+                                                    {/if}
+                                                {foreachelse}
+                                                    {$APP.NTC_NO_ITEMS_DISPLAY}
+                                                {/foreach}
                                             {/if}
-                                            {foreachelse}
-                                            {$APP.NTC_NO_ITEMS_DISPLAY}
-                                        {/foreach}
-                                    </ul>
+
+
+
+                                            {if $foundFavorits}
+                                                <h3 class="recent_h3">{$APP.LBL_FAVORITES}</h3>
+                                                {foreach from=$favoriteRecords item=item name=lastViewed}
+                                                    {if $item.module_name == $name}
+                                                        <div class="recently_viewed_link_container">
+                                                            <li class="recentlinks_topedit">
+                                                                <a href="{sugar_link module=$item.module_name action='EditView' record=$item.id link_only=1}"
+                                                                   style="margin-left:10px;"><span
+                                                                            class=" glyphicon glyphicon-pencil" aria-hidden="true"></a>
+                                                            </li>
+                                                            <li class="recentlinks_top" role="presentation">
+                                                                <a title="{$item.module_name}"
+                                                                   accessKey="{$smarty.foreach.lastViewed.iteration}"
+                                                                   href="{sugar_link module=$item.module_name action='DetailView' record=$item.id link_only=1}">{$item.item_summary_short}</a>
+                                                            </li>
+                                                        </div>
+                                                    {/if}
+                                                    {foreachelse}
+                                                    {$APP.NTC_NO_ITEMS_DISPLAY}
+                                                {/foreach}
+                                            {/if}
+
+                                        </ul>
+
+                                    {/if}
+
                                  </li>
                             {/if}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
this PR for task 215 - Action menu text too big [updated!]

The dropdown action menu text it too big and need reformatted
better in menu when Module Menu Filters is disabled but Favourites displays in line with Recent item
pref don't show favourites / Recent Items if there isn't any, especially on administration

## Motivation and Context
task 215

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
