### PR TITLE
Fixes #2112. Text in labels doesn't break and can overlay fields

### DIFF
--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -1056,7 +1056,7 @@ th, td {
     font-weight: 700;
     line-height: 48px;
     text-align: left;
-    white-space: nowrap;
+    white-space: normal;
     vertical-align: baseline;
 
 }


### PR DESCRIPTION
## Description

Changed css around text for labels on edit and detail view
## Motivation and Context

Text didn't break and longer labels would disappear under fields

relates issue #2112 
## How To Test This

View a field with a longer label on edit view and reduce your browser size and check it still displays properly at all sizes.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
### Final checklist

<!--- Go over all the following points and check all the boxes that apply. --->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
