### PR TITLE
fix List view menu going off screen in SuiteP

### DIFF
--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -3934,7 +3934,6 @@ ul.clickMenu ul.subnav-sub,
 ul.SugarActionMenuIESub {
     list-style: none;
     position: absolute;
-    right: 0;
     top: 20px;
     margin: 0;
     display: none;
@@ -3948,9 +3947,15 @@ ul.SugarActionMenuIESub {
     overflow: hidden;
 }
 
+ul.clickMenu ul.subnav-sub,
+ul.SugarActionMenuIESub {
+    right: 0;
+}
+
 ul.clickMenu li ul.subnav {
     margin-top: 12px;
     min-width: 128px;
+    right: auto;
 }
 
 ul.clickMenu li ul.subnav li, ul.clickMenu ul.subnav-sub li, ul.SugarActionMenuIESub li {


### PR DESCRIPTION
## Description
CSS change to fix menu in List View

## Motivation and Context
The options in the menu couldn't be seen.

## How To Test This
Go to any list view, click the checkbox next to an item to select it, then click the button that says Delete. Before this fix the menu went of the left hand side of the screen and you couldn't read the options. It should now display so all the menu options can be read correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
