### PR TITLE
early change broke the listview on mobile

### DIFF
--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -8100,16 +8100,6 @@ div.list-view-rounded-corners > table th:last-of-type {
 
 @media (max-width: 600px) {
 
-    table tr td {
-        display: block;
-        float: left;
-    }
-
-    table tr td.buttons {
-        width: initial;
-    }
-
-
     #bootstrap-container {
         margin-top: 110px !important;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
this pull request contains a fix for Hotfix footer task 212 (2) and issue #2125
the early change broken the listview on mobile (width:600px-)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
