### PR TITLE
SuiteP: fixing duration field in calls

### DIFF
--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -4885,23 +4885,23 @@ input#btn_ActionLine.button[type="button"] {
     width: 50%;
 }
 
+.edit-view-field #duration_hours {
+    width: 80px;
+    margin-right: 8px;
+}
+
 
 #billing_address_street, #shipping_address_street, #primary_address_street, #alt_address_street {
     height: 54px;
 }
 
-#primary_address_street, #alt_address_street {
-    width: 60% !important;
-}
-
-
 .col-sm-6 .edit-view-field[field="billing_address_street"] input[type="text"],
 .col-sm-6 .edit-view-field[field="shipping_address_street"] input[type="text"] {
-    width: 88% !important;
+    width: 88%;
 }
 
  .col-sm-12 .edit-view-field input[type="text"]:not(.sqsEnabled) {
-    width: 100% !important;
+    width: 100%;
 }
 
 table#lineItems tr td table tfoot tr td span {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This fix corrects the width of the duration field in the edit view of the calls module. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When user edits a call the duration field task up the entire horizontal area.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

- Go to calls
- Edit / Create A Call
- Check the width of the duration field

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
