### PR TITLE
the text for 'Recent Viewed' etc should be smaller/ fit in

### DIFF
--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -5074,7 +5074,7 @@ textarea#description {
     margin-top: 0px !important;
     border-top-right-radius: 0px;
     border-top-left-radius: 0px;
-    font-size: 14px;
+    font-size: 10px;
 }
 
 .navbar-right .dropdown-menu {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

## Motivation and Context
task 215
doesn't fix the actual issue - Action menu text too big, and now if Module Menu Filters is disable the menus all show the just the recently viewed for every module should be consistent, accross the board and the text for "Recent Viewed" etc should be smaller/ fit in

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
