### PR TITLE
remove an extra div closure

### DIFF
--- a/themes/SuiteP/include/DetailView/DetailView.tpl
+++ b/themes/SuiteP/include/DetailView/DetailView.tpl
@@ -155,7 +155,7 @@
             <div class="panel-heading {{$panelHeadingCollapse}}">
                 <a class="{{$collapsed}}" role="button" data-toggle="collapse" href="#{{$panelId}}" aria-expanded="false">
                     <div class="col-xs-10 col-sm-11 col-md-11">
-                         {sugar_translate label='{{$label}}' module='{{$module}}'}</div>
+                         {sugar_translate label='{{$label}}' module='{{$module}}'}
                     </div>
                 </a>
 

--- a/themes/SuiteP/js/style.js
+++ b/themes/SuiteP/js/style.js
@@ -537,4 +537,26 @@ $(function () {
         initFooterPopups();
     }
 
+    // Fix for main sub-panels on detail view
+    var resetTopSubpanelSpacing = function() {
+        $('.panel.panel-default').css('margin-bottom', '0');
+        $('.panel-body.panel-collapse.collapse.in').closest('.panel.panel-default').css('margin-bottom', '30px');
+        $('.panel-body.panel-collapse.collapse.in').closest('.panel.panel-default').prev('.panel.panel-default').css('margin-bottom', '30px');
+    };
+
+    $('li.noBullet').click(function(){
+        setTimeout(function(){
+            resetTopSubpanelSpacing();
+        }, 400);
+    });
+
+    $(window).click(function(){
+        setTimeout(function(){
+            resetTopSubpanelSpacing();
+        }, 400);
+    });
+
+    resetTopSubpanelSpacing();
+
+
 });


### PR DESCRIPTION
sub panels can go behind sidebar

## Description
Daniel @ 08/09/2016 16:49

link
Issue:

When you create a new panel in the detail view. The subpanel ul no longer reside in the #content div. The #content div is what helps to set the width of the content area.

I am still trying to work out why the ul is in the wrong place.

AFAIK there are not issues with closing tags. I can't see any javascript that is moving it out of the content div. It might be somthing to do with smarty.

## Motivation and Context
task/270

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
