### PR TITLE
Adding module id to second group by

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -1187,6 +1187,7 @@ class AOR_Report extends Basic {
 
         if(!$found) {
             $query['select'][] = $this->db->quoteIdentifier($table_name).".id AS ".$table_name."_id";
+            $query['second_group_by'][] = $this->db->quoteIdentifier($table_name).".id";
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When a user selects a date field to use in a report, then selects the group by with a format. The query fails on the MS SQL due to the group by requirements specified in ANSI SQL 3. This is due to the module id not being included in the group by. This change fixes the issue.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes the group by function for ANSI SQL 3.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
See description

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
