### PR TITLE
fix for non-responsive dashlets

### DIFF
--- a/themes/SuiteP/js/style.js
+++ b/themes/SuiteP/js/style.js
@@ -537,4 +537,14 @@ $(function () {
         initFooterPopups();
     }
 
+    // Fix responsive dashlets on Home page
+    setInterval(function(){
+        $('#pageContainer div[id^=pageNum_] table tbody tr td[valign="top"][width="60%"], ' +
+          '#pageContainer div[id^=pageNum_] table tbody tr td[valign="top"][width="40%"]').each(function(i,e){
+            $(e).removeAttr('width');
+            $(e).addClass('dashletcontainer');
+            $(e).addClass('col-50');
+        });
+    }, 100);
+
 });


### PR DESCRIPTION
Home page not responsive

## Description
up to width approx of 1600(1275 with sidebar closed), with a standard home page of 2 columns of dashboards, they are not responsive and cause scrollbars to appear.

This can be seen best on an upgraded instance

## Motivation and Context
task/287

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
