### PR TITLE
Fixed #1288 - Marker legend overlap Toggle Clustering button

### DIFF
--- a/modules/jjwg_Maps/views/view.map_markers.php
+++ b/modules/jjwg_Maps/views/view.map_markers.php
@@ -349,6 +349,8 @@ function setClusterControl() {
     // Setting padding to 5 px will offset the control
     // from the edge of the map
     clusterControlDiv.style.padding = '6px';
+    clusterControlDiv.style.marginTop = '4px';
+    clusterControlDiv.style.marginRight = '170px';
 
     // Set CSS for the control border
     var controlUI = document.createElement('div');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixed issue with Marker legend overlap Toggle Clustering button.
## Description

<!--- Describe your changes in detail -->

References issue #1288 
Fixed issue with Marker legend overlap Toggle Clustering button.

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here unless your commit contains the issue number -->
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
## How To Test This

<!--- Please describe in detail how to test your changes. -->
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
### Final checklist

<!--- Go over all the following points and check all the boxes that apply. --->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
