### PR TITLE
wrap text in line items

### DIFF
--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -4972,6 +4972,7 @@ table#lineItems {
 
 #line_items_span {
     width: 100%;
+    white-space: normal;
 }
 
 table#lineItems tr td table tfoot tr td span {


### PR DESCRIPTION
Relate fields extra long

## Description
Fixes to line items have broken relate fields which now show extra long

## Motivation and Context
task/292

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
