### PR TITLE
Fixed #1433 - Removed duplicate name Polar Chart.

### DIFF
--- a/include/language/en_us.lang.php
+++ b/include/language/en_us.lang.php
@@ -3362,7 +3362,6 @@ $app_list_strings['aor_chart_types']['bar'] = 'Bar chart';
 $app_list_strings['aor_chart_types']['line'] = 'Line chart';
 $app_list_strings['aor_chart_types']['pie'] = 'Pie chart';
 $app_list_strings['aor_chart_types']['radar'] = 'Radar chart';
-$app_list_strings['aor_chart_types']['polar'] = 'Polar chart';
 $app_list_strings['aor_chart_types']['stacked_bar'] = 'Stacked bar';
 $app_list_strings['aor_chart_types']['grouped_bar'] = 'Grouped bar';
 $app_list_strings['aor_scheduled_report_schedule_types']['monthly'] = 'Monthly';

--- a/modules/AOR_Charts/AOR_Chart.php
+++ b/modules/AOR_Charts/AOR_Chart.php
@@ -569,11 +569,6 @@ EOF;
         $yName = str_replace(' ','_',$y->label) . $this->y_field;
 
         switch($this->type){
-            case 'polar':
-                $chartFunction = 'PolarArea';
-                $data = $this->getPolarChartData($reportData, $xName,$yName);
-                $config = $this->getPolarChartConfig();
-                break;
             case 'radar':
                 $chartFunction = 'Radar';
                 $data = $this->getRadarChartData($reportData, $xName,$yName);
@@ -778,17 +773,10 @@ EOF;
         return $this->getBarChartData($reportData, $xName,$yName);
     }
 
-    private function getPolarChartData($reportData, $xName,$yName){
-        return $this->getPieChartData($reportData, $xName,$yName);
-    }
-
     private function getRadarChartConfig(){
         return array();
     }
 
-    private function getPolarChartConfig(){
-        return $this->getPieChartConfig();
-    }
     private function getPieChartConfig(){
         $config = array();
         $config['legendTemplate'] = "<ul class=\"<%=name.toLowerCase()%>-legend\"><% for (var i=0; i<segments.length; i++){%><li><span style=\"background-color:<%=segments[i].fillColor%>\">&nbsp;&nbsp;&nbsp;&nbsp;</span>&nbsp;<%if(segments[i].label){%><%=segments[i].label%><%}%></li><%}%></ul>";


### PR DESCRIPTION
## Description
references issue #1433
1. Removed the "Polar Chart" option from the charts dropdown.
2. Removed case "Polar" from AOR_Chart.php line 572
3. Removed getPolarChartData() and getPolarChartConfig() from AOR_Chart.php as they were only utilised by Polar Chart.
## Motivation and Context
1. The polar chart option does not render anything in the Reports module.
2. Polar Chart is a synonym for Radar Chart which already exists in the module. Radar chart is a generally used term.
## How To Test This

Reports module -> Create a new report -> add chart -> Polar Chart does not render anything
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
