### PR TITLE
Fix  - #2247 MultiSelect field issue in PDF

### DIFF
--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -63,7 +63,7 @@ class templateParser
                 } else if (($field_def['type'] == 'radioenum' || $field_def['type'] == 'enum') && isset($field_def['options'])) {
                     $repl_arr[$key . "_" . $fieldName] = translate($field_def['options'], $focus->module_dir, $focus->$fieldName);
                 } else if ($field_def['type'] == 'multienum' && isset($field_def['options'])) {
-                    $mVals = unencodeMultienum($focus->$field_def['name']);
+                    $mVals = unencodeMultienum($focus->$fieldName);
                     $translatedVals = array();
                     foreach($mVals as $mVal){
                         $translatedVals[] = translate($field_def['options'], $focus->module_dir, $mVal);

--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -63,7 +63,7 @@ class templateParser
                 } else if (($field_def['type'] == 'radioenum' || $field_def['type'] == 'enum') && isset($field_def['options'])) {
                     $repl_arr[$key . "_" . $fieldName] = translate($field_def['options'], $focus->module_dir, $focus->$fieldName);
                 } else if ($field_def['type'] == 'multienum' && isset($field_def['options'])) {
-                    $repl_arr[$key . "_" . $fieldName] = implode(', ', unencodeMultienum($focus->$fieldName));
+                    $repl_arr[$key . "_" . $fieldName] = translate($field_def['options'], $focus->module_dir, implode(', ', unencodeMultienum($focus->$fieldName)));
                 } //Fix for Windows Server as it needed to be converted to a string.
                 else if ($field_def['type'] == 'int') {
                     $repl_arr[$key . "_" . $fieldName] = strval($focus->$fieldName);

--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -63,7 +63,12 @@ class templateParser
                 } else if (($field_def['type'] == 'radioenum' || $field_def['type'] == 'enum') && isset($field_def['options'])) {
                     $repl_arr[$key . "_" . $fieldName] = translate($field_def['options'], $focus->module_dir, $focus->$fieldName);
                 } else if ($field_def['type'] == 'multienum' && isset($field_def['options'])) {
-                    $repl_arr[$key . "_" . $fieldName] = translate($field_def['options'], $focus->module_dir, implode(', ', unencodeMultienum($focus->$fieldName)));
+                    $mVals = unencodeMultienum($focus->$field_def['name']);
+                    $translatedVals = array();
+                    foreach($mVals as $mVal){
+                        $translatedVals[] = translate($field_def['options'], $focus->module_dir, $mVal);
+                    }
+                    $repl_arr[$key . "_" . $fieldName] = implode(", ", $translatedVals);
                 } //Fix for Windows Server as it needed to be converted to a string.
                 else if ($field_def['type'] == 'int') {
                     $repl_arr[$key . "_" . $fieldName] = strval($focus->$fieldName);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Fix  - #2247 MultiSelect field issue in PDF
Issue: Multi select displays key instead of value. To recreate create a multiselect with different keys and values, then create a pdf template which uses this field. 
## Motivation and Context

It solves the bug of multi selects displaying the key instead of value.
## How To Test This

Create a multiselect field(or use existing) where the key is different to the value. Then create a pdf template with this field in it, and print to pdf. 
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
### Final checklist

<!--- Go over all the following points and check all the boxes that apply. --->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
