### PR TITLE
 Fixed #1733 - PDF Templates truncate data on save

### DIFF
--- a/modules/AOS_PDF_Templates/vardefs.php
+++ b/modules/AOS_PDF_Templates/vardefs.php
@@ -41,6 +41,16 @@ $dictionary['AOS_PDF_Templates'] = array(
 	'table'=>'aos_pdf_templates',
 	'audited'=>true,
 	'fields'=>array (
+        'description' =>
+            array (
+                'name' => 'description',
+                'vname' => 'LBL_DESCRIPTION',
+                'type' => 'text',
+                'comment' => 'Full text of the note',
+                'rows' => 6,
+                'cols' => 80,
+                'dbType' => 'mediumtext',
+            ),
   'active' =>
   array (
     'name' => 'active',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

 Fixed #1733  - PDF Templates truncate data on save
Modifies the dbType of description field so that larger pdf templates are able to be entered, as the limit is currently 64kb due to the text db type.
## Motivation and Context

It allows users to use larger pdf templates.

<!--- Why is this change required? What problem does it solve? -->
## How To Test This

To test create a large pdf template on older version and see it truncated. Try again with this and it should work.

<!--- Please describe in detail how to test your changes. -->
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
### Final checklist

<!--- Go over all the following points and check all the boxes that apply. --->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
