### PR TITLE
Fixed #2106 - each subquery now queries the correct table in its WHERE clause.

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -824,6 +824,11 @@ class SugarBean
                 $submodule = new $submoduleclass();
                 $subwhere = $where_definition;
 
+                if($this_subpanel->parent_bean->table_name == "fp_events") {
+                    if (strpos($where_definition, strtolower($submodulename) ) === false) {
+                        $subwhere = str_replace("contacts", strtolower($submodulename), $subwhere);
+                    }
+                }
 
                 $list_fields = $this_subpanel->get_list_fields();
                 foreach ($list_fields as $list_key => $list_field) {


### PR DESCRIPTION
## Description

references issue #2106
Added a statement which changes the current table for each subquery WHERE clause based on the module it is queering. 
Before, it just used a generic WHERE clause (which comes from the subpanel definition), which was not a problem for most of the subpanels/modules, but caused an error with the Event module -> Delegates subpanel due to the fact that this subpanel needs to query multiple tables (Contacts, Prospects, Leads).
## Motivation and Context

The original problem was: when filtering delegates in an event, the delegates sub panel is no longer displayed. 
It was not displayed due to a mysql error as each subquery for the delegates sub panel tried to query contacts table in the WHERE clause, while the subquery itself was selecting from prospect or leads table.
The example error it generated:
MySQL error 1054: Unknown column 'contacts.last_name' in 'where clause'
## How To Test This

Navigate to Events -> Delegates subpanel -> choose Filter from the dropdown -> search by any field -> should display the correct result.
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
