### PR TITLE
Fixed  #543 -inline editing on text area - cannot create line breaks

### DIFF
--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -212,7 +212,7 @@ function validateFormAndSave(field,id,module,type){
     // also want to save on enter/return being pressed
     $(document).keypress(function(e) {
 
-        if (e.which == 13) {
+        if (e.which == 13 && !e.shiftKey) {
             e.preventDefault();
             $("#inlineEditSaveButton").click();
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed  #543  -inline editing on text area - cannot create line breaks
Adds the ability to press shift and enter to get a new line when inline editing
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
Allows users to press shift and enter to get a new line.
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
Inline edit a field such as the description field in accounts, press shift and enter and you will then be able to go to a newline
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
