### PR TITLE
Fixed #2153 - added image generating link to the template parser.

### DIFF
--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -52,7 +52,7 @@ class templateParser
 
     function parse_template_bean($string, $key, &$focus)
     {
-        global $app_strings;
+        global $app_strings, $sugar_config;
         $repl_arr = array();
 
         foreach ($focus->field_defs as $field_def) {
@@ -68,8 +68,17 @@ class templateParser
                 else if ($field_def['type'] == 'int') {
                     $repl_arr[$key . "_" . $fieldName] = strval($focus->$fieldName);
                 } else if ($field_def['type'] == 'image') {
-                    $link = str_replace('index.php?entryPoint=generatePdf', '', "http://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]") . 'upload/' . $focus->id .  '_' . $fieldName;
-                    $repl_arr[$key . "_" . $fieldName] = '<img src="' . $link . '" width="50" height="50"/>';
+                    $secureLink = $sugar_config['site_url'] . '/' . "public/". $focus->id .  '_' . $fieldName;
+                    $file_location = $sugar_config['upload_dir'] . '/'  . $focus->id .  '_' . $fieldName;
+                    // create a copy with correct extension by mime type
+                    if(!file_exists('public')) {
+                        sugar_mkdir('public', 0777);
+                    }
+                    if(!copy($file_location, "public/{$focus->id}".  '_' . "$fieldName")) {
+                        $secureLink = $sugar_config['site_url'] . '/'. $file_location;
+                    }
+                    $link = $secureLink;
+                    $repl_arr[$key . "_" . $fieldName] = '<img src="' . $link . '" width="'.$field_def['width'].'" height="'.$field_def['height'].'"/>';
                 } else {
                     $repl_arr[$key . "_" . $fieldName] = $focus->$fieldName;
                 }

--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -67,6 +67,9 @@ class templateParser
                 } //Fix for Windows Server as it needed to be converted to a string.
                 else if ($field_def['type'] == 'int') {
                     $repl_arr[$key . "_" . $fieldName] = strval($focus->$fieldName);
+                } else if ($field_def['type'] == 'image') {
+                    $link = str_replace('index.php?entryPoint=generatePdf', '', "http://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]") . 'upload/' . $focus->id .  '_' . $fieldName;
+                    $repl_arr[$key . "_" . $fieldName] = '<img src="' . $link . '" width="50" height="50"/>';
                 } else {
                     $repl_arr[$key . "_" . $fieldName] = $focus->$fieldName;
                 }


### PR DESCRIPTION
## Description

references issue #2153
Added a conditional statement which checks whether field is of type image. 
If the field is of type image then a link pointing to the location of the image is generated.
## Motivation and Context

PDF images showing up in templates are not created when PDF is generated.
## How To Test This
1. Create a new field on invoice of type image
2. Add the new field to the edit screen of invoice
3. Create an invoice record and upload a jpg image to the new field.
4. Create a pdf template on invoice and add the image field to it.
5. Select Print as PDF on the created invoice record.
6. Select the PDF template that you added the image field to.
7. Examine the generated PDF.
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
