### PR TITLE
Fixed #958 - Ctrl click (open in new tab) does not work in detailview…

### DIFF
--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -69,6 +69,10 @@ function buildEditField(){
                 clicks = 0;
             }
             clicks++;
+            
+            if(e.ctrlKey && clicks == 1){
+                return;
+            }
 
             e.preventDefault();
             // if single click just want default action of following link, but want to wait in case user is actually trying to double click to edit field


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Ctrl -> click (open in new tab) does work in detailview and listview
## Description
<!--- Describe your changes in detail -->
Ctrl -> click (open in new tab) does work in detailview and listview
references issue #958 
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
If you ctrl + left mouse usually it opens the link in a new tab. In suitecrm it does not work on detailview and listview. It still works in subpanels.
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
… and listview