### PR TITLE
Fixed #2339 - Campaign view status page "Filter Chart By"

### DIFF
--- a/modules/Campaigns/TrackDetailView.php
+++ b/modules/Campaigns/TrackDetailView.php
@@ -164,7 +164,7 @@ if(isset($focus->campaign_type) && $focus->campaign_type == "NewsLetter"){
         $latest_marketing_id = '';
         if(isset($_REQUEST['mkt_id'])) $selected_marketing_id = $_REQUEST['mkt_id'];
 
-        $options_str .= '<option value="all">{$app_strings["LBL_CAMPAIGN_NONE"]}</option>';
+        $options_str .= "<option value=\"all\">{$app_strings["LBL_CAMPAIGN_NONE"]}</option>";
         //query for all email marketing records related to this campaign
         $latest_marketing_query = "select id, name, date_modified from email_marketing where campaign_id = '$focus->id' order by date_modified desc";
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed - Campaign view status page "Filter Chart By"
## Description
<!--- Describe your changes in detail -->
Fixed - Campaign view status page "Filter Chart By"
References issue #2339
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Open campaign page
View status
On the page, there is "Filter Chart By:" field.
In drop down, there is a code which is "{$app_strings["LBL_CAMPAIGN_NONE"]}"
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
improve functionality of campaign module
## How To Test This
<!--- Please describe in detail how to test your changes. -->
Repeat steps from replication issue section
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
