### PR TITLE
Fixed #1987 - Quick create arrow not aligning to the button text

### DIFF
--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -8743,16 +8743,16 @@ div.list-view-rounded-corners > table th:last-of-type {
     }
 
     #quickcreatetop {
-        margin-top: 25px;
+        margin: 25px;
     }
 
     #quickcreatetop a {
         padding: 13px 32px 13px 12px;
-        background-position: 80px 2px;
+        background-position: 90% 100%;
     }
 
     #quickcreatetop a:hover {
-        background-position: 80px -56px;
+        background-position: 90% 100%;
     }
 
     #quickcreatetop ul.dropdown-menu {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixed - Quick create arrow not aligning to the button text
## Description

<!--- Describe your changes in detail -->

Fixed - Quick create arrow not aligning to the button text
References issue #1987 

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

Open SuiteCRM with a language pack installed where the CREATE label is localized to a longer text.

<!--- Please link to the issue here unless your commit contains the issue number -->
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Improve design and appearience of the quick search drop-down
## How To Test This

<!--- Please describe in detail how to test your changes. -->

Repeat steps from replication issue section
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
### Final checklist

<!--- Go over all the following points and check all the boxes that apply. --->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
