### PR TITLE
Fixed #2373 - Project - after save action, it takes you on Giant view…

### DIFF
--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -2622,6 +2622,11 @@ li.noBullet {
     border-radius: 4px;
 }
 
+input.reqired {
+    color: #222;
+}
+
+
 .error {
     background-color: #f08377;
     color: #ffffff;
@@ -2631,6 +2636,9 @@ li.noBullet {
     border-radius: 4px;
 }
 
+input.error, input.required {
+    color: #222;
+}
 
 /*The nonPaddedError class is to remove the padding from interal error messages during the upgrade wizard*/
 span.error.nonPaddedError{
@@ -7090,10 +7098,10 @@ div.action_buttons form {
 }
 
 div.action_buttons .button {
-    background-color: #94A6B5;
+    background-color: #F08377;
 }
 div.action_buttons .button:hover {
-    background-color: #7B8A96;
+    background-color: #d66c60;
 }
 
 .paginationWrapper {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed Project - after save action, text color and button color
## Description
<!--- Describe your changes in detail -->
Fixed Project - after save action, text color and button color
References to issue #2373 
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
the Save&Cancel buttons in Editview - bellow buttons different colors (Project module)
Create Project Task --> Calendar --> Date color, if you choose the date from calendar
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve appearience of Project module.
## How To Test This
<!--- Please describe in detail how to test your changes. -->
Read replication section.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
… + SuiteP 2 css issue of Projects