### PR TITLE
Hotfix task 283 edit buttons

### DIFF
--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -1189,7 +1189,23 @@ slot, #lead_queries_Div td {
 
 #EditView > table {
     overflow: auto;
-    margin-bottom: 2px;
+    margin-bottom: 0px;
+}
+
+#EditView_tabs.yui-navset.yui-navset-top {
+    padding: 0px 5px 5px 5px;
+}
+
+#EditView_tabs.yui-navset.yui-navset-top .nav.nav-tabs {
+    margin-top: 15px;
+}
+
+#EditView_tabs .nav.nav-tabs {
+    margin: 0;
+}
+
+#EditView_tabs .tab-content {
+    margin: 0;
 }
 
 #EditView .edit tr td {

--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -7081,6 +7081,11 @@ tr:hover img.info {
     padding: 0;
 }
 
+
+#EditView .paginationWrapper {
+    padding-top: 4px;
+}
+
 .paginationWrapper span, .paginationWrapper span {
     padding: 0;
     margin: 0;
@@ -10258,3 +10263,20 @@ body.yui-skin-sam.masked #dlg.SuiteP-configureDashlet.yui-module.yui-overlay.yui
     }
 }
 
+@media(max-width: 600px) {
+
+    #EditView table.dcQuickEdit,
+    #EditView table.dcQuickEdit tr,
+    #EditView table.dcQuickEdit tr td,
+    #EditView table.dcQuickEdit tr td[align="right"] table,
+    #EditView table.dcQuickEdit tr td[align="right"] table tr,
+    #EditView table.dcQuickEdit tr td[align="right"] table tr td.paginationWrapper.SuiteP {
+        display: block;
+        float: left;
+    }
+
+    #EditView table.dcQuickEdit tr td[align="right"] table tr td.paginationWrapper.SuiteP span.pagination {
+        float: right;
+    }
+
+}

--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -1182,10 +1182,6 @@ slot, #lead_queries_Div td {
     margin-left: 1.5em;
 }
 
-#EditView .action_buttons {
-    margin-top: 16px;
-    margin-bottom: 16px;
-}
 
 #EditView > table {
     overflow: auto;

--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -10266,12 +10266,12 @@ body.yui-skin-sam.masked #dlg.SuiteP-configureDashlet.yui-module.yui-overlay.yui
     #EditView table.dcQuickEdit tr td,
     #EditView table.dcQuickEdit tr td[align="right"] table,
     #EditView table.dcQuickEdit tr td[align="right"] table tr,
-    #EditView table.dcQuickEdit tr td[align="right"] table tr td.paginationWrapper.SuiteP {
+    #EditView table.dcQuickEdit tr td[align="right"] table tr td.paginationWrapper {
         display: block;
         float: left;
     }
 
-    #EditView table.dcQuickEdit tr td[align="right"] table tr td.paginationWrapper.SuiteP span.pagination {
+    #EditView table.dcQuickEdit tr td[align="right"] table tr td.paginationWrapper span.pagination {
         float: right;
     }
 

--- a/themes/SuiteP/include/EditView/SugarVCR.tpl
+++ b/themes/SuiteP/include/EditView/SugarVCR.tpl
@@ -40,9 +40,9 @@
 *}
 <table border="0" cellpadding="0" cellspacing="0" width="100%">
     <tr>
-        <td nowrap class="paginationWrapper">
+        <td nowrap class="paginationWrapper SuiteP">
             {if !empty($list_link)}
-            <button type="button" id="save_and_continue" class="button" title="{$app_strings.LBL_SAVE_AND_CONTINUE}" onClick="this.form.action.value='Save';if(check_form('EditView')){ldelim}sendAndRedirect('EditView', '{$app_strings.LBL_SAVING} {$module}...', '{$list_link}');{rdelim}">
+            <button type="button" id="save_and_continue" class="button vcr-right" title="{$app_strings.LBL_SAVE_AND_CONTINUE}" onClick="this.form.action.value='Save';if(check_form('EditView')){ldelim}sendAndRedirect('EditView', '{$app_strings.LBL_SAVING} {$module}...', '{$list_link}');{rdelim}">
                 {$app_strings.LBL_SAVE_AND_CONTINUE}
             </button>
             &nbsp;&nbsp;&nbsp;&nbsp;

--- a/themes/SuiteP/include/EditView/SugarVCR.tpl
+++ b/themes/SuiteP/include/EditView/SugarVCR.tpl
@@ -40,9 +40,9 @@
 *}
 <table border="0" cellpadding="0" cellspacing="0" width="100%">
     <tr>
-        <td nowrap class="paginationWrapper SuiteP">
+        <td nowrap class="paginationWrapper">
             {if !empty($list_link)}
-            <button type="button" id="save_and_continue" class="button vcr-right" title="{$app_strings.LBL_SAVE_AND_CONTINUE}" onClick="this.form.action.value='Save';if(check_form('EditView')){ldelim}sendAndRedirect('EditView', '{$app_strings.LBL_SAVING} {$module}...', '{$list_link}');{rdelim}">
+            <button type="button" id="save_and_continue" class="button" title="{$app_strings.LBL_SAVE_AND_CONTINUE}" onClick="this.form.action.value='Save';if(check_form('EditView')){ldelim}sendAndRedirect('EditView', '{$app_strings.LBL_SAVING} {$module}...', '{$list_link}');{rdelim}">
                 {$app_strings.LBL_SAVE_AND_CONTINUE}
             </button>
             &nbsp;&nbsp;&nbsp;&nbsp;


### PR DESCRIPTION

Edit view buttons do display in line with the design (/task/283)

and

SuiteP on mobile - Save&Continue or Pagination button is pushing others on one left site (issue #2338 )

## Description

This PR contains fix for task 283 and issue #2338 (focused on EditView)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->