### PR TITLE
Fixed #2430 - global search autofilled background colour

### DIFF
--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -6653,11 +6653,12 @@ form#MassAssign_SecurityGroups {
     padding: 0;
 }
 
-#searchform input#query_string {
+#searchform input#query_string,
+#searchform input#query_string:-webkit-autofill {
     background-color: #65697A;
     float: left;
-    border: none;
-    padding: 14px 12px 14px 12px;
+    border: 3px solid #65697A;
+    padding: 12px 12px 12px 12px;
     color: #A2A5AF;
     font-size: 14px;
     letter-spacing: 1px;
@@ -6665,6 +6666,8 @@ form#MassAssign_SecurityGroups {
     border-radius: 3px;
     height: auto;
     line-height: normal;
+    -webkit-text-fill-color:  #A2A5AF;
+    -webkit-box-shadow: 0 0 0 1000px #65697A inset !important;
 }
 
 #searchform button {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request contains a simple fix for issue #2430 does not change the bgcolour of search input when it's autofilled by browser

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
