### PR TITLE
mysql 5.7 date/time values at insert queries

### DIFF
--- a/include/database/DBManager.php
+++ b/include/database/DBManager.php
@@ -544,6 +544,23 @@ protected function checkQuery($sql, $object_name = false)
 		if (empty($values))
 			return $execute?true:''; // no columns set
 
+		if($this instanceof MysqliManager && version_compare($this->database->server_info, '5.7', '>=')) {
+			foreach ($values as $key => $value) {
+				switch ($field_defs[$key]['type']) {
+					case 'date':
+						if ($value == "'0000-00-00'") {
+							$values[$key] = "NULL";
+						}
+						break;
+					case 'datetime':
+						if ($value == "'0000-00-00 00:00:00'") {
+							$values[$key] = "NULL";
+						}
+						break;
+				}
+			}
+		}
+
 		// get the entire sql
 		$query = "INSERT INTO $table (".implode(",", array_keys($values)).")
 					VALUES (".implode(",", $values).")";


### PR DESCRIPTION
Campaigns Breaks on MySQL 5.7
## Description

<!--- Describe your changes in detail -->
References issue #1719
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here unless your commit contains the issue number -->

An MySQL error appears when entering a non date value into the database - this causes a white screen.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

task 317
## How To Test This

<!--- Please describe in detail how to test your changes. -->

error occured only with mysql5.7
- create a new campaign via wizard
- set name => next
- add some target list => next
- it shows a blank white screen.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
### Final checklist

<!--- Go over all the following points and check all the boxes that apply. --->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
