### PR TITLE
fixed - #2521 Unused language strings (AOD_Index)

### DIFF
--- a/modules/AOD_Index/language/en_us.lang.php
+++ b/modules/AOD_Index/language/en_us.lang.php
@@ -74,7 +74,6 @@ $mod_strings = array (
   'LBL_SEARCH_BUTTON' => 'Search',
   'LBL_SEARCH_QUERY_PLACEHOLDER' => 'Enter search...',
   'LBL_INDEX_STATS' => 'Index stats',
-  'LBL_SEARCH_LABEL' => "Term",
   'LBL_OPTIMISE_NOW' => "Optimise now",
   'LBL_TOTAL_RECORDS' => 'Total records',
   'LBL_INDEXED_RECORDS' => 'Indexed records',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Unused language strings (AOD_Index) - fixed
## Description
<!--- Describe your changes in detail -->
Unused language strings (AOD_Index) - fixed
References issue #2521 
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
