### PR TITLE
Fix #2246 - Notifications / Alerts do not trigger depending on some user date formats

### DIFF
--- a/modules/Reminders/Reminder.php
+++ b/modules/Reminders/Reminder.php
@@ -56,8 +56,6 @@ class Reminder extends Basic
     var $importable = false;
     var $disable_row_level_security = true;
 
-    var $assigned_user_id;
-
     var $popup;
     var $email;
     var $email_sent = false;
@@ -294,21 +292,9 @@ class Reminder extends Basic
             foreach ($popupReminders as $popupReminder) {
                 $relatedEvent = BeanFactory::getBean($popupReminder->related_event_module, $popupReminder->related_event_module_id);
 
-if ($relatedEvent) 
-{
-//	print("\nDate1 " . $relatedEvent->date_start);
-//	print("\nDate2 " . $timedate->fromUser($relatedEvent->date_start));
-//	print("\nNow " . $dateTimeNow);
-//	print("\nDate " . strtotime($relatedEvent->date_start));
-//	print("\nNow  " . strtotime(self::unQuoteTime($dateTimeNow)));
-//	print("\nEnd  " . strtotime(self::unQuoteTime($dateTimeMax)));
-//    print("\nDelay " . $app_list_strings['reminder_max_time']);
-//    print("\nNow Db " . $timedate->getNow(true)->asDb(true));
-}
-
                 if ($relatedEvent && isset($relatedEvent->date_start))
                 {
-                    // Start date from the bean is in user timezone and format
+                    // Start date from the bean is a string in user timezone and format
                     // convert using user format to a GMT timestamp
                     $dateTimeStart = $timedate->fromUser($relatedEvent->date_start)->ts;
                 }
@@ -317,7 +303,6 @@ if ($relatedEvent)
                     // The start date is not set so default it to the current time
                     $dateTimeStart = $dateTimeNow;
                 }        
-//print("\nTimes " . $dateTimeStart . " " . $dateTimeNow . " " . $dateTimeMax);
 
                 if ($relatedEvent &&
                     (!isset($relatedEvent->status) || $relatedEvent->status == 'Planned') &&

--- a/modules/Reminders/Reminder.php
+++ b/modules/Reminders/Reminder.php
@@ -266,7 +266,7 @@ class Reminder extends Basic
             return;
         }
 
-        // Create separate variable to hold datetime value
+        // Create separate variables to hold datetime values
         // To keep things simple use GMT for all datetimes
         // and use GMT timestamps
         $dateTimeMax = $timedate->getNow()->modify("+{$app_list_strings['reminder_max_time']} seconds")->ts;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When a user has set the date format to dd/mm/yyyy reminders will not trigger. Setting the date format to yyyy-mm-dd or mm/dd/yyyy works ok.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fix for #2246 
The reminders module looks at the list of reminders, when the date and time of the reminder gets close it will trigger an alert count down to start.
Problem was that strtotime() was converting the textual start datetime read from the database into  timestamp. If the server is using mm/dd/yyyy and the input string is dd/mm/yyyy errors will occur. E.g. for the 5th of Jan 2016 the timestamp will be for the 1st of May 2016 and for the 21st Jan 2016 a null timestamp will be returned as 21 is an invalid month. In the code strtotime($relatedEvent->date_start)

$relatedEvent->date_start is from the bean and is in the User timezone and date time format. In this case if the user date format is set to dd/mm/yyyy the calculated timestamp will be incorrect.

Note that email reminders work, the code for this is 
`$remind_ts = $timedate->fromUser($eventBean->date_start)->modify("-{$reminderBean->timer_email} seconds")->ts;`

In this case the bean date time string is converted to a DateTime object using the fromUser() function that takes into account the user settings and therefore operates correctly. This method should be used.
The following testing was performed with the user timezone set to Sydney Australia +11, and the server timezone as USA CET.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Reminders do not work with some user date formats

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Set user date format to d/m/y and create a call with a reminder. Ensure a notification triggers.

I have tested using the following user date formats

- Y-m-d OK
- m-d-y OK 
- d-m-y OK
- y/m/d OK
- m/d/y OK
- d/m/y OK
- y.m.d OK
- m.d.y OK
- d.m.y OK 

And with these date time formats
- d/m/y  h:ia
- d/m/y  h:iA
- d/m/y  h:i a

Also unit tests were written for the Reminder module. Currently no unit test exists for this module.  Technically it is probably more functional testing rather than unit testing. This work is in my GitHub at https://github.com/KhyberPass/SuiteCRM in branch [IssueReminderTest](https://github.com/KhyberPass/SuiteCRM/tree/IssueReminderTest/tests/tests/modules/Reminders)
I need to do a bit more testing on it before submitting this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->