### PR TITLE
Fixed #1178 - Confirm popup for delete empty reminders

### DIFF
--- a/include/language/en_us.lang.php
+++ b/include/language/en_us.lang.php
@@ -2429,6 +2429,9 @@ $app_strings = array(
     'ERR_A_REMINDER_IS_EMPTY_OR_INCORRECT' => 'A reminder is empty or incorrect.',
     'ERR_REMINDER_IS_NOT_SET_POPUP_OR_EMAIL' => 'Reminder is not set for either a popup or email.',
     'ERR_NO_INVITEES_FOR_REMINDER' => 'No invitees for reminder.',
+    'LBL_DELETE_REMINDER_CONFIRM' => 'Reminder doesn\'t include any invitees, do you want to remove the reminder?',
+    'LBL_DELETE_REMINDER' => 'Delete Reminder',
+    'LBL_OK' => 'Ok',
 
 );
 

--- a/modules/Reminders/Reminders.js
+++ b/modules/Reminders/Reminders.js
@@ -194,6 +194,44 @@ var Reminders = {
         Reminders.createRemindersPostData();
     },
     onInviteeClick: function(e) {
+        var parentReminderItem = $(e).closest('.reminder_item');
+        var parentReminderId = parentReminderItem.attr('data-reminder-id');
+        var reminders = Reminders.getRemindersData();
+        var _e = e;
+        $.each(reminders, function(i, reminder) {
+            if(reminder.id == parentReminderId && reminder.invitees.length == 1) {
+                var confirmDeletePopup = new YAHOO.widget.SimpleDialog("Confirm ", {
+                    //width: "400px",
+                    draggable: false,
+                    constraintoviewport: true,
+                    modal: true,
+                    fixedcenter: true,
+                    text: SUGAR.language.get('app_strings', 'LBL_DELETE_REMINDER_CONFIRM'),
+                    bodyStyle: "padding:5px",
+                    buttons: [{
+                        text: SUGAR.language.get('app_strings', 'LBL_OK'),
+                        handler: function(){
+                            // YES
+                            confirmDeletePopup.hide();
+                            parentReminderItem.remove();
+                            Reminders.createRemindersPostData();
+                            return false;
+                        },
+                        isDefault:true
+                    }, {
+                        text: SUGAR.language.get('app_strings', 'LBL_CANCEL_BUTTON_LABEL'),
+                        handler: function() {
+                            // NO
+                            confirmDeletePopup.hide();
+                            Reminders.createRemindersPostData();
+                            return false;
+                        }
+                    }]
+                });
+                confirmDeletePopup.setHeader(SUGAR.language.get('app_strings', 'LBL_DELETE_REMINDER'));
+                confirmDeletePopup.render(document.body);
+            }
+        });
         $(e).closest('.invitees_item').remove();
         Reminders.createRemindersPostData();
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

This PR contains a popup confirmation for ask user to delete Remainder when the user deleted the last one invitee too because if the reminder is empty then the remainder could be useless (without invitees..) it cause a Validation error why the form 'Save' failed and the original problem still there (see issue #1178)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Reminder invitees validation was not clear

## How To Test This
<!--- Please describe in detail how to test your changes. -->

Remove all invitees from a reminder on Meetings or Calls

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
