### PR TITLE
bugfix date type when searching using a subquery

### DIFF
--- a/include/SearchForm/SearchForm2.php
+++ b/include/SearchForm/SearchForm2.php
@@ -895,12 +895,14 @@ require_once('include/EditView/EditView2.php');
 
                          if($type == 'date') {
                             // The regular expression check is to circumvent special case YYYY-MM
-                             $operator = '=';
+                             $operator = $operator != 'subquery' ? '=' : $operator;
                              if(preg_match('/^\d{4}.\d{1,2}$/', $field_value) != 0) { // preg_match returns number of matches
                                 $db_field = $this->seed->db->convert($db_field, "date_format", array("%Y-%m"));
                             } else {
                                 $field_value = $timedate->to_db_date($field_value, false);
-                                $db_field = $this->seed->db->convert($db_field, "date_format", array("%Y-%m-%d"));
+                                 if ($operator != 'subquery') {
+                                     $db_field = $this->seed->db->convert($db_field, "date_format", array("%Y-%m-%d"));
+                                 }
                             }
                          }
 


### PR DESCRIPTION
## Description
When add a type of **date** field into a searchfield and set the operator key to subquery, the operator always be equal and you cannot use greater_than, less_than, etc. operators in your subquery

## Motivation and Context
I would like to improve the searching.

## How To Test This
Customize a date field to search using a subquery and see how it works

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.