### PR TITLE
fixed - #327 Selecting Monitored folders popup appears half off screen

### DIFF
--- a/themes/Suite7/css/yui.css
+++ b/themes/Suite7/css/yui.css
@@ -1060,6 +1060,8 @@ span.yui-carousel-first-button-disabled {
 
 .yui-panel-container.shadow {
     padding: 2px 4px 0 2px;
+    left: 216px !important;
+    top: 35px !important;
 }
 
 .yui-panel-container.shadow .underlay {

--- a/themes/SuiteP/css/yui.css
+++ b/themes/SuiteP/css/yui.css
@@ -958,8 +958,8 @@ span.yui-carousel-first-button-disabled {
 
 .yui-panel {
     position: relative;
-    left: 0;
-    top: 0;
+    left: 261px;
+    top: 88px;
     border-style: solid;
     border-width: 1px 0;
     border-color: #808080;

--- a/themes/SuiteR/css/yui.css
+++ b/themes/SuiteR/css/yui.css
@@ -1046,10 +1046,7 @@ span.yui-carousel-first-button-disabled {
 
 .yui-panel-container.shadow {
     padding: 2px 4px 0 2px;
-}
-
-.yui-panel-container.shadow .underlay {
-
+    left: 216px !important;
 }
 
 .yui-dialog .ft {

--- a/themes/SuiteR/css/yui.css
+++ b/themes/SuiteR/css/yui.css
@@ -962,8 +962,8 @@ span.yui-carousel-first-button-disabled {
 
 .yui-panel {
     position: relative;
-    left: 0;
-    top: 0;
+    left: 70px;
+    top: 38px;
     border-style: solid;
     border-width: 1px 0;
     border-color: #808080;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Selecting Monitored folders popup appears half off screen
## Description
<!--- Describe your changes in detail -->
Selecting Monitored folders popup appears half off screen
References issue #327
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
