### PR TITLE
Fixed #2293 - Dashlet Header Edit, Refresh, Delete links are not acce…

### DIFF
--- a/include/Dashlets/Dashlet.php
+++ b/include/Dashlets/Dashlet.php
@@ -121,7 +121,7 @@ class Dashlet
     public function setConfigureIcon()
     {
         if($this->isConfigurable) {
-            $additionalTitle = '<td nowrap width="1%" style="padding-right: 0px;"><div class="dashletToolSet"><a href="javascript:void(0)" onclick="SUGAR.mySugar.configureDashlet(\''
+            $additionalTitle = '<td nowrap width="1%" style="padding-right: 0px;"><div class="dashletToolSet"><a href="javascript:void(0)"  aria-label="'.translate('LBL_DASHLET_EDIT', 'Home').'" onclick="SUGAR.mySugar.configureDashlet(\''
                 . $this->id . '\'); return false;">'
                 . SugarThemeRegistry::current()->getImage('dashlet-header-edit','title="' . translate('LBL_DASHLET_EDIT', 'Home') . '" border="0"  align="absmiddle"', null,null,'.gif',translate('LBL_DASHLET_EDIT', 'Home')).'</a>'
                 . '';
@@ -142,7 +142,7 @@ class Dashlet
     {
         $additionalTitle = '';
         if($this->isRefreshable) {
-            $additionalTitle .= '<a href="javascript:void(0)" onclick="SUGAR.mySugar.retrieveDashlet(\''
+            $additionalTitle .= '<a href="javascript:void(0)" aria-label="'.translate('LBL_DASHLET_REFRESH', 'Home').'" onclick="SUGAR.mySugar.retrieveDashlet(\''
                 . $this->id . '\'); return false;">'
                 . SugarThemeRegistry::current()->getImage('dashlet-header-refresh','border="0" align="absmiddle" title="' . translate('LBL_DASHLET_REFRESH', 'Home') . '"',null,null,'.gif',translate('LBL_DASHLET_REFRESH', 'Home'))
                 . '</a>';
@@ -163,7 +163,7 @@ class Dashlet
         if (!empty($sugar_config['lock_homepage']) && $sugar_config['lock_homepage'] == true) {
             return '</div></td></tr></table>';
         }
-        $additionalTitle = '<a href="javascript:void(0)" onclick="SUGAR.mySugar.deleteDashlet(\''
+        $additionalTitle = '<a href="javascript:void(0)" aria-label="'.translate('LBL_DASHLET_DELETE', 'Home').'" onclick="SUGAR.mySugar.deleteDashlet(\''
             . $this->id . '\'); return false;">'
             . SugarThemeRegistry::current()->getImage('dashlet-header-close','border="0" align="absmiddle" title="' . translate('LBL_DASHLET_DELETE', 'Home') . '"',null,null,'.gif',translate('LBL_DASHLET_DELETE', 'Home'))
             . '</a></div></td></tr></table>';
@@ -243,6 +243,9 @@ class Dashlet
         $template->assign('REFRESH_ICON', $this->setRefreshIcon());
         $template->assign('DELETE_ICON',$this->setDeleteIcon());
         $template->assign('DASHLET_MODULE',$this->seedBean->module_name);
+        $template->assign('DASHLET_BUTTON_ARIA_EDIT', translate('LBL_DASHLET_EDIT', 'Home'));
+        $template->assign('DASHLET_BUTTON_ARIA_REFRESH',  translate('LBL_DASHLET_REFRESH', 'Home'));
+        $template->assign('DASHLET_BUTTON_ARIA_DELETE',  translate('LBL_DASHLET_DELETE', 'Home'));
 
 
         $template->assign('GET_FORM_HEADER', get_form_header($this->title, $title, false));

--- a/themes/SuiteP/include/Dashlets/DashletHeader.tpl
+++ b/themes/SuiteP/include/Dashlets/DashletHeader.tpl
@@ -17,7 +17,7 @@
                 <td style="padding-right: 0px;" nowrap="" width="1%">
                     <div class="dashletToolSet">
                         <a href="javascript:void(0)"
-                                                   onclick="SUGAR.mySugar.configureDashlet('{$DASHLET_ID}'); return false;">
+                           aria-label="{$DASHLET_BUTTON_ARIA_EDIT}" onclick="SUGAR.mySugar.configureDashlet('{$DASHLET_ID}'); return false;">
 
                             <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
                                  width="25px" height="25px" viewBox="0 0 512 512" enable-background="new 0 0 512 512"
@@ -32,7 +32,7 @@
 </svg>
                         </a>
                         <a href="javascript:void(0)"
-                               onclick="SUGAR.mySugar.retrieveCurrentPage(); return false;">
+                           aria-label="{$DASHLET_BUTTON_ARIA_REFRESH}" onclick="SUGAR.mySugar.retrieveCurrentPage(); return false;">
 
                             <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
                                  width="25px" height="25px" viewBox="0 0 512 512" enable-background="new 0 0 512 512"
@@ -48,7 +48,7 @@
 </svg>
                         </a>
                         <a href="javascript:void(0)"
-                               onclick="SUGAR.mySugar.deleteDashlet('{$DASHLET_ID}'); return false;">
+                           aria-label="{$DASHLET_BUTTON_ARIA_DELETE}" onclick="SUGAR.mySugar.deleteDashlet('{$DASHLET_ID}'); return false;">
 
                             <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
                                  width="25px" height="25px" viewBox="0 0 512 512" enable-background="new 0 0 512 512"


### PR DESCRIPTION
…ssible by screen readers
<!--- Provide a general summary of your changes in the Title above -->

This fix was an alternative method provided by the PR https://github.com/salesagility/SuiteCRM/pull/2311.

## Description
Using the aria label attribute to a link screenreaders should be able to read out the purpose of the link without impacting on the design for non visually impaired users.

## Motivation and Context

Screen readers read text that is on a user's screen. These programs help blind people use computers for all different purposes. Links need to be properly labeled on web sites or in web apps so those who are blind will have an idea of what the link leads to since screen readers do not read graphics.

## How To Test This
When on the Home page of SuiteCRM application and using a screenreader when clicking around or on any dashlet's header buttons (edit, refresh or delete) the screenreader should discribe the purpose of the link.  This was tested using ChromeVox.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
