### PR TITLE
Fixed Issue With LEADs // Opportunity (critical) in 7.7.7

### DIFF
--- a/include/SearchForm/SearchForm2.php
+++ b/include/SearchForm/SearchForm2.php
@@ -791,7 +791,7 @@ require_once('include/EditView/EditView2.php');
                                   if (!empty($field_value)) {
                                       $field_value .= ',';
                                   }
-                                  $field_value .= $val;
+                                  $field_value .= $db->quoteType($type, $val);
                               }
                               // Bug 41209: adding a new operator "isnull" here
                               // to handle the case when blank is selected from dropdown.


### PR DESCRIPTION
Hi, after upgrade of SUITECRm to latest version 7.7.7 we have a BUG in list of leads.

Not shows any lead. (with advanced search opened)

Some information:

When i go to opportunities, we can search for a name of opportunity and work fine. If i use advanced search, and filter for any field, return 0 results.

This issue is after install upgrade of 7.7.7, is very important for us to know how can i resolve this issue, it's affecting all of our users.

Context

Your Environment

SuiteCRM Version used: 7.7.7
Browser name and version (e.g. Chrome Version 51.0.2704.63 (64-bit)): All Browser
Environment name and version (e.g. MySQL, PHP 7): MSSQL, PHP7
Operating System and version (e.g Ubuntu 16.04): MS 2012 R2

## Description
Hi, after upgrade of SUITECRm to latest version 7.7.7 we have a BUG in list of leads.

Not shows any lead. (with advanced search opened)

Some information:

When i go to opportunities, we can search for a name of opportunity and work fine. If i use advanced search, and filter for any field, return 0 results.

## Motivation and Context
https://github.com/salesagility/SuiteCRM/issues/2612

## How To Test This
Use advance search

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.
