### PR TITLE
Add ability to get the parent of a task

### DIFF
--- a/modules/Tasks/Task.php
+++ b/modules/Tasks/Task.php
@@ -380,8 +380,8 @@ class Task extends SugarBean {
 			//parent_name_owner not being set for whatever reason so we need to figure this out
 			else if(!empty($this->parent_type) && !empty($this->parent_id)) {
 				global $current_user;
-                $parent_bean = BeanFactory::getBean($this->parent_type,$this->parent_id);
-                if($parent_bean !== false) {
+                $parent_bean = $this->getParent();
+                if ($parent_bean !== false && $parent_bean !== null) {
                 	$is_owner = $current_user->id == $parent_bean->assigned_user_id;
                 }
 			}
@@ -450,4 +450,15 @@ class Task extends SugarBean {
         return '';
     }
 
+    /**
+     * @return null|SugarBean
+     */
+    public function getParent()
+    {
+        if ($this->parent_type === null || $this->parent_id === null) {
+            return null;
+        }
+
+        return BeanFactory::getBean($this->parent_type, $this->parent_id);
+    }
 }


### PR DESCRIPTION
## Description
A task in suitecrm has a parent_type and parent_id but no easy way to get this parent bean.

## Motivation and Context
When we have access to a certain task this way it's easy to fetch the parent of this task and use it.

## How To Test This
/

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

