### PR TITLE
Fixed #2642 - changed line 63 to make sure that it applies special formatting if the type of $field_def is dynamicenum

### DIFF
--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -60,7 +60,7 @@ class templateParser
                 $fieldName = $field_def['name'];
                 if ($field_def['type'] == 'currency') {
                     $repl_arr[$key . "_" . $fieldName] = currency_format_number($focus->$fieldName, $params = array('currency_symbol' => false));
-                } else if (($field_def['type'] == 'radioenum' || $field_def['type'] == 'enum') && isset($field_def['options'])) {
+                } else if (($field_def['type'] == 'radioenum' || $field_def['type'] == 'enum' || $field_def['type'] == 'dynamicenum') && isset($field_def['options'])) {
                     $repl_arr[$key . "_" . $fieldName] = translate($field_def['options'], $focus->module_dir, $focus->$fieldName);
                 } else if ($field_def['type'] == 'multienum' && isset($field_def['options'])) {
                     $repl_arr[$key . "_" . $fieldName] = implode(', ', unencodeMultienum($focus->$fieldName));


### PR DESCRIPTION
## Description
Emails which are based on Email Templates with some fields that have variables representing Dynamic DropDowns have keys inserted instead of values (e.g americas_bolivia instead of Bolivia).
This can be fixed by changing line 63 to make sure that it applies special formatting if the type of $field_def is dynamicenum .

references issue #2642

## How To Test This
1. Created a dropdown called ARC_Sub_Region in Admin -> Dropdown Editor

2. Created a field for the Contact module called 'Test Dropdown'. This field is a Dynamic Dropdown type field and has ARC_Sub_Region as its dropdown. Added this field to the EditView and DetailsView of the Contact module.

3. Went to the Contacts record for Britney Walraven (example user) and set the 'Test Dropdown' to Bolivia.

4. Created an Email template for testing the dropdown values. Where variable corresponding to the 'Test Dropdown' field is included.

5. Created a WorkFlow record to send emails based on the above mentioned template.

6. Made sure that Admin -> Email Settings is setup correctly and sent a test email.

7. Made sure that Process Workflow Tasks sheduler is active.

8. Made sure that crontab is running for my instance.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)

