### PR TITLE
Fixed #2644 created an entry point to allow callback.php authorisation, added correct path to config.php

### DIFF
--- a/include/MVC/Controller/entry_point_registry.php
+++ b/include/MVC/Controller/entry_point_registry.php
@@ -86,6 +86,7 @@ $entry_point_registry = array(
 	'campaignTrackerSave' => array('file' => 'modules/CampaignTrackers/Save.php', 'auth' => true),
 	'emailMarketingList' => array('file' => 'modules/EmailMarketing/List.php', 'auth' => true),
 	'setCampaignMarketingAndTemplate' => array('file' => 'modules/Campaigns/WizardCampaignSave.php', 'auth' => true),
+	'twitter_callback' => array('file' => 'include/social/twitter/twitter_auth/callback.php', 'auth' => true),
 );
 
 ?>

--- a/include/social/twitter/twitter_auth/callback.php
+++ b/include/social/twitter/twitter_auth/callback.php
@@ -5,7 +5,7 @@
  * Verify credentials and redirect to based on response from Twitter.
  */
 
-include_once('../../../../../config.php');
+include_once('../../../../config.php');
 
 global $sugar_config;
 

--- a/include/social/twitter/twitter_helper.php
+++ b/include/social/twitter/twitter_helper.php
@@ -80,7 +80,7 @@ function duplicate_check($db, $text, $date)
 function check_auth($url)
 {
 
-    $url = $url . "/include/social/twitter/twitter_auth/callback.php";
+    $url = $url . "/index.php?entryPoint=twitter_callback";
 
     $config = '';
 


### PR DESCRIPTION
references issue #2644

## Description
The following error message is received when trying to log in to Twitter:
Error: cannot access include/social/twitter/twitter_auth/callback.php

The problem is that callback.php is not an entry point so the .htaccess prevents twitter from accessing this file.

This issue can be fixed by creating an entry point to allow callback.php authorisation, also $url variable in twitter_helper.php needs to be changed in order to reflect that we call an entry point.

Another fix is to call config.php by specifying the correct path - include_once('../../../../../config.php');

## How To Test This
- Setup Twitter App
  1. https://apps.twitter.com/app/

  2. Settings tab
  Name * - any 
  Description * - any
  Website * - http://example.com/twitteroauth
  Callback URL - http://example.com/twitteroauth/callback.php

  3. Keys and Access Tokens tab 
  Application Settings -> need to "Reganerate Consumer Key and Secret" !!! do it every time smth is changed
  Your Access Token -> might need to "Regenerate My Access Token and Token Secret"

  4. Permissions tab
  leave on "Read only"

- Setup Connector in your SuiteCRM instance
  1. Admin -> Connectors -> Set Connector Properties -> Twitter tab

  2. Consumer Key:  * -> enter your "Consumer Key (API Key)" from Twitter

  3. Consumer Secret:  * -> enter your "Consumer Secret (API Secret)" from Twitter

- if Home page is already opened Ctrl F5 on the Home page - so the new token will be generated for the "Log into Twitter" button

- click on the "Log into Twitter" button

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)