### PR TITLE
Fine tuned SuiteP theme such that it gives more space to work on smal…

### DIFF
--- a/modules/Calendar/tpls/main.tpl
+++ b/modules/Calendar/tpls/main.tpl
@@ -191,7 +191,7 @@
 	});
 </script>
 
-<div class="modal fade modal-cal-edit" tabindex="-1" role="dialog">
+<div class="modal fade modal-cal-edit" tabindex="-1" role="dialog" id="calendar_modal">
 	<div class="modal-dialog modal-lg">
 		<div class="modal-content">
 			<div class="modal-header">

--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -145,13 +145,13 @@ div.p_login #loginform .input-group input#user_name, #user_name:-webkit-autofill
 
 div.p_login #loginform .input-group input#user_name {
     background-position: 12px 9px;
-	background-repeat: no-repeat;
+    background-repeat: no-repeat;
     background-image: none, url("../../../../themes/SuiteP/images/login_bg.svg");
 }
 
 div.p_login #loginform .input-group input#user_password {
     background-position: 12px -51px;
-	background-repeat: no-repeat;
+    background-repeat: no-repeat;
     background-image: none, url("../../../../themes/SuiteP/images/login_bg.png");
 }
 
@@ -192,12 +192,12 @@ div.p_login #loginform #bigbutton:hover {
 
 #bootstrap-container {
     background-color: #f5f5f5;
-    margin-top: 110px !important;
+    margin-top: 65px !important;
 }
 
 li#usermenu a {
     background-color: #534d64;
-    padding: 35px 0px 10px 0px;
+    padding: 22px 0px 10px 0px;
     font-size: 14px;
 }
 
@@ -308,7 +308,7 @@ div#pageContainer td.dashletcontainer div.hd .icon {
 
 .sidebar {
     position: fixed;
-    top: 90px;
+    top: 60px;
     bottom: 0;
     left: 0;
     z-index: 1000;
@@ -319,7 +319,7 @@ div#pageContainer td.dashletcontainer div.hd .icon {
 }
 
 #actionMenuSidebar {
-    margin-bottom: 24px;
+    margin-bottom: 15px;
 }
 
 #actionMenuSidebar_top {
@@ -484,7 +484,7 @@ div#pageContainer td.dashletcontainer div.hd .icon {
     width: 100%;
     min-height: 48px;
     padding: 16px 8px 16px 0px;
-    line-height: 24px;
+    /*line-height: 24px;*/
 }
 
 .side-bar-action-icon {
@@ -509,7 +509,7 @@ div#pageContainer td.dashletcontainer div.hd .icon {
 
 .button-toggle-collapsed {
     position: fixed;
-    top: 100px;
+    top: 70px;
     background: #778591;
     z-index: 1000;
     height: 30px;
@@ -523,7 +523,7 @@ div#pageContainer td.dashletcontainer div.hd .icon {
 
 .button-toggle-expanded {
     position: fixed;
-    top: 100px;
+    top: 70px;
     background: #778591;
     z-index: 1000;
     height: 30px;
@@ -744,7 +744,7 @@ li.favoritelinks img {
 
 #content {
     width: 100%;
-    padding: 30px 3% 40px 3%;
+    padding: 10px 3% 30px 3%;
 }
 
 #bootstrap-container.col-md-offset-2 {
@@ -1076,7 +1076,7 @@ th, td {
 }
 
 .basic textarea {
-    height: 48px;
+    /*height: 48px;*/
     width: 100%;
 }
 
@@ -1097,14 +1097,14 @@ th, td {
 
 .detail-view-row, .detail-view-row-item {
     margin: 0 0 2px 0;
-    min-width: 48px;
-    min-height: 24px;
+    /*min-width: 48px;
+    min-height: 24px;*/
 }
 
 .edit-view-row, .edit-view-row-item {
     margin: 0 0 8px 0;
-    min-width: 48px;
-    min-height: 24px;
+    /*min-width: 48px;
+    min-height: 24px;*/
 }
 
 .detail-view-row .label, .edit-view-row .label, #lineItems {
@@ -1113,7 +1113,7 @@ th, td {
     padding: 0 0 0 8px;
     font-size: 14px;
     font-weight: 700;
-    line-height: 48px;
+    /*line-height: 48px;*/
     text-align: left;
     white-space: nowrap;
     vertical-align: baseline;
@@ -1124,7 +1124,7 @@ slot, #lead_queries_Div td {
       color: #534D64;
       font-size: 14px;
       font-weight: 700;
-      line-height: 48px;
+      /*line-height: 48px;*/
       text-align: left;
       white-space: nowrap;
       vertical-align: baseline;
@@ -1136,18 +1136,18 @@ slot, #lead_queries_Div td {
 }
 
 .dataField {
-    min-height: 48px;
-    line-height: 48px;
+    /*min-height: 48px;
+    line-height: 48px;*/
 }
 
 .detail-view-field {
     color: #534D64;
     display: inline;
-    padding:  12px;
+    padding:  10px;
     font-size: 14px;
     font-weight: 400;
-    line-height: 20px;
-    min-height: 48px;
+    /*line-height: 20px;
+    min-height: 48px;*/
     text-align: left;
     white-space: nowrap;
     vertical-align: baseline;
@@ -1178,7 +1178,7 @@ slot, #lead_queries_Div td {
 
 .edit-view-field textarea,
 .inline_edit_field textarea {
-    line-height: 24px;
+    /*line-height: 24px;*/
     padding-top: 14px;
 }
 
@@ -1456,7 +1456,7 @@ button#listViewEndButton_top img, button#listViewEndButton_bottom img {
 }
 
 .list tr.pagination td table td button {
-    width: 25px;
+    /*width: 25px;*/
 }
 
 .list tr.pagination td table td a:link, .list tr.pagination td table td a:visited, .reportGroupByDataChildTablelistViewThS1 a:link, .reportGroupByDataChildTablelistViewThS1 a:visited {
@@ -1484,7 +1484,7 @@ button#listViewEndButton_top img, button#listViewEndButton_bottom img {
 .td_alt, .list tr th, .list tr td[scope=col], .edit .list tr th, .edit .list tr td[scope=col] {
     font-weight: 800;
     text-align: left;
-    padding: 16px 10px 16px 10px !important;
+    padding: 11px 10px 11px 10px !important;
     border-left: none;
     border-right: none;
     white-space: nowrap;
@@ -1709,7 +1709,7 @@ table#mass_update_table {
 
 table#mass_update_table td {
     padding-left: 15px;
-    line-height: 40px;
+    /*line-height: 40px;*/
 }
 
 table#mass_update_table td select {
@@ -1733,7 +1733,7 @@ table#mass_update_table td select {
 
     table#mass_update_table td {
         padding-left: 0;
-        line-height: 30px;
+        /*line-height: 30px;*/
     }
 
 }
@@ -2824,11 +2824,13 @@ table.dateTime {
 }
 
 #parent_name, input.sqsEnabled {
+/*
     display: inline-block;
     clear: both;
     margin-top: 8px;
     width: 50%;
     margin-right: 8px;
+    */
 }
 
 .pageNumbers {
@@ -3201,8 +3203,8 @@ table#goto_date_trigger_div_t thead {
 
 .yui-calendar .calheader {
     padding: 4px;
-    height: 48px;
-    line-height: 48px;
+    /*height: 48px;
+    line-height: 48px;*/
 }
 
 .yui-calendar .calnavleft {
@@ -3358,11 +3360,11 @@ a:link, a:visited, a:hover {
 .moduleTitle h2 {
     display: block;
     float: left;
-    font-size: 26px;
+    font-size: 20px;
     color: #534D64;
     text-transform: uppercase;
     letter-spacing: 2px;
-    margin: 0px 0 40px 0;
+    margin: 0px 0 10px 0;
     font-weight: 300;
 }
 
@@ -3813,18 +3815,18 @@ ul.yui-nav li.selected {
 
 ul.nav-tabs {
     border: hidden;
-    margin: 16px 0 16px 0;
+    /*margin: 16px 0 16px 0;*/
 }
 
 ul.nav-tabs > li > a, ul.nav-tabs > li.active > a:focus {
     font-weight: 400;
-    letter-spacing: 2px;
+    letter-spacing: 1px;
     font-size: 13px;
-    text-transform: uppercase;
+    /*text-transform: uppercase;*/
     background-color: #BFCAD3;
     margin: 0 2px 0 2px;
     color: #ffffff;
-    line-height: 32px;
+    /*line-height: 32px;*/
     border-color: #eee #eee #fff;
     cursor: pointer;
 }
@@ -3934,7 +3936,7 @@ li#tab-actions > a {
     padding-right: 42px;
     background-image: none, url("../../../../index.php?entryPoint=getImage&themeName=SuiteP&imageName=p_create_arrow.svg"), url("../../../../index.php?entryPoint=getImage&themeName=SuiteP&imageName=p_create_arrow.png");
     background-repeat: no-repeat;
-    background-position: 80% 120%;
+    background-position: 80% 103%;
     background-origin: border-box;
     background-size: 10px 95px;
     border-color: #F08377;
@@ -3994,7 +3996,7 @@ div.tab-content {
     border-bottom-left-radius: 4px;
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
-    margin-bottom: 30px;
+    /*margin-bottom: 30px;*/
 }
 
 #basic_search_link {
@@ -4451,11 +4453,11 @@ iframe.teamNoticeBox {
 }
 
 .globalLinks-desktop ul{
-    top: 90px !important;
+    top: 60px !important;
 }
 
 .globalLinks-desktop #usermenu {
-    height: 90px;
+    height: 60px;
 }
 .iconed {
     padding: 5px 5px 2px 0;
@@ -4553,8 +4555,8 @@ iframe.teamNoticeBox {
 }
 
 td.dashlet-title {
-    height: 52px;
-    line-height: 48px;
+    height: 35px;
+    /*line-height: 48px;*/
 }
 
 td.dashlet-title > h3 > span {
@@ -5222,7 +5224,7 @@ input[type=button].btn-info:active, input[type=button].btn-info:focus {
 }
 
 #EditView_tabs .id-ff-remove, #EditView_tabs .edit [type="radio"]  {
-    margin-top: 8px;
+    /*margin-top: 8px;*/
 }
 
 #EditView_tabs .edit [type="radio"], #EditView_tabs .edit [type="checkbox"]  {
@@ -5261,8 +5263,8 @@ input#btn_ActionLine.button[type="button"] {
 
 #deleteGroup img {
     content: url('../../../../index.php?entryPoint=getImage&themeName=SuiteP&imageName=id-ff-clear.png');
-    height: 32px;
-    width: 32px;
+    height: 30px;
+    width: 30px;
 }
 
 #EditView_tabs .edit input, #EditView_tabs .edit textarea {
@@ -5271,16 +5273,16 @@ input#btn_ActionLine.button[type="button"] {
 }
 
 .col-sm-6 .edit-view-field input[type="text"] {
-    width: 50%;
+    /*width: 50%;*/
 }
 
 .edit-view-field #duration_hours {
-    width: 80px;
+    /*width: 80px;*/
     margin-right: 8px;
 }
 
 .col-sm-6 .edit-view-field input[type="text"].datetimecombo_date {
-    width: 84px;
+    /*width: 84px;*/
 }
 .col-sm-6 .edit-view-field .datetimecombo_time_section {
     display: inline-block;
@@ -5292,7 +5294,7 @@ input#btn_ActionLine.button[type="button"] {
 }
 
 #primary_address_street, #alt_address_street {
-    width: 60%;
+    /*width: 60%;*/
 }
 
 
@@ -5300,7 +5302,7 @@ input#btn_ActionLine.button[type="button"] {
 .col-sm-6 .edit-view-field[field="primary_address_street"] input[type="text"],
 .col-sm-6 .edit-view-field[field="shipping_address_street"] input[type="text"],
 .col-sm-6 .edit-view-field[field="alt_address_street"] input[type="text"]{
-    width: 88%;
+    /*width: 88%;*/
 }
 
 #conditionLines_head,
@@ -5600,8 +5602,8 @@ table#lineItems tr td table tfoot tr td span input[type="text"] {
 #EditView #shipping_tax_amt,
 #EditView #tax_amount,
 #EditView #total_amount {
-    max-width: 40%;
-    width: 40%;
+    /*max-width: 40%;
+    width: 40%;*/
 }
 
 #EditView #shipping_tax {
@@ -5670,15 +5672,15 @@ div.col-sm-6 #email1_span td.email-address-add-button {
 
 .emailaddresses > tbody:nth-child(1) > tr > td:nth-child(1) button img {
     content: url('../../../../index.php?entryPoint=getImage&themeName=SuiteP&imageName=id-ff-add.png');
-    height: 32px;
-    width: 32px;
+    height: 30px;
+    width: 30px;
 }
 
 
 .emailaddresses button {
     content: url('../../../../index.php?entryPoint=getImage&themeName=SuiteP&imageName=id-ff-add.png');
-    height: 34px;
-    width: 34px;
+    height: 30px;
+    width: 30px;
     line-height: 0;
 }
 
@@ -5721,7 +5723,7 @@ textarea#primary_address_street, textarea#alt_address_street {
 }
 
 textarea#description {
-    width: 100%;
+    /*width: 100%;*/
 }
 
 .dropdown-menu {
@@ -5770,7 +5772,7 @@ textarea#description {
     color: #fff;
     background-color: #5d5670;
     text-decoration: none;
-    padding: 12px 15px 12px 15px !important;
+    padding: 10px 15px 10px 15px !important;
     display: block;
     font-size: 14px;
     border-bottom: 1px solid #757083;
@@ -5800,7 +5802,7 @@ textarea#description {
 
 .recent_h3 {
     color: #ffffff;
-    line-height:42px;
+    /*line-height:42px;*/
 }
 
 .recent_h3 > strong {
@@ -5813,8 +5815,8 @@ textarea#description {
 
 ul.nav li.topnav a {
     border-top: 3px solid #534d64;
-    padding-top: 36px;
-    padding-bottom: 35px;
+    padding-top: 22px;
+    /*padding-bottom: 35px;*/
 }
 
 ul.nav li.topnav a:hover {
@@ -5834,10 +5836,10 @@ li.topnav {
     margin: 0;
     font-size: 1.1em;
     font-size: 13px;
-    height: 90px;
-    letter-spacing: 2px;
-    line-height: 95px;
-    padding: 0 7px 0 7px;
+    height: 60px;
+    letter-spacing: 1px;
+    line-height: 65px;
+    padding: 0 5px 0 5px;
     text-transform: uppercase;
 }
 
@@ -6010,13 +6012,13 @@ li.topnav ul.dropdown-menu li:last-child a {
     cursor: pointer;
     font-size: 13px !important;
     margin: 0 0 0 0;
-    padding: 0 20px 0 20px;
+    padding: 0 15px 0 15px;
     border-radius: 3px;
     text-transform: uppercase;
     font-weight: 500;
     letter-spacing: 1px;
-    height: 40px;
-    line-height: 40px;
+    height: 30px;
+    line-height: 30px;
 }
 button, html input[type=button], input[type=reset], input[type=submit],
 .button, input[type=button], input[type=reset]{
@@ -6060,10 +6062,10 @@ button[disabled], input[type="submit"][disabled], input[type="reset"][disabled],
     border-radius: 3px;
     text-transform: uppercase;
     font-weight: 500;
-    padding: 0 20px 0 20px;
+    /*padding: 0 20px 0 20px;
     letter-spacing: 1px;
     height: 40px;
-    line-height: 40px;
+    line-height: 40px;*/
 }
 
 .yui-layout-hd .button, .yui-layout-hd input[type=submit], .yui-layout-hd input[type=button] {
@@ -6116,8 +6118,8 @@ input[type=text], input[type=password], input[type=email], input:not([type]), te
 }
 
 input[type=text], input[type=password], input[type=email], input:not([type]) {
-    line-height: 40px;
-    min-height: 48px;
+    /*line-height: 40px;
+    min-height: 48px;*/
 }
 
 .search_form input[type=text], .search_form textarea {
@@ -6125,7 +6127,7 @@ input[type=text], input[type=password], input[type=email], input:not([type]) {
 }
 
 div.search_fields_basic {
-    line-height: 48px;
+    /*line-height: 48px;*/
 }
 
 div.search_fields_basic select[multiple] {
@@ -6152,7 +6154,7 @@ div.search_fields_basic:nth-of-type(3n+1) {
 }
 
 div.search_name_basic input {
-    width: 75%;
+    /*width: 75%;*/
 }
 
 div.search_fields_basic .dateTimeRangeChoice, div.search_fields_basic .dateTimeRangeChoice + div {
@@ -6177,12 +6179,12 @@ div.search_fields_basic .dateTimeRangeChoice, div.search_fields_basic .dateTimeR
     float: left;
     width: 128px;
     color: #ffffff;
-    line-height: 18px;
+    /*line-height: 18px;*/
 }
 
 .qtip-title-buttons {
     display: inline-block;
-    width: 46px;
+    /*width: 46px;*/
     float: right;
     vertical-align: middle;
     padding: 0 0 0 4px;
@@ -6191,7 +6193,7 @@ div.search_fields_basic .dateTimeRangeChoice, div.search_fields_basic .dateTimeR
 .qtip-title-buttons a {
     padding-left: 8px;
     color: #ffffff;
-    margin: 0 0 0 4px;
+    margin: 0 4px 0 4px;
     padding: 0;
 }
 
@@ -6320,7 +6322,7 @@ div.search_fields_basic .dateTimeRangeChoice, div.search_fields_basic .dateTimeR
 /*lg-col-*/
 @media (min-width: 1260px) {
     li.topnav {
-        padding: 0 5px 0 5px;
+        padding: 0 3px 0 3px;
     }
 }
 
@@ -6356,7 +6358,7 @@ div.search_fields_basic .dateTimeRangeChoice, div.search_fields_basic .dateTimeR
 }
 
 textarea {
-    width: 50%;
+    /*width: 50%;*/
 }
 
 select[size],
@@ -6368,15 +6370,15 @@ select {
     border-radius: 4px;
     padding: 0px 35px 0px 5px;
     background: url("../../../../themes/SuiteP/images/forms/select.ico") no-repeat right #ffffff;
-    background-size: 52px 52px;
+    background-size: 30px 30px;
     -moz-appearance: none;
     -webkit-appearance: none;
     appearance: none;
     outline: 0;
     scrollbar-base-color: #A5E8D6;
     scrollbar-arrow-color: #A5E8D6;
-    height: 52px;
-    line-height: 52px;
+    /*height: 52px;
+    line-height: 52px;*/
     color: #534D64;
 }
 
@@ -6413,12 +6415,14 @@ option:checked {
     border-size: 1px;
     border-color: #A5E8D6;
     border-radius: 4px;
-    padding: 16px 55px 16px 5px;
+    padding: 4px 6px;/*16px 55px 16px 5px;*/
     background: url("../../../../themes/SuiteP/images/forms/select.ico") no-repeat right #ffffff;
+    /*
     background-size: 52px 52px;
     -moz-appearance: none;
     -webkit-appearance: none;
     appearance: none;
+    */
 }
 
 select[multiple] {
@@ -6535,20 +6539,20 @@ ul::-webkit-resizer
 
 .navbar-inverse .navbar-brand {
     color: #ffffff;
-    height: 90px;
-    line-height: 90px;
+    height: 60px;
+    line-height: 60px;
     padding: 0;
     display: inline;
     background-image: url('../../../../themes/SuiteP/images/p_icon_home.png');
     background-repeat: no-repeat;
-    background-position: 0px 35px;
+    background-position: 0px 20px;
     text-indent: -9999px;
     overflow: hidden;
     width: 40px;
 }
 
 .navbar-inverse .navbar-brand:hover {
-    background-position: 0px -145px;
+    background-position: 0px -160px;
 }
 
 .btn-success {
@@ -6660,7 +6664,7 @@ table legend {
 
 #searchform {
     margin-right: -10px;
-    margin-top: 25px;
+    margin-top: 10px;
     margin-right: 15px;
 }
 
@@ -6694,8 +6698,7 @@ form#MassAssign_SecurityGroups {
     padding: 0;
 }
 
-#searchform input#query_string,
-#searchform input#query_string:-webkit-autofill {
+#searchform input#query_string {
     background-color: #65697A;
     float: left;
     border: 3px solid #65697A;
@@ -6751,12 +6754,13 @@ a#advanced_search_link {
     text-transform: uppercase;
     font-weight: 500;
     letter-spacing: 1px;
-    height: 40px;
-    line-height: 40px;
+    height: 30px;
+    line-height: 30px;
     display: inline-block;
     background-image: none, url("../../../../index.php?entryPoint=getImage&themeName=SuiteP&imageName=p_create_arrow.svg"), url("../../../../index.php?entryPoint=getImage&themeName=SuiteP&imageName=p_create_arrow.png");
     background-repeat: no-repeat;
-    background-position: 173px 2px;
+    /*background-position: 173px 2px;*/
+    background-position: 90% 4%;
 }
 
 a#advanced_search_link:hover {
@@ -6775,12 +6779,13 @@ a#basic_search_link {
     text-transform: uppercase;
     font-weight: 500;
     letter-spacing: 1px;
-    height: 40px;
-    line-height: 40px;
+    height: 30px;
+    line-height: 30px;
     display: inline-block;
     background-image: none, url("../../../../index.php?entryPoint=getImage&themeName=SuiteP&imageName=p_create_arrow.svg"), url("../../../../index.php?entryPoint=getImage&themeName=SuiteP&imageName=p_up_arrow.png");
     background-repeat: no-repeat;
-    background-position: 136px 13px;
+    /*background-position: 136px 13px;*/
+    background-position: 90% 65%;
 }
 
 a#basic_search_link:hover {
@@ -7138,7 +7143,7 @@ a[id^=grouptab]:visited, a[id^=grouptab]:active {
     font-size: 14px;
     padding: 8px;
     display: inherit;
-    height: 48px;
+    /*height: 48px;*/
     line-height: 32px;
 }
 
@@ -7189,7 +7194,7 @@ a[id^=grouptab]:visited, a[id^=grouptab]:active {
 }
 
 .ui-state-highlight {
-    height: 48px;
+    /*height: 48px;*/
     border: 1px solid #778591;
     border-radius: 4px;
     background: #E6E6E6;
@@ -7515,7 +7520,7 @@ h3 span {
 
 #quickcreatetop {
     float: left;
-    margin-top: 25px;
+    margin-top: 10px;
     margin-right: 15px;
 }
 
@@ -7586,7 +7591,7 @@ h3 span {
 #desktop_notifications {
     float: left;
     width: 44px;
-    height: 48px;
+    /*height: 48px;*/
     margin-right: 15px;
     background-image: none, url("../../../../themes/SuiteP/images/p_icon_alert.svg"), url("../../../../themes/SuiteP/images/p_icon_alert.png");
     background-repeat: no-repeat;
@@ -7778,10 +7783,10 @@ h3 span {
 
 @media (min-width: 768px) and (min-height: 381px) {
     .mobile-bar #globalLinks {
-        height: 90px;
+        height: 48px;
     }
     .mobile-bar ul.dropdown-menu.user-dropdown{
-        top: 78px !important;
+        top: 48px !important;
         left: -140px !important;
     }
 
@@ -7792,10 +7797,10 @@ h3 span {
 
 @media (min-width: 768px) and (min-height: 381px) {
     .mobile-bar #globalLinks {
-        height: 90px;
+        height: 48px;
     }
     .mobile-bar ul.dropdown-menu.user-dropdown{
-        top: 78px !important;
+        top: 48px !important;
         left: -140px !important;
     }
 
@@ -7989,9 +7994,9 @@ object {
     font-family: 'Lato', Lato, Arial, sans-serif;
     font-size: 12px;
     background: #ffffff;
-    border: none;
+    border: 1px solid #cccccc;
     -webkit-border-radius: 0px;
-    border-radius: 4px;
+    border-radius: 0px;
 }
 
 .qtip-tipped .qtip-titlebar {
@@ -8118,15 +8123,15 @@ object {
     color: white;
     padding: 0px;
     vertical-align: middle;
-    height: 52px;
+    height: 32px;
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
 }
 
 .panel-default > .panel-heading > div {
     color: #ffffff;
-    height: 52px;
-    line-height: 52px;
+    height: 32px;
+    line-height: 32px;
     font-weight: 500;
     font-size: 14px !important;
     background-color: #66727D;
@@ -8147,27 +8152,27 @@ object {
 
 .panel-default > .panel-heading {
     display: block;
-    text-transform: uppercase;
+    /*text-transform: uppercase;*/
 }
 
 .panel-default > .panel-heading > a {
     color: #ffffff;
     display: block;
-    height: 52px;
+    height: 32px;
     font-weight: 500;
     font-size: 14px !important;
     background-color: #66727D;
-    padding: 15px 10px 0 10px;
+    padding: 6px 10px 0 10px;
 }
 
 .panel-default.sub-panel > .panel-heading  > a {
     color: #ffffff;
     display: block;
-    height: 52px;
+    height: 32px;
     font-weight: 500;
     font-size: 14px !important;
     background-color: #66727D;
-    padding: 10px 10px 0 10px;
+    padding: 0px 10px 0 10px;
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
 }
@@ -8651,7 +8656,7 @@ div.list-view-rounded-corners > table th:last-of-type {
 
 #history_search table td:nth-of-type(2) select[multiple],
 #history_search table td:nth-of-type(2) select[size] {
-    height: 48px;
+    /*height: 48px;*/
 }
 
 #history_search table td:nth-of-type(8) div {
@@ -8666,13 +8671,15 @@ div.list-view-rounded-corners > table th:last-of-type {
     font-weight: 700;
 }
 
-/*////////////////////////////////////////////////////////////////////////////////////////// MEDIA QUERIES //////////*/
+nav.navbar{
+    min-height: 60px;
+}/*////////////////////////////////////////////////////////////////////////////////////////// MEDIA QUERIES //////////*/
 
 @media (max-width: 1560px) {
 
     .navbar-fixed-top {
-        height: 90px;
-        max-height: 90px;
+        height: 60px;
+        max-height: 60px;
     }
 
     #searchform {
@@ -8732,8 +8739,15 @@ div.list-view-rounded-corners > table th:last-of-type {
         border-radius: 3px;
         padding: 12px 12px 12px 12px;
         height: auto;
+        left: -185px;
     }
-
+ #search #query_string {
+        left: -100px;
+        top: 48px;
+        padding-top: 7px;
+        padding-bottom: 7px;
+        margin-top: -9px;
+    }   
     #usermenucollapsed, #usermenucollapsed-mobile {
         background-color: transparent;
         height: 42px;
@@ -8741,7 +8755,7 @@ div.list-view-rounded-corners > table th:last-of-type {
         background-image: none, url("../../../../themes/SuiteP/images/p_user_icon.svg"), url("../../../../themes/SuiteP/images/p_user_icon.png");
         background-repeat: no-repeat;
         background-position: 0 0 !important;
-        margin-top: 14px;
+        margin-top: 0px;
         border: none;
         margin-left: 0px;
     }
@@ -8949,7 +8963,7 @@ div.list-view-rounded-corners > table th:last-of-type {
         overflow: hidden;
         padding: 12px 0px 12px 0px;
         width: 28px;
-        height: 40px!important;
+        height: 28px!important;
     }
 
     #search.open #searchbutton {
@@ -8991,26 +9005,28 @@ div.list-view-rounded-corners > table th:last-of-type {
 
 @media (min-width: 750px) {
     .modulename {
-        line-height: 90px;
+        line-height: 60px;
     }
 
     .navbar-toggle {
-        height: 90px;
+        height: 60px;
     }
 
     #mobile_menu {
-        top: 90px;
+        top: 60px;
         left: 10px;
         -webkit-overflow-scrolling: touch;
     }
 
     #search .dropdown-menu {
         position: absolute;
-        top: 14px;
+        /*top: 14px;*/
         right:  0;
         bottom: auto;
         left: -224px;
+        margin-top:-60px;
         background: transparent;
+        margin-top: -60px !important;
     }
 
     #search .dropdown-menu,
@@ -9031,7 +9047,7 @@ div.list-view-rounded-corners > table th:last-of-type {
     }
 
     #quickcreatetop {
-        margin-top: 25px;
+        /*margin-top: 25px;*/
     }
 
     #quickcreatetop a {
@@ -9074,7 +9090,7 @@ div.list-view-rounded-corners > table th:last-of-type {
         float: left;
         width: 44px;
         height: 48px;
-        margin-top: 22px;
+        margin-top: 10px;
         margin-right: 10px;
         background-image: none, url("../../../../themes/SuiteP/images/p_icon_alert.svg"), url("../../../../themes/SuiteP/images/p_icon_alert.png");
         background-repeat: no-repeat;
@@ -9091,7 +9107,7 @@ div.list-view-rounded-corners > table th:last-of-type {
 
 
     #search.open #searchbutton {
-        margin: 25px 15px 0 0;
+        /*margin: 25px 15px 0 0;*/
         background-color: transparent;
         border: none;
         background-image: url("../../../../themes/SuiteP/images/sidebar/modules/search-close.svg");
@@ -9110,10 +9126,10 @@ div.list-view-rounded-corners > table th:last-of-type {
 
 
     #searchbutton {
-        margin: 25px 15px 0 0;
+        /*margin: 15px 15px 0 0;*/
         background-color: transparent;
         border: none;
-        background-image: url("../../../../themes/SuiteP/images/p_search_button.svg"), url("../../../../themes/SuiteP/images/p_search_button.png");
+        background-image: none,url("../../../../themes/SuiteP/images/p_search_button.svg"), url("../../../../themes/SuiteP/images/p_search_button.png");
         background-repeat: no-repeat;
         background-position: 0px -46px;
         text-indent: -9999px;
@@ -9776,7 +9792,7 @@ div.list-view-rounded-corners > table th:last-of-type {
     }
 
     #usermenucollapsed:hover {
-        background-position: 0 -99px;
+        background-position: 0 -99px !important;
     }
 
     #search .dropdown-menu {
@@ -10934,6 +10950,14 @@ table.list.view.subpanel-table tr.pagination button.button[name="listViewEndButt
 }
 
 
+
+/*calander bootstrap modal was using modal-lg which was 900px so the elements were getting shrinked*/
+#calendar_modal .modal-dialog{
+    width:90%;
+    /*height:100%;*/
+}
+
+
 /* admin / inbound emails styles */
 
 div#content div#pagecontent form#MassUpdate table.list.view tbody tr.pagination td table tbody tr {
@@ -11086,8 +11110,8 @@ div#content div#pagecontent form#MassUpdate table.list.view tbody tr.pagination 
 /* list items */
 
 div#content div#pagecontent form#MassUpdate table.list.view tbody tr td {
-    padding-top: 0;
-    padding-bottom: 0;
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
 }
 
 /* edit form */


### PR DESCRIPTION
Fine tuned SuiteP theme such that it gives more space to work on smaller devices including laptops.

## Description
We have tried to fix SuiteP theme to have more usable space over the screen on smaller devices.

The major areas of changes were the Top menu, Empty space between the menu and the detailview, Large textbox, textareas, huge select boxes, Reduced button sizes. Improved the Calander quick create view so that the element can load up properly and have space between them, The popup has been increased in size.

Our blog explained overview of the changes here
[http://urdhva-tech.com/blogs/fine-tunning-the-suitecrm-new-theme](url)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
