### PR TITLE
Fixed #2689 - inline editing removes related parent from Calls by assigning id to accounts_id

### DIFF
--- a/include/InlineEditing/InlineEditing.php
+++ b/include/InlineEditing/InlineEditing.php
@@ -340,6 +340,13 @@ function saveField($field, $id, $module, $value)
             }
         }
 
+        // Fix for gitHub issue 2689 - inline editing removes related Account from Calls
+        if(isset($bean->parent_id) && $bean->parent_id != null && $bean->parent_id != '') {
+            if($bean->account_id == null || $bean->account_id == ''){
+                $bean->account_id = $bean->parent_id;
+            }
+        }
+
         $bean->save($check_notify);
         return getDisplayValue($bean, $field);
     } else {


### PR DESCRIPTION

## Description
The issue is that after inline editing bean is saved with parent relationship field having null value. It can be fixed by assigning $bean->parent_id to this parent relationship field.

references issue #2689

## Motivation and Context
Inline editing of any field on the Detail View of the Calls module removes related Account.

## How To Test This
1. go to Calls module
2. enter into detail view of a call
3. inline edit any field
4. hit enter to save
5. the parent record link disappear

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)