### PR TITLE
Fix #2765 - Saving EditView from Studio breaks if top row has only one field

### DIFF
--- a/modules/ModuleBuilder/parsers/views/GridLayoutMetaDataParser.php
+++ b/modules/ModuleBuilder/parsers/views/GridLayoutMetaDataParser.php
@@ -142,9 +142,8 @@ class GridLayoutMetaDataParser extends AbstractMetaDataParser implements MetaDat
     function getLayout ()
     {
     	$viewdefs = array () ;
-    	$fielddefs = $this->_fielddefs;
-    	$fielddefs [ $this->FILLER [ 'name' ] ] = $this->FILLER ;
-    	$fielddefs [ MBConstants::$EMPTY [ 'name' ] ] = MBConstants::$EMPTY ;
+	$this->_fielddefs [ $this->FILLER [ 'name' ] ] = $this->FILLER ;
+	$this->_fielddefs [ MBConstants::$EMPTY [ 'name' ] ] = MBConstants::$EMPTY ;
     	
 		foreach ( $this->_viewdefs [ 'panels' ] as $panelID => $panel )
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix for bug #2765 

Fix the view metadata parser (GridLayoutMetaDataParser) to properly initialize the "(filler)" and the "(empty)" dummy field definitions.

Rendering of the template breaks if these values are not set properly.

## How To Test This
Modify an EditView inside Studio. Change the top row in any panel to display only one field instead of two. Click  "Save & Deploy".

Before the fix this would break; now it works.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
