### PR TITLE
Fix #758 - Accessing static property ImportFieldSanitize::$createdBea…

### DIFF
--- a/include/SugarFields/Fields/Relate/SugarFieldRelate.php
+++ b/include/SugarFields/Fields/Relate/SugarFieldRelate.php
@@ -384,7 +384,7 @@ class SugarFieldRelate extends SugarFieldBase {
 
                         $newbean->save(false);
                         $focus->$idField = $newbean->id;
-                        $settings->createdBeans[] = ImportFile::writeRowToLastImport(
+                        ImportFieldSanitize::$createdBeans[] = ImportFile::writeRowToLastImport(
                                 $focus->module_dir,$newbean->object_name,$newbean->id);
                     }
                 }

--- a/modules/Import/Importer.php
+++ b/modules/Import/Importer.php
@@ -140,7 +140,7 @@ class Importer
         $focus->unPopulateDefaultValues();
         $focus->save_from_post = false;
         $focus->team_id = null;
-        $this->ifs->createdBeans = array();
+        ImportFieldSanitize::$createdBeans = array();
         $this->importSource->resetRowErrorCounter();
         $do_save = true;
 
@@ -352,7 +352,7 @@ class Importer
             if ( $idc->isADuplicateRecord($enabled_dupes) )
             {
                 $this->importSource->markRowAsDuplicate($idc->_dupedFields);
-                $this->_undoCreatedBeans($this->ifs->createdBeans);
+                $this->_undoCreatedBeans(ImportFieldSanitize::$createdBeans);
                 return;
             }
         }
@@ -365,7 +365,7 @@ class Importer
             if ( $idc->isADuplicateRecordByFields($enabled_dup_fields) )
             {
                 $this->importSource->markRowAsDuplicate($idc->_dupedFields);
-                $this->_undoCreatedBeans($this->ifs->createdBeans);
+                $this->_undoCreatedBeans(ImportFieldSanitize::$createdBeans);
                 return;
             }
         }
@@ -396,7 +396,7 @@ class Importer
                     if( ! $this->isUpdateOnly )
                     {
                         $this->importSource->writeError($mod_strings['LBL_ID_EXISTS_ALREADY'],'ID',$focus->id);
-                        $this->_undoCreatedBeans($this->ifs->createdBeans);
+                        $this->_undoCreatedBeans(ImportFieldSanitize::$createdBeans);
                         return;
                     }
 
@@ -404,7 +404,7 @@ class Importer
                     if($clonedBean === FALSE)
                     {
                         $this->importSource->writeError($mod_strings['LBL_RECORD_CANNOT_BE_UPDATED'],'ID',$focus->id);
-                        $this->_undoCreatedBeans($this->ifs->createdBeans);
+                        $this->_undoCreatedBeans(ImportFieldSanitize::$createdBeans);
                         return;
                     }
                     else
@@ -427,7 +427,7 @@ class Importer
             $this->importSource->markRowAsImported($newRecord);
         }
         else
-            $this->_undoCreatedBeans($this->ifs->createdBeans);
+            $this->_undoCreatedBeans(ImportFieldSanitize::$createdBeans);
 
         unset($defaultRowValue);
 


### PR DESCRIPTION
## Description
Fixes #1416 

The original pull request for this was against the wrong branch. I simply applied it to the hotfix branch.

We are manually patching this with each release in production.


## Motivation and Context
See #758

## How To Test This
- Turn on logging in the admin panel, general settings
- Perform an import, on contacts for example, and watch the suitecrm.log
- Pre-patch, errors for import are fired depending on your PHP strict level, or warnings. 
- After patch  no errors fire.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.