### PR TITLE
add missing method stream_metadata for streamWrapper class for upload…

### DIFF
--- a/include/upload_file.php
+++ b/include/upload_file.php
@@ -820,6 +820,32 @@ class UploadStream
         return @stat(self::path($path));
     }
 
+    public function stream_metadata( $path, $option, $value )
+    {
+
+        $path = self::path( $path );
+
+        switch ( $option )
+        {
+            case STREAM_META_TOUCH:
+                return @touch($path, $value[0], $value[1]);
+                break;
+            case STREAM_META_OWNER_NAME:
+            case STREAM_META_OWNER:
+                return @chown($path, $value);
+                break;
+            case STREAM_META_GROUP_NAME:
+            case STREAM_META_GROUP:
+                return @chgrp($path, $value);
+                break;
+            case STREAM_META_ACCESS:
+                return @chmod($path, $value);
+                break;
+        }
+
+        return false;
+    }
+
     public static function move_uploaded_file($upload, $path)
     {
         return move_uploaded_file($upload, self::path($path));


### PR DESCRIPTION
The streamWrapper interface prescribes the method stream_metadata per http://php.net/manual/en/streamwrapper.stream-metadata.php. We have added it here.

## Description
We simply added the missing method.

## Motivation and Context
We get errors on import and the status and errors csv files are not populating correctly, leaving the UI lacking proper feedback for the user.

## How To Test This
- Import a file larger than the maximum split. For default install this is 100 rows. So, 200+ should do it.
- Make sure the file has various errors in it, at different rows (some in the 1-100 range, some in the 200+ range)
- Watch the error log and look at the results at the end of the import. Errors will be missing.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.
