### PR TITLE
fixed - #2795 Checkbox Internal on Cases Detail View is without label

### DIFF
--- a/modules/Cases/language/en_us.lang.php
+++ b/modules/Cases/language/en_us.lang.php
@@ -163,6 +163,8 @@ $mod_strings = array(
     'LBL_SELECT_EXTERNAL_CASE_DOCUMENT' => 'External file',
     'LBL_CONTACT_CREATED_BY_NAME' => 'Created by contact',
     'LBL_CASE_UPDATE_FORM' => 'Update attachment form',
+
+    'LBL_AOP_INTERNAL' => 'Internal',
 );
 
 ?>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Checkbox Internal on Cases Detail View is without label - fixed
## Description
<!--- Describe your changes in detail -->
Checkbox Internal on Cases Detail View is without label - fixed
References issue #2795
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->