### PR TITLE
Cases module - Missing string LBL_CONTACT_CREATED_BY

### DIFF
--- a/modules/Cases/language/en_us.lang.php
+++ b/modules/Cases/language/en_us.lang.php
@@ -162,6 +162,7 @@ $mod_strings = array(
     'LBL_SELECT_INTERNAL_CASE_DOCUMENT' => 'Internal CRM document',
     'LBL_SELECT_EXTERNAL_CASE_DOCUMENT' => 'External file',
     'LBL_CONTACT_CREATED_BY_NAME' => 'Created by contact',
+    'LBL_CONTACT_CREATED_BY' => 'Created by',
     'LBL_CASE_UPDATE_FORM' => 'Update attachment form',
 );
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

There is a missing string in language file for Modules / Cases /  line 165
`    'LBL_CONTACT_CREATED_BY' => 'Created by',`

this is called from \modules\Cases\vardefs.php
`                'vname' => 'LBL_CONTACT_CREATED_BY',`

Note: The language file string was removed on an previous PR but should be reverted 
https://github.com/shogunpol/SuiteCRM/commit/a52a93b372c7117b4c4dda55ae0c4389acc17bd3


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.