### PR TITLE
Fixed #2866 removed links parameter from the build_report_html function signature

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -513,20 +513,20 @@ class AOR_Report extends Basic {
             while ($row = $this->db->fetchByAssoc($result)) {
                 if($html != '') $html .= '<br />';
 
-                $html .= $this->build_report_html($offset, $links, $row[$field_label], '', $extra);
+                $html .= $this->build_report_html($offset, $row[$field_label], '', $extra);
 
             }
         }
 
         if($html == ''){
-            $html = $this->build_report_html($offset, $links);
+            $html = $this->build_report_html($offset);
         }
         return $html;
 
     }
 
 
-    function build_report_html($offset = -1, $links = true, $group_value = '', $tableIdentifier = '', $extra = array()){
+    function build_report_html($offset = -1, $group_value = '', $tableIdentifier = '', $extra = array()){
 
         global $beanList, $sugar_config;
 
@@ -700,7 +700,7 @@ class AOR_Report extends Basic {
             foreach($fields as $name => $att){
                 if($att['display']){
                     $html .= "<td class='' valign='top' align='left'>";
-                    if($att['link'] && $links){
+                    if($att['link']){
                         $html .= "<a href='" . $sugar_config['site_url'] . "/index.php?module=".$att['module']."&action=DetailView&record=".$row[$att['alias'].'_id']."'>";
                     }
 
@@ -715,7 +715,7 @@ class AOR_Report extends Basic {
                     if($att['total']){
                         $totals[$name][] = $row[$name];
                     }
-                    if($att['link'] && $links) $html .= "</a>";
+                    if($att['link']) $html .= "</a>";
                     $html .= "</td>";
                 }
             }


### PR DESCRIPTION
## Description
references issue #2866
Removed links parameter from the build_report_html function signature.

There is no point to have a $links = true parameter in the function build_report_html signature as every time it is called, it needs to be true. If the parameter always needs to be true then there is no need to have this parameter.

## Motivation and Context
In one place links was set to false and users were complaining that whether they choose display as link or not PDF do not display links at all

## How To Test This
1. All -> Reports -> Create Report
2. Report Module -> Opportunities (for example)
3. Fields -> add Opportunity Name -> tick Display, tick Link
4. Save
5. Generated report would display Opportunity Name as a link.
6. Click on Download PDF (from the dropdown menu).
7. Generated PDF will display Opportunity Name as a link.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)