### PR TITLE
Adding 'enable_action_menu' to config during install

### DIFF
--- a/install/suite_install/suite_install.php
+++ b/install/suite_install/suite_install.php
@@ -8,6 +8,7 @@ $sugar_config['default_max_tabs'] = 10;
 $sugar_config['suitecrm_version'] = $suitecrm_version;
 $sugar_config['sugar_version'] = $sugar_version;
 $sugar_config['sugarbeet'] = false;
+$sugar_config['enable_action_menu'] = true;
 
 ksort($sugar_config);
 write_array_to_file('sugar_config', $sugar_config, 'config.php');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When a user installs suitecrm the enable_action_menu is not set, which causes issues with some views in SuiteCRM eg. Meetings/Calls. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* Fixes bug

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Install the SuiteCRM
2. Check config.php for 'enable_action_menu'
3. Also check the detail views for each module to ensure that you see the action menu


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->