### PR TITLE
Fixed #2183 - only check for duplicate field names if it is not an update

### DIFF
--- a/jssource/src_files/include/javascript/sugar_3.js
+++ b/jssource/src_files/include/javascript/sugar_3.js
@@ -1208,15 +1208,17 @@ function validate_form(formname, startsWith){
 									}
 								});
 
-								for (k = 0; k < current_fields.length; k++) {
-									if(isError != true) {
-										val = current_fields[k].toUpperCase();
-										if ((operator == "==" && val == item1) || (operator == "!=" && val != item1)) {
-											isError = true;
-											add_error_style(formname, validate[formname][i][nameIndex], 'Invalid Value: Field Name already exists');
+								if(document.getElementsByName('is_update')[0].value == 'false') {
+									for (k = 0; k < current_fields.length; k++) {
+										if(isError != true) {
+											val = current_fields[k].toUpperCase();
+											if ((operator == "==" && val == item1) || (operator == "!=" && val != item1)) {
+												isError = true;
+												add_error_style(formname, validate[formname][i][nameIndex], 'Invalid Value: Field Name already exists');
+											}
 										}
 									}
-								}
+								}s
 							break;
 							case 'verified':
 							if(trim(form[validate[formname][i][nameIndex]].value) == 'false'){

--- a/jssource/src_files/include/javascript/sugar_3.js
+++ b/jssource/src_files/include/javascript/sugar_3.js
@@ -1218,7 +1218,7 @@ function validate_form(formname, startsWith){
 											}
 										}
 									}
-								}s
+								}
 							break;
 							case 'verified':
 							if(trim(form[validate[formname][i][nameIndex]].value) == 'false'){

--- a/modules/ModuleBuilder/tpls/MBModule/field.tpl
+++ b/modules/ModuleBuilder/tpls/MBModule/field.tpl
@@ -54,7 +54,11 @@ addForm('popup_form');
 {if isset($package->name)}
     <input type='hidden' name='view_package' value='{$package->name}'>
 {/if}
-<input type='hidden' name='is_update' value='true'>
+{if $is_update}
+	<input type='hidden' name='is_update' value='true'>
+{else}
+	<input type='hidden' name='is_update' value='false'>
+{/if}
 	{if $hideLevel < 5}
 	    &nbsp;
 	    <input type='button' class='button' name='fsavebtn' value='{$mod_strings.LBL_BTN_SAVE}' 

--- a/modules/ModuleBuilder/views/view.modulefield.php
+++ b/modules/ModuleBuilder/views/view.modulefield.php
@@ -360,6 +360,15 @@ class ViewModulefield extends SugarView
         }
 
         $fv->ss->assign('help_group', $edit_or_add);
+
+        // Fix for case 2183 - the form in the field.tpl needs to know whether it is an update
+        if($field_name == '') {
+            $is_update = false;
+        } else {
+            $is_update = true;
+        }
+        $fv->ss->assign('is_update', $is_update);
+
         $body = $this->fetchTemplate($fv, 'modules/ModuleBuilder/tpls/MBModule/field.tpl');
         $ac->addSection('east', translate('LBL_SECTION_FIELDEDITOR','ModuleBuilder'), $body );
         return $ac;


### PR DESCRIPTION
## Description
references issue #2183
The following file - modules/ModuleBuilder/tpls/MBModule/field.tpl had this input field with a value always true - <input type='hidden' name='is_update' value='true'>

So the form could not differentiate whether it was creating a new field or just updating an existing field.

This caused a problem with saving already existing fields - it tried to check whether the field name already exists (this check is only required if the user creates a new field, if the user updates an already existing field, then there is no need to check for duplicate field name as the user cannot change the field name anyway it will always stay the same in case of an update).

The following changes were applied: 
1. modules/ModuleBuilder/views/view.modulefield.php
        if($field_name == '') {
            $is_update = false;
        } else {
            $is_update = true;
        }
        $fv->ss->assign('is_update', $is_update);

This change is required to tell the template modules/ModuleBuilder/tpls/MBModule/field.tpl whether it's an update or creation of a new field.
$field_name will be '' if the user clicks on 'Add field' (creation of a new field).
$field_name will be '... specific field name ...' if the user clicks on already existing field name (update of already existing field).

2. modules/ModuleBuilder/tpls/MBModule/field.tpl
{if $is_update}
	<input type='hidden' name='is_update' value='true'>
{else}
	<input type='hidden' name='is_update' value='false'>
{/if}

This change outputs is_update hidden field with a true or false value instead of just always true value.

3. jssource/src_files/include/javascript/sugar_3.js
    if(document.getElementsByName('is_update')[0].value == 'false') {
         ... check for duplicate name ...
    }
    Only check for duplicate name if the form creates a new field 

## How To Test This
1. Navigate to Admin -> Studio -> Accounts -> Fields -> click on description
2. Change the value of Display Label: to New Description 
3. Save
4. The field should successfully save without error - 'Invalid Value: Field Name already exists'
5. Display label for the field should now be New Description 

1. Navigate to Admin -> Studio -> Accounts -> Fields -> click on 'ADD FIELD'
2. Enter description into Field Name:	
3. Save
4. 'Invalid Value: Field Name already exists' error message should appear as description field already exists.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
