### PR TITLE
Fix #2344/#2499 - Quicksearch not populating after first inline edit.

### DIFF
--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -142,6 +142,11 @@ function buildEditField(){
                     var relate_js = getRelateFieldJS(field, module, id);
                     $(_this).append(relate_js);
                     SUGAR.util.evalScript($(_this).html());
+                    // Issue 2344 and 2499 changes - Dump existing QSProcessedFieldsArray to enable multiple QS on multiple rows.
+                    var fieldToCheck = 'EditView_' + field + '_display';
+                    if(fieldToCheck in QSProcessedFieldsArray) {
+                        delete QSProcessedFieldsArray[fieldToCheck];
+                    }
                     //Needs to be called to enable quicksearch/typeahead functionality on the field.
                     enableQS(true);
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

Quick Search population when using inline-editing would not populate after the first inline-edit on any page. (Referenced in issues #2344 and #2499 which both contain steps for reproduction.)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Resolving a bug that was raised in two seperate issues regarding the same functionality.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
As described in Issue #2344 the following steps could be used to replicate the bug, when following these steps now, it's resolved:

1. Open list view of any module
2. Double click on Assigned to field in any row to inline edit selected record.
3. When typing, suggestion items show up.
4. Save row by clicking on tick icon.
5. Double click on Assigned to once again, this time suggestions do not show after typing.

Issue #2499 also lists a scenario on a different page which has since been resolved with this change, also:

1. open Opportunities details view module;
2. click on inline edit sign for Accounts field;
3. in appeared field type some data to see list of Accounts;
4. chose one of them and click on save sign;
5. after successful save -> repeat step 2) and 3)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->