### PR TITLE
Fix for Missing Header

### DIFF
--- a/modules/AOS_PDF_Templates/formLetterPdf.php
+++ b/modules/AOS_PDF_Templates/formLetterPdf.php
@@ -155,11 +155,11 @@ foreach ($recordIds as $recordId) {
         $pdf_history->WriteHTML($printable);
         $pdf_history->Output($sugar_config['upload_dir'] . 'nfile.pdf', 'F');
 
-        $pdf->AddPage();
-        $pdf->SetAutoFont();
         $pdf->SetHTMLHeader($header);
+        $pdf->AddPage();
+        $pdf->setAutoFont();
         $pdf->SetHTMLFooter($footer);
-        $pdf->WriteHTML($printable);
+        $pdf->writeHTML($printable);
 
         rename($sugar_config['upload_dir'] . 'nfile.pdf', $sugar_config['upload_dir'] . $note->id);
 


### PR DESCRIPTION
On some browsers, if the header is not generated first then it doesn't appear on the first page.

To fix this, the order of the generation is changed.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->