### PR TITLE
Fix #2545 - Warning about loss of changes appears multiple times

### DIFF
--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -56,20 +56,20 @@ timer = null;
 
 function buildEditField(){
     $(".inlineEdit a").click(function (e) {
-    	
-    	if(e.which !== undefined && e.which === 2){
+
+        if(e.which !== undefined && e.which === 2){
             return;
         }
-        
+
         if(this.id != "inlineEditSaveButton") {
             var linkUrl = $(this).attr("href");
-			var linkTarget = $(this).attr("target");
-			
+            var linkTarget = $(this).attr("target");
+
             if (typeof clicks == 'undefined') {
                 clicks = 0;
             }
             clicks++;
-            
+
             if(e.ctrlKey && clicks == 1){
                 return;
             }
@@ -85,10 +85,10 @@ function buildEditField(){
 
                 timer = setTimeout(function () {
                     // if reaches end of timeout without another click follow link
-					if (linkTarget)
-						window.open(linkUrl, linkTarget);
-					else
-						window.location.href = linkUrl;
+                    if (linkTarget)
+                        window.open(linkUrl, linkTarget);
+                    else
+                        window.location.href = linkUrl;
                     clicks = 0;             //after action performed, reset counter
 
                 }, 500);
@@ -259,6 +259,7 @@ $(document).on('click', function (e) {
         var module = ie_module;
         var type = ie_type;
         var message_field = ie_message_field;
+        var alertFlag = true;
 
         if (!$(e.target).parents().is(".inlineEditActive, .cal_panel") && !$(e.target).hasClass("inlineEditActive")) {
             var output_value = loadFieldHTMLValue(field, id, module);
@@ -267,20 +268,15 @@ $(document).on('click', function (e) {
 
             /**
              * A flag to fix Issue 2545, some parts of the site were comparing HTML to plain text, this flag checks
-             * against Plain Text and normal HTML to trigger the alert/confirm dialogue box. Due to the function
-             * "LoadFieldHTMLValue" called on line #270, declared at line #509, comparison has to be done this way.
-             *
-             * Additionally, auto populated fields (QS fields) have '_display' at the end of their field names which
-             * throws off any form of comparison check. An additional check has to be done to ensure we're considering
-             * these field names. An alternative solution would be to ensure these names do not have a trailing
-             * '_display' in the field names in the future.
+             * against Plain Text and normal HTML to trigger the alert/confirm dialogue box.
              */
 
             // Return user value to empty string for comparison if undefined at this stage (empty field check fix)
-            if (user_value == undefined) {
+            if (typeof user_value === "undefined") {
                 user_value = '';
             }
 
+            // QS Fields have '_display' in their field names. An additional check for the this field name pattern.
             if (outputValueParse != user_value && output_value != user_value) {
                 var fieldName = field + '_display';
                 var replacementUserValue = $("#" + fieldName).val();
@@ -294,8 +290,6 @@ $(document).on('click', function (e) {
 
             if (user_value == outputValueParse || user_value == output_value) {
                 var alertFlag = false;
-            } else {
-                var alertFlag = true;
             }
 
             if (alertFlag) {
@@ -371,7 +365,7 @@ function getInputValue(field,type){
                 break;
             case 'bool':
                 if($('#'+ field).is(':checked')){
-                   return "on";
+                    return "on";
                 }else{
                     return "off";
                 }
@@ -413,7 +407,7 @@ function handleSave(field,id,module,type){
     }
 
     if(type == "parent") {
-            parent_type = $('#parent_type').val();
+        parent_type = $('#parent_type').val();
     }
 
 
@@ -494,16 +488,16 @@ function loadFieldHTML(field,module,id) {
         }
     );
     $.ajaxSetup({"async": true});
-     if(result.responseText){
-         try {
-             return (JSON.parse(result.responseText));
-         } catch(e) {
-             return false;
-         }
+    if(result.responseText){
+        try {
+            return (JSON.parse(result.responseText));
+        } catch(e) {
+            return false;
+        }
 
-     }else{
-         return false;
-     }
+    }else{
+        return false;
+    }
 
 
 }

--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -260,7 +260,6 @@ $(document).on('click', function (e) {
         var type = ie_type;
         var message_field = ie_message_field;
 
-
         if (!$(e.target).parents().is(".inlineEditActive, .cal_panel") && !$(e.target).hasClass("inlineEditActive")) {
             var output_value = loadFieldHTMLValue(field, id, module);
             var outputValueParse = $(output_value).text();
@@ -292,11 +291,6 @@ $(document).on('click', function (e) {
                     user_value = replacementUserValue;
                 }
             }
-
-            // Debug Output
-            console.log('Output Value: ' + output_value);
-            console.log('Output Value Parse: ' + outputValueParse);
-            console.log('User Value: ' + user_value);
 
             if (user_value == outputValueParse || user_value == output_value) {
                 var alertFlag = false;

--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -223,8 +223,6 @@ function validateFormAndSave(field,id,module,type){
     });
 }
 
-
-
 /**
  * Checks if any of the parent elemenets of the current element have the class inlineEditActive this means they are within
  * the current element and have not clicked away from the field. Note we need to check on .cal_panel too for the calendar popup.
@@ -235,6 +233,7 @@ function validateFormAndSave(field,id,module,type){
 
 var ie_field, ie_id, ie_module, ie_type, ie_message_field;
 var clickListenerActive = false;
+
 function clickedawayclose(field,id,module, type){
     // Fix for issue #373 get name from system field name.
     message_field = 'LBL_' + field.toUpperCase();
@@ -252,6 +251,7 @@ function clickedawayclose(field,id,module, type){
     ie_message_field = message_field;
     clickListenerActive = true;
 }
+
 $(document).on('click', function (e) {
     if(clickListenerActive) {
         var field = ie_field;
@@ -267,23 +267,36 @@ $(document).on('click', function (e) {
             var user_value = getInputValue(field, type);
 
             /**
-             * A flag to fix Issue #2545, some parts of the site were comparing HTML to plain text, this flag checks
+             * A flag to fix Issue 2545, some parts of the site were comparing HTML to plain text, this flag checks
              * against Plain Text and normal HTML to trigger the alert/confirm dialogue box. Due to the function
-             * "LoadFieldHTMLValue" called on line 270, declared at line 509, comparison has to be done this way.
+             * "LoadFieldHTMLValue" called on line #270, declared at line #509, comparison has to be done this way.
              *
              * Additionally, auto populated fields (QS fields) have '_display' at the end of their field names which
              * throws off any form of comparison check. An additional check has to be done to ensure we're considering
              * these field names. An alternative solution would be to ensure these names do not have a trailing
              * '_display' in the field names in the future.
-             *
-             * @param fieldName = String of the field name with the trailing '_display' attached.
-             * @param alertFlag = Flag to trigger the alert/confirmation dialogue if the output/input doesn't match.
              */
+
+            // Return user value to empty string for comparison if undefined at this stage (empty field check fix)
+            if (user_value == undefined) {
+                user_value = '';
+            }
 
             if (outputValueParse != user_value && output_value != user_value) {
                 var fieldName = field + '_display';
-                user_value = $("#" + fieldName).val();
+                var replacementUserValue = $("#" + fieldName).val();
+
+                // Parsing empty text returns undefined, if the string returns anything other than undefined, replace
+                // user_value with this value.
+                if (replacementUserValue != undefined) {
+                    user_value = replacementUserValue;
+                }
             }
+
+            // Debug Output
+            console.log('Output Value: ' + output_value);
+            console.log('Output Value Parse: ' + outputValueParse);
+            console.log('User Value: ' + user_value);
 
             if (user_value == outputValueParse || user_value == output_value) {
                 var alertFlag = false;

--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -259,13 +259,40 @@ $(document).on('click', function (e) {
         var module = ie_module;
         var type = ie_type;
         var message_field = ie_message_field;
+
+
         if (!$(e.target).parents().is(".inlineEditActive, .cal_panel") && !$(e.target).hasClass("inlineEditActive")) {
             var output_value = loadFieldHTMLValue(field, id, module);
+            var outputValueParse = $(output_value).text();
             var user_value = getInputValue(field, type);
-            // Fix for issue #373 strip HTML tags for correct comparison
-            var output_value_compare = $(output_value).text();
-            if (user_value != output_value_compare) {
-                var r = confirm(SUGAR.language.translate('app_strings', 'LBL_CONFIRM_CANCEL_INLINE_EDITING') + message_field);
+
+            /**
+             * A flag to fix Issue #2545, some parts of the site were comparing HTML to plain text, this flag checks
+             * against Plain Text and normal HTML to trigger the alert/confirm dialogue box. Due to the function
+             * "LoadFieldHTMLValue" called on line 270, declared at line 509, comparison has to be done this way.
+             *
+             * Additionally, auto populated fields (QS fields) have '_display' at the end of their field names which
+             * throws off any form of comparison check. An additional check has to be done to ensure we're considering
+             * these field names. An alternative solution would be to ensure these names do not have a trailing
+             * '_display' in the field names in the future.
+             *
+             * @param fieldName = String of the field name with the trailing '_display' attached.
+             * @param alertFlag = Flag to trigger the alert/confirmation dialogue if the output/input doesn't match.
+             */
+
+            if (outputValueParse != user_value && output_value != user_value) {
+                var fieldName = field + '_display';
+                user_value = $("#" + fieldName).val();
+            }
+
+            if (user_value == outputValueParse || user_value == output_value) {
+                var alertFlag = false;
+            } else {
+                var alertFlag = true;
+            }
+
+            if (alertFlag) {
+                var r = confirm(SUGAR.language.translate('app_strings', 'LBL_CONFIRM_CANCEL_INLINE_EDITING') + ' ' + message_field);
                 if (r == true) {
                     var output = setValueClose(output_value);
                     clickListenerActive = false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixing issue #2545 - Often times the warning loss of changes dialogue window would appear when entering an inline edit box (upon double click). The Window would also be prompted if there were no changes made.

## Motivation and Context
A potential frustrating (from user interface point of view, user experience) bug that shouldn't have been present. Removal of the dialogue window appearing upon entering (sometimes) and clicking away without changes to the window should result in some less frustrating in-line editing experience.

## How To Test This
In issue #2545 the user provided a note for reproduction:
"When i mark some field for inline editing and click ouside the message show
up. I click cancel on message and second message popup immediatlety. When I
click cancel second time focus goes back to edited field."

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->