### PR TITLE
Fixed #2917 - template should save a relationship name in the relate_to input

### DIFF
--- a/modules/AOS_Products/tpls/EditViewHeader.tpl
+++ b/modules/AOS_Products/tpls/EditViewHeader.tpl
@@ -52,7 +52,7 @@
 <input type="hidden" name="return_id" value="{$smarty.request.return_id}">
 <input type="hidden" name="contact_role">
 {if !empty($smarty.request.return_module)}
-<input type="hidden" name="relate_to" value="{$smarty.request.return_module}">
+<input type="hidden" name="relate_to" value="{$smarty.request.return_relationship}">
 <input type="hidden" name="relate_id" value="{$smarty.request.return_id}">
 {/if}
 <input type="hidden" name="offset" value="{$offset}">


### PR DESCRIPTION
## Description
references issue #2917
Even though the relationship between Product and Product Category is created correctly, the following file modules/AOS_Products/tpls/EditViewHeader.tpl was trying to save is as a return_module instead of return_relationship.

## Motivation and Context
The products created in the "Products" subpanel of "Product Categories“ are not related to the category. A product can be created but not shown in the subpanel unless you select the product category in the full form.

## How To Test This
1. Navigate to Product Categories -> Products subpanel -> Create
2. Enter the details of the product and click Save.
3. The new Product is created, and is linked to the Product Category (displayed under the Products subpanel).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)


