### PR TITLE
Fixed #2928 - ListView Save and Deploy - prevent displaying old layout

### DIFF
--- a/modules/ModuleBuilder/javascript/ModuleBuilder.js
+++ b/modules/ModuleBuilder/javascript/ModuleBuilder.js
@@ -631,6 +631,15 @@ if (typeof(ModuleBuilder) == 'undefined') {
 				close: false
 			});
 
+			// get bookmarked url state
+			var YUI_HistoryBookmarkedState = YAHOO.util.History.getBookmarkedState('mbContent');
+			var urlVars = {};
+			var splits = YUI_HistoryBookmarkedState.split('&');
+			for(key in splits) {
+				var urlVar = splits[key].split('=');
+				urlVars[urlVar[0]] = urlVar[1];
+			}
+
 			if (typeof(successCall) == 'undefined') {
 				onSuccess = function(o) {
 					YAHOO.SUGAR.MessageBox.hide();
@@ -640,7 +649,9 @@ if (typeof(ModuleBuilder) == 'undefined') {
 						width: 500,
 						close: true
 					});
-					ModuleBuilder.updateContent(o);
+					if(urlVars.action != 'editLayout' && urlVars.view != 'listview') {
+						ModuleBuilder.updateContent(o);
+					}
 				}
 
 				onFailure = function(o) {
@@ -652,15 +663,6 @@ if (typeof(ModuleBuilder) == 'undefined') {
 						close: true
 					});
 					ModuleBuilder.updateContent(o);
-				}
-
-				// get bookmarked url state
-				var YUI_HistoryBookmarkedState = YAHOO.util.History.getBookmarkedState('mbContent');
-				var urlVars = {};
-				var splits = YUI_HistoryBookmarkedState.split('&');
-				for(key in splits) {
-					var urlVar = splits[key].split('=');
-					urlVars[urlVar[0]] = urlVar[1];
 				}
 
 				// check where we are and do it if we are in field editor in module builder


### PR DESCRIPTION
## Description
references issue #2928 

Added a conditional statement which prevents refresh in case it is a Layouts > ListView -> Save &Deploy action, as this refresh is meant for the DetailView, EditView and QuickCreate. In case of a ListView it just refreshes it with old layout.

## Motivation and Context
Save & Deploy does not work as required for Layouts -> ListView.
It doesn't refresh the fields on Default and Available after click on "Save & Deploy".
But if you leave, by clicking on "Layouts", and re-enter, clicking on "ListView" - the refreshed/correct layout is displayed.

## How To Test This
1. Navigate to Studio -> any module -> Layouts -> ListView
2. Drag and drop a couple of fields
3. click Save & Deploy
4. "In Progress" message will appear.
5. "This operation is completed successfully" message will be displayed if the save is successful

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)