### PR TITLE
Hiding nav menus when the current module text is too large.

### DIFF
--- a/themes/SuiteP/css/navbar.scss
+++ b/themes/SuiteP/css/navbar.scss
@@ -2125,6 +2125,26 @@
   }
 }
 
+.topnav #overflow-menu > li.with-actions .dropdown-menu {
+  display: none;
+  visibility: collapse;
+}
+
+.topnav #overflow-menu > li.with-actions > span > a {
+  padding: 12px 15px;
+  display: block;
+  border-bottom: none;
+}
+
+.topnav #overflow-menu > li.with-actions {
+  border-bottom: 1px solid $navbar-menu-seperator;
+}
+
+.topnav #overflow-menu > li.with-actions .notCurrentTabLeft {
+  display: none;
+  visibility: collapse;
+}
+
 @media (min-width: 1250px) {
   .desktop-bar {
     display: inline-block;

--- a/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -266,7 +266,7 @@
                     {/foreach}
                     {foreach from=$groupTabs item=modules key=group name=groupList}
                         {capture name=extraparams assign=extraparams}parentTab={$group}{/capture}
-                        <li class="topnav">
+                        <li class="topnav {if $smarty.foreach.groupList.last}all{/if}">
                             <span class="notCurrentTabLeft">&nbsp;</span><span class="notCurrentTab">
                             <a href="#" id="grouptab_{$smarty.foreach.groupList.index}" class="dropdown-toggle grouptab"
                                data-toggle="dropdown">{$group}</a>
@@ -287,6 +287,43 @@
                         </li>
                     {/foreach}
                 </ul>
+                {* 7.8 Hide filter menu items when the windows is too small to display them *}
+            {literal}
+                <script>
+                  var windowResize = function() {
+
+                    // only run if the desktop toolbar is in view
+                    if($(window).width() < 1201) { return true; }
+
+                    $('.desktop-toolbar ul.navbar-nav > li.hidden').removeClass('hidden');
+
+                    var tw = ($(window).width()) - $('.desktop-bar').width() - ($(window).width() * 0.05);
+                    var ti = $('.desktop-toolbar ul.navbar-nav > li');
+                    var tiw = 0;
+
+                    var calcTiw = function() {
+                      var paddingLeft = parseInt( $(this).css('padding-left').replace('px', '') );
+                      var paddingRight = parseInt( $(this).css('padding-right').replace('px', '') );
+                      var marginLeft = parseInt( $(this).css('margin-left').replace('px', '') );
+                      var marginRight = parseInt( $(this).css('margin-right').replace('px', '') );
+                      tiw += $(this).width() + paddingLeft + paddingRight + marginLeft + marginRight;
+                    }
+
+                    ti.each(calcTiw);
+
+                    while (tiw > tw) {
+                      ti = $('.desktop-toolbar ul.navbar-nav > li').not('.hidden').not('.all');
+                      $(ti).last().addClass('hidden');
+                      tiw = 0;
+                      ti.each(calcTiw);
+                    }
+
+                    $('.desktop-toolbar ul.navbar-nav > li.all').removeClass('hidden');
+                  };
+                  $(window).resize(windowResize);
+                  windowResize();
+                </script>
+            {/literal}
             {else}
 
                 <ul class="nav navbar-nav navbar-horizontal-fluid">
@@ -392,7 +429,7 @@
                     </li>
                 </ul>
                 <div class="hidden hidden-actions"></div>
-
+                {* Hide nav items when the window size is too small to display them *}
                 {literal}
                     <script>
                         var windowResize = function() {


### PR DESCRIPTION
This prevents the toolbar on the right hand side from wrapping to the next line.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When a user access a module that has a name which is very long. The toolbar on the right hand side wraps to the next line. This is due to a change I made the the spacing of the home button.

So to ensure that this doesn't happen again I have implemented a script which is similar the one we used for non filter menus; where it hides the menu item. However this implementation doesn't put the element in the All menu.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* prevents the nav bar style from breaking.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* Compile style.css from sass
* Access a user that utilises the filter menus
* Access a module like MAP ADDRESS CACHE

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->