### PR TITLE
Fixed #551 add functionality to save new labels for relationships

### DIFF
--- a/modules/ModuleBuilder/parsers/parser.label.php
+++ b/modules/ModuleBuilder/parsers/parser.label.php
@@ -271,6 +271,11 @@ class ParserLabel
                     }
                 }
 
+                // Fix for issue #551 - save new labels
+                foreach ($labels as $key => $value) {
+                    $mod_strings[$key] = $value;
+                }
+
                 foreach ($mod_strings as $key => $val) {
                     $out .= override_value_to_string_recursive2('mod_strings', $key, $val);
                 }
@@ -310,6 +315,11 @@ class ParserLabel
                             $changed_mod_strings = true;
                         }
                     }
+                }
+
+                // Fix for issue #551 - save new labels
+                foreach ($labels as $key => $value) {
+                    $mod_strings[$key] = $value;
                 }
 
                 foreach ($mod_strings as $key => $val) {


### PR DESCRIPTION
## Description
references issue #551

Added a foreach loop which enumerates through the $labels array and populates the $mod_strings array. This is done so the new labels contained in the $labels array can be added to the labels already existing in the $mod_strings array. 

This foreach loop is added twice in the modules/ModuleBuilder/parsers/parser.label.php file. Once to save new labels in the custom/Extension/modules/Accounts/Ext/Language/en_us.file_name.php file and once to save new labels in the custom/modules/Accounts/Ext/Language/en_us.lang.ext.php file. 

Adding the above mentioned code allows to save new labels for relationships. Before this change Studio would not save new labels into the Extension framework, which caused them to wiped out after Quick Repair and Rebuild.

## Motivation and Context
Field labels constantly revert back to default after Repair&Rebuild for relationships.

## How To Test This
1. Navigate to Studio -> module_name -> Relationships
2. Click on any relationship
3. Modify label
4. Click Save
5. Check that label has been saved
6. Do QR&R
7. Come back to the same label and check that it hasn't changed.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)