### PR TITLE
Fixed #794 added some functionality to change currency symbol from dollar to the symbol defined by the reported module

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -715,7 +715,15 @@ class AOR_Report extends Basic {
                     if($att['function'] == 'COUNT' || !empty($att['params'])){
                         $html .= $row[$name];
                     } else {
-                        $html .= getModuleField($att['module'], $att['field'], $att['field'], 'DetailView',$row[$name],'',$currency_id);
+                        $field_string = getModuleField($att['module'], $att['field'], $att['field'], 'DetailView',$row[$name],'',$currency_id);
+                        if ($currency_id != '-99') {
+                            if (strpos($field_string, '$') !== false) {
+                                $currency = new Currency();
+                                $currency->retrieve($currency_id);
+                                $field_string = str_replace("$", $currency->symbol, $field_string);
+                            }
+                        }
+                        $html .= $field_string;
                     }
 
                     if($att['total']){


### PR DESCRIPTION
## Description
references issue #794

Changed the function build_report_html from the following file: modules/AOR_Reports/AOR_Report.php.
Added some functionality to change currency symbol from system default currency sign to the currency symbol defined by the reported module.

## Motivation and Context
AOR_Reports disregards currency displayed by modules and always shows system default currency sign.

## How To Test This
1. Create 3 opportunities: one with Currency as Yen, one with Currency as Dollars, one with Currency as Pounds.
2. Create a report that runs on Opportunities. The results show correct values and it also should display the correct currency symbols (Yen, Dollar, Pound before the fix it would display Dollar, Dollar, Dollar).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)