### PR TITLE
Fixed #838 - fixed code for buttons Create Contract and Create Opportunity

### DIFF
--- a/modules/AOS_Quotes/metadata/detailviewdefs.php
+++ b/modules/AOS_Quotes/metadata/detailviewdefs.php
@@ -29,7 +29,7 @@ array (
           ),
           7 => 
           array (
-            'customCode' => '<input type="submit" class="button" onClick="this.form.action.value=\'createOpportunity\';" value="{$MOD.LBL_CREATE_OPPORTUNITY}">',
+            'customCode' => '<input type="submit" class="button" onClick="document.location.href=\'index.php?module=Opportunities&action=EditView&return_module=AOS_Quotes&return_action=DetailView&return_id={$id}\'" value="{$MOD.LBL_CREATE_OPPORTUNITY}">',
             'sugar_html' => 
             array (
               'type' => 'submit',
@@ -39,14 +39,14 @@ array (
                 'class' => 'button',
                 'id' => 'create_contract_button',
                 'title' => '{$MOD.LBL_CREATE_OPPORTUNITY}',
-                'onclick' => 'this.form.action.value=\'createOpportunity\';',
+                'onclick' => 'document.location.href=\'index.php?module=Opportunities&action=EditView&return_module=AOS_Quotes&return_action=DetailView&return_id={$id}\'',
                 'name' => 'Create Opportunity',
               ),
             ),
           ),
           8 => 
           array (
-            'customCode' => '<input type="submit" class="button" onClick="this.form.action.value=\'createContract\';" value="{$MOD.LBL_CREATE_CONTRACT}">',
+            'customCode' => '<input type="submit" class="button" onClick="document.location.href=\'index.php?module=AOS_Contracts&action=EditView&return_module=AOS_Quotes&return_action=DetailView&return_id={$id}\'" value="{$MOD.LBL_CREATE_CONTRACT}">',
             'sugar_html' => 
             array (
               'type' => 'submit',
@@ -56,7 +56,7 @@ array (
                 'class' => 'button',
                 'id' => 'create_contract_button',
                 'title' => '{$MOD.LBL_CREATE_CONTRACT}',
-                'onclick' => 'this.form.action.value=\'createContract\';',
+                'onclick' => 'document.location.href=\'index.php?module=AOS_Contracts&action=EditView&return_module=AOS_Quotes&return_action=DetailView&return_id={$id}\'',
                 'name' => 'Create Contract',
               ),
             ),


### PR DESCRIPTION
## Description
references issue #838

Added correct parameters to the following buttons: "Create Contract" and "Create Opportunity" on the Quotes module dropdown menu . 

## Motivation and Context
The following issues were caused by the incorrect code for the "Create Contract" and "Create Opportunity" buttons:

- If I choose "Create Contract" from detail view of a quote,
Contract Manager is set to the owner of the related quote "SalesAgility"..
Then, if I hit "Cancel", the contract is still saved! and linked to the original quote.
I then see list view of the module contracts (instead of jumping back to Quotes)

- The same behaviour was noticed if the user clicks on the "Create Opportunity" button

## How To Test This
1. Navigate to the Quotes module -> DetailView
2. Click on the "Create Contract" button -> EditView for the AOS_Contracts module will open
3. click Cancel -> the new Contract record will be saved in spite that the user clicked the "Cancel" button

4. Navigate to the Quotes module -> DetailView
5. Click on the "Create Opportunity" button -> EditView for the Opportunities module will open
6. click Cancel -> the new Opportunity record will be saved in spite that the user clicked the "Cancel" button

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)

