### PR TITLE
Fix #2559 - History sub-panel filter

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -824,6 +824,14 @@ class SugarBean
                 $submodule = new $submoduleclass();
                 $subwhere = $where_definition;
 
+                if($subpanel_def->search_query != '') {
+                    if($_REQUEST['collection_basic'][0] != 'null') {
+                        $subwhere = $subwhere . ' AND ' . str_replace(strtolower($_REQUEST['collection_basic'][0]),strtolower($submodulename),$subpanel_def->search_query);
+                    } else {
+                        $subwhere = $subwhere . ' AND ' . str_replace('meetings',strtolower($submodulename),$subpanel_def->search_query);
+                    }
+                }
+
 
                 $list_fields = $this_subpanel->get_list_fields();
                 foreach ($list_fields as $list_key => $list_field) {

--- a/include/SubPanel/SubPanel.php
+++ b/include/SubPanel/SubPanel.php
@@ -224,6 +224,10 @@ class SubPanel
 
 		//function returns the query that was used to populate sub-panel data.
 
+		if($this->subpanel_defs->search_query == '') {
+			$this->subpanel_defs->search_query = $this->search_query;
+		}
+
 		$query=$ListView->process_dynamic_listview($this->parent_module, $this->parent_bean,$this->subpanel_defs);
 		$this->subpanel_query=$query;
 		$ob_contents = ob_get_contents();
@@ -401,18 +405,21 @@ class SubPanel
 
 		require_once('include/SubPanel/SubPanelSearchForm.php');
 
+
 		if (isset($subpanel_defs['type']) && $subpanel_defs['type'] == 'collection') {
-			$arrayValues = array_values($subpanel_defs['collection_list']);
+			$arrayValues = is_array($this->collections) ? array_values($this->collections) : array_values($subpanel_defs['collection_list']);
 			$collection = array_shift($arrayValues);
-			$module = $collection['module'];
+			$module = $collection;
 		} else {
 			$module = $subpanel_defs['module'];
 		}
 		if($module) {
 			$seed = BeanFactory::getBean($module);
 		} else {
+			$module = 'Meetings';
 			$seed = new Meeting();
 		}
+
 
 		$_REQUEST['searchFormTab'] = 'basic_search';
 		$searchForm = new SubPanelSearchForm($seed, $module, $this);


### PR DESCRIPTION
(cherry picked from commit de78e09)

Ensure subpanel search query is passed to sugarBean and handled appropriately

## Description
as above
References issue #2559
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
history subpanle filters now work

## How To Test This
From history sub panel filter options, select and search

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->