### PR TITLE
Fix #2219 - Description field not wrapping with SuiteP theme after in…

### DIFF
--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -104,6 +104,7 @@ function buildEditField(){
 
 
     var onInlineEditDblClick = function(elem, e) {
+
         var _this = elem;
         e.preventDefault();
         // depending on what view you are using will find the id,module,type of field, and field name from the view
@@ -123,6 +124,10 @@ function buildEditField(){
             var type = $(_this).attr( "type" );
             var module = $("#displayMassUpdate input[name=module]").val();
             var id = $(_this).closest('tr').find('[type=checkbox]').attr( "value" );
+        }
+
+        if ($('[field="'+field+'"]').attr('class').indexOf('fix-inlineEdit-textarea') > 0) {
+            $('[field="'+field+'"]').removeClass('fix-inlineEdit-textarea');
         }
 
         //If we find all the required variables to do inline editing.
@@ -204,12 +209,15 @@ function buildEditField(){
  * @param type - the type of the field we are editing.
  */
 function validateFormAndSave(field,id,module,type){
+
     $("#inlineEditSaveButton").on('click', function () {
         var valid_form = check_form("EditView");
         if(valid_form){
             handleSave(field, id, module, type)
             clickListenerActive = false;
+            $('[field="'+field+'"]').addClass('fix-inlineEdit-textarea');
         }else{
+            $('[field="'+field+'"]').removeClass('fix-inlineEdit-textarea');
             return false
         };
     });

--- a/themes/SuiteP/css/style.css
+++ b/themes/SuiteP/css/style.css
@@ -5296,11 +5296,6 @@ input#btn_ActionLine.button[type="button"] {
 
 
 .col-sm-6 .edit-view-field[field="billing_address_street"] input[type="text"],
-.col-sm-6 .edit-view-field[field="primary_address_street"] input[type="text"],
-.col-sm-6 .edit-view-field[field="shipping_address_street"] input[type="text"],
-.col-sm-6 .edit-view-field[field="alt_address_street"] input[type="text"]{
-    width: 88%;
-}
 
 #conditionLines_head,
 #fieldLines_head {
@@ -11204,4 +11199,9 @@ div#content div#pagecontent form#EditView div.edit.view table tbody tr td input[
         height: initial;
         padding: 0px 0px 15px 0px !important;
     }
+}
+
+.fix-inlineEdit-textarea {
+    word-wrap: break-word;
+    white-space: pre-wrap;
 }


### PR DESCRIPTION
… line editing

Fix #2219 add fix-inlineEdit-textarea class to css, and javascript to add/remove the class as required

## Description
add word-wrap and white-space rules for new fix-inlineEdit-textarea css class. In InlineEditing.js, validateFormAndSave & onInlineEditDblClick functions add or remove the css class as required.
Reminder: This may need to be added into new SASS as developed!!!

## Motivation and Context
Fixes the issue when you edit a text area field using in-line editing it doesn't wrap after save.

## How To Test This
Open an account. In detail view enter a long block of text into inline editor & save.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->