### PR TITLE
Fixed #1857 - added an exception to bugfix 37043 to prevent merge_filter being overriden for last_name

### DIFF
--- a/modules/ModuleBuilder/parsers/StandardField.php
+++ b/modules/ModuleBuilder/parsers/StandardField.php
@@ -124,8 +124,14 @@ class StandardField extends DynamicField
             		|| (isset($currdef[$property]) && $currdef[$property] != $newDef[$property])
             	)
             ){
-            	$this->custom_def[$property] =
-                    is_string($newDef[$property]) ? htmlspecialchars_decode($newDef[$property], ENT_QUOTES) : $newDef[$property];
+                // Fix for issue #1857 - unless it is a 'last_name' field and 'merge_filter' property,
+                // as we still need a 'selected' value for find duplicate function
+                if($this->module == 'Contacts' && $field->name == 'last_name' && isset($currdef[$property]) && $property == 'merge_filter') {
+                    $this->custom_def[$property] = $currdef[$property];
+                } else {
+                    $this->custom_def[$property] =
+                        is_string($newDef[$property]) ? htmlspecialchars_decode($newDef[$property], ENT_QUOTES) : $newDef[$property];
+                }
             }
             
             //Remove any orphaned entries


### PR DESCRIPTION

## Description
references issue #1857

bugfix 37043 added the following change: avoid writing out vardef defintions that are the default value.

The problem is that we still need a definition from $currdef[$property] not the definition from $newDef[$property] for the merge_filter property if the field is a last_name from Contacts module. This is required for finding duplicates from the Contacts module.

## Motivation and Context
When audit is enabled for 'last name' within the studio and you use the find duplicate function 'last name' disappears. This is because when audit is enabled it creates the line " $dictionary['Contact']['fields']['last_name']['merge_filter']='disabled'; " within the files hiding the last name field.

## How To Test This
1. Navigate to Studio -> Contacts module -> Fields -> last_name 
2. tick the Audit field
3. Save
4. The audit field has a checkbox ticked now
5. Navigate to Contacts -> choose any record -> click on "Actions" -> "Find Duplicates" button
6. Filter Condition "Last Name" remains in place.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)