### PR TITLE
use stored query when colums changed on listview

### DIFF
--- a/include/MVC/View/views/view.list.php
+++ b/include/MVC/View/views/view.list.php
@@ -150,7 +150,7 @@ class ViewList extends SugarView
             $this->storeQuery->populateRequest();
         } else {
             $this->storeQuery->saveFromRequest($this->module);
-            if($_REQUEST['use_stored_query']) {
+            if(isset($_REQUEST['use_stored_query']) && $_REQUEST['use_stored_query']) {
                 die();
             }
         }

--- a/include/MVC/View/views/view.list.php
+++ b/include/MVC/View/views/view.list.php
@@ -150,6 +150,9 @@ class ViewList extends SugarView
             $this->storeQuery->populateRequest();
         } else {
             $this->storeQuery->saveFromRequest($this->module);
+            if($_REQUEST['use_stored_query']) {
+                die();
+            }
         }
 
         $this->seed = $this->bean;

--- a/modules/MySettings/StoreQuery.php
+++ b/modules/MySettings/StoreQuery.php
@@ -209,7 +209,7 @@ class StoreQuery
                 // Bug 39580 - Added 'EmailTreeLayout','EmailGridWidths' to the list as these are added merely as side-effects of the fact that we store the entire
                 // $_REQUEST object which includes all cookies.  These are potentially quite long strings as well.
                 $blockVariables = array('mass', 'uid', 'massupdate', 'delete', 'merge', 'selectCount', 'current_query_by_page', 'EmailTreeLayout', 'EmailGridWidths');
-                if ($_REQUEST['use_stored_query']) {
+                if (isset($_REQUEST['use_stored_query']) && $_REQUEST['use_stored_query']) {
                     $this->query = array_merge(StoreQuery::getStoredQueryForUser($name), $_REQUEST);
                 } else {
                     $this->query = $_REQUEST;


### PR DESCRIPTION
use stored query and do not store an empty data when columns changed on listview
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

ref: SCRM-140 Maintain Search Filter when adjusted Listview Layout - Issue 1
Changing Layout will display all records, and ignore the search. (Rather than showing the same search terms, with a new layout)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

when you change columns order on the listview and save it, the list view forget/clear the actual search criterias

## How To Test This
<!--- Please describe in detail how to test your changes. -->
- set something on the search form popup
- change the colums order and save

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->