### PR TITLE
Fixed #2963 Report Count Functionality is Broken (Again) in v7.7.9

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -1145,11 +1145,12 @@ class AOR_Report extends Basic {
                 if ($field->group_by == 1) {
                     $query['group_by'][] = $select_field;
                 }
-                elseif ($field->field_function != null) {
-                    $select_field = $field->field_function . '(' . $select_field . ')';
-                }
                 else {
                     $query['second_group_by'][] = $select_field;
+                }
+                
+                if ($field->field_function != null) {
+                    $select_field = $field->field_function . '(' . $select_field . ')';
                 }
 
                 if($field->sort_by != ''){


### PR DESCRIPTION
Fixed #2963  - Report Count Functionality is Broken (Again) in v7.7.9

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
In reports, you cannot group by and use a function on the same report. This fixes this issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug Fix.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Create a report with a group by and count. Test - then apply fix and see it working correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->