### PR TITLE
Fix #2927 - Emails View Relationship popup collapses on second use

### DIFF
--- a/modules/Emails/javascript/ajax.js
+++ b/modules/Emails/javascript/ajax.js
@@ -853,7 +853,7 @@ AjaxObject.detailView = {
 			});
 			SED.quickCreateDialog.renderEvent.subscribe(function() {
             	var viewHeight = YAHOO.util.Dom.getViewportHeight();
-            	var contH = 0;
+            	var contH = document.body["scrollHeight"];
             	for (var i in this.body.childNodes) {
             		if (this.body.childNodes[i].offsetHeight)
             			contH += this.body.childNodes[i].offsetHeight;


### PR DESCRIPTION
Set contH to document.body["scrollHeight"] as default.

## Description
#2927 - On second click body.childNodes[i] isn't available so height calculation defaults to original (default) setting. Setting this to document.body["scrollHeight"] ensure the height calculation works on subsequent clicks.

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
This changes ensures the the 'view relationships' pop up is viewable on multiple clicks.
Once implemented, requires rebuild JS grouping files.

## How To Test This
For the email list, right click an email, select 'view relationships'. After the pop up opens, close it and repeat. The subsequent pop up will remain viewable, where previously it was limited to a height of 10px.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->