### PR TITLE
Fix #2423 - Line breaks disappear in Text-Only draft emails

### DIFF
--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -489,7 +489,9 @@ class Email extends SugarBean {
 			$_REQUEST['description_html'] = $_REQUEST['sendDescription'];
 			$this->description_html = $_REQUEST['description_html'];
 		} else {
-			$this->description_html = '';
+			//$this->description_html = '';
+            $_REQUEST['description_html'] = $_REQUEST['sendDescription'];
+            $this->description_html = $_REQUEST['description_html'];
 			$this->description = $_REQUEST['sendDescription'];
 		}
 		// end work-around


### PR DESCRIPTION
#2423 line breaks disappear in text only draft emails

## Description
#2423 line breaks disappear in text only draft emails
set description_html so that the display presents correctly.
NOTE: This also corrects draft emails not appearing in the draft email list after saving as draft.

## Motivation and Context
line breaks are retained in the editor when text only draft emails are saved in edit email.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->