### PR TITLE
DetailView(mobile): Fixed issue when the panels and tabs are in a mixed order in studio.

### DIFF
--- a/themes/SuiteP/js/style.js
+++ b/themes/SuiteP/js/style.js
@@ -364,7 +364,7 @@ function changeFirstTab(src) {
     var selectedHtml = $(selected.context).html();
     $('#xstab0').html(selectedHtml);
 
-    var i = $(src).attr('id').replace('tab','') - 1;
+    var i = $(src).parents('li').index();
     selectTab(parseInt(i));
     return true;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When a administrator/developer changes the layout of a detail view in studio, so that the panel types are mixed between "tab" and "panel" eg Tab, Tab, Panel, Tab, Panel. This causes and issue with the javascript for the first tab in the mobile detail view. Where as a User: after selecting a tab in the dropdown menu in the first tab, the contents of the tab displays as none / blank. 

Example
![screenshot_20170126_122857](https://cloud.githubusercontent.com/assets/12231216/22331401/223b15da-e3c3-11e6-96a8-84fb7abc8cb8.png)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The reason is because the index of the dropdown menu and the tab contents are out off by 1. This fixe selects the correct tab content number. 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* In studio add panels and set the type (Tab/Panel) in a random order.
* Check that you can see those tabs in the mobile view.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->