### PR TITLE
Making sugarmenu flat

### DIFF
--- a/modules/ACLRoles/DetailView.tpl
+++ b/modules/ACLRoles/DetailView.tpl
@@ -44,6 +44,7 @@
 *}
 
 
+<div class="actionsContainer">
 <form action="index.php" method="post" name="DetailView" id="form">
 
 			<input type="hidden" name="module" value="ACLRoles">
@@ -59,23 +60,24 @@
     $APP = $this->get_template_vars('APP');
     $this->append('buttons',
     <<<EOD
-    <input title="{$APP['LBL_EDIT_BUTTON_TITLE']}" accessKey="{$APP['LBL_EDIT_BUTTON_KEY']}" class="button" onclick="var _form = $('#form')[0]; _form.action.value='EditView'; _form.submit();" type="submit" name="button" value="{$APP['LBL_EDIT_BUTTON']}" />
+    <input title="{$APP['LBL_EDIT_BUTTON_TITLE']}" accessKey="{$APP['LBL_EDIT_BUTTON_KEY']}" class="btn btn-danger" onclick="var _form = $('#form')[0]; _form.action.value='EditView'; _form.submit();" type="submit" name="button" value="{$APP['LBL_EDIT_BUTTON']}" />
 EOD
     );
     $this->append('buttons',
     <<<EOD
-    <input title="{$APP['LBL_DUPLICATE_BUTTON_TITLE']}" accessKey="{$APP['LBL_DUPLICATE_BUTTON_KEY']}" class="button" onclick="this.form.isDuplicate.value='1'; this.form.action.value='EditView'" type="submit" name="button" value=" {$APP['LBL_DUPLICATE_BUTTON']} " />
+    <input title="{$APP['LBL_DUPLICATE_BUTTON_TITLE']}" accessKey="{$APP['LBL_DUPLICATE_BUTTON_KEY']}" class="btn btn-danger" onclick="this.form.isDuplicate.value='1'; this.form.action.value='EditView'" type="submit" name="button" value=" {$APP['LBL_DUPLICATE_BUTTON']} " />
 EOD
     );
     $this->append('buttons',
     <<<EOD
-    <input title="{$APP['LBL_DELETE_BUTTON_TITLE']}" accessKey="{$APP['LBL_DELETE_BUTTON_KEY']}" class="button" onclick="this.form.return_module.value='ACLRoles'; this.form.return_action.value='index'; this.form.action.value='Delete'; return confirm('{$APP['NTC_DELETE_CONFIRMATION']}')" type="submit" name="button" value=" {$APP['LBL_DELETE_BUTTON']} " />
+    <input title="{$APP['LBL_DELETE_BUTTON_TITLE']}" accessKey="{$APP['LBL_DELETE_BUTTON_KEY']}" class="btn btn-danger" onclick="this.form.return_module.value='ACLRoles'; this.form.return_action.value='index'; this.form.action.value='Delete'; return confirm('{$APP['NTC_DELETE_CONFIRMATION']}')" type="submit" name="button" value=" {$APP['LBL_DELETE_BUTTON']} " />
 EOD
     );
 {/php}
-            {sugar_action_menu id="userEditActions" class="clickMenu fancymenu" buttons="$buttons"}
+		{sugar_action_menu id="userEditActions" class="clickMenu fancymenu SugarActionMenu" buttons="$buttons" flat=true}
 		</form>
 		</p>
+</div>
 		<p>
 		<TABLE width='100%' class='detail view' border='0' cellpadding=0 cellspacing = 1  >
 		<TR>

--- a/themes/SuiteP/css/forms.scss
+++ b/themes/SuiteP/css/forms.scss
@@ -309,22 +309,18 @@ fieldset[disabled] .btn-primary.active {
 
 .btn-danger {
   background-color: $danger-btn-bg;
-  border: 1px solid $danger-btn-bg;
 }
 
 .btn-danger:hover {
-  background-color: $danger-btn-bg;
-  border: 1px solid $danger-btn-bg;
+  background-color: $danger-btn-bg-hover;
 }
 
 .btn-danger:active {
   background-color: $danger-btn-bg;
-  border: 1px solid $danger-btn-bg;
 }
 
 .btn-danger:focus {
   background-color: $danger-btn-bg;
-  border: 1px solid $danger-btn-bg;
 }
 
 /** EditView action buttons ***/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Sugar Action Menu seems broken across all themes for Roles admin panel. I have made this flat menu instead.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows users to edit, duplicated and delete roles

## How To Test This
<!--- Please describe in detail how to test your changes. -->
See roles admin
* rebuild sass for testing SuiteP

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->