### PR TITLE
Fix #2806 - Dashlets wrong data on auto refresh

### DIFF
--- a/jssource/src_files/include/MySugar/javascript/MySugar.js
+++ b/jssource/src_files/include/MySugar/javascript/MySugar.js
@@ -232,6 +232,7 @@ SUGAR.mySugar = function() {
 		 * @param bool dynamic does the script load dynamic javascript, set to true if you user needs to refresh the dashlet after load
 		 */
 		retrieveDashlet: function(id, url, callback, dynamic, pageReload, pageTabElement) {
+
 			var _pageReload = typeof pageReload == 'undefined' ? false : pageReload;
       var _pageTabElement = typeof pageTabElement == 'undefined' || pageTabElement.length == 0 ? false : pageTabElement;
       if(!_pageTabElement && SUGAR.mySugar.currentDashlet && $('#' + SUGAR.mySugar.currentDashlet.id).closest('.tab-pane').length > 0) {
@@ -266,7 +267,7 @@ SUGAR.mySugar = function() {
 				}
 
 
-				$(SUGAR.mySugar.currentDashlet)
+				$('#dashlet_entire_' + id)
 					.find('.bd-center')
 					.html(updateDashlet);
 


### PR DESCRIPTION
Fix #2806 - Correction for Dashlets wrong data on auto refresh

## Description
#2806 Fix ties the dashlet reload to the specific dashlet id
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
If Dashlets are set to auto-refresh then randomly the wrong data is displayed

## How To Test This
set dashlets to auto-refresh every 30s and ensure correct data shows in correct dashlet.
Requires rebuild of js minified file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->