### PR TITLE
Change the PHP version that install checks to 5.3.0 from 5.2.0.

### DIFF
--- a/install.php
+++ b/install.php
@@ -52,8 +52,8 @@ if(isset($_POST['smtp_tab_selected'])) {
 }
 
 //session_destroy();
-if (version_compare(phpversion(),'5.2.0') < 0) {
-	$msg = 'Minimum PHP version required is 5.2.0.  You are using PHP version  '. phpversion();
+if (version_compare(phpversion(),'5.3.0') < 0) {
+	$msg = 'Minimum PHP version required is 5.3.0.  You are using PHP version  '. phpversion();
     die($msg);
 }
 $session_id = session_id();


### PR DESCRIPTION
Bumps the PHP version checked by the installer to 5.3.0

## Description
Changes the PHP version checked by the installer to 5.3.0

## Motivation and Context
SuiteCRM 7.7.x requires, at least, PHP version 5.3. 
While tinkering with the installer, I've noticed that the php_version check is still validating 5.2.x, but, further down the same file there is code that uses Namespaces (introduced in 5.3).
This change prevents this mismatch, and allows SuiteCRM to refuse anything below 5.3.0.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->