### PR TITLE
Fixed #1200 - Emails: save() does not recognize parent_(bean|id) modifications in fetched_row

### DIFF
--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -1078,7 +1078,8 @@ class Email extends SugarBean {
                  }
 			}
 
-			parent::save($check_notify);
+			// croessler: has the parent-bean or its id been modified? compare via fetched-row...
+            // if so, delete the old relation and add the new one. one email can only be related to one parent, not multiple parents.
 
 			if(!empty($this->parent_type) && !empty($this->parent_id)) {
                 if(!empty($this->fetched_row) && !empty($this->fetched_row['parent_id']) && !empty($this->fetched_row['parent_type'])) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Emails: save() does not recognize parent_(bean|id) modifications in fetched_row - fixed
## Description
<!--- Describe your changes in detail -->
proposition of @croessler (pull on right "Hotfix" branch)
References issue #1200

updated save() method, fixed logical error when accessing bean->fetched_row AFTER parent::save(). Doing so leads to bean->fetched_row not to contain the fields before modifying and thus the email is in state "nothing has been modified".
new: save checks the fetched_row contents correctly. modifications to the parent type/id are being recognized, the old parent-relation is deleted, the new one is added.
a bit of code styling applied so one can read that stuff.

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->