### PR TITLE
Removes duplicate Internal label on cases

### DIFF
--- a/include/language/en_us.lang.php
+++ b/include/language/en_us.lang.php
@@ -2452,8 +2452,6 @@ $app_strings = array(
 
     'LBL_FILTER_HEADER_TITLE' => 'Filter',
 
-    'LBL_AOP_INTERNAL' => 'Internal',
-
 );
 
 $app_list_strings['moduleList']['Library'] = 'Library';

--- a/modules/AOP_Case_Updates/Case_Updates.php
+++ b/modules/AOP_Case_Updates/Case_Updates.php
@@ -341,7 +341,6 @@ function quick_edit_case_updates($case)
     if (isset($case->internal) && $case->internal) {
         $internalChecked = "checked='checked'";
     }
-    $internal = $app_strings['LBL_AOP_INTERNAL'];
     $saveBtn = $app_strings['LBL_SAVE_BUTTON_LABEL'];
     $saveTitle = $app_strings['LBL_SAVE_BUTTON_TITLE'];
 
@@ -352,7 +351,7 @@ function quick_edit_case_updates($case)
     <textarea id="update_text" name="update_text" cols="80" rows="4"></textarea>
 
     <div><label>{$mod_strings['LBL_INTERNAL']}</label>
-    <input id='internal' type='checkbox' name='internal' tabindex=0 title='' value='1' $internalChecked > $internal</input>
+    <input id='internal' type='checkbox' name='internal' tabindex=0 title='' value='1' $internalChecked ></input>
     </div>
     <input type='button' value='$saveBtn' onclick="caseUpdates('$record')" title="$saveTitle" name="button"> </input>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
There are 2 internal update labels on cases. I suggest removing one and keeping the bold one that says 'Internal Update'

## How To Test This
<!--- Please describe in detail how to test your changes. -->
 - Go into the detail view of a case
- View that there is now only 1 internal update label
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->