### PR TITLE
Fixed Desktop Toolbar visual overflow issue

### DIFF
--- a/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -287,7 +287,7 @@
                         </li>
                     {/foreach}
                 </ul>
-                {* 7.8 Hide filter menu items when the windows is too small to display them *}
+                {* 7.8 Hide filter menu items when the window is too small to display them *}
             {literal}
                 <script>
                   var windowResize = function() {
@@ -295,33 +295,23 @@
                     // only run if the desktop toolbar is in view
                     if($(window).width() < 1201) { return true; }
 
+                    // Since the height can be changed in Sass.
+                    // Take a measurement of the initial desktop navigation bar height with just one menu item
+                    $('.desktop-toolbar ul.navbar-nav > li').not('.all').addClass('hidden');
+                    var dth = $('.desktop-toolbar').outerHeight();
+
+                    // Show all desktop menu items
                     $('.desktop-toolbar ul.navbar-nav > li.hidden').removeClass('hidden');
 
-                    var tw = ($(window).width()) - $('.desktop-bar').width() - ($(window).width() * 0.05);
-                    var ti = $('.desktop-toolbar ul.navbar-nav > li');
-                    var tiw = 0;
-
-                    var calcTiw = function() {
-                      var paddingLeft = parseInt( $(this).css('padding-left').replace('px', '') );
-                      var paddingRight = parseInt( $(this).css('padding-right').replace('px', '') );
-                      var marginLeft = parseInt( $(this).css('margin-left').replace('px', '') );
-                      var marginRight = parseInt( $(this).css('margin-right').replace('px', '') );
-                      tiw += $(this).width() + paddingLeft + paddingRight + marginLeft + marginRight;
-                    }
-
-                    ti.each(calcTiw);
-
-                    while (tiw > tw) {
+                    // Remove the each menu item from the end of the toolbar until
+                    // the navigation bar is the matches the initial height.
+                    while($('.desktop-toolbar').outerHeight() > dth) {
                       ti = $('.desktop-toolbar ul.navbar-nav > li').not('.hidden').not('.all');
                       $(ti).last().addClass('hidden');
-                      tiw = 0;
-                      ti.each(calcTiw);
                     }
-
-                    $('.desktop-toolbar ul.navbar-nav > li.all').removeClass('hidden');
                   };
                   $(window).resize(windowResize);
-                  windowResize();
+                  $(document).ready(windowResize);
                 </script>
             {/literal}
             {else}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This is a second attempt to fix #2936. Using the height of the desktop toolbar to detect if the navigation menus are wrapping to the next line, instead of the width of the desktop toolbar.

![screenshot_20170201_151308](https://cloud.githubusercontent.com/assets/12231216/22512822/267b2bac-e892-11e6-9d9f-c018c31e4578.png)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* Fixes bug with the navigation bar in the large desktop view

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* Add many menu filters
* Resize browser width to around 1605px
* Access a module who name is longer the 17 characters

The navigation elements should not wrap. However this hides some navigation menus:
![screenshot_20170201_152327](https://cloud.githubusercontent.com/assets/12231216/22512986/aea4959a-e892-11e6-9376-c55b68c089e7.png)


Menu items should not wrap to the next line
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->