### PR TITLE
Missing closing tag </b>

### DIFF
--- a/modules/Studio/language/en_us.lang.php
+++ b/modules/Studio/language/en_us.lang.php
@@ -97,7 +97,7 @@ $mod_strings = array (
 
 
 //SELECT MODULE WIZARD
-'LBL_SMW_WELCOME'=>'<h2>Welcome to Studio!</h2><br><b>Please select a module from below.',
+'LBL_SMW_WELCOME'=>'<h2>Welcome to Studio!</h2><br><b>Please select a module from below.</b>',
 
 //SELECT MODULE ACTION
 'LBL_SMA_WELCOME'=>'<h2>Edit a Module</h2>What do you want to do with that module?<br><b>Please select what action you would like to take.',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
missing closing tag `</b>`

Note: no issue created for this PR
Found a related duplicated issue: https://github.com/salesagility/SuiteCRM/issues/2676
So this string must be removed or fixed!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.
