### PR TITLE
Fix campaign email issue

### DIFF
--- a/modules/EmailMan/EmailManDelivery.php
+++ b/modules/EmailMan/EmailManDelivery.php
@@ -222,7 +222,7 @@ do {
             $outboundEmailAccount = BeanFactory::getBean('OutboundEmailAccounts',
                 $current_emailmarketing->outbound_email_id);
 
-            if ($outboundEmailAccount->mail_sendtype == "smtp") {
+            if (strtolower($outboundEmailAccount->mail_sendtype) == "smtp") {
                 $mail->Mailer = "smtp";
                 $mail->Host = $outboundEmailAccount->mail_smtpserver;
                 $mail->Port = $outboundEmailAccount->mail_smtpport;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When creating a new outbound email, or updating system settings and using SMTP it is saved in the field mail_sendtype as "SMTP". When checking before sending a campaign it is checking for "smtp" and then when this fails it is using sendmail. This means you can never send a campaign using smtp.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It solves the issue of not being able to use smtp to send emails.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Test sending a campaign and see that the system email settings have not been used to send an email. Apply fix and see that it has.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->