### PR TITLE
Fixed - Calendar is displaying Closed (HELD|NOT HELD) Meetings when $show_completed is false

### DIFF
--- a/modules/Calendar/CalendarActivity.php
+++ b/modules/Calendar/CalendarActivity.php
@@ -229,7 +229,7 @@ class CalendarActivity
                     isset($bean->rel_users_table) ? $bean->rel_users_table : null, $view_start_time, $view_end_time,
                     $activity['start'], $activity['end']);
 
-                if ($key === 'Meeting') {
+                if ($key === 'Meetings') {
                     $where .= $completedMeetings;
                 } elseif ($key === 'Calls') {
                     $where .= $completedCalls;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed provided by @adamjakab 


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Correcting a typo which stops Meetings being filtered correctly on Calendar


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Set Calendar Settings to 'Show Completed Meetings,Calls and Tasks' to false.
2. Confirm that the Meetings, Calls and Tasks are not displayed if Held/completed.
3.  Ensure existing functionality is maintained.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->