### PR TITLE
Fix #2695 - Users Are Able To View Other User Detail By Entering ID Into URL Params

### DIFF
--- a/modules/Users/controller.php
+++ b/modules/Users/controller.php
@@ -1,9 +1,10 @@
 <?php
-if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
 /*********************************************************************************
  * SugarCRM Community Edition is a customer relationship management program developed by
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
-
  * SuiteCRM is an extension to SugarCRM Community Edition developed by Salesagility Ltd.
  * Copyright (C) 2011 - 2014 Salesagility Ltd.
  *
@@ -39,7 +40,6 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  ********************************************************************************/
 
 /*********************************************************************************
-
  * Portions created by SugarCRM are Copyright (C) SugarCRM, Inc.
  * All Rights Reserved.
  * Contributor(s): ______________________________________..
@@ -48,30 +48,30 @@ require_once("include/OutboundEmail/OutboundEmail.php");
 
 class UsersController extends SugarController
 {
-	/**
-	 * bug 48170
-	 * Action resetPreferences gets fired when user clicks on  'Reset User Preferences' button
-	 * This action is set in UserViewHelper.php
-	 */
-	protected function action_resetPreferences(){
-	    if($_REQUEST['record'] == $GLOBALS['current_user']->id || ($GLOBALS['current_user']->isAdminForModule('Users'))){
-	        $u = new User();
-	        $u->retrieve($_REQUEST['record']);
-	        $u->resetPreferences();
-	        if($u->id == $GLOBALS['current_user']->id) {
-	            SugarApplication::redirect('index.php');
-	        }
-	        else{
-	            SugarApplication::redirect("index.php?module=Users&record=".$_REQUEST['record']."&action=DetailView"); //bug 48170]
-	
-	        }
-	    }
-	}
+    /**
+     * bug 48170
+     * Action resetPreferences gets fired when user clicks on  'Reset User Preferences' button
+     * This action is set in UserViewHelper.php
+     */
+    protected function action_resetPreferences()
+    {
+        if ($_REQUEST['record'] == $GLOBALS['current_user']->id || ($GLOBALS['current_user']->isAdminForModule('Users'))) {
+            $u = new User();
+            $u->retrieve($_REQUEST['record']);
+            $u->resetPreferences();
+            if ($u->id == $GLOBALS['current_user']->id) {
+                SugarApplication::redirect('index.php');
+            } else {
+                SugarApplication::redirect("index.php?module=Users&record=" . $_REQUEST['record'] . "&action=DetailView"); //bug 48170]
+
+            }
+        }
+    }
 
     protected function action_editview()
     {
         $this->view = 'edit';
-        if (!(is_admin($GLOBALS['current_user']) || $_REQUEST['record'] == $GLOBALS['current_user']->id)){
+        if (!(is_admin($GLOBALS['current_user']) || $_REQUEST['record'] == $GLOBALS['current_user']->id)) {
             SugarApplication::redirect("index.php?module=Home&action=index");
         }
     }
@@ -79,16 +79,16 @@ class UsersController extends SugarController
     protected function action_detailview()
     {
         $this->view = 'detail';
-        if (!(is_admin($GLOBALS['current_user']) || $_REQUEST['record'] == $GLOBALS['current_user']->id)){
+        if (!(is_admin($GLOBALS['current_user']) || $_REQUEST['record'] == $GLOBALS['current_user']->id)) {
             SugarApplication::redirect("index.php?module=Home&action=index");
         }
     }
 
-	protected function action_delete()
-	{
-	    if($_REQUEST['record'] != $GLOBALS['current_user']->id && ($GLOBALS['current_user']->isAdminForModule('Users')
-            ))
-        {
+    protected function action_delete()
+    {
+        if ($_REQUEST['record'] != $GLOBALS['current_user']->id && ($GLOBALS['current_user']->isAdminForModule('Users')
+            )
+        ) {
             $u = new User();
             $u->retrieve($_REQUEST['record']);
             $u->status = 'Inactive';
@@ -100,38 +100,39 @@ class UsersController extends SugarController
             $eapm = loadBean('EAPM');
             $eapm->delete_user_accounts($_REQUEST['record']);
             $GLOBALS['log']->info("Removing user's External Accounts");
-            
-            SugarApplication::redirect("index.php?module=Users&action=index");
-        }
-        else 
-            sugar_die("Unauthorized access to administration.");
-	}
-	protected function action_wizard() 
-	{
-		$this->view = 'wizard';
-	}
 
-	protected function action_saveuserwizard() 
-	{
-	    global $current_user, $sugar_config;
-	    
-	    // set all of these default parameters since the Users save action will undo the defaults otherwise
-	    $_POST['record'] = $current_user->id;
-	    $_POST['is_admin'] = ( $current_user->is_admin ? 'on' : '' );
-	    $_POST['use_real_names'] = true;
-		$_POST['reminder_checked'] = '1';
-		$_POST['email_reminder_checked'] = '1';
-	    $_POST['reminder_time'] = 1800;
-		$_POST['email_reminder_time'] = 3600;
+            SugarApplication::redirect("index.php?module=Users&action=index");
+        } else {
+            sugar_die("Unauthorized access to administration.");
+        }
+    }
+
+    protected function action_wizard()
+    {
+        $this->view = 'wizard';
+    }
+
+    protected function action_saveuserwizard()
+    {
+        global $current_user, $sugar_config;
+
+        // set all of these default parameters since the Users save action will undo the defaults otherwise
+        $_POST['record'] = $current_user->id;
+        $_POST['is_admin'] = ($current_user->is_admin ? 'on' : '');
+        $_POST['use_real_names'] = true;
+        $_POST['reminder_checked'] = '1';
+        $_POST['email_reminder_checked'] = '1';
+        $_POST['reminder_time'] = 1800;
+        $_POST['email_reminder_time'] = 3600;
         $_POST['mailmerge_on'] = 'on';
         $_POST['receive_notifications'] = $current_user->receive_notifications;
-        $_POST['user_theme'] = (string) SugarThemeRegistry::getDefault();
-	    
-	    // save and redirect to new view
-	    $_REQUEST['return_module'] = 'Home';
-	    $_REQUEST['return_action'] = 'index';
-		require('modules/Users/Save.php');
-	}
+        $_POST['user_theme'] = (string)SugarThemeRegistry::getDefault();
+
+        // save and redirect to new view
+        $_REQUEST['return_module'] = 'Home';
+        $_REQUEST['return_action'] = 'index';
+        require('modules/Users/Save.php');
+    }
 
     protected function action_saveftsmodules()
     {

--- a/modules/Users/controller.php
+++ b/modules/Users/controller.php
@@ -66,7 +66,24 @@ class UsersController extends SugarController
 	
 	        }
 	    }
-	}  
+	}
+
+    protected function action_editview()
+    {
+        $this->view = 'edit';
+        if (!(is_admin($GLOBALS['current_user']) || $_REQUEST['record'] == $GLOBALS['current_user']->id)){
+            SugarApplication::redirect("index.php?module=Home&action=index");
+        }
+    }
+
+    protected function action_detailview()
+    {
+        $this->view = 'detail';
+        if (!(is_admin($GLOBALS['current_user']) || $_REQUEST['record'] == $GLOBALS['current_user']->id)){
+            SugarApplication::redirect("index.php?module=Home&action=index");
+        }
+    }
+
 	protected function action_delete()
 	{
 	    if($_REQUEST['record'] != $GLOBALS['current_user']->id && ($GLOBALS['current_user']->isAdminForModule('Users')

--- a/modules/Users/views/view.detail.php
+++ b/modules/Users/views/view.detail.php
@@ -1,9 +1,10 @@
 <?php
-if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
 /*********************************************************************************
  * SugarCRM Community Edition is a customer relationship management program developed by
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
-
  * SuiteCRM is an extension to SugarCRM Community Edition developed by Salesagility Ltd.
  * Copyright (C) 2011 - 2014 Salesagility Ltd.
  *
@@ -41,31 +42,34 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 
 require_once('modules/Users/UserViewHelper.php');
 
-class UsersViewDetail extends ViewDetail {
+class UsersViewDetail extends ViewDetail
+{
 
-    function __construct(){
+    public function __construct()
+    {
         parent::__construct();
     }
 
     /**
      * @deprecated deprecated since version 7.6, PHP4 Style Constructors are deprecated and will be remove in 7.8, please update your code, use __construct instead
      */
-    public function UsersViewDetail(){
+    public function UsersViewDetail()
+    {
         $deprecatedMessage = 'PHP4 Style Constructors are deprecated and will be remove in 7.8, please update your code';
-        if(isset($GLOBALS['log'])) {
+        if (isset($GLOBALS['log'])) {
             $GLOBALS['log']->deprecated($deprecatedMessage);
-        }
-        else {
+        } else {
             trigger_error($deprecatedMessage, E_USER_DEPRECATED);
         }
         self::__construct();
     }
 
 
-    function preDisplay() {
+    function preDisplay()
+    {
         global $current_user, $app_strings, $sugar_config;
 
-        if(!isset($this->bean->id) ) {
+        if (!isset($this->bean->id)) {
             // No reason to set everything up just to have it fail in the display() call
             return;
         }
@@ -77,48 +81,53 @@ class UsersViewDetail extends ViewDetail {
 
         $errors = "";
         $msgGood = false;
-        if (isset($_REQUEST['pwd_set']) && $_REQUEST['pwd_set']!= 0){
-            if ($_REQUEST['pwd_set']=='4'){
+        if (isset($_REQUEST['pwd_set']) && $_REQUEST['pwd_set'] != 0) {
+            if ($_REQUEST['pwd_set'] == '4') {
                 require_once('modules/Users/password_utils.php');
-                $errors.=canSendPassword();
-            }
-            else {
-                $errors.=translate('LBL_NEW_USER_PASSWORD_'.$_REQUEST['pwd_set'],'Users');
+                $errors .= canSendPassword();
+            } else {
+                $errors .= translate('LBL_NEW_USER_PASSWORD_' . $_REQUEST['pwd_set'], 'Users');
                 $msgGood = true;
             }
-        }else{
+        } else {
             //IF BEAN USER IS LOCKOUT
-            if($this->bean->getPreference('lockout')=='1') {
-                $errors.=translate('ERR_USER_IS_LOCKED_OUT','Users');
+            if ($this->bean->getPreference('lockout') == '1') {
+                $errors .= translate('ERR_USER_IS_LOCKED_OUT', 'Users');
             }
         }
         $this->ss->assign("ERRORS", $errors);
-        $this->ss->assign("ERROR_MESSAGE", $msgGood ? translate('LBL_PASSWORD_SENT','Users') : translate('LBL_CANNOT_SEND_PASSWORD','Users'));
+        $this->ss->assign("ERROR_MESSAGE",
+            $msgGood ? translate('LBL_PASSWORD_SENT', 'Users') : translate('LBL_CANNOT_SEND_PASSWORD', 'Users'));
         $buttons = array();
         if ((is_admin($current_user) || $_REQUEST['record'] == $current_user->id
-                )
+            )
             && !empty($sugar_config['default_user_name'])
             && $sugar_config['default_user_name'] == $this->bean->user_name
             && isset($sugar_config['lock_default_user_name'])
-            && $sugar_config['lock_default_user_name']) {
-            $buttons[] = "<input id='edit_button' accessKey='".$app_strings['LBL_EDIT_BUTTON_KEY']."' name='Edit' title='".$app_strings['LBL_EDIT_BUTTON_TITLE']."' value='".$app_strings['LBL_EDIT_BUTTON_LABEL']."' onclick=\"this.form.return_module.value='Users'; this.form.return_action.value='DetailView'; this.form.return_id.value='".$this->bean->id."'; this.form.action.value='EditView'\" type='submit' value='" . $app_strings['LBL_EDIT_BUTTON_LABEL'] .  "'>";
+            && $sugar_config['lock_default_user_name']
+        ) {
+            $buttons[] = "<input id='edit_button' accessKey='" . $app_strings['LBL_EDIT_BUTTON_KEY'] . "' name='Edit' title='" . $app_strings['LBL_EDIT_BUTTON_TITLE'] . "' value='" . $app_strings['LBL_EDIT_BUTTON_LABEL'] . "' onclick=\"this.form.return_module.value='Users'; this.form.return_action.value='DetailView'; this.form.return_id.value='" . $this->bean->id . "'; this.form.action.value='EditView'\" type='submit' value='" . $app_strings['LBL_EDIT_BUTTON_LABEL'] . "'>";
 
-        }
-        elseif (is_admin($current_user)|| ($GLOBALS['current_user']->isAdminForModule('Users')&& !$this->bean->is_admin)
-                || $_REQUEST['record'] == $current_user->id) {
-            $buttons[] = "<input title='".$app_strings['LBL_EDIT_BUTTON_TITLE']."' accessKey='".$app_strings['LBL_EDIT_BUTTON_KEY']."' name='Edit' id='edit_button' value='".$app_strings['LBL_EDIT_BUTTON_LABEL']."' onclick=\"this.form.return_module.value='Users'; this.form.return_action.value='DetailView'; this.form.return_id.value='".$this->bean->id."'; this.form.action.value='EditView'\" type='submit' value='" . $app_strings['LBL_EDIT_BUTTON_LABEL'] .  "'>";
-            if ((is_admin($current_user)|| $GLOBALS['current_user']->isAdminForModule('Users')
-                    )) {
-                if (!$current_user->is_group){
-                    $buttons[] = "<input id='duplicate_button' title='".$app_strings['LBL_DUPLICATE_BUTTON_TITLE']."' accessKey='".$app_strings['LBL_DUPLICATE_BUTTON_KEY']."' class='button' onclick=\"this.form.return_module.value='Users'; this.form.return_action.value='DetailView'; this.form.isDuplicate.value=true; this.form.action.value='EditView'\" type='submit' name='Duplicate' value='".$app_strings['LBL_DUPLICATE_BUTTON_LABEL']."'>";
+        } elseif (is_admin($current_user) || ($GLOBALS['current_user']->isAdminForModule('Users') && !$this->bean->is_admin)
+            || $_REQUEST['record'] == $current_user->id
+        ) {
+            $buttons[] = "<input title='" . $app_strings['LBL_EDIT_BUTTON_TITLE'] . "' accessKey='" . $app_strings['LBL_EDIT_BUTTON_KEY'] . "' name='Edit' id='edit_button' value='" . $app_strings['LBL_EDIT_BUTTON_LABEL'] . "' onclick=\"this.form.return_module.value='Users'; this.form.return_action.value='DetailView'; this.form.return_id.value='" . $this->bean->id . "'; this.form.action.value='EditView'\" type='submit' value='" . $app_strings['LBL_EDIT_BUTTON_LABEL'] . "'>";
+            if ((is_admin($current_user) || $GLOBALS['current_user']->isAdminForModule('Users')
+            )
+            ) {
+                if (!$current_user->is_group) {
+                    $buttons[] = "<input id='duplicate_button' title='" . $app_strings['LBL_DUPLICATE_BUTTON_TITLE'] . "' accessKey='" . $app_strings['LBL_DUPLICATE_BUTTON_KEY'] . "' class='button' onclick=\"this.form.return_module.value='Users'; this.form.return_action.value='DetailView'; this.form.isDuplicate.value=true; this.form.action.value='EditView'\" type='submit' name='Duplicate' value='" . $app_strings['LBL_DUPLICATE_BUTTON_LABEL'] . "'>";
 
-                    if($this->bean->id != $current_user->id) {
-                        $buttons[] ="<input id='delete_button' type='button' class='button' onclick='confirmDelete();' value='".$app_strings['LBL_DELETE_BUTTON_LABEL']."' />";
+                    if ($this->bean->id != $current_user->id) {
+                        $buttons[] = "<input id='delete_button' type='button' class='button' onclick='confirmDelete();' value='" . $app_strings['LBL_DELETE_BUTTON_LABEL'] . "' />";
                     }
 
                     if (!$this->bean->portal_only && !$this->bean->is_group && !$this->bean->external_auth_only
-                        && isset($sugar_config['passwordsetting']['SystemGeneratedPasswordON']) && $sugar_config['passwordsetting']['SystemGeneratedPasswordON']){
-                        $buttons[] = "<input title='".translate('LBL_GENERATE_PASSWORD_BUTTON_TITLE','Users')."' class='button' LANGUAGE=javascript onclick='generatepwd(\"".$this->bean->id."\");' type='button' name='password' value='".translate('LBL_GENERATE_PASSWORD_BUTTON_LABEL','Users')."'>";
+                        && isset($sugar_config['passwordsetting']['SystemGeneratedPasswordON']) && $sugar_config['passwordsetting']['SystemGeneratedPasswordON']
+                    ) {
+                        $buttons[] = "<input title='" . translate('LBL_GENERATE_PASSWORD_BUTTON_TITLE',
+                                'Users') . "' class='button' LANGUAGE=javascript onclick='generatepwd(\"" . $this->bean->id . "\");' type='button' name='password' value='" . translate('LBL_GENERATE_PASSWORD_BUTTON_LABEL',
+                                'Users') . "'>";
                     }
                 }
             }
@@ -126,13 +135,14 @@ class UsersViewDetail extends ViewDetail {
 
         $buttons = array_merge($buttons, $this->ss->get_template_vars('BUTTONS_HEADER'));
 
-        $this->ss->assign('EDITBUTTONS',$buttons);
+        $this->ss->assign('EDITBUTTONS', $buttons);
 
-        $show_roles = (!($this->bean->is_group=='1' || $this->bean->portal_only=='1'));
+        $show_roles = (!($this->bean->is_group == '1' || $this->bean->portal_only == '1'));
         $this->ss->assign('SHOW_ROLES', $show_roles);
         //Mark whether or not the user is a group or portal user
-        $this->ss->assign('IS_GROUP_OR_PORTAL', ($this->bean->is_group=='1' || $this->bean->portal_only=='1') ? true : false);
-        if ( $show_roles ) {
+        $this->ss->assign('IS_GROUP_OR_PORTAL',
+            ($this->bean->is_group == '1' || $this->bean->portal_only == '1') ? true : false);
+        if ($show_roles) {
             ob_start();
             echo "<div>";
             require_once('modules/ACLRoles/DetailUserRole.php');
@@ -141,42 +151,45 @@ class UsersViewDetail extends ViewDetail {
 
             $role_html = ob_get_contents();
             ob_end_clean();
-            $this->ss->assign('ROLE_HTML',$role_html);
+            $this->ss->assign('ROLE_HTML', $role_html);
         }
 
     }
 
-    public function getMetaDataFile() {
+    public function getMetaDataFile()
+    {
         $userType = 'Regular';
-        if($this->bean->is_group == 1){
+        if ($this->bean->is_group == 1) {
             $userType = 'Group';
         }
 
-        if ( $userType != 'Regular' ) {
+        if ($userType != 'Regular') {
             $oldType = $this->type;
-            $this->type = $oldType.'group';
+            $this->type = $oldType . 'group';
         }
         $metadataFile = parent::getMetaDataFile();
-        if ( $userType != 'Regular' ) {
+        if ($userType != 'Regular') {
             $this->type = $oldType;
         }
+
         return $metadataFile;
     }
 
-    function display() {
-        if ($this->bean->portal_only == 1 || $this->bean->is_group == 1 ) {
+    function display()
+    {
+        if ($this->bean->portal_only == 1 || $this->bean->is_group == 1) {
             $this->options['show_subpanels'] = false;
             $this->dv->formName = 'DetailViewGroup';
             $this->dv->view = 'DetailViewGroup';
         }
 
-	    //handle request to reset the homepage
-        if(isset($_REQUEST['reset_homepage'])){
+        //handle request to reset the homepage
+        if (isset($_REQUEST['reset_homepage'])) {
             $this->bean->resetPreferences('Home');
             global $current_user;
-            if($this->bean->id == $current_user->id) {
+            if ($this->bean->id == $current_user->id) {
                 $_COOKIE[$current_user->id . '_activePage'] = '0';
-                setcookie($current_user->id . '_activePage','0',3000,null,null,false,true);
+                setcookie($current_user->id . '_activePage', '0', 3000, null, null, false, true);
             }
         }
 
@@ -198,11 +211,11 @@ class UsersViewDetail extends ViewDetail {
     {
         $theTitle = '';
 
-        if($GLOBALS['current_user']->isAdminForModule('Users')
+        if ($GLOBALS['current_user']->isAdminForModule('Users')
         ) {
-        $createImageURL = SugarThemeRegistry::current()->getImageURL('create-record.gif');
-        $url = ajaxLink("index.php?module=$module&action=EditView&return_module=$module&return_action=DetailView");
-        $theTitle = <<<EOHTML
+            $createImageURL = SugarThemeRegistry::current()->getImageURL('create-record.gif');
+            $url = ajaxLink("index.php?module=$module&action=EditView&return_module=$module&return_action=DetailView");
+            $theTitle = <<<EOHTML
 &nbsp;
 <img src='{$createImageURL}' alt='{$GLOBALS['app_strings']['LNK_CREATE']}'>
 <a href="{$url}" class="utilsLink">
@@ -210,6 +223,7 @@ class UsersViewDetail extends ViewDetail {
 </a>
 EOHTML;
         }
+
         return $theTitle;
     }
 

--- a/modules/Users/views/view.detail.php
+++ b/modules/Users/views/view.detail.php
@@ -43,9 +43,18 @@ require_once('modules/Users/UserViewHelper.php');
 
 class UsersViewDetail extends ViewDetail {
 
- 	public function __construct(){
- 		parent::__construct();
- 	}
+    function __construct(){
+        parent::__construct();
+
+        $recordid = $_REQUEST['record'];
+        $currentuserid = $GLOBALS['current_user']->id;
+        $isAdmin = $GLOBALS['current_user']->isAdminForModule('Users');
+        if( $recordid == $currentuserid || $isAdmin) {
+
+        }else{
+            SugarApplication::redirect("index.php?module=Home&action=index");
+        }
+    }
 
     /**
      * @deprecated deprecated since version 7.6, PHP4 Style Constructors are deprecated and will be remove in 7.8, please update your code, use __construct instead

--- a/modules/Users/views/view.detail.php
+++ b/modules/Users/views/view.detail.php
@@ -45,13 +45,6 @@ class UsersViewDetail extends ViewDetail {
 
     function __construct(){
         parent::__construct();
-
-        $recordid = $_REQUEST['record'];
-        $currentuserid = $GLOBALS['current_user']->id;
-        $isAdmin = $GLOBALS['current_user']->isAdminForModule('Users');
-        if( !($recordid == $currentuserid || $isAdmin)) {
-            SugarApplication::redirect("index.php?module=Home&action=index");
-        }
     }
 
     /**

--- a/modules/Users/views/view.detail.php
+++ b/modules/Users/views/view.detail.php
@@ -49,9 +49,7 @@ class UsersViewDetail extends ViewDetail {
         $recordid = $_REQUEST['record'];
         $currentuserid = $GLOBALS['current_user']->id;
         $isAdmin = $GLOBALS['current_user']->isAdminForModule('Users');
-        if( $recordid == $currentuserid || $isAdmin) {
-
-        }else{
+        if( !($recordid == $currentuserid || $isAdmin)) {
             SugarApplication::redirect("index.php?module=Home&action=index");
         }
     }

--- a/modules/Users/views/view.edit.php
+++ b/modules/Users/views/view.edit.php
@@ -44,9 +44,18 @@ require_once('modules/Users/UserViewHelper.php');
 
 class UsersViewEdit extends ViewEdit {
 var $useForSubpanel = true;
- 	function __construct(){
- 		parent::__construct();
- 	}
+    function __construct(){
+        parent::__construct();
+
+        $recordid = $_REQUEST['record'];
+        $currentuserid = $GLOBALS['current_user']->id;
+        $isAdmin = $GLOBALS['current_user']->isAdminForModule('Users');
+        if( $recordid == $currentuserid || $isAdmin) {
+
+        }else{
+            SugarApplication::redirect("index.php?module=Home&action=index");
+        }
+    }
 
     /**
      * @deprecated deprecated since version 7.6, PHP4 Style Constructors are deprecated and will be remove in 7.8, please update your code, use __construct instead

--- a/modules/Users/views/view.edit.php
+++ b/modules/Users/views/view.edit.php
@@ -1,9 +1,10 @@
 <?php
-if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
 /*********************************************************************************
  * SugarCRM Community Edition is a customer relationship management program developed by
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
-
  * SuiteCRM is an extension to SugarCRM Community Edition developed by Salesagility Ltd.
  * Copyright (C) 2011 - 2014 Salesagility Ltd.
  *
@@ -42,87 +43,92 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 require_once('modules/Users/UserViewHelper.php');
 
 
-class UsersViewEdit extends ViewEdit {
-var $useForSubpanel = true;
-    function __construct(){
+class UsersViewEdit extends ViewEdit
+{
+    var $useForSubpanel = true;
+
+    public function __construct()
+    {
         parent::__construct();
     }
 
     /**
      * @deprecated deprecated since version 7.6, PHP4 Style Constructors are deprecated and will be remove in 7.8, please update your code, use __construct instead
      */
-    function UsersViewEdit(){
+    function UsersViewEdit()
+    {
         $deprecatedMessage = 'PHP4 Style Constructors are deprecated and will be remove in 7.8, please update your code';
-        if(isset($GLOBALS['log'])) {
+        if (isset($GLOBALS['log'])) {
             $GLOBALS['log']->deprecated($deprecatedMessage);
-        }
-        else {
+        } else {
             trigger_error($deprecatedMessage, E_USER_DEPRECATED);
         }
         self::__construct();
     }
 
 
-    function preDisplay() {
+    function preDisplay()
+    {
         $this->fieldHelper = new UserViewHelper($this->ss, $this->bean, 'EditView');
         $this->fieldHelper->setupAdditionalFields();
 
         parent::preDisplay();
     }
 
-    public function getMetaDataFile() {
+    public function getMetaDataFile()
+    {
         $userType = 'Regular';
-        if($this->fieldHelper->usertype == 'GROUP'){
+        if ($this->fieldHelper->usertype == 'GROUP') {
             $userType = 'Group';
         }
 
-        if ( $userType != 'Regular' ) {
+        if ($userType != 'Regular') {
             $oldType = $this->type;
-            $this->type = $oldType.'group';
+            $this->type = $oldType . 'group';
         }
         $metadataFile = parent::getMetaDataFile();
-        if ( $userType != 'Regular' ) {
+        if ($userType != 'Regular') {
             $this->type = $oldType;
         }
 
         return $metadataFile;
     }
 
-    function display() {
+    function display()
+    {
         global $current_user, $app_list_strings;
 
 
         //lets set the return values
-        if(isset($_REQUEST['return_module'])){
-            $this->ss->assign('RETURN_MODULE',$_REQUEST['return_module']);
+        if (isset($_REQUEST['return_module'])) {
+            $this->ss->assign('RETURN_MODULE', $_REQUEST['return_module']);
         }
 
         $this->ss->assign('IS_ADMIN', $current_user->is_admin ? true : false);
 
         //make sure we can populate user type dropdown.  This usually gets populated in predisplay unless this is a quickeditform
-        if(!isset($this->fieldHelper)){
+        if (!isset($this->fieldHelper)) {
             $this->fieldHelper = new UserViewHelper($this->ss, $this->bean, 'EditView');
             $this->fieldHelper->setupAdditionalFields();
         }
 
-        if(isset($_REQUEST['isDuplicate']) && $_REQUEST['isDuplicate'] == 'true') {
+        if (isset($_REQUEST['isDuplicate']) && $_REQUEST['isDuplicate'] == 'true') {
             $this->ss->assign('RETURN_MODULE', $_REQUEST['return_module']);
             $this->ss->assign('RETURN_ACTION', $_REQUEST['return_action']);
             $this->ss->assign('RETURN_ID', $_REQUEST['record']);
             $this->bean->id = "";
             $this->bean->user_name = "";
-            $this->ss->assign('ID','');
+            $this->ss->assign('ID', '');
         } else {
-            if(isset($_REQUEST['return_module']))
-            {
+            if (isset($_REQUEST['return_module'])) {
                 $this->ss->assign('RETURN_MODULE', $_REQUEST['return_module']);
             } else {
                 $this->ss->assign('RETURN_MODULE', $this->bean->module_dir);
             }
 
-            $return_id = isset($_REQUEST['return_id'])?$_REQUEST['return_id']:$this->bean->id;
+            $return_id = isset($_REQUEST['return_id']) ? $_REQUEST['return_id'] : $this->bean->id;
             if (isset($return_id)) {
-                $return_action = isset($_REQUEST['return_action'])?$_REQUEST['return_action']:'DetailView';
+                $return_action = isset($_REQUEST['return_action']) ? $_REQUEST['return_action'] : 'DetailView';
                 $this->ss->assign('RETURN_ID', $return_id);
                 $this->ss->assign('RETURN_ACTION', $return_action);
             }
@@ -131,7 +137,7 @@ var $useForSubpanel = true;
 
         ///////////////////////////////////////////////////////////////////////////////
         ////	REDIRECTS FROM COMPOSE EMAIL SCREEN
-        if(isset($_REQUEST['type']) && (isset($_REQUEST['return_module']) && $_REQUEST['return_module'] == 'Emails')) {
+        if (isset($_REQUEST['type']) && (isset($_REQUEST['return_module']) && $_REQUEST['return_module'] == 'Emails')) {
             $this->ss->assign('REDIRECT_EMAILS_TYPE', $_REQUEST['type']);
         }
         ////	END REDIRECTS FROM COMPOSE EMAIL SCREEN
@@ -139,12 +145,12 @@ var $useForSubpanel = true;
 
         ///////////////////////////////////////////////////////////////////////////////
         ////	NEW USER CREATION ONLY
-        if(empty($this->bean->id)) {
-            $this->ss->assign('SHOW_ADMIN_CHECKBOX','height="30"');
-            $this->ss->assign('NEW_USER','1');
-        }else{
-            $this->ss->assign('NEW_USER','0');
-            $this->ss->assign('NEW_USER_TYPE','DISABLED');
+        if (empty($this->bean->id)) {
+            $this->ss->assign('SHOW_ADMIN_CHECKBOX', 'height="30"');
+            $this->ss->assign('NEW_USER', '1');
+        } else {
+            $this->ss->assign('NEW_USER', '0');
+            $this->ss->assign('NEW_USER_TYPE', 'DISABLED');
         }
 
         ////	END NEW USER CREATION ONLY
@@ -152,37 +158,43 @@ var $useForSubpanel = true;
 
 
         // FIXME: Translate error prefix
-        if(isset($_REQUEST['error_string'])) $this->ss->assign('ERROR_STRING', '<span class="error">Error: '.$_REQUEST['error_string'].'</span>');
-        if(isset($_REQUEST['error_password'])) $this->ss->assign('ERROR_PASSWORD', '<span id="error_pwd" class="error">Error: '.$_REQUEST['error_password'].'</span>');
-
-
+        if (isset($_REQUEST['error_string'])) {
+            $this->ss->assign('ERROR_STRING', '<span class="error">Error: ' . $_REQUEST['error_string'] . '</span>');
+        }
+        if (isset($_REQUEST['error_password'])) {
+            $this->ss->assign('ERROR_PASSWORD',
+                '<span id="error_pwd" class="error">Error: ' . $_REQUEST['error_password'] . '</span>');
+        }
 
 
         // Build viewable versions of a few fields for non-admins
-        if(!empty($this->bean->id)) {
-            if( !empty($this->bean->status) ) {
-                $this->ss->assign('STATUS_READONLY',$app_list_strings['user_status_dom'][$this->bean->status]); }
-            if( !empty($this->bean->employee_status) ) {
-                $this->ss->assign('EMPLOYEE_STATUS_READONLY', $app_list_strings['employee_status_dom'][$this->bean->employee_status]);
+        if (!empty($this->bean->id)) {
+            if (!empty($this->bean->status)) {
+                $this->ss->assign('STATUS_READONLY', $app_list_strings['user_status_dom'][$this->bean->status]);
             }
-            if( !empty($this->bean->reports_to_id) ) {
+            if (!empty($this->bean->employee_status)) {
+                $this->ss->assign('EMPLOYEE_STATUS_READONLY',
+                    $app_list_strings['employee_status_dom'][$this->bean->employee_status]);
+            }
+            if (!empty($this->bean->reports_to_id)) {
                 $reportsToUser = get_assigned_user_name($this->bean->reports_to_id);
                 $reportsToUserField = "<input type='text' name='reports_to_name' id='reports_to_name' value='{$reportsToUser}' disabled>\n";
                 $reportsToUserField .= "<input type='hidden' name='reports_to_id' id='reports_to_id' value='{$this->bean->reports_to_id}'>";
                 $this->ss->assign('REPORTS_TO_READONLY', $reportsToUserField);
             }
-            if( !empty($this->bean->title) ) {
+            if (!empty($this->bean->title)) {
                 $this->ss->assign('TITLE_READONLY', $this->bean->title);
             }
-            if( !empty($this->bean->department) ) {
+            if (!empty($this->bean->department)) {
                 $this->ss->assign('DEPT_READONLY', $this->bean->department);
             }
         }
 
         $processSpecial = false;
         $processFormName = '';
-        if ( isset($this->fieldHelper->usertype) && ($this->fieldHelper->usertype == 'GROUP'
-            )) {
+        if (isset($this->fieldHelper->usertype) && ($this->fieldHelper->usertype == 'GROUP'
+            )
+        ) {
             $this->ev->formName = 'EditViewGroup';
 
             $processSpecial = true;
@@ -201,19 +213,17 @@ var $useForSubpanel = true;
         $RETURN_ID = $this->ss->get_template_vars('RETURN_ID');
 
         $minpwdlength = !empty($PWDSETTINGS['minpwdlength']) ? $PWDSETTINGS['minpwdlength'] : '';
-        $maxpwdlength =  !empty($PWDSETTINGS['maxpwdlength']) ? $PWDSETTINGS['maxpwdlength'] : '';
+        $maxpwdlength = !empty($PWDSETTINGS['maxpwdlength']) ? $PWDSETTINGS['maxpwdlength'] : '';
         $action_button_header[] = <<<EOD
                     <input type="button" id="SAVE_HEADER" title="{$APP['LBL_SAVE_BUTTON_TITLE']}" accessKey="{$APP['LBL_SAVE_BUTTON_KEY']}"
                           class="button primary" onclick="var _form = $('#EditView')[0]; if (!set_password(_form,newrules('{$minpwdlength}','{$maxpwdlength}','{$REGEX}'))) return false; if (!Admin_check()) return false; _form.action.value='Save'; {$CHOOSER_SCRIPT} {$REASSIGN_JS} if(verify_data(EditView)) _form.submit();"
                           name="button" value="{$APP['LBL_SAVE_BUTTON_LABEL']}">
-EOD
-        ;
+EOD;
         $action_button_header[] = <<<EOD
                     <input	title="{$APP['LBL_CANCEL_BUTTON_TITLE']}" id="CANCEL_HEADER" accessKey="{$APP['LBL_CANCEL_BUTTON_KEY']}"
                               class="button" onclick="var _form = $('#EditView')[0]; _form.action.value='{$RETURN_ACTION}'; _form.module.value='{$RETURN_MODULE}'; _form.record.value='{$RETURN_ID}'; _form.submit()"
                               type="button" name="button" value="{$APP['LBL_CANCEL_BUTTON_LABEL']}">
-EOD
-        ;
+EOD;
         $action_button_header = array_merge($action_button_header, $this->ss->get_template_vars('BUTTONS_HEADER'));
         $this->ss->assign('ACTION_BUTTON_HEADER', $action_button_header);
 
@@ -221,25 +231,23 @@ EOD
                     <input type="button" id="SAVE_FOOTER" title="{$APP['LBL_SAVE_BUTTON_TITLE']}" accessKey="{$APP['LBL_SAVE_BUTTON_KEY']}"
                           class="button primary" onclick="var _form = $('#EditView')[0]; if (!set_password(_form,newrules('{$minpwdlength}','{$maxpwdlength}','{$REGEX}'))) return false; if (!Admin_check()) return false; _form.action.value='Save'; {$CHOOSER_SCRIPT} {$REASSIGN_JS} if(verify_data(EditView)) _form.submit();"
                           name="button" value="{$APP['LBL_SAVE_BUTTON_LABEL']}">
-EOD
-        ;
+EOD;
         $action_button_footer[] = <<<EOD
                     <input	title="{$APP['LBL_CANCEL_BUTTON_TITLE']}" id="CANCEL_FOOTER" accessKey="{$APP['LBL_CANCEL_BUTTON_KEY']}"
                               class="button" onclick="var _form = $('#EditView')[0]; _form.action.value='{$RETURN_ACTION}'; _form.module.value='{$RETURN_MODULE}'; _form.record.value='{$RETURN_ID}'; _form.submit()"
                               type="button" name="button" value="{$APP['LBL_CANCEL_BUTTON_LABEL']}">
-EOD
-        ;
+EOD;
         $action_button_footer = array_merge($action_button_footer, $this->ss->get_template_vars('BUTTONS_FOOTER'));
         $this->ss->assign('ACTION_BUTTON_FOOTER', $action_button_footer);
 
         //if the request object has 'scrolltocal' set, then we are coming here from the tour window box and need to set flag to true
         // so that footer.tpl fires off script to scroll to calendar section
-        if(!empty($_REQUEST['scrollToCal'])){
+        if (!empty($_REQUEST['scrollToCal'])) {
             $this->ss->assign('scroll_to_cal', true);
         }
-        $this->ev->process($processSpecial,$processFormName);
+        $this->ev->process($processSpecial, $processFormName);
 
-		echo $this->ev->display($this->showTitle);
+        echo $this->ev->display($this->showTitle);
 
     }
 
@@ -258,11 +266,11 @@ EOD
     {
         $theTitle = '';
 
-        if($GLOBALS['current_user']->isAdminForModule('Users')
+        if ($GLOBALS['current_user']->isAdminForModule('Users')
         ) {
-        $createImageURL = SugarThemeRegistry::current()->getImageURL('create-record.gif');
-        $url = ajaxLink("index.php?module=$module&action=EditView&return_module=$module&return_action=DetailView");
-        $theTitle = <<<EOHTML
+            $createImageURL = SugarThemeRegistry::current()->getImageURL('create-record.gif');
+            $url = ajaxLink("index.php?module=$module&action=EditView&return_module=$module&return_action=DetailView");
+            $theTitle = <<<EOHTML
 &nbsp;
 <img src='{$createImageURL}' alt='{$GLOBALS['app_strings']['LNK_CREATE']}'>
 <a href="{$url}" class="utilsLink">
@@ -270,6 +278,7 @@ EOD
 </a>
 EOHTML;
         }
+
         return $theTitle;
     }
 }

--- a/modules/Users/views/view.edit.php
+++ b/modules/Users/views/view.edit.php
@@ -50,9 +50,7 @@ var $useForSubpanel = true;
         $recordid = $_REQUEST['record'];
         $currentuserid = $GLOBALS['current_user']->id;
         $isAdmin = $GLOBALS['current_user']->isAdminForModule('Users');
-        if( $recordid == $currentuserid || $isAdmin) {
-
-        }else{
+        if( !($recordid == $currentuserid || $isAdmin)) {
             SugarApplication::redirect("index.php?module=Home&action=index");
         }
     }

--- a/modules/Users/views/view.edit.php
+++ b/modules/Users/views/view.edit.php
@@ -46,13 +46,6 @@ class UsersViewEdit extends ViewEdit {
 var $useForSubpanel = true;
     function __construct(){
         parent::__construct();
-
-        $recordid = $_REQUEST['record'];
-        $currentuserid = $GLOBALS['current_user']->id;
-        $isAdmin = $GLOBALS['current_user']->isAdminForModule('Users');
-        if( !($recordid == $currentuserid || $isAdmin)) {
-            SugarApplication::redirect("index.php?module=Home&action=index");
-        }
     }
 
     /**


### PR DESCRIPTION
## Description
reference #2695 
Added check into users view.edit.php and view.detail.php to check if user is allow to edit or view requested userid if not redirect to index 


## Motivation and Context
Security bug


## How To Test This
Test if users admin can still view all users
Test that non admin logged in user cannot view another users details and that the user is indeed redirected to index
Test that a user can change password from forgot password section


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.
