### PR TITLE
Improving SQL performance when retrieving reminders

### DIFF
--- a/modules/Reminders/Reminder.php
+++ b/modules/Reminders/Reminder.php
@@ -46,23 +46,23 @@ class Reminder extends Basic
 
     const UPGRADE_VERSION = '7.4.3';
 
-    var $name;
+    public $name;
 
-    var $new_schema = true;
-    var $module_dir = 'Reminders';
-    var $object_name = 'Reminder';
-    var $table_name = 'reminders';
-    var $tracker_visibility = false;
-    var $importable = false;
-    var $disable_row_level_security = true;
+    public $new_schema = true;
+    public $module_dir = 'Reminders';
+    public $object_name = 'Reminder';
+    public $table_name = 'reminders';
+    public $tracker_visibility = false;
+    public $importable = false;
+    public $disable_row_level_security = true;
 
-    var $popup;
-    var $email;
-    var $email_sent = false;
-    var $timer_popup;
-    var $timer_email;
-    var $related_event_module;
-    var $related_event_module_id;
+    public $popup;
+    public $email;
+    public $email_sent = false;
+    public $timer_popup;
+    public $timer_email;
+    public $related_event_module;
+    public $related_event_module_id;
 
     private static $remindersData = array();
 

--- a/modules/Reminders/Reminder.php
+++ b/modules/Reminders/Reminder.php
@@ -403,7 +403,8 @@ FROM
 	JOIN reminders r ON r.id = ri.reminder_id 
 	AND r.popup = 1 
 	LEFT JOIN meetings m ON m.id = r.related_event_module_id 
-	AND r.related_event_module = 'Meetings' 
+	AND r.related_event_module = 'Meetings'
+	AND m.status = 'Planned'
 	LEFT JOIN meetings_users mu ON mu.meeting_id = m.id
 	{$meetingParentJoin}
     AND ri.related_invitee_module = 'Users' 
@@ -411,6 +412,7 @@ FROM
     AND mu.accept_status LIKE 'accept'
 	LEFT JOIN calls c ON c.id = r.related_event_module_id 
 	AND r.related_event_module = 'Calls' 
+	AND c.status = 'Planned'
 	LEFT JOIN calls_users cu ON cu.call_id = c.id
     AND ri.related_invitee_module = 'Users' 
     AND cu.user_id = ri.related_invitee_module_id

--- a/modules/Reminders/Reminder.php
+++ b/modules/Reminders/Reminder.php
@@ -446,8 +446,8 @@ ORDER BY
                     $f = BeanFactory::getBean($module);
                     $table = $f->table_name;
                     if (is_subclass_of($f, 'Person')) {
-                        $callParentSelect .= "\t" . "(c_" . $table . ".first_name + ' ' + c_" . $table . ".last_name) as Calls_parent_name_" . $table . "," . PHP_EOL;
-                        $meetingParentSelect .= "\t" . "(m_" . $table . ".first_name + ' ' + m_" . $table . ".last_name) as Meetings_parent_name_" . $table . "," . PHP_EOL;
+                        $callParentSelect .= "\t" . " CONCAT(CONCAT(c_" . $table . ".first_name, ' '), c_" . $table . ".last_name) as Calls_parent_name_" . $table . "," . PHP_EOL;
+                        $meetingParentSelect .= "\t" . " CONCAT(CONCAT(m_" . $table . ".first_name, ' '), m_" . $table . ".last_name) as Meetings_parent_name_" . $table . "," . PHP_EOL;
 
                     } else {
                         $callParentSelect .= "\t" . "c_" . $table . ".name as Calls_parent_name_" . $table . "," . PHP_EOL;
@@ -459,7 +459,6 @@ ORDER BY
                 $limitTop = " ";
                 $limitBottom = "LIMIT {$_maxEventsInADay}";
                 $query ="
-USE suitecrm;
 SELECT
 	m.name as Meetings_name, 
 	m.description as Meetings_description, 
@@ -531,7 +530,6 @@ ORDER BY
         }
 
         $popupReminders = $db->query($query);
-
         if (empty($db->last_error)) {
             while ($row = $db->fetchByAssoc($popupReminders)) {
 

--- a/modules/Reminders/Reminder.php
+++ b/modules/Reminders/Reminder.php
@@ -355,110 +355,20 @@ class Reminder extends Basic
         $meetingParentSelect = PHP_EOL;
         $meetingParentJoin = PHP_EOL;
 
-
-        switch ($sugar_config['dbconfig']['db_type']) {
-            case "mssql":
-                foreach ($app_list_strings['parent_type_display'] as $module => $label) {
-                    $f = BeanFactory::getBean($module);
-                    $table = $f->table_name;
-                    if (is_subclass_of($f, 'Person')) {
-                        $callParentSelect .= "\t" . "(c_" . $table . ".first_name + ' ' + c_" . $table . ".last_name) as Calls_parent_name_" . $table . "," . PHP_EOL;
-                        $meetingParentSelect .= "\t" . "(m_" . $table . ".first_name + ' ' + m_" . $table . ".last_name) as Meetings_parent_name_" . $table . "," . PHP_EOL;
-
-                    } else {
-                        $callParentSelect .= "\t" . "c_" . $table . ".name as Calls_parent_name_" . $table . "," . PHP_EOL;
-                        $meetingParentSelect .= "\t" . "m_" . $table . ".name as Meetings_parent_name_" . $table . "," . PHP_EOL;
-                    }
-                    $callParentJoin .= "\t" . "LEFT JOIN " . $table . " " . "c_" . $table . " ON c.parent_id = " . "c_" . $table . ".id" . PHP_EOL;
-                    $meetingParentJoin .= "\t" . "LEFT JOIN " . $table . " " . "m_" . $table . " ON m.parent_id = " . "m_" . $table . ".id" . PHP_EOL;
-
-                }
-                $limitTop = "TOP {$_maxEventsInADay}".PHP_EOL;
-                $limitBottom = " ";
-                $query ="
-SELECT {$limitTop}
-	m.name as Meetings_name, 
-	m.description as Meetings_description, 
-	m.date_start as Meetings_date_start, 
-	m.duration_hours as Meetings_duration_hours, 
-	m.duration_minutes as Meetings_duration_minutes, 
-	m.location as Meetings_location, 
-	m.status as Meetings_status, 
-	m.parent_type as Meetings_parent_type, 
-	m.parent_id as Meetings_parent_id, 
-    {$meetingParentSelect}
-	c.name as Calls_name, 
-	c.description as Calls_description, 
-	c.date_start as Calls_date_start, 
-	c.duration_hours as Calls_duration_hours, 
-	c.duration_minutes as Calls_duration_minutes, 
-	c.status as Calls_status,
-	c.parent_type as Calls_parent_type, 
-	c.parent_id as Calls_parent_id, 
-    {$callParentSelect} 
-	ri.related_invitee_module as reminder_invitees_related_invitee_module, 
-	ri.related_invitee_module_id as reminder_invitees_related_invitee_module_id, 
-	r.id as reminder_id, 
-	r.timer_popup as reminder_timer_popup,
-	r.related_event_module as reminder_related_event_module,
-	r.related_event_module_id as reminder_related_event_module_id 
-FROM 
-	reminders_invitees ri 
-	JOIN reminders r ON r.id = ri.reminder_id 
-	AND r.popup = 1 
-	LEFT JOIN meetings m ON m.id = r.related_event_module_id 
-	AND r.related_event_module = 'Meetings'
-	AND m.status = 'Planned'
-	LEFT JOIN meetings_users mu ON mu.meeting_id = m.id
-	{$meetingParentJoin}
-    AND ri.related_invitee_module = 'Users' 
-    AND mu.user_id = ri.related_invitee_module_id
-    AND mu.accept_status LIKE 'accept'
-	LEFT JOIN calls c ON c.id = r.related_event_module_id 
-	AND r.related_event_module = 'Calls' 
-	AND c.status = 'Planned'
-	LEFT JOIN calls_users cu ON cu.call_id = c.id
-    AND ri.related_invitee_module = 'Users' 
-    AND cu.user_id = ri.related_invitee_module_id
-    AND cu.accept_status LIKE 'accept'
-    {$callParentJoin}
-WHERE 
-	ri.related_invitee_module = 'Users' 
-	AND ri.related_invitee_module_id = '{$current_user->id}' 
-	AND r.deleted != 1 
-	AND 
-	(
-		(
-			m.date_start > CAST('{$userNOW}' AS datetime) 
-			AND m.deleted != 1
-		) 
-		OR (
-			c.date_start > CAST('{$userNOW}' AS datetime) 
-			AND c.deleted != 1
-		)
-	)
-ORDER BY 
-	m.date_start ASC, c.date_start ASC
-";
-                break;
-            case "mysql":
-                foreach ($app_list_strings['parent_type_display'] as $module => $label) {
-                    $f = BeanFactory::getBean($module);
-                    $table = $f->table_name;
-                    if (is_subclass_of($f, 'Person')) {
-                        $callParentSelect .= "\t" . " CONCAT(CONCAT(c_" . $table . ".first_name, ' '), c_" . $table . ".last_name) as Calls_parent_name_" . $table . "," . PHP_EOL;
-                        $meetingParentSelect .= "\t" . " CONCAT(CONCAT(m_" . $table . ".first_name, ' '), m_" . $table . ".last_name) as Meetings_parent_name_" . $table . "," . PHP_EOL;
-
-                    } else {
-                        $callParentSelect .= "\t" . "c_" . $table . ".name as Calls_parent_name_" . $table . "," . PHP_EOL;
-                        $meetingParentSelect .= "\t" . "m_" . $table . ".name as Meetings_parent_name_" . $table . "," . PHP_EOL;
-                    }
-                    $callParentJoin .= "\t" . "LEFT JOIN " . $table . " " . "c_" . $table . " ON c.parent_id = " . "c_" . $table . ".id" . PHP_EOL;
-                    $meetingParentJoin .= "\t" . "LEFT JOIN " . $table . " " . "m_" . $table . " ON m.parent_id = " . "m_" . $table . ".id" . PHP_EOL;
-                }
-                $limitTop = " ";
-                $limitBottom = "LIMIT {$_maxEventsInADay}";
-                $query ="
+        foreach ($app_list_strings['parent_type_display'] as $module => $label) {
+            $f = BeanFactory::getBean($module);
+            $table = $f->table_name;
+            if (is_subclass_of($f, 'Person')) {
+                $callParentSelect .= "\t" . "(" . $db->convert('c_' . $table . '.first_name', 'concat', array('c_' . $table . '.last_name')) . ") as Calls_parent_name_" . $table . "," . PHP_EOL;
+                $meetingParentSelect .= "\t" . "(" . $db->convert('c_' . $table . '.first_name', 'concat', array('m_' . $table . '.last_name') ) . ") as Meetings_parent_name_" . $table . "," . PHP_EOL;
+            } else {
+                $callParentSelect .= "\t" . "c_" . $table . ".name as Calls_parent_name_" . $table . "," . PHP_EOL;
+                $meetingParentSelect .= "\t" . "m_" . $table . ".name as Meetings_parent_name_" . $table . "," . PHP_EOL;
+            }
+            $callParentJoin .= "\t" . "LEFT JOIN " . $table . " " . "c_" . $table . " ON c.parent_id = " . "c_" . $table . ".id" . PHP_EOL;
+            $meetingParentJoin .= "\t" . "LEFT JOIN " . $table . " " . "m_" . $table . " ON m.parent_id = " . "m_" . $table . ".id" . PHP_EOL;
+        }
+        $query ="
 SELECT
 	m.name as Meetings_name, 
 	m.description as Meetings_description, 
@@ -522,14 +432,8 @@ WHERE
 	)
 ORDER BY 
 	m.date_start ASC, c.date_start ASC
-{$limitBottom}
 ";
-                break;
-            default:
-                break;
-        }
-
-        $popupReminders = $db->query($query);
+        $popupReminders = $db->limitQuery($query, 0, $_maxEventsInADay);
         if (empty($db->last_error)) {
             while ($row = $db->fetchByAssoc($popupReminders)) {
 

--- a/modules/Reminders/Reminder.php
+++ b/modules/Reminders/Reminder.php
@@ -358,16 +358,16 @@ class Reminder extends Basic
         foreach ($app_list_strings['parent_type_display'] as $module => $label) {
             $f = BeanFactory::getBean($module);
             $table = $f->table_name;
-            if(is_subclass_of($f, 'Person')) {
-                $callParentSelect .= "\t". " CONCAT(CONCAT(c_" . $table . ".first_name, ' '), c_" . $table . ".last_name) as Calls_parent_name_" . $table . "," . PHP_EOL;
-                $meetingParentSelect .= "\t". " CONCAT(CONCAT(m_" . $table . ".first_name, ' '), m_" . $table . ".last_name) as Meetings_parent_name_" . $table . "," . PHP_EOL;
+            if (is_subclass_of($f, 'Person')) {
+                $callParentSelect .= "\t" . " CONCAT(CONCAT(c_" . $table . ".first_name, ' '), c_" . $table . ".last_name) as Calls_parent_name_" . $table . "," . PHP_EOL;
+                $meetingParentSelect .= "\t" . " CONCAT(CONCAT(m_" . $table . ".first_name, ' '), m_" . $table . ".last_name) as Meetings_parent_name_" . $table . "," . PHP_EOL;
 
             } else {
-                $callParentSelect .= "\t". "c_" . $table . ".name as Calls_parent_name_" . $table . "," . PHP_EOL;
-                $meetingParentSelect .= "\t". "m_" . $table . ".name as Meetings_parent_name_" . $table . "," . PHP_EOL;
+                $callParentSelect .= "\t" . "c_" . $table . ".name as Calls_parent_name_" . $table . "," . PHP_EOL;
+                $meetingParentSelect .= "\t" . "m_" . $table . ".name as Meetings_parent_name_" . $table . "," . PHP_EOL;
             }
-            $callParentJoin .= "\t". "LEFT JOIN " . $table . " " . "c_" . $table . " ON c.parent_id = " . "c_" . $table . ".id" . PHP_EOL;
-            $meetingParentJoin .= "\t". "LEFT JOIN " . $table . " " . "m_" . $table . " ON m.parent_id = " . "m_" . $table . ".id" . PHP_EOL;
+            $callParentJoin .= "\t" . "LEFT JOIN " . $table . " " . "c_" . $table . " ON c.parent_id = " . "c_" . $table . ".id" . PHP_EOL;
+            $meetingParentJoin .= "\t" . "LEFT JOIN " . $table . " " . "m_" . $table . " ON m.parent_id = " . "m_" . $table . ".id" . PHP_EOL;
 
         }
 
@@ -452,7 +452,7 @@ LIMIT
                         $event_parent_id =& $row['Calls_parent_id'];
                         $f = BeanFactory::getBean($event_parent_type);
                         $table = $f->table_name;
-                        $event_parent_name =& $row['Calls_parent_name_'.$table];
+                        $event_parent_name =& $row['Calls_parent_name_' . $table];
                         break;
                     case 'Meetings':
                         $date_start =& $row['Meetings_date_start'];
@@ -466,7 +466,7 @@ LIMIT
                         $event_parent_id =& $row['Meetings_parent_id'];
                         $f = BeanFactory::getBean($event_parent_type);
                         $table = $f->table_name;
-                        $event_parent_name =& $row['Meetings_parent_name_'.$table];
+                        $event_parent_name =& $row['Meetings_parent_name_' . $table];
                         break;
                     default:
                         return;

--- a/modules/Reminders/Reminder.php
+++ b/modules/Reminders/Reminder.php
@@ -416,24 +416,24 @@ LIMIT
 
                 switch ($row['reminder_related_event_module']) {
                     case 'Calls':
-                        $date_start = $row['Calls_date_start'];
-                        $name = $row['Calls_name'];
-                        $description = $row['Calls_description'];
-                        $duration_hours = $row['Calls_duration_hours'];
-                        $duration_minutes = $row['Calls_duration_minutes'];
-                        $duration_duration_minutes = $row['Calls_duration_minutes'];
-                        $status = $row['Calls_status'];
+                        $date_start =& $row['Calls_date_start'];
+                        $name =& $row['Calls_name'];
+                        $description =& $row['Calls_description'];
+                        $duration_hours =& $row['Calls_duration_hours'];
+                        $duration_minutes =& $row['Calls_duration_minutes'];
+                        $duration_duration_minutes =& $row['Calls_duration_minutes'];
+                        $status =& $row['Calls_status'];
                         break;
                     case 'Meetings':
-                        $date_start = $row['Meetings_date_start'];
-                        $name = $row['Meetings_name'];
-                        $description = $row['Meetings_description'];
-                        $duration_hours = $row['Meetings_duration_hours'];
-                        $duration_minutes = $row['Meetings_duration_minutes'];
-                        $duration_location = $row['Meetings_location'];
-                        $status = $row['Meetings_status'];
-                        $event_parent_type = $row['Meetings_parent_type'];
-                        $event_parent_id = $row['Meetings_parent_id'];
+                        $date_start =& $row['Meetings_date_start'];
+                        $name =& $row['Meetings_name'];
+                        $description =& $row['Meetings_description'];
+                        $duration_hours =& $row['Meetings_duration_hours'];
+                        $duration_minutes =& $row['Meetings_duration_minutes'];
+                        $duration_location =& $row['Meetings_location'];
+                        $status =& $row['Meetings_status'];
+                        $event_parent_type =& $row['Meetings_parent_type'];
+                        $event_parent_id =& $row['Meetings_parent_id'];
                         break;
                     default:
                         return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Moved the logic from php to sql

Tested On: 
- Ubuntu 14.04 MySQL 5.5 and PHP 5.5
- Windows Server 2008 r2 with SQL Server 2008

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* Removes the need for multiple queries
* Improves performance

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->