### PR TITLE
Fixed MySQL/MS SQL Strict Mode

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -4068,7 +4068,7 @@ class SugarBean
                     }
 
                     if ($type == 'date') {
-                        if ($this->$field == '0000-00-00') {
+                        if ($this->$field == '0000-00-00' || empty($this->$field)) {
                             $this->$field = '';
                         } elseif (!empty($this->field_name_map[$field]['rel_field'])) {
                             $rel_field = $this->field_name_map[$field]['rel_field'];
@@ -4084,7 +4084,7 @@ class SugarBean
                             }
                         }
                     } elseif ($type == 'datetime' || $type == 'datetimecombo') {
-                        if ($this->$field == '0000-00-00 00:00:00') {
+                        if ($this->$field == '0000-00-00 00:00:00' || empty($this->$field)) {
                             $this->$field = '';
                         } else {
                             if (empty($disable_date_format)) {
@@ -4092,7 +4092,7 @@ class SugarBean
                             }
                         }
                     } elseif ($type == 'time') {
-                        if ($this->$field == '00:00:00') {
+                        if ($this->$field == '00:00:00' || empty($this->$field)) {
                             $this->$field = '';
                         } else {
                             if (empty($this->field_name_map[$field]['rel_field']) && empty($disable_date_format)) {

--- a/include/database/MssqlManager.php
+++ b/include/database/MssqlManager.php
@@ -1220,13 +1220,13 @@ class MssqlManager extends DBManager
     {
         $ctype = $this->getColumnType($type);
         if ($ctype == 'datetime') {
-            return $this->convert($this->quoted('1970-01-01 00:00:00'), 'datetime');
+            return 'NULL';
         }
         if ($ctype == 'date') {
-            return $this->convert($this->quoted('1970-01-01'), 'datetime');
+            return 'NULL';
         }
         if ($ctype == 'time') {
-            return $this->convert($this->quoted('00:00:00'), 'time');
+            return 'NULL';
         }
 
         return parent::emptyValue($type);

--- a/include/database/MysqlManager.php
+++ b/include/database/MysqlManager.php
@@ -1105,13 +1105,13 @@ class MysqlManager extends DBManager
 	{
 		$ctype = $this->getColumnType($type);
 		if($ctype == "datetime") {
-			return $this->convert($this->quoted("0000-00-00 00:00:00"), "datetime");
+			return 'NULL';
 		}
 		if($ctype == "date") {
-			return $this->convert($this->quoted("0000-00-00"), "date");
+			return 'NULL';
 		}
 		if($ctype == "time") {
-			return $this->convert($this->quoted("00:00:00"), "time");
+			return 'NULL';
 		}
 		return parent::emptyValue($type);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This pull request is in relation to issue #1719 and pull request #2454.

The issue is that as of MySQL 5.7 strict mode is enabled by default. This means that you must pass the correct data type into each field of a SQL query. SuiteCRM historically used "0000-00-00" and "0000-00-00 00:00:00" to define null values, instead of passing in NULL. Older versions of MySQL and MS SQL both support use NULL for dates and times.  As do other database engines like SQLite.

So I have updated the DB Manager to pass a NULL instead. To ensure that we have support for legacy code bases, I have also added an empty check in the SugarBean so that date and time fields are set to '' instead of NULL. This is because most codes bases check for  '', however they really should use the empty() function in PHP.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* Support for future versions of MySQL
* More correct solution to the issue

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* Use functionality which passes empty or NULL or '0000-00-00' and '0000-00-00 00:00:00' values into the database.
* Ensure that the core code base handle '0000-00-00' and '0000-00-00 00:00:00' values correctly.

I have tested this on:
* Ubuntu 14.04 with PHP 5.5, MySQL 5.6
* Ubuntu 16.04 with PHP 7, MySQL 5.7 (with the default Strict Mode)
* Microsoft Server 2008 R2 with SQL 2008 R2

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->