### PR TITLE
Fixed #3072 - show search form for save query if popuplate only

### DIFF
--- a/include/ListView/ListViewSearchLink.tpl
+++ b/include/ListView/ListViewSearchLink.tpl
@@ -39,6 +39,13 @@
 */
 *}
 
+{if !$currentModule}
+    {assign var="currentModule" value=$savedSearchData.module}
+    {if !$currentModule}
+        {assign var="currentModule" value=$pageData.bean.moduleName}
+    {/if}
+{/if}
+
 {if $savedSearchData.hasOptions}
     <ul class="action-link action-link-{$action_menu_location} clickMenu selectActions fancymenu show listViewLinkButton listViewLinkButton_{$action_menu_location}">
         <li class="sugar_action_button">
@@ -47,7 +54,7 @@
             </a>
             <ul class="subnav">
                 {foreach from=$savedSearchData.options key=id item=option}
-                    <li><a href="javascript:void(0)" class="parent-dropdown-action-handler"{if $id!=$savedSearchData.selected} onclick="SUGAR.savedViews.shortcutDropdown('{$id}', '{if $savedSearchData.module}{$savedSearchData.module}{else}{$pageData.bean.moduleName}{/if}');"{/if}>{$option}{if $id==$savedSearchData.selected}&nbsp;&#10004{/if}</a></li>
+                    <li><a href="javascript:void(0)" class="parent-dropdown-action-handler"{if $id!=$savedSearchData.selected} onclick="SUGAR.savedViews.shortcutDropdown('{$id}', '{$currentModule}');"{/if}>{$option}{if $id==$savedSearchData.selected}&nbsp;&#10004{/if}</a></li>
                 {/foreach}
             </ul>
             <span></span>
@@ -62,11 +69,11 @@
 </ul>
 <ul class="searchAppliedAlert hidden clickMenu selectmenu searchAppliedAlertLink SugarActionMenu listViewLinkButton listViewLinkButton_{$action_menu_location}">
     <li class="sugar_action_button desktopOnly">
-        <a href="javascript:void(0)" class="glyphicon glyphicon-list-alt clearSearchIcon parent-dropdown-handler" onclick="SUGAR.savedViews.shortcutDropdown('_none', '{if $savedSearchData.module}{$savedSearchData.module}{else}{$pageData.bean.moduleName}{/if}');"></a>
-        <a href="javascript:void(0)" class="glyphicon glyphicon-remove" onclick="SUGAR.savedViews.shortcutDropdown('_none', '{if $savedSearchData.module}{$savedSearchData.module}{else}{$pageData.bean.moduleName}{/if}');">&Cross;</a>
+        <a href="javascript:void(0)" class="glyphicon glyphicon-list-alt clearSearchIcon parent-dropdown-handler" onclick="SUGAR.savedViews.shortcutDropdown('_none', '{$currentModule}');"></a>
+        <a href="javascript:void(0)" class="glyphicon glyphicon-remove" onclick="SUGAR.savedViews.shortcutDropdown('_none', '{$currentModule}');">&Cross;</a>
     </li>
     <li class="sugar_action_button mobileOnly">
         <a href="javascript:void(0)" class="glyphicon glyphicon-list-alt clearSearchIcon parent-dropdown-handler" onclick=""></a>
-        <a href="javascript:void(0)" class="glyphicon glyphicon-remove" onclick="SUGAR.savedViews.shortcutDropdown('_none', '{if $savedSearchData.module}{$savedSearchData.module}{else}{$pageData.bean.moduleName}{/if}');"></a>
+        <a href="javascript:void(0)" class="glyphicon glyphicon-remove" onclick="SUGAR.savedViews.shortcutDropdown('_none', '{$currentModule}');"></a>
     </li>
 </ul>

--- a/include/ListView/ListViewSmarty.php
+++ b/include/ListView/ListViewSmarty.php
@@ -219,7 +219,7 @@ class ListViewSmarty extends ListViewDisplay
      */
     function display($end = true) {
 
-        if(!$this->should_process) return $GLOBALS['app_strings']['LBL_SEARCH_POPULATE_ONLY'];
+        if(!$this->should_process) return $this->getSearchIcon().$GLOBALS['app_strings']['LBL_SEARCH_POPULATE_ONLY'];
         global $app_strings, $sugar_version, $sugar_flavor, $currentModule, $app_list_strings;
         $this->ss->assign('moduleListSingular', $app_list_strings["moduleListSingular"]);
         $this->ss->assign('moduleList', $app_list_strings['moduleList']);
@@ -252,6 +252,14 @@ class ListViewSmarty extends ListViewDisplay
 
         return $str . $this->ss->fetch($this->tpl) . (($end) ? $strend : '');
     }
+
+
+    private function getSearchIcon() {
+        $ss = new Sugar_Smarty();
+        return $ss->fetch('include/ListView/ListViewSearchLink.tpl') . '<br>';
+    }
+
+
     function displayEnd() {
         $str = '';
         if($this->show_mass_update_form) {

--- a/include/ListView/ListViewSmarty.php
+++ b/include/ListView/ListViewSmarty.php
@@ -262,6 +262,7 @@ class ListViewSmarty extends ListViewDisplay
             return ;
         }
         $ss = new Sugar_Smarty();
+        $ss->assign('currentModule', $_REQUEST['module']);
         return $ss->fetch('include/ListView/ListViewSearchLink.tpl') . '<br>';
     }
 

--- a/include/ListView/ListViewSmarty.php
+++ b/include/ListView/ListViewSmarty.php
@@ -255,6 +255,12 @@ class ListViewSmarty extends ListViewDisplay
 
 
     private function getSearchIcon() {
+        global $sugar_config;
+
+        $searchFormInPopup = !in_array($_REQUEST['module'], isset($sugar_config['enable_legacy_search']) ? $sugar_config['enable_legacy_search'] : array());
+        if($sugar_config['save_query'] == 'populate_only' && !$searchFormInPopup) {
+            return ;
+        }
         $ss = new Sugar_Smarty();
         return $ss->fetch('include/ListView/ListViewSearchLink.tpl') . '<br>';
     }

--- a/include/SearchForm/SearchForm2.php
+++ b/include/SearchForm/SearchForm2.php
@@ -286,7 +286,7 @@ class SearchForm
         $this->th->ss->assign('searchInfoJson', $this->getSearchInfoJson());
 
 
-        $searchFormInPopup = !in_array($this->module, isset($sugar_config['enable_legacy_search']) ? $sugar_config['enable_legacy_search'] : array());
+        $searchFormInPopup = empty($this->getSearchInfo()) && $sugar_config['save_query'] == 'populate_only' ? false : (!in_array($this->module, isset($sugar_config['enable_legacy_search']) ? $sugar_config['enable_legacy_search'] : array()));
         $this->th->ss->assign('searchFormInPopup', $searchFormInPopup);
 
         $return_txt = $this->th->displayTemplate($this->seed->module_dir, 'SearchForm_' . $this->parsedView, $this->locateFile($this->tpl));

--- a/include/SearchForm/SearchForm2.php
+++ b/include/SearchForm/SearchForm2.php
@@ -286,7 +286,7 @@ class SearchForm
         $this->th->ss->assign('searchInfoJson', $this->getSearchInfoJson());
 
 
-        $searchFormInPopup = empty($this->getSearchInfo()) && $sugar_config['save_query'] == 'populate_only' ? false : (!in_array($this->module, isset($sugar_config['enable_legacy_search']) ? $sugar_config['enable_legacy_search'] : array()));
+        $searchFormInPopup = !in_array($this->module, isset($sugar_config['enable_legacy_search']) ? $sugar_config['enable_legacy_search'] : array());
         $this->th->ss->assign('searchFormInPopup', $searchFormInPopup);
 
         $return_txt = $this->th->displayTemplate($this->seed->module_dir, 'SearchForm_' . $this->parsedView, $this->locateFile($this->tpl));

--- a/modules/MySettings/StoreQuery.php
+++ b/modules/MySettings/StoreQuery.php
@@ -209,7 +209,7 @@ class StoreQuery
                 // Bug 39580 - Added 'EmailTreeLayout','EmailGridWidths' to the list as these are added merely as side-effects of the fact that we store the entire
                 // $_REQUEST object which includes all cookies.  These are potentially quite long strings as well.
                 $blockVariables = array('mass', 'uid', 'massupdate', 'delete', 'merge', 'selectCount', 'current_query_by_page', 'EmailTreeLayout', 'EmailGridWidths');
-                if ($_REQUEST['use_stored_query']) {
+                if (isset($_REQUEST['use_store_query']) && $_REQUEST['use_stored_query']) {
                     $this->query = array_merge(StoreQuery::getStoredQueryForUser($name), $_REQUEST);
                 } else {
                     $this->query = $_REQUEST;

--- a/themes/SuiteP/css/editview.scss
+++ b/themes/SuiteP/css/editview.scss
@@ -2025,6 +2025,10 @@ ul.clickMenu li a {
   text-decoration: none;
 }
 
+ul.clickMenu li a.clearSearchIcon {
+  margin: 3px 0px 0px 8px;
+}
+
 ul.clickMenu li.single a {
   padding-right: 8px;
 }

--- a/themes/SuiteP/css/listview.scss
+++ b/themes/SuiteP/css/listview.scss
@@ -3516,10 +3516,6 @@ ul.clickMenu > li > span.searchAppliedAlert {
   display: none;
 }
 
-td.paginationActionButtons ul.selectmenu > li > a.clearSearchIcon {
-  padding: 3px 4px 4px 7px;
-}
-
 .listViewEmpty .clearSearchIcon {
   margin: 3px 0px 0px 8px;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This change shows search form at list view area only if $sugar_config['save_query'] set to 'populate_only' so that the user able to set search parameters when the list view is empty

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->
- needs to rebuild style.css
- for next steps, please see related issue: #3072 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->