### PR TITLE
Fixed - Edit View Tabs for mobile (SuiteP)

### DIFF
--- a/themes/SuiteP/include/EditView/EditView.tpl
+++ b/themes/SuiteP/include/EditView/EditView.tpl
@@ -143,7 +143,7 @@
 
             <div class="panel panel-default">
                 <div class="panel-heading {{$panelHeadingCollapse}}">
-                    <a class="{{$collapsed}}" role="button" data-toggle="collapse" aria-expanded="false">
+                    <a class="{{$collapsed}}" role="button" data-toggle="collapse-edit" aria-expanded="false">
                         <div class="col-xs-10 col-sm-11 col-md-11">
                             {sugar_translate label='{{$label}}' module='{{$module}}'}
                         </div>
@@ -222,26 +222,26 @@ $(document).ready(function() {ldelim}
             }
         });
 
-        $('a[data-toggle="collapse"]').click(function(e){
-            var content;
+        $('a[data-toggle="collapse-edit"]').click(function(e){
+          // this == <a> link in the header of the panel:
+          //
+          // .panel
+          //     .panel-header
+          //        (a || a.collapsed) == this
+          //     .panel-body
+          //
             if($(this).hasClass('collapsed')) {
+              // Expand panel
+                // Change style of .panel-header
                 $(this).removeClass('collapsed');
-                if($(this).closest('.panel-content').length) {
-                    content = $(this).closest('.panel-content').find('.panel-body.panel-collapse.collapse');
-                }
-                else if($(this).closest('.panel.panel-default').length){
-                    content = $(this).closest('.panel.panel-default').next();
-                }
-                content.addClass('in');
+                // Expand .panel-body
+                $(this).parents('.panel').find('.panel-body').removeClass('in').addClass('in');
             } else {
+              // Collapse panel
+                // Change style of .panel-header
                 $(this).addClass('collapsed');
-                if($(this).closest('.panel-content').length) {
-                    content = $(this).closest('.panel-content').find('.panel-body.panel-collapse.collapse');
-                }
-                else if($(this).closest('.panel.panel-default').length){
-                    content = $(this).closest('.panel.panel-default').next();
-                }
-                content.removeClass('in');
+                // Collapse .panel-body
+                $(this).parents('.panel').find('.panel-body').removeClass('in').removeClass('in');
             }
         });
     });

--- a/themes/SuiteP/include/EditView/EditView.tpl
+++ b/themes/SuiteP/include/EditView/EditView.tpl
@@ -58,20 +58,40 @@
             <a id="tab{{$tabCount}}" data-toggle="tab" class="hidden-xs">
                 {sugar_translate label='{{$label}}' module='{{$module}}'}
             </a>
-            <a id="xstab{{$tabCount}}" href="#" class="visible-xs first-tab-xs dropdown-toggle" data-toggle="dropdown">
+            {* Count Tabs *}
+            {{counter name="tabCountOnlyXS" start=-1 print=false assign="tabCountOnlyXS"}}
+            {{foreach name=sectionOnlyXS from=$sectionPanels key=labelOnly item=panelOnlyXS}}
+            {{capture name=label_upper_count_only assign=label_upper_count_only}}{{$labelOnly|upper}}{{/capture}}
+            {{if (isset($tabDefs[$label_upper_count_only].newTab) && $tabDefs[$label_upper_count_only].newTab == true)}}
+                {{counter name="tabCountOnlyXS" print=false}}
+            {{/if}}
+            {{/foreach}}
+
+            {*
+                For the mobile view, only show the first tab has a drop down when:
+                * There is more than one tab set
+                * When Acton Menu's are enabled
+            *}
+            <!-- Counting Tabs {{$tabCountOnlyXS}}-->
+            <a id="xstab{{$tabCount}}" href="#" class="visible-xs first-tab{{if $tabCountOnlyXS > 0}}-xs{{/if}} dropdown-toggle" data-toggle="dropdown">
                 {sugar_translate label='{{$label}}' module='{{$module}}'}
             </a>
+            {{if $tabCountOnlyXS > 0}}
             <ul id="first-tab-menu-xs" class="dropdown-menu">
-                {{counter name="tabCountXS" start=-1 print=false assign="tabCountXS"}}
+                {{counter name="tabCountXS" start=0 print=false assign="tabCountXS"}}
                 {{foreach name=sectionXS from=$sectionPanels key=label item=panelXS}}
-                {{counter name="tabCountXS" print=false}}
+                {{capture name=label_upper_xs assign=label_upper_xs}}{{$label|upper}}{{/capture}}
+                {{if (isset($tabDefs[$label_upper_xs].newTab) && $tabDefs[$label_upper_xs].newTab == true)}}
                 <li role="presentation">
-                    <a id="tab{{$tabCountXS}}"  data-toggle="tab" onclick="changeFirstTab(this, 'tab-content-{{$tabCountXS}}');">
+                    <a id="tab{{$tabCountXS}}" data-toggle="tab" onclick="changeFirstTab(this, 'tab-content-{{$tabCountXS}}');">
                         {sugar_translate label='{{$label}}' module='{{$module}}'}
                     </a>
                 </li>
+                {{counter name="tabCountXS" print=false}}
+                {{/if}}
                 {{/foreach}}
             </ul>
+            {{/if}}
         </li>
         {{else}}
         <li role="presentation" class="hidden-xs">
@@ -94,26 +114,26 @@
         {{else}}
         <div class="tab-content" style="padding: 0; border: 0;">
             {{/if}}
-            {* Loop through all top level panels first *}
             {{counter name="tabCount" start=0 print=false assign="tabCount"}}
+            {* Loop through all top level panels first *}
             {{if $useTabs}}
             {{foreach name=section from=$sectionPanels key=label item=panel}}
             {{capture name=label_upper assign=label_upper}}{{$label|upper}}{{/capture}}
             {{if isset($tabDefs[$label_upper].newTab) && $tabDefs[$label_upper].newTab == true}}
             {{if $tabCount == '0'}}
-            <div class="tab-pane-NOBOOTSTRAPTOGGLER active fade in" id='detailpanel_{{$tabCount}}' style="display: block;">
+            <div class="tab-pane-NOBOOTSTRAPTOGGLER active fade in" id='tab-content-{{$tabCount}}'>
                 {{include file='themes/SuiteP/include/EditView/tab_panel_content.tpl'}}
             </div>
             {{else}}
-            <div class="tab-pane-NOBOOTSTRAPTOGGLER fade active in" id='detailpanel_{{$tabCount}}' style="display: none;">
+            <div class="tab-pane-NOBOOTSTRAPTOGGLER fade" id='tab-content-{{$tabCount}}'>
                 {{include file='themes/SuiteP/include/EditView/tab_panel_content.tpl'}}
             </div>
             {{/if}}
+             {{counter name="tabCount" print=false}}
             {{/if}}
-            {{counter name="tabCount" print=false}}
             {{/foreach}}
             {{else}}
-            <div class="tab-pane panel-collapse">test</div>
+            <div class="tab-pane panel-collapse">&nbsp;</div>
             {{/if}}
         </div>
         {*display panels*}
@@ -215,10 +235,11 @@ $(document).ready(function() {ldelim}
 
 
     $(function(){
-        $('#EditView_tabs ul.nav.nav-tabs li').click(function(e){
-            if(typeof $(this).find('a').first().attr('id') != 'undefined') {
-                var tab = parseInt($(this).find('a').first().attr('id').match(/^tab(.)*$/)[1]);
+        $('#EditView_tabs ul.nav.nav-tabs li > a[data-toggle="tab"]').click(function(e){
+            if(typeof $(this).parent().find('a').first().attr('id') != 'undefined') {
+                var tab = parseInt($(this).parent().find('a').first().attr('id').match(/^tab(.)*$/)[1]);
                 selectTab(tab);
+                console.log(tab)
             }
         });
 

--- a/themes/SuiteP/include/EditView/EditView.tpl
+++ b/themes/SuiteP/include/EditView/EditView.tpl
@@ -239,7 +239,6 @@ $(document).ready(function() {ldelim}
             if(typeof $(this).parent().find('a').first().attr('id') != 'undefined') {
                 var tab = parseInt($(this).parent().find('a').first().attr('id').match(/^tab(.)*$/)[1]);
                 selectTab(tab);
-                console.log(tab)
             }
         });
 

--- a/themes/SuiteP/include/EditView/EditView.tpl
+++ b/themes/SuiteP/include/EditView/EditView.tpl
@@ -244,13 +244,6 @@ $(document).ready(function() {ldelim}
         });
 
         $('a[data-toggle="collapse-edit"]').click(function(e){
-          // this == <a> link in the header of the panel:
-          //
-          // .panel
-          //     .panel-header
-          //        (a || a.collapsed) == this
-          //     .panel-body
-          //
             if($(this).hasClass('collapsed')) {
               // Expand panel
                 // Change style of .panel-header


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

Same is as #2988 but in the edit view.

When a administrator/developer changes the layout of a detail view in studio, so that the panel types are mixed between "tab" and "panel" eg Tab, Tab, Panel, Tab, Panel. This causes and issue with the javascript for the first tab in the mobile edit view. Where as a User: after selecting a tab in the dropdown menu in the first tab, the contents of the tab displays as none / blank.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* fixes the bug
* includes the fix in #3073 (in order to prevent merge conflicts)

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* In studio add panels and set the type (Tab/Panel) in a random order.
* Check that you can see those tabs in the mobile view.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->