### PR TITLE
Fix #3048 - Append and display messages by type

### DIFF
--- a/include/MVC/SugarApplication.php
+++ b/include/MVC/SugarApplication.php
@@ -682,7 +682,7 @@ class SugarApplication
 	}
 
 	/**
-	 * classic redirect to another URL, but check first that URL start with "Location:"... 
+	 * classic redirect to another URL, but check first that URL start with "Location:"...
 	 * @param $header_URL
 	 */
 	public static function headerRedirect($header_URL) {
@@ -696,28 +696,19 @@ class SugarApplication
 	}
 
     /**
-	 * Redirect to another URL
+	 * Add an error message for the user
 	 *
 	 * @access	public
-	 * @param	string	$url	The URL to redirect to
+	 * @param	string
 	 */
  	public static function appendErrorMessage($error_message)
 	{
-        if (empty($_SESSION['user_error_message']) || !is_array($_SESSION['user_error_message'])){
-            $_SESSION['user_error_message'] = array();
-        }
-		$_SESSION['user_error_message'][] = $error_message;
+        SugarApplication::appendMessage($error_message, 'error');
 	}
 
     public static function getErrorMessages()
 	{
-		if (isset($_SESSION['user_error_message']) && is_array($_SESSION['user_error_message']) ) {
-            $msgs = $_SESSION['user_error_message'];
-            unset($_SESSION['user_error_message']);
-            return $msgs;
-        }else{
-            return array();
-        }
+        return SugarApplication::getMessages('error');
 	}
 
 	/**
@@ -814,4 +805,60 @@ class SugarApplication
             return "index.php?".http_build_query($vars);
         }
 	}
+
+    /**
+     * Set a message which reflects the status of the performed operation.
+     *
+     * @param string $message the message to be displayed to the user.
+     * For consistency with other messages, it should begin with a capital letter and end with a period.
+     *
+     * @param string $type the type of the message. Values allowed: error, info, alert, okay, warning.
+     *
+     * @param boolean $repeat if this is FALSE and the message is already set, then the message won't be repeated.
+     *
+     */
+    public static function appendMessage($message, $type = 'info', $repeat = true){
+        if (!empty($message)) {
+            $type = preg_replace('[^a-z]', '', strtolower($type));
+            if (!isset($_SESSION['suite_messages'][$type]) || !is_array($_SESSION['suite_messages'][$type])) {
+                $_SESSION['suite_messages'][$type] = array();
+            }
+            if (($repeat) || (!in_array($message, $_SESSION['suite_messages'][$type]))) {
+                $_SESSION['suite_messages'][$type][] = $message;
+            }
+        }
+    }
+
+    /**
+     * Return all messages that have been set.
+     *
+     * @param string $type optional, values allowed: error, info, alert, okay, warning.
+     *
+     * @param boolean $clear_qeue optional, set to FALSE if you do not want to clear the messages queue
+     *
+     * @return associative array, the key is the message type, the value an array of messages.
+     * If the $type parameter is passed, you get only that type, or an empty array if there are no such messages.
+     * If $type is not passed, all message types are returned, or an empty array if none exist.
+     */
+    public static function getMessages($type = null, $clear_queue = true){
+
+        $messages = array();
+
+        if (isset($_SESSION['suite_messages'])) {
+            if (isset($type)) {
+                if (isset($_SESSION['suite_messages'][$type])) {
+                    $messages[$type] = $_SESSION['suite_messages'][$type];
+                    if ($clear_queue) {
+                        unset($_SESSION['suite_messages'][$type]);
+                    }
+                }
+            } else {
+                $messages = $_SESSION['suite_messages'];
+                if ($clear_queue) {
+                    unset($_SESSION['suite_messages']);
+                }
+            }
+        }
+        return($messages);
+    }
 }

--- a/include/MVC/View/SugarView.php
+++ b/include/MVC/View/SugarView.php
@@ -723,18 +723,13 @@ class SugarView
         if ($retModTabs) {
             return $ss->fetch($themeObject->getTemplate('_headerModuleList.tpl'));
         } else {
-            $ss->display($headerTpl);
-
-            $this->includeClassicFile('modules/Administration/DisplayWarnings.php');
-
-            $errorMessages = SugarApplication::getErrorMessages();
-            if (!empty($errorMessages)) {
-                foreach ($errorMessages as $error_message) {
-                    echo '<p class="error">' . $error_message . '</p>';
-                }
+            $messages = SugarApplication::getMessages();
+            if (!empty($messages)) {
+                $ss->assign("messages", $messages);
             }
+            $ss->display($headerTpl);
+            $this->includeClassicFile('modules/Administration/DisplayWarnings.php');
         }
-
     }
 
     public function getModuleMenuHTML()

--- a/jssource/src_files/include/javascript/sugar_3.js
+++ b/jssource/src_files/include/javascript/sugar_3.js
@@ -190,7 +190,7 @@ SUGAR.isSupportedBrowser = function(){
         msie : {min:9, max:11}, // IE 9, 11
         safari : {min:534}, // Safari 5.1
         mozilla : {min:31.0}, // Firefox 31.0
-        chrome : {min:37} // Chrome 37 
+        chrome : {min:37} // Chrome 37
     };
     var current = String($.browser.version);
     var supported;
@@ -3763,7 +3763,7 @@ SUGAR.searchForm = function() {
                 }else{
                     adv.setAttribute('accesskey',a_key);
                 }
-                
+
 				// show the good search form.
 				document.getElementById(module + theView + 'SearchForm').style.display = '';
                 //if its not the first tab show there is a previous tab.
@@ -5089,4 +5089,63 @@ function convertReportDateTimeToDB(dateValue, timeValue)
         return date_match[date_reg_positions['Y']] + "-"+date_match[date_reg_positions['m']] + "-"+date_match[date_reg_positions['d']] + ' '+ time_match[1] + ':' + time_match[2] + ':00';
     }
     return '';
+}
+
+
+
+/**
+ *  Displays a message after the last message shown, into a div
+ *  with the specified class according to the type passed.
+ *  Useful for SuiteP and SuiteR themes.
+ */
+function displayMessage(type, message)
+{
+    if($('#pagecontent .message').length != 0){
+	$('div.message').last().after(
+	    renderHtmlMessage(type, message)
+	);
+    } else {
+	$('#pagecontent').prepend(
+	    renderHtmlMessage(type, message)
+	);
+    }
+}
+
+/**
+ *  Displays a message after the selector passed, into a div
+ *  with the specified class according to the type passed.
+ *  Useful for default and Suite7 themes.
+ */
+function displayMessageAfterSelector(type, message, selector)
+{
+    $(selector).after(renderHtmlMessage(type, message));
+}
+
+/**
+ * Deletes all messages of the type passed.
+ * If a selector is passed it only deletes messages inside that selector.
+ *
+ */
+function clearMessagesByType(type, selector)
+{
+    if(typeof(selector) != 'undefined'){
+     $('.message.' + type , selector).remove();
+    }else{
+     $('.message.' + type).remove();
+    }
+}
+
+/**
+* Displays a message into a div  with the specified class according to the type passed.
+* Types allowed: error, info, alert, working, okay.
+*/
+function renderHtmlMessage(type, message)
+{
+  htmlMessage = $('<div />');
+
+  htmlMessage
+    .addClass('message ' + type)
+	.html(message);
+
+  return(htmlMessage);
 }

--- a/tests/tests/include/MVC/SugarApplicationTest.php
+++ b/tests/tests/include/MVC/SugarApplicationTest.php
@@ -19,19 +19,19 @@ class SugarApplicationTest extends PHPUnit_Framework_TestCase
     {
 
         //cannot test this method as it uses die which stops execution of php unit as well
-        /*  
+        /*
         error_reporting(E_ERROR | E_PARSE);
-        
+
         $SugarApplication = new SugarApplication();
         $SugarApplication->controller = new SugarController();
-        
+
         try {
             $SugarApplication->loadUser();
-        } 
+        }
         catch (Exception $e) {
             $this->fail();
         }
-        
+
         $this->assertTrue(TRUE);
         */
         $this->markTestIncomplete('Can Not be implemented');
@@ -262,13 +262,13 @@ class SugarApplicationTest extends PHPUnit_Framework_TestCase
         //execute the method and check if it works and doesn't throws an exception
         try {
             ob_start();
-        
+
             $SugarApplication->redirect();
-        
+
             $renderedContent = ob_get_contents();
             ob_end_clean();
             $this->assertGreaterThan(0,strlen($renderedContent));
-             
+
         } catch (Exception $e) {
             $this->fail();
         }
@@ -280,14 +280,14 @@ class SugarApplicationTest extends PHPUnit_Framework_TestCase
     {
         //execute the method and check that the method adds the message to user_error_message array.
         //there should be one more array element after method execution.
-        $user_error_message_count = count($_SESSION['user_error_message']);
+        $user_error_message_count = count($_SESSION['suite_messages']['error']);
         SugarApplication::appendErrorMessage('some error');
-        $this->assertGreaterThan($user_error_message_count, count($_SESSION['user_error_message']));
+        $user_error_message_count = count($_SESSION['suite_messages']['error']);
     }
 
     public function testgetErrorMessages()
     {
-        //execute the method and check if it returns a array. 
+        //execute the method and check if it returns a array.
         $errorMessages = SugarApplication::getErrorMessages();
         $this->assertTrue(is_array($errorMessages));
     }
@@ -329,5 +329,31 @@ class SugarApplicationTest extends PHPUnit_Framework_TestCase
         //execute the method and test that it returns a plus length string
         $redirect = $SugarApplication->getLoginRedirect();
         $this->assertGreaterThan(0, strlen($redirect));
+    }
+
+    public function testappendMessage()
+    {
+        //execute the method and check that the method adds one message for each type.
+        //there should be one more array element at the end of each iteration.
+        $types = array(
+            'error',
+            'info',
+            'alert',
+            'okay',
+            'working'
+        );
+
+        foreach ($types as $type) {
+            $user_error_message_count = count($_SESSION['suite_messages'][$type]);
+            SugarApplication::appendMessage('a new message', $type);
+            $this->assertGreaterThan($user_error_message_count, count($_SESSION['suite_messages'][$type]));
+        }
+    }
+
+    public function testgetMessages()
+    {
+        //execute the method and check if it returns a array.
+        $messages = SugarApplication::getMessages();
+        $this->assertTrue(is_array($messages));
     }
 }

--- a/themes/Suite7/css/style.css
+++ b/themes/Suite7/css/style.css
@@ -6678,3 +6678,30 @@ ul.clickMenu.searchAppliedAlert {
 .action-link label {
   padding: 5px 0 0 0;
 }
+
+.message {
+    padding: 10px;
+    margin-bottom: 20px;
+    border: 1px solid transparent;
+    border-radius: 4px;
+}
+
+.info {
+    background-color: #d8f5ee;
+    color: #778591;
+}
+
+.alert {
+    background-color: #F5E79E;
+    color: #ad9d4a;
+}
+
+.working {
+    background-color: #e6e6e6;
+    color: #898a8a;
+}
+
+.okay {
+    background-color: #83c489;
+    color: #fff;
+}

--- a/themes/Suite7/tpls/header.tpl
+++ b/themes/Suite7/tpls/header.tpl
@@ -76,3 +76,8 @@
 <main>
     <div id="content" {if !$AUTHENTICATED}class="noLeftColumn" {/if}>
         <table style=""" id="contentTable"><tr><td>
+{foreach from=$messages item=typedmessages key=type}
+{foreach from=$typedmessages item=msg}
+<div class="message {$type}">{$msg}</div>
+{/foreach}
+{/foreach}

--- a/themes/SuiteP/css/messages.scss
+++ b/themes/SuiteP/css/messages.scss
@@ -1,0 +1,34 @@
+/**** Messages ***/
+@import 'variables';
+
+.message {
+padding: $message-padding;
+margin-bottom: $message-margin-bottom;
+border: $message-border;
+border-radius: $message-border-radius;
+}
+
+.error {
+    color: $error-message-text-color;
+    background-color: $error-message-bg-color;
+}
+
+.info {
+    color: $info-message-text-color;
+    background-color: $info-message-bg-color;
+}
+
+.alert {
+    color: $alert-message-text-color;
+    background-color: $alert-message-bg-color;
+}
+
+.okay {
+    color: $okay-message-text-color;
+    background-color: $okay-message-bg-color;
+}
+
+.working {
+    color: $working-message-text-color;
+    background-color: $working-message-bg-color;
+}

--- a/themes/SuiteP/css/style.scss
+++ b/themes/SuiteP/css/style.scss
@@ -15,3 +15,4 @@
 @import 'yui';
 @import 'cases';
 @import 'calendar';
+@import 'messages';

--- a/themes/SuiteP/css/variables.scss
+++ b/themes/SuiteP/css/variables.scss
@@ -232,6 +232,21 @@ $scheduler-free-color: #6a80e6;
 $scheduler-free-border-color: #FFFFFF;
 $scheduler-busy-color: #e67c73;
 
-
 // Line Items
 $line-item-group-width: 100%;
+
+// Messages
+$info-message-text-color: #778591;
+$info-message-bg-color: #d8f5ee;
+$error-message-text-color: #fff;
+$error-message-bg-color: #f08377;
+$alert-message-text-color: #ad9d4a;
+$alert-message-bg-color: #F5E79E;
+$okay-message-text-color: #fff;
+$okay-message-bg-color: #83c489;
+$working-message-text-color: #898a8a;
+$working-message-bg-color: #e6e6e6;
+$message-padding: 10px;
+$message-margin-bottom: 20px;
+$message-border: 1px solid transparent;
+$message-border-radius: 4px;

--- a/themes/SuiteP/tpls/header.tpl
+++ b/themes/SuiteP/tpls/header.tpl
@@ -66,3 +66,8 @@
     <div id="content" class="content">
         <div id="pagecontent" class=".pagecontent">
 {/if}
+{foreach from=$messages item=typedmessages key=type}
+{foreach from=$typedmessages item=msg}
+<div class="message {$type}">{$msg}</div>
+{/foreach}
+{/foreach}

--- a/themes/SuiteR/css/style.css
+++ b/themes/SuiteR/css/style.css
@@ -6211,3 +6211,30 @@ ul.clickMenu.SugarActionMenu.listViewLinkButton > li .ddopen {
         float: none;
     }
 }
+
+.message {
+    padding: 10px;
+    margin-bottom: 20px;
+    border: 1px solid transparent;
+    border-radius: 4px;
+}
+
+.info {
+    background-color: #d8f5ee;
+    color: #778591;
+}
+
+.alert {
+    background-color: #F5E79E;
+    color: #ad9d4a;
+}
+
+.working {
+    background-color: #e6e6e6;
+    color: #898a8a;
+}
+
+.okay {
+    background-color: #83c489;
+    color: #fff;
+}

--- a/themes/SuiteR/tpls/header.tpl
+++ b/themes/SuiteR/tpls/header.tpl
@@ -61,3 +61,8 @@
         <div id="content">
             <div id="pagecontent">
 {/if}
+{foreach from=$messages item=typedmessages key=type}
+{foreach from=$typedmessages item=msg}
+ <div class="message {$type}">{$msg}</div>
+{/foreach}
+{/foreach}

--- a/themes/default/less/bootstrap-mobile.less
+++ b/themes/default/less/bootstrap-mobile.less
@@ -56,3 +56,6 @@
 
 // Utility classes
 @import "utilities";
+
+// Messages;
+@import 'messages';

--- a/themes/default/less/bootstrap.less
+++ b/themes/default/less/bootstrap.less
@@ -67,3 +67,6 @@
 
 // Responsive
 @import "responsive";
+
+// Messages
+@import "messages";

--- a/themes/default/less/messages.less
+++ b/themes/default/less/messages.less
@@ -1,0 +1,34 @@
+// MESSAGES
+// ---------
+
+.message {
+padding: @messagePadding;
+margin-bottom: @messageMarginBottom;
+border: @messageBorder;
+border-radius: @messageBorderRadius;
+}
+
+.error {
+    color: @errorMessageTextColor;
+    background-color: @errorMessageBgColor;
+}
+
+.info {
+    color: @infoMessageTextColor;
+    background-color: @infoMessageBgColor;
+}
+
+.alert {
+    color: @alertMessageTextColor;
+    background-color: @alertMessageBgColor;
+}
+
+.okay {
+    color: @okayMessageTextColor;
+    background-color: @okayMessageBgColor;
+}
+
+.working {
+    color: @workingMessageTextColor;
+    background-color: @workingMessageBgColor;
+}

--- a/themes/default/less/variables.less
+++ b/themes/default/less/variables.less
@@ -205,3 +205,19 @@
 @fluidGridColumnWidth:    6.382978723%;
 @fluidGridGutterWidth:    2.127659574%;
 
+// Messages
+// -------------------------
+@infoMessageTextColor:  	#778591;
+@infoMessageBgColor: 	        #d8f5ee;
+@errorMessageTextColor:         #fff;
+@errorMessageBgColor:	        #f08377;
+@alertMessageTextColor: 	#ad9d4a;
+@alertMessageBgColor:	        #F5E79E;
+@okayMessageTextColor: 	        #fff;
+@okayMessageBgColor: 	        #83c489;
+@workingMessageTextColor:	#898a8a;
+@workingMessageBgColor: 	#e6e6e6;
+@messagePadding: 		10px;
+@messageMarginBottom: 	        20px;
+@messageBorder: 		1px solid transparent;
+@messageBorderRadius: 	        4px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Feature of setting and displaying different types of color-coded messages for the user. 

![suitecrm_msgs](https://cloud.githubusercontent.com/assets/5542756/22796134/ff78ed9a-eed7-11e6-9ee8-0b10e5f754dc.png)

## Description
<!--- Describe your changes in detail -->
We had implemented this feature in SugarCRM 6.5 a while ago and now adapted the code for the current version of SuiteCRM.
Basically it allows to set messages by using static method SugarApplication::appendMessage, which is meant to be called from controller.php or any other place in the application. We also added the messages rendering to the header in SugarView.php and in the Smarty templates for each theme available, also setting up the code for the different CSS implementations currently used, in order to show color-coded errors with different styling classes.
As a second approach we also found useful to have a JS implementation for this functionality, so we have added that in sugar_3.js, using the functions displayMessage for the header area and displayMessagesAfterSelector for any other area you wish to show the messages on.
Also, this feature offers the possibility for implementing any new type of color-coded message you need. Now to accomplish that you only have to ensure that the corresponding CSS classes for your custom type exist and are available. For example:

```css
.myCustomType {
background-color: #700614;
color: #CCCCCC;
}
```
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
https://github.com/salesagility/SuiteCRM/issues/3048

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Please refer to issue: https://github.com/salesagility/SuiteCRM/issues/3048

## How To Test This
You need to clean application cache. Also remember to repair compiled CSS stylesheets and minifyied JS cache files. Then run SugarApplicationTest.php with PHPUnit and/or call displayMessage function from JS console into to the browser. The type parameter currently has the following allowed values: info, error, alert, okay, working. When you use these remember to quote them as their expected data-type is string.  See some examples below.

In javascript:
```javascript
// Insert this directly into the browser console
displayMessage('working', 'working class hero');
```
In PHP:
```php
// Put this in controller.php or any other PHP file in the view
SugarApplication::appendMessage('some info', 'info');
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->