### PR TITLE
Added missing labels for Studio -> Export Customisation

### DIFF
--- a/modules/ModuleBuilder/language/en_us.lang.php
+++ b/modules/ModuleBuilder/language/en_us.lang.php
@@ -630,6 +630,14 @@ $mod_strings = array(
     'LBL_EC_EXPORTBTN' => 'Export',
     'LBL_MODULE_DEPLOYED' => 'Module has been deployed.',
     'LBL_UNDEFINED' => 'undefined',
+    'LBL_EC_VIEWS'=>'customized view(s)',
+    'LBL_EC_SUGARFEEDS'=>'customized SugarFeeds(s)',
+    'LBL_EC_DASHLETS'=>'customized Dashlets(s)',
+    'LBL_EC_CSS'=>'customized css(s)',
+    'LBL_EC_TPLS'=>'customized tpls(s)',
+    'LBL_EC_IMAGES'=>'customized image(s)',
+    'LBL_EC_JS'=>'customized js(s)',
+    'LBL_EC_QTIP'=>'customized qtip(s)',
 
 //AJAX STATUS
     'LBL_AJAX_FAILED_DATA' => 'Failed to retrieve data',


### PR DESCRIPTION
 Added the missing labels that are necessary to view correctly when user exports customisations

<!--- Provide a general summary of your changes in the Title above -->
view issue description here: https://github.com/salesagility/SuiteCRM/issues/3081

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
View description here: https://github.com/salesagility/SuiteCRM/issues/3081

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
view issue description here: https://github.com/salesagility/SuiteCRM/issues/3081

## How To Test This
<!--- Please describe in detail how to test your changes. -->
go to: Admin -> Studio and click on the button "Export Customisation"

Without this fix a list of "undefined" labels appears.

This fix displays the correct labels for the customisation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->