### PR TITLE
Fix - Insert image also attaches it in tinymce

### DIFF
--- a/modules/Emails/javascript/Email.js
+++ b/modules/Emails/javascript/Email.js
@@ -222,22 +222,21 @@ function multiFiles( list_target){
 					}
 				}}, null);
                 //AJAX call ends
-
-                // New file input
-                new_element = document.createElement('input');
-                new_element.type = 'file';
-                // new_element.name = 'email_attachment' +up++;
-
-                // Add new element
-                this.parentNode.insertBefore(new_element, this);
-                // Apply 'update' to element
-                this.multi_selector.addElement(new_element);
-                // Update list
-                this.multi_selector.addListRow(this);
-                // Hide this: we can't use display:none because Safari doesn't like it
-                //this.style.display='none';
-                //display none works fine for FF and IE
-                this.style.display = 'none';
+				if(!mozaik.uploadPathField) {
+					// New file input
+					new_element = document.createElement('input');
+					new_element.type = 'file';
+					// Add new element
+					this.parentNode.insertBefore(new_element, this);
+					// Apply 'update' to element
+					this.multi_selector.addElement(new_element);
+					// Update list
+					this.multi_selector.addListRow(this);
+					// Hide this: we can't use display:none because Safari doesn't like it
+					//this.style.display='none';
+					//display none works fine for FF and IE
+					this.style.display = 'none';
+				}
                 //later for Safari add following
                 //this.style.position = 'absolute';
                 //this.style.left = '-5000px';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When you insert an image in tinyMCE - it also attaches it. As it links to a URL in the public folder it does not need to attach it. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It allows you to insert an image without it being attached.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Create template and insert image - see that it's attached. Apply fix and clear browser cache and see that it does not anymore.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->