### PR TITLE
Fix #2203 - Overflowing text from div container

### DIFF
--- a/themes/SuiteP/css/editview.scss
+++ b/themes/SuiteP/css/editview.scss
@@ -606,7 +606,7 @@ slot {
   text-align: left;
   min-height: 48px;
   vertical-align: baseline;
-  white-space: nowrap;
+  white-space: inherit;
 }
 
 .detail-view-field a {


### PR DESCRIPTION
## Description
Addressing Issue #2203 regarding overflow of text.

Changed ```white-space: no-wrap``` on line 609 to ```white-space: inherit``` within editview.scss

Reasoning behind this is to stop the overflow (escaping) of text from the containing div when a long string is entered into a field in a detail view.

## Motivation and Context
To resolve a bug flagged by the users where the display would become messed up if they exceeded the space of the div with the input into the fields to enhance user experience should they require to input long information.

## How To Test This
* Go to Accounts or Contacts
* From the list view and click on the name to enter the detail view.
* In the address inline edit, apply a long name such as:
```
THIS IS A REALLY REALLY LONG DESCRIPTION OF A LATIN AMERICAN STREET ADDRESS WITH MULTIPLE  DETAILS ON NEIGHBOURS LOCATIONS.
```

* Apply the name.
* Look at the field upon saving, it should be presented normally.
* Refresh the page and check to make sure it's fine on first load also as save is populated differently to load.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->