### PR TITLE
Fix #2277 - Mass Update with Dynamic Dropdowns

### DIFF
--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -1332,7 +1332,7 @@ EOQ;
                     case "account_name":
                     case "bool":
                     case "enum":
-					case "dynamicenum":
+		    case "dynamicenum":
                     case "multienum":
                     case "radioenum":
                     case "datetimecombo":

--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -462,6 +462,7 @@ eoq;
 						case "account_name":$even = !$even; $newhtml .= $this->addAccountID($displayname,  $field["id_name"]); break;
 						case "bool": $even = !$even; $newhtml .= $this->addBool($displayname,  $field["name"]); break;
 						case "enum":
+						case "dynamicenum":
 						case "multienum":
 							if(!empty($field['isMultiSelect']))
 							{
@@ -1331,6 +1332,7 @@ EOQ;
                     case "account_name":
                     case "bool":
                     case "enum":
+					case "dynamicenum":
                     case "multienum":
                     case "radioenum":
                     case "datetimecombo":

--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -1322,24 +1322,24 @@ EOQ;
                 if(isset($field['custom_type']))$field['type'] = $field['custom_type'];
                 if(isset($field['type']))
                 {
-                    switch($field["type"]){
-                    case "relate":
-                    case "parent":
-                    case "int":
-                    case "contact_id":
-                    case "assigned_user_name":
-                    case "account_id":
-                    case "account_name":
-                    case "bool":
-                    case "enum":
-		    case "dynamicenum":
-                    case "multienum":
-                    case "radioenum":
-                    case "datetimecombo":
-                    case "datetime":
-                    case "date":
-                        return true;
-                        break;
+                    switch ($field["type"]) {
+                        case "relate":
+                        case "parent":
+                        case "int":
+                        case "contact_id":
+                        case "assigned_user_name":
+                        case "account_id":
+                        case "account_name":
+                        case "bool":
+                        case "enum":
+                        case "dynamicenum":
+                        case "multienum":
+                        case "radioenum":
+                        case "datetimecombo":
+                        case "datetime":
+                        case "date":
+                            return true;
+                            break;
                     }
                 }
             }


### PR DESCRIPTION
## Description
Fix for Issue #2277 - Dynamic dropdowns didn't show up when performing a mass update, even if the mass update checkbox was checked in Studio when editing the field.

Inclusion of the type within the MassUpdate.php class for dynamicenum within two case statements where dynamicenum was missing from the type of inputs. With this change, dynamic dropdowns now show up in mass editing when the checkbox is checked in studio.

## Motivation and Context
The issue raises broken functionality within Studio - a checkbox which is supposed to allow functionality didn't work. The issue was raised back in September and can be seen as a user frustration if they require to have this functionality for any mass-changes to information.

## How To Test This
Without the applied changes in the MassUpdate.php file, within Issue #2277, there are steps listed to reproduce the problem:

* Go to Studio and select the module (from a clean installation, cases works with the field of status) which has a dynamic dropdown.
* Select the field and then check the checkbox within Studio and apply your changes.
* Do a Repair and Rebuild.
* In list view (cases, in this example), try to do a mass update for more than one row. Status won't appear.

Try these steps with the applied changes to MassUpdate.php and you'll see that status does appear as it should after the checkbox is applied in studio.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->