### PR TITLE
Module Menu Filters: Overflow issue (SuiteP)

### DIFF
--- a/themes/SuiteP/css/admin.scss
+++ b/themes/SuiteP/css/admin.scss
@@ -228,7 +228,7 @@
 
 #edittabs #groupTable .tdContainer {
   display: inline-block;
-  width: 16%;
+  width: 15%;
 }
 
 .slotB {

--- a/themes/SuiteP/modules/Studio/TabGroups/EditViewTabs.tpl
+++ b/themes/SuiteP/modules/Studio/TabGroups/EditViewTabs.tpl
@@ -77,7 +77,7 @@
 	</td>
 </tr>
 </table>
-<table><tr><td valign='top' nowrap class="edit view" style="width: auto;">
+<table><tr><td valign='top' nowrap class="edit view" >
 <table  cellpadding="0" cellspacing="0" width="100%"   id='s_field_delete'>
 							<tr><td ><ul id='trash' class='listContainer'>
 <li class='nobullet' id='trashcan'><table>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When the user has a display which is less than 1500px in width, the module filters on the right hand side overflow.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* This change corrects the issue

## How To Test This
<!--- Please describe in detail how to test your changes. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->