### PR TITLE
Log slow queries for MySQL

### DIFF
--- a/include/database/MysqliManager.php
+++ b/include/database/MysqliManager.php
@@ -140,6 +140,7 @@ class MysqliManager extends MysqlManager
 
 		$this->query_time = microtime(true) - $this->query_time;
 		$GLOBALS['log']->info('Query Execution Time:'.$this->query_time);
+		$this->dump_slow_queries($sql);
 
 		// This is some heavy duty debugging, leave commented out unless you need this:
 		/*


### PR DESCRIPTION
## Description
Bug fix related to issue #3119. It was a simple fix, just had to add the call to the dump_slow_queries() function.

## Motivation and Context
Functionality is there, just wasn't working for MySQL.

## How To Test This
Simply enable log slow queries from system settings.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.