### PR TITLE
Fix #3136 - Correct newline in textarea when save/close to line breaks

### DIFF
--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -429,6 +429,9 @@ function handleSave(field,id,module,type){
 function setValueClose(value){
 
     $.get('themes/SuiteR/images/inline_edit_icon.svg', function(data) {
+        // Fix for #3136 - replace new line characters with <br /> for html on close.
+        value = value.replace(/(?:\r\n|\r|\n)/g, '<br />');
+
         $(".inlineEditActive").html("");
         $(".inlineEditActive").html(value + '<div class="inlineEditIcon">' + inlineEditIcon + '</div>');
         $(".inlineEditActive").removeClass("inlineEditActive");


### PR DESCRIPTION
## Description
Fix for Issue #3136 - Translates the newline ```\n``` and carriage return character ```\r``` to line break  ```<br />``` for the save/closure of inline editing fields where new lines can be taken (mainly textareas).

## Motivation and Context
User within the community was experiencing data being presented wrong to them upon saving unless they refreshed. As it can be annoying feedback to not see the information as you've specified it upon saving unless you do a page refresh, I looked into this alongside of the other inline editing changes I'm currently working on.

## How To Test This
* Go into a detail view that has a textarea.
* Insert some information, taking new lines after writing text with <kbd>shift</kbd> + <kbd>enter</kbd>
* Save process and view output.

_This also corrects the issue if you open content with already existing line breaks and the information looking different upon closure with no changes._

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->