### PR TITLE
Fix #3148 - Hyperlinks not followed after entering Relate/QS field

### DIFF
--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -68,7 +68,11 @@ function buildEditField(){
             if (typeof clicks == 'undefined') {
                 clicks = 0;
             }
-            clicks++;
+
+            // Fix for Issue #3148, force it so clicks is only ever = 1 when clicked, never higher.
+            if (clicks == 0) {
+                clicks++;
+            }
 
             if(e.ctrlKey && clicks == 1){
                 return;


### PR DESCRIPTION
## Description
Issue #3148 was raised by a community member regarding entering a Relate/QS field, closing it then clicking on a hyperlink would result in the hyperlink not following to the url.

## Motivation and Context
The community member who opened up the issue raised it as a frustrating issue. Frustrating user experience is a priority to resolve where/if possible.

The bug is that the clicks would increment to 2 instead of 1 where a URL is not followed unless the clicks are 1. The function for buildEditField() is called twice or a part of the function is executed twice to increment clicks one click higher than it should be. This is a bigger issue at scale though and this resolves the issue for the time until time can be made to look into addressing this further.

## How To Test This
In a vanilla installation, do the following:

* Enter an Accounts list view
* Double click on the user field in any column.
* Click out of the user field in the column you entered.
* Click on the hyperlink in the name column.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->