### PR TITLE
Removing "`" from db query.

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -1378,7 +1378,7 @@ class AOR_Report extends Basic {
                                 $value = $condition_module->table_name . '_cstm.' . $condition->value;
                                 $query = $this->build_report_query_join($condition_module->table_name . '_cstm', $table_alias . '_cstm', $table_alias, $condition_module, 'custom', $query);
                             } else {
-                                $value = ($table_alias ? "`$table_alias`" : $condition_module->table_name) . '.' . $condition->value;
+                                $value = ($table_alias ? $this->db->quoteIdentifier($table_alias) : $condition_module->table_name) . '.' . $condition->value;
                             }
                             break;
 

--- a/modules/ProspectLists/ProspectList.php
+++ b/modules/ProspectLists/ProspectList.php
@@ -190,11 +190,7 @@ class ProspectList extends SugarBean {
 
 		// query all custom fields in the fields_meta_data table for the modules which are being exported
 		$db = DBManagerFactory::getInstance();
-		$typeField = '`type`';
-		if($db->dbType=='mssql') {
-			$typeField = '[type]';
-		}
-		$result = $db->query("select name, custom_module, $typeField, ext1, ext2, ext3, ext4 from fields_meta_data where custom_module in ('" .
+		$result = $db->query("select name, custom_module, type, ext1, ext2, ext3, ext4 from fields_meta_data where custom_module in ('" .
 			implode("', '", array_keys($members)) . "')",
 			true,
 			"ProspectList::create_export_members_query() : error querying custom fields");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
The issue was related to #1525, #856 and #875.

**Prospect Lists:**
Quoting the column 'type' because it is a keyword in MySQL is bug.
The responsibility should be in the database manager. I have
removed the quotes and the query seems to work without them.

I can't see why it was added in the first place as both engines on
MySQL and SQL seem to process the query without the need for
quotations or brackets. Perhaps it was just as a precaution.

**Reports:**
I have added the quoteIdentifier to reports, because the table alias is quoted and the quotation should be handled by the database manager.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* Provides a more correct solution

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* Retest the issues I have linked.

This change has been tested on:
* Ubuntu 14.04 PHP 5.6 / MySQL 5.6
* Ubuntu 16.04 PHP 7 / MySQL 5.7
* Windows Server 2008 R2 / SQL Server 2008 R2

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->