### PR TITLE
7x faster performance. Connect thru socket to MySQL database.

### DIFF
--- a/include/database/MysqliManager.php
+++ b/include/database/MysqliManager.php
@@ -281,7 +281,9 @@ class MysqliManager extends MysqlManager
 				$dbport=substr($configOptions['db_host_name'],$pos+1);
 			}
 
-			$this->database = @mysqli_connect($dbhost,$configOptions['db_user_name'],$configOptions['db_password'],isset($configOptions['db_name'])?$configOptions['db_name']:'',$dbport);
+			$dbsocket = isset($configOptions['db_socket']) ? $configOptions['db_socket'] : '';
+			
+			$this->database = @mysqli_connect($dbhost,$configOptions['db_user_name'],$configOptions['db_password'],isset($configOptions['db_name'])?$configOptions['db_name']:'',$dbport,$dbsocket);
 			if(empty($this->database)) {
 				$GLOBALS['log']->fatal("Could not connect to DB server ".$dbhost." as ".$configOptions['db_user_name'].". port " .$dbport . ": " . mysqli_connect_error());
 				if($dieOnError) {


### PR DESCRIPTION
Add support for config option to connect to MySQL database by unix domain socket (UDS), for faster performance, when using a locally hosted database, than the only previous option of connecting by network connection to the database server.

This socket upgrade delivers 66% less latency, and 7X more throughput vs. TCP network connection to MySQL through the network interface.

```
Here you have the results on a single CPU 3.3GHz Linux machine :

TCP average latency: 6 us

UDS average latency: 2 us

PIPE average latency: 2 us

TCP average throughput: 253702 msg/s

UDS average throughput: 1733874 msg/s

PIPE average throughput: 1682796 msg/s
```
Source: https://github.com/rigtorp/ipc-bench

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Check for new config option `db_socket`, the name of the socket to connect to the mysql database.
If config option `db_socket` exists and has a value, then connect to MySQL by the name of the socket.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Socket connection is preferred over the network connection thru localhost.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* Add option to `config.php`, after `db_port`, called `db_socket`.
* Set the value of `db_socket` to the full path of the mysql socket, which is a special file created by mysql server when it starts.
To find the full path of the mysql socket, do the following shell command, on debian/ubuntu/mint:
`# cat /etc/mysql/my.cnf  | grep socket`
On CentOS/Scientific/RedHat/Fedora:
`# cat /etc/my.cnf | grep socket`
On debian 8, the full path to the mysql 5.6 socket, happens to be: `/var/run/mysqld/mysqld.sock`.
On CentOS 7, the full path to the mysql (mariadb) 5.5 socket happens to be, `/var/lib/mysql/mysql.sock`.
So on debian 8/ubuntu 14, after the line with `'db_port'`, you add:
`'db_socket' => '/var/run/mysqld/mysqld.sock',`
And on CentOS 7/RedHat 7/Fedora, after the line `'db_port'`, you add:
`'db_socket' => '/var/lib/mysql/mysql.sock',`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->