### PR TITLE
Fix Email Settings test with differents admin user

### DIFF
--- a/modules/EmailMan/testOutboundEmail.php
+++ b/modules/EmailMan/testOutboundEmail.php
@@ -62,7 +62,11 @@ if(!empty($_REQUEST['mail_smtppass'])) {
     $pass = $_REQUEST['mail_smtppass'];
 } elseif(isset($_REQUEST['mail_type'])) {
     $oe = new OutboundEmail();
-    $oe = $oe->getMailerByName($current_user, $_REQUEST['mail_type']);
+    if(is_admin($current_user) && $_REQUEST['mail_type'] == 'system') {
+        $oe = $oe->getSystemMailerSettings();
+    } else {
+        $oe = $oe->getMailerByName($current_user, $_REQUEST['mail_type']);
+    }
     if(!empty($oe)) {
         $pass = $oe->mail_smtppass;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

- Fix Email Settings test with differents admin user
(ref: case 7148)

When the admin user changed to the difference one admin user the test Email Setting function failed,
Email Settings at testOutboundEmail action tried to get an Outbound Email record by current user id however the user id of 'system' typed Outbound Email is always 1.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

login with admin user
set Email Settings in Admin menu
test email => ok

add a second admin user
Logout and log in with second admin user
select Email Settings in Admin menu
test email => failed (which is bad)

retype the password
test email => ok

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->