### PR TITLE
Fix example display in importer

### DIFF
--- a/modules/Import/views/view.confirm.php
+++ b/modules/Import/views/view.confirm.php
@@ -494,6 +494,7 @@ document.getElementById('custom_delimiter').onchange = function()
 }
 
 document.getElementById('toggleImportOptions').onclick = function() {
+    setPreview();
     if (document.getElementById('importOptions').style.display == 'none'){
         document.getElementById('importOptions').style.display = '';
         document.getElementById('toggleImportOptions').value='  {$mod_strings['LBL_HIDE_ADVANCED_OPTIONS']}  ';
@@ -603,7 +604,6 @@ if(deselectEl)
 {$getNumberJs}
 {$getNameJs}
 setSigDigits();
-setPreview();
 setSymbolValue(document.getElementById('currency_select').selectedIndex);
 
 EOJAVASCRIPT;

--- a/modules/Import/views/view.confirm.php
+++ b/modules/Import/views/view.confirm.php
@@ -603,6 +603,7 @@ if(deselectEl)
 {$getNumberJs}
 {$getNameJs}
 setSigDigits();
+setPreview();
 setSymbolValue(document.getElementById('currency_select').selectedIndex);
 
 EOJAVASCRIPT;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When you click view import file properties in the importer, the example for name display does not show initially·
## Description
Show the example on the page load instead of only after modifying the field.
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes the example being blank

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Begin to import a file, then click view import file properties - see the name example is blank. Apply fix and see that the example is there.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->