### PR TITLE
Support UTF8MB4 charset and collation in MySQL

### DIFF
--- a/include/database/MysqlManager.php
+++ b/include/database/MysqlManager.php
@@ -554,9 +554,11 @@ class MysqlManager extends DBManager
             }
         }
 
+        $charset = $this->getOption('charset') ?: 'utf8';
+
         // cn: using direct calls to prevent this from spamming the Logs
-        mysql_query("SET CHARACTER SET utf8", $this->database);
-        $names = "SET NAMES 'utf8'";
+        mysql_query("SET CHARACTER SET $charset", $this->database);
+        $names = "SET NAMES '$charset'";
         $collation = $this->getOption('collation');
         if (!empty($collation)) {
             $names .= " COLLATE '$collation'";
@@ -775,12 +777,11 @@ class MysqlManager extends DBManager
             $keys = ",$keys";
         }
 
+        $charset = $this->getOption('charset') ?: 'utf8';
+
         // cn: bug 9873 - module tables do not get created in utf8 with assoc collation
-        $collation = $this->getOption('collation');
-        if (empty($collation)) {
-            $collation = 'utf8_general_ci';
-        }
-        $sql = "CREATE TABLE $tablename ($columns $keys) CHARACTER SET utf8 COLLATE $collation";
+        $collation = $this->getOption('collation') ?: $this->getDefaultCollation();
+        $sql = "CREATE TABLE $tablename ($columns $keys) CHARACTER SET $charset COLLATE $collation";
 
         if (!empty($engine)) {
             $sql .= " ENGINE=$engine";
@@ -1506,13 +1507,17 @@ class MysqlManager extends DBManager
      */
     public function createDatabase($dbname)
     {
-        $this->query("CREATE DATABASE `$dbname` CHARACTER SET utf8 COLLATE utf8_general_ci", true);
+        $charset = $this->getOption('charset') ?: 'utf8';
+        $collation = $this->getOption('collation') ?: $this->getDefaultCollation();
+        $this->query("CREATE DATABASE `$dbname` CHARACTER SET $charset COLLATE $collation", true);
     }
 
     public function preInstall()
     {
-        $db->query("ALTER DATABASE `{$setup_db_database_name}` DEFAULT CHARACTER SET utf8", true);
-        $db->query("ALTER DATABASE `{$setup_db_database_name}` DEFAULT COLLATE utf8_general_ci", true);
+        $charset = $this->getOption('charset') ?: 'utf8';
+        $collation = $this->getOption('collation') ?: $this->getDefaultCollation();
+        $db->query("ALTER DATABASE `{$setup_db_database_name}` DEFAULT CHARACTER SET $charset", true);
+        $db->query("ALTER DATABASE `{$setup_db_database_name}` DEFAULT COLLATE $collation", true);
     }
 
     /**

--- a/include/database/MysqliManager.php
+++ b/include/database/MysqliManager.php
@@ -348,13 +348,14 @@ class MysqliManager extends MysqlManager
         }
 
         // cn: using direct calls to prevent this from spamming the Logs
+        $charset = $this->getOption('charset') ?: 'utf8';
 
         $collation = $this->getOption('collation');
         if (!empty($collation)) {
-            $names = "SET NAMES 'utf8' COLLATE '$collation'";
+            $names = "SET NAMES '$charset' COLLATE '$collation'";
             mysqli_query($this->database, $names);
         }
-        mysqli_set_charset($this->database, "utf8");
+        mysqli_set_charset($this->database, "$charset");
 
         if ($this->checkError('Could Not Connect', $dieOnError)) {
             $GLOBALS['log']->info("connected to db");

--- a/install/install_utils.php
+++ b/install/install_utils.php
@@ -653,8 +653,10 @@ function handleDbCharsetCollation()
 
     if ($_SESSION['setup_db_type'] == 'mysql') {
         $db = getDbConnection();
-        $db->query("ALTER DATABASE `{$setup_db_database_name}` DEFAULT CHARACTER SET utf8", true);
-        $db->query("ALTER DATABASE `{$setup_db_database_name}` DEFAULT COLLATE utf8_general_ci", true);
+        $charset = $db->getOption('charset') ?: 'utf8';
+        $collation = $db->getOption('collation') ?: 'utf8_general_ci';
+        $db->query("ALTER DATABASE `{$setup_db_database_name}` DEFAULT CHARACTER SET $charset", true);
+        $db->query("ALTER DATABASE `{$setup_db_database_name}` DEFAULT COLLATE $collation", true);
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Support UTF8MB4 charset and collation in MySQL
@see issue #3192

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
Hypothesis: we are using a MySQL storage engine.

1. Perform a fresh install without Lead and Marketing packages
2. Create a new quote custom field
3. Save

Without the patch, you get an error as the SQL query is wrong. With the patch, the field is created as expected.

## Types of changes
Bug fix: I specified always the current values as the default ones so this will not cause side effects on existing installs.