### PR TITLE
Fixing default icons when Menu.php is missing.

### DIFF
--- a/include/MVC/View/SugarView.php
+++ b/include/MVC/View/SugarView.php
@@ -1325,13 +1325,13 @@ EOHTML;
             $module_menu[] = array(
                 "index.php?module=$module&action=EditView&return_module=$module&return_action=DetailView",
                 $GLOBALS['mod_strings']['LNK_NEW_RECORD'],
-                "{$GLOBALS['app_strings']['LBL_CREATE_BUTTON_LABEL']}$module",
+                "Create",
                 $module
             );
             $module_menu[] = array(
                 "index.php?module=$module&action=index",
                 $GLOBALS['mod_strings']['LNK_LIST'],
-                $module,
+                "View",
                 $module
             );
             if (($this->bean instanceof SugarBean) && !empty($this->bean->importable)) {

--- a/themes/SuiteP/css/sidebar.scss
+++ b/themes/SuiteP/css/sidebar.scss
@@ -123,7 +123,7 @@
     background-image: url("../../../../themes/SuiteP/images/sidebar/View_Create_Email_Templates.svg");
   }
 
-  .actionMenuSidebar li a.side-bar-View, .actionMenuSidebar li a .side-bar-List {
+  .actionMenuSidebar li a .side-bar-View, .actionMenuSidebar li a .side-bar-List {
     background-image: url("../../../../themes/SuiteP/images/sidebar/View.png");
     background-image: url("../../../../themes/SuiteP/images/sidebar/View.svg");
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When a user upgrades suitecrm, the modules which do not contain Menu.php will not display the icon in the sidebar correctly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This corrects the issue.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* Remove Menu.php from a module
* Access the module
* You should see create and list action items with their respective icons.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->