### PR TITLE
Fix #3212 Update systemCheck.php to confirm file exists before permission check

### DIFF
--- a/modules/UpgradeWizard/systemCheck.php
+++ b/modules/UpgradeWizard/systemCheck.php
@@ -76,33 +76,35 @@ $filesOut = "
 
 $isWindows = is_windows();
 foreach($files as $file) {
-	if($isWindows) {
-		if(!is_writable_windows($file)) {
-			logThis('WINDOWS: File ['.$file.'] not readable - saving for display');
-			// don't warn yet - we're going to use this to check against replacement files
-			$filesNotWritable[$i] = $file;
-			$filesNWPerms[$i] = substr(sprintf('%o',fileperms($file)), -4);
-			$filesOut .= "<tr>".
-							"<td><span class='error'>{$file}</span></td>".
-							"<td>{$filesNWPerms[$i]}</td>".
-							"<td>".$mod_strings['ERR_UW_CANNOT_DETERMINE_USER']."</td>".
-							"<td>".$mod_strings['ERR_UW_CANNOT_DETERMINE_GROUP']."</td>".
-						  "</tr>";
-		}
-	} else {
-		if(!is_writable($file)) {
-			logThis('File ['.$file.'] not writable - saving for display');
-			// don't warn yet - we're going to use this to check against replacement files
-			$filesNotWritable[$i] = $file;
-			$filesNWPerms[$i] = substr(sprintf('%o',fileperms($file)), -4);
-			$owner = posix_getpwuid(fileowner($file));
-			$group = posix_getgrgid(filegroup($file));
-			$filesOut .= "<tr>".
+	if(file_exists($file)) {
+		if($isWindows) {
+			if(!is_writable_windows($file)) {
+				logThis('WINDOWS: File ['.$file.'] not readable - saving for display');
+				// don't warn yet - we're going to use this to check against replacement files
+				$filesNotWritable[$i] = $file;
+				$filesNWPerms[$i] = substr(sprintf('%o',fileperms($file)), -4);
+				$filesOut .= "<tr>".
+								"<td><span class='error'>{$file}</span></td>".
+								"<td>{$filesNWPerms[$i]}</td>".
+								"<td>".$mod_strings['ERR_UW_CANNOT_DETERMINE_USER']."</td>".
+								"<td>".$mod_strings['ERR_UW_CANNOT_DETERMINE_GROUP']."</td>".
+							  "</tr>";
+			}
+		} else {
+			if(!is_writable($file)) {
+				logThis('File ['.$file.'] not writable - saving for display');
+				// don't warn yet - we're going to use this to check against replacement files
+				$filesNotWritable[$i] = $file;
+				$filesNWPerms[$i] = substr(sprintf('%o',fileperms($file)), -4);
+				$owner = posix_getpwuid(fileowner($file));
+				$group = posix_getgrgid(filegroup($file));
+				$filesOut .= "<tr>".
 							"<td><span class='error'>{$file}</span></td>".
 							"<td>{$filesNWPerms[$i]}</td>".
 							"<td>".$owner['name']."</td>".
 							"<td>".$group['name']."</td>".
 						  "</tr>";
+			}
 		}
 	}
 	$i++;

--- a/modules/UpgradeWizard/systemCheck.php
+++ b/modules/UpgradeWizard/systemCheck.php
@@ -76,35 +76,33 @@ $filesOut = "
 
 $isWindows = is_windows();
 foreach($files as $file) {
-	if(file_exists($file)) {
-		if($isWindows) {
-			if(!is_writable_windows($file)) {
-				logThis('WINDOWS: File ['.$file.'] not readable - saving for display');
-				// don't warn yet - we're going to use this to check against replacement files
-				$filesNotWritable[$i] = $file;
-				$filesNWPerms[$i] = substr(sprintf('%o',fileperms($file)), -4);
-				$filesOut .= "<tr>".
-								"<td><span class='error'>{$file}</span></td>".
-								"<td>{$filesNWPerms[$i]}</td>".
-								"<td>".$mod_strings['ERR_UW_CANNOT_DETERMINE_USER']."</td>".
-								"<td>".$mod_strings['ERR_UW_CANNOT_DETERMINE_GROUP']."</td>".
-							  "</tr>";
-			}
-		} else {
-			if(!is_writable($file)) {
-				logThis('File ['.$file.'] not writable - saving for display');
-				// don't warn yet - we're going to use this to check against replacement files
-				$filesNotWritable[$i] = $file;
-				$filesNWPerms[$i] = substr(sprintf('%o',fileperms($file)), -4);
-				$owner = posix_getpwuid(fileowner($file));
-				$group = posix_getgrgid(filegroup($file));
-				$filesOut .= "<tr>".
+	if($isWindows) {
+		if(!is_writable_windows($file) && file_exists($file)) {
+			logThis('WINDOWS: File ['.$file.'] not readable - saving for display');
+			// don't warn yet - we're going to use this to check against replacement files
+			$filesNotWritable[$i] = $file;
+			$filesNWPerms[$i] = substr(sprintf('%o',fileperms($file)), -4);
+			$filesOut .= "<tr>".
+							"<td><span class='error'>{$file}</span></td>".
+							"<td>{$filesNWPerms[$i]}</td>".
+							"<td>".$mod_strings['ERR_UW_CANNOT_DETERMINE_USER']."</td>".
+							"<td>".$mod_strings['ERR_UW_CANNOT_DETERMINE_GROUP']."</td>".
+						  "</tr>";
+		}
+	} else {
+		if(!is_writable($file) && file_exists($file)) {
+			logThis('File ['.$file.'] not writable - saving for display');
+			// don't warn yet - we're going to use this to check against replacement files
+			$filesNotWritable[$i] = $file;
+			$filesNWPerms[$i] = substr(sprintf('%o',fileperms($file)), -4);
+			$owner = posix_getpwuid(fileowner($file));
+			$group = posix_getgrgid(filegroup($file));
+			$filesOut .= "<tr>".
 							"<td><span class='error'>{$file}</span></td>".
 							"<td>{$filesNWPerms[$i]}</td>".
 							"<td>".$owner['name']."</td>".
 							"<td>".$group['name']."</td>".
-						  "</tr>";
-			}
+					  	"</tr>";
 		}
 	}
 	$i++;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When checking the modules/AOD_Index/Index/Index directory, if the lucene index process is running, files are being created and deleted very quickly.  The uwFindAllFiles call takes long enough that files may be deleted before they can be checked for permissions.  This change checks to see if the found file still exists before checking permissions.

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
https://github.com/salesagility/SuiteCRM/issues/3212

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The AOD_Index process can quickly create and delete a large number of files. If it is running when an upgrade check is performed, some files can be reported as being owned by root. Upon checking for the files manually, users find that they do not exist.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Have an AOD_Index process currently running
Perform an upgrade/system check
See files in the AOD_Index directory and not flagged as having bad permissions

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ x ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->