### PR TITLE
Fix Default Value in Importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ##SuiteCRM 7.8.2
 
-[![Build Status](https://travis-ci.org/salesagility/SuiteCRM.svg?branch=hotfix)](https://travis-ci.org/salesagility/SuiteCRM)
+[![Build Status](https://travis-ci.org/salesagility/SuiteCRM.svg?branch=master)](https://travis-ci.org/salesagility/SuiteCRM)
 
 
 ### What's in this repository ###

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ##SuiteCRM 7.8.2
 
-[![Build Status](https://travis-ci.org/salesagility/SuiteCRM.svg?branch=master)](https://travis-ci.org/salesagility/SuiteCRM)
+[![Build Status](https://travis-ci.org/salesagility/SuiteCRM.svg?branch=hotfix)](https://travis-ci.org/salesagility/SuiteCRM)
 
 
 ### What's in this repository ###

--- a/modules/Import/views/view.step3.php
+++ b/modules/Import/views/view.step3.php
@@ -518,6 +518,7 @@ class ImportViewStep3 extends ImportView
                     background: transparent url('index.php?entryPoint=getImage&themeName=Sugar&themeName=Sugar&imageName=sugar-yui-sprites.png') no-repeat 0 -90px;
                     padding-left: 10px;
                     cursor: pointer;
+		    display: inline; 
                 }
 
                 span.expand{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When you are importing, on Step 3 you can click "< Default Value". After clicking this the option to hide it again should be shown with "> Default Value". It is not currently shown and is just blank.
This Fixes that issue
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allow you to hide the default value entry.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Try importing and clicking default value and see that it is blank. Apply fix and see that you can now hide it again.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->