### PR TITLE
Add Visual Studio exclusions to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,10 @@ Thumbs.db
 Desktop.ini
 .DS_Store
 .DS_Store?
+#Visual Studio
+*.sln
+*.suo
+*.phpproj
 # Disytel
 lang_cmp.php
 .kdev4/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ##SuiteCRM 7.8.2
 
-[![Build Status](https://travis-ci.org/salesagility/SuiteCRM.svg?branch=hotfix)](https://travis-ci.org/salesagility/SuiteCRM)
+[![Build Status](https://travis-ci.org/salesagility/SuiteCRM.svg?branch=master)](https://travis-ci.org/salesagility/SuiteCRM)
 
 
 ### What's in this repository ###


### PR DESCRIPTION
Microsoft Visual Studio is a free IDE that can be used for PHP projects, including SuiteCRM.

This makes the generated project files be excluded from Git, similarly to what is already there for other IDE's.