### PR TITLE
Fixed #3225 - Calendar body is not shown after PHP 7.x update

### DIFF
--- a/modules/Calendar/CalendarDisplay.php
+++ b/modules/Calendar/CalendarDisplay.php
@@ -173,7 +173,7 @@ class CalendarDisplay {
 		$user_default_date_start  = $timedate->asUser($timedate->getNow());
 		$ss->assign('user_default_date_start',$user_default_date_start);
 		// end form
-		$location_array = "";
+		$location_array = array();
 		foreach($this->views as $view){
 			$location_array[] = $view;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

Issue raised via Issue 3225 - https://github.com/salesagility/SuiteCRM/issues/3225
Calendar not displaying on PHP 7.1

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Enables users on PHP 7.x to view Calendar display

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Test on PHP 7.x environment.
Access Calendar module it should display as expected in older PHP environments.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->