### PR TITLE
Fix for #3108 - Campaigns results not using smarty template.

### DIFF
--- a/modules/Campaigns/SubPanelViewer.php
+++ b/modules/Campaigns/SubPanelViewer.php
@@ -87,7 +87,7 @@ if(!empty($_REQUEST['layout_def_key'])){
 
 $subpanel_object = new SubPanel($module, $record, $subpanel,null, $layout_def_key);
 
-$subpanel_object->setTemplateFile('include/SubPanel/SubPanelDynamic.html');
+$subpanel_object->setTemplateFile('include/SubPanel/tpls/SubPanelDynamic.tpl');
 
 if(!empty($_REQUEST['mkt_id']) && $_REQUEST['mkt_id'] != 'all') {// bug 32910
     $mkt_id = $_REQUEST['mkt_id'];


### PR DESCRIPTION
 Changes to be committed:
	modified:   modules/Campaigns/SubPanelViewer.php

 Use .tpl instead of .html

## Description
One liner to fix bug from issue #3108

## Motivation and Context
Pager on Campaigns result returned error.

## How To Test This
Described in issue 

## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)

### Final checklist
