### PR TITLE
Fix #3250 - Resolving Telephone Number Inline Edit

### DIFF
--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -268,7 +268,14 @@ $(document).on('click', function (e) {
 
         if (!$(e.target).parents().is(".inlineEditActive, .cal_panel") && !$(e.target).hasClass("inlineEditActive")) {
             var output_value = loadFieldHTMLValue(field, id, module);
-            var outputValueParse = $(output_value).text();
+
+            // Resolve issues with telephone number throwing exception.
+            if (/<[a-z][\s\S]*>/i.test(output_value)) {
+                var outputValueParse = $(output_value).text();
+            } else {
+                var outputValueParse = output_value;
+            }
+
             var user_value = getInputValue(field, type);
 
             /**
@@ -427,7 +434,6 @@ function handleSave(field,id,module,type){
  */
 
 function setValueClose(value){
-
     $.get('themes/SuiteR/images/inline_edit_icon.svg', function(data) {
         $(".inlineEditActive").html("");
         $(".inlineEditActive").html(value + '<div class="inlineEditIcon">' + inlineEditIcon + '</div>');


### PR DESCRIPTION
## Description
Fix for Issue #3250 - Whenever clicking into an inline edit field with the value matching up to be an area telephone number, such as, "(00000) 000000" - the field will populate as expected, but when trying to close (click away) or save, an exception will be thrown due to not parsing the area code brackets properly.

## Motivation and Context
Inline Edit doesn't work for Telephone Numbers when it should... it can prove to be a frustrating user experience.

## How To Test This
* Install SuiteCRM
* Go to a module with a telephone field in list view, e.g: Accounts
* Double click the field
* Try to either click away or close it (save).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->