### PR TITLE
Fix #3203 - Leads DetailView table cell color issue (Suite 7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ##SuiteCRM 7.8.2
 
-[![Build Status](https://travis-ci.org/salesagility/SuiteCRM.svg?branch=hotfix)](https://travis-ci.org/salesagility/SuiteCRM)
+[![Build Status](https://travis-ci.org/salesagility/SuiteCRM.svg?branch=master)](https://travis-ci.org/salesagility/SuiteCRM)
 
 
 ### What's in this repository ###

--- a/include/DetailView/DetailView.tpl
+++ b/include/DetailView/DetailView.tpl
@@ -120,7 +120,7 @@ class="yui-navset detailview_tabs"
 		{{assign var='columnsInRow' value=$rowData|@count}}
 		{{assign var='columnsUsed' value=0}}
 		{{foreach name=colIteration from=$rowData key=col item=colData}}
-		{{if !empty($colData.field.name)}}
+		{{if isset($colData.field.tabindex)}}
 	    {{if !empty($colData.field.hideIf)}}
 	    	{if !({{$colData.field.hideIf}}) }
 	    {{/if}}

--- a/include/DetailView/DetailView.tpl
+++ b/include/DetailView/DetailView.tpl
@@ -120,6 +120,7 @@ class="yui-navset detailview_tabs"
 		{{assign var='columnsInRow' value=$rowData|@count}}
 		{{assign var='columnsUsed' value=0}}
 		{{foreach name=colIteration from=$rowData key=col item=colData}}
+		{{if !empty($colData.field.name)}}
 	    {{if !empty($colData.field.hideIf)}}
 	    	{if !({{$colData.field.hideIf}}) }
 	    {{/if}}
@@ -196,6 +197,7 @@ class="yui-navset detailview_tabs"
 
 			<td>&nbsp;</td><td>&nbsp;</td>
 			{/if}
+	    {{/if}}
 	    {{/if}}
 
 		{{/foreach}}


### PR DESCRIPTION
## Description
Fix for Issue [3203](https://github.com/salesagility/SuiteCRM/issues/3203) - When i expand my row in studio, there is a cell color issue on DetailView.

## How To Test This
1. Change theme to Suite7
2. Open Studio
3. Add some field to leads (or any modules) detailview.
4. Expand added field.
5. See result in detailview of leads (or any modules)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->