### PR TITLE
Fix #3202 - Repair functionality of "reply-to" checkbox on profile

### DIFF
--- a/include/SugarEmailAddress/templates/forEditView.tpl
+++ b/include/SugarEmailAddress/templates/forEditView.tpl
@@ -100,7 +100,7 @@ var emailAddressWidgetLoaded = false;
 				{if $useReplyTo == true}
 				<div class="col-xs-3 col-sm-2 col-md-2 col-lg-2 text-center email-address-option">
 					<label class="text-sm  col-xs-12">{$app_strings.LBL_EMAIL_REPLY_TO}</label>
-					<div><input type="checkbox" name="" id="email-address-reply-to-flag" class="email-address-reply-to-flag" value="" enabled="true"></div>
+					<div><input type="radio" name="" id="email-address-reply-to-flag" class="email-address-reply-to-flag" value="" enabled="true" tabindex="0" checked="true" title="{$app_strings.LBL_EMAIL_REPLY_TO}"></div>
 				</div>
 				{/if}
 

--- a/jssource/src_files/include/SugarEmailAddress/SugarEmailAddress.js
+++ b/jssource/src_files/include/SugarEmailAddress/SugarEmailAddress.js
@@ -299,7 +299,7 @@
       // Reply to checkbox
       var replyToCheckbox = lineContainer.find('input#email-address-reply-to-flag');
       if (replyToCheckbox.length == 1) {
-        replyToCheckbox.attr('name', this.module + _eaw.id + '"emailAddressReplyToFlag');
+        replyToCheckbox.attr('name', this.module + _eaw.id + 'emailAddressReplyToFlag');
         replyToCheckbox.attr('id', this.module + _eaw.id + 'emailAddressReplyToFlag' + _eaw.totalEmailAddresses);
         replyToCheckbox.attr('value', this.module + _eaw.id + 'emailAddress' + _eaw.totalEmailAddresses);
         replyToCheckbox.attr('tabindex', tabIndexCount);

--- a/jssource/src_files/include/SugarEmailAddress/SugarEmailAddress.js
+++ b/jssource/src_files/include/SugarEmailAddress/SugarEmailAddress.js
@@ -315,48 +315,6 @@
         removeButton.prop('disabled', true);
       }
 
-      // Reply to checkbox
-      // var replyToCheckbox = lineContainer.find('input#email-address-reply-to-flag');
-      // if (replyToCheckbox.length == 1) {
-        // replyToCheckbox.attr('name', this.module + _eaw.id + 'emailAddressReplyToFlag');
-        // replyToCheckbox.attr('id', this.module + _eaw.id + 'emailAddressReplyToFlag' + _eaw.totalEmailAddresses);
-        // replyToCheckbox.attr('value', this.module + _eaw.id + 'emailAddress' + _eaw.totalEmailAddresses);
-        // replyToCheckbox.attr('tabindex', tabIndexCount);
-        // replyToCheckbox.attr('enabled', "true");
-        // replyToCheckbox.eaw = _eaw;
-        // replyToCheckbox.prop("checked", (replyToFlag == '1'));
-        // _eaw.replyToFlagObject[replyToCheckbox.attr('id')] = (replyToFlag == '1');
-        //replyToCheckbox.click(function () {
-        //  var form = document.forms[_eaw.emailView];
-        //  if (!form) {
-        //    form = document.forms['editContactForm'];
-        //  }
-        //  var nav = new String(navigator.appVersion);
-        //
-        //  if (nav.match(/MSIE/gim)) {
-        //    for (i = 0; i < form.elements.length; i++) {
-        //      var id = new String(form.elements[i].id);
-        //      if (id.match(/emailAddressReplyToFlag/gim) && form.elements[i].type == 'radio' && id != _eaw.id) {
-        //        form.elements[i].checked = false;
-        //      }
-        //    }
-        //  }
-        //  for (i = 0; i < form.elements.length; i++) {
-        //    var id = new String(form.elements[i].id);
-        //    if (id.match(/emailAddressReplyToFlag/gim) && form.elements[i].type == 'radio' && id != _eaw.id) {
-        //      _eaw.replyToFlagObject[_eaw.id] = false;
-        //    }
-        //  } // for
-        //  if (_eaw.replyToFlagObject[this.id]) {
-        //    _eaw.replyToFlagObject[this.id] = false;
-        //    this.checked = false;
-        //  } else {
-        //    _eaw.replyToFlagObject[this.id] = true;
-        //    this.checked = true;
-        //  } // else
-        //});
-      // }
-
 
       // Opt Out checkbox
       var optOutCheckbox = lineContainer.find('input#email-address-opt-out-flag');

--- a/jssource/src_files/include/SugarEmailAddress/SugarEmailAddress.js
+++ b/jssource/src_files/include/SugarEmailAddress/SugarEmailAddress.js
@@ -298,15 +298,34 @@
 
       // Reply to checkbox
       var replyToCheckbox = lineContainer.find('input#email-address-reply-to-flag');
-      if (replyToCheckbox.length == 1) {
-        replyToCheckbox.attr('name', this.module + _eaw.id + 'emailAddressReplyToFlag');
-        replyToCheckbox.attr('id', this.module + _eaw.id + 'emailAddressReplyToFlag' + _eaw.totalEmailAddresses);
-        replyToCheckbox.attr('value', this.module + _eaw.id + 'emailAddress' + _eaw.totalEmailAddresses);
-        replyToCheckbox.attr('tabindex', tabIndexCount);
-        replyToCheckbox.attr('enabled', "true");
-        replyToCheckbox.eaw = _eaw;
-        replyToCheckbox.prop("checked", (replyToFlag == '1'));
-        _eaw.replyToFlagObject[replyToCheckbox.attr('id')] = (replyToFlag == '1');
+      replyToCheckbox.attr('name', this.module + _eaw.id + 'emailAddressReplyToFlag');
+      replyToCheckbox.attr('id', this.module + _eaw.id + 'emailAddressReplyToFlag' + _eaw.totalEmailAddresses);
+      replyToCheckbox.attr('value', this.module + _eaw.id + 'emailAddress' + _eaw.totalEmailAddresses);
+      replyToCheckbox.attr('tabindex', tabIndexCount);
+      replyToCheckbox.attr('enabled', "true");
+      replyToCheckbox.attr("checked", (replyToFlag == '1'));
+
+      if (_eaw.totalEmailAddresses == 0 && replyToFlag != '1') {
+        replyToCheckbox.prop("checked", true);
+      }
+
+
+      // Prevent users from removing their primary email address
+      if (this.module == 'Users' &&  replyToCheckbox.attr("checked")) {
+        removeButton.prop('disabled', true);
+      }
+
+      // Reply to checkbox
+      // var replyToCheckbox = lineContainer.find('input#email-address-reply-to-flag');
+      // if (replyToCheckbox.length == 1) {
+        // replyToCheckbox.attr('name', this.module + _eaw.id + 'emailAddressReplyToFlag');
+        // replyToCheckbox.attr('id', this.module + _eaw.id + 'emailAddressReplyToFlag' + _eaw.totalEmailAddresses);
+        // replyToCheckbox.attr('value', this.module + _eaw.id + 'emailAddress' + _eaw.totalEmailAddresses);
+        // replyToCheckbox.attr('tabindex', tabIndexCount);
+        // replyToCheckbox.attr('enabled', "true");
+        // replyToCheckbox.eaw = _eaw;
+        // replyToCheckbox.prop("checked", (replyToFlag == '1'));
+        // _eaw.replyToFlagObject[replyToCheckbox.attr('id')] = (replyToFlag == '1');
         //replyToCheckbox.click(function () {
         //  var form = document.forms[_eaw.emailView];
         //  if (!form) {
@@ -336,7 +355,7 @@
         //    this.checked = true;
         //  } // else
         //});
-      }
+      // }
 
 
       // Opt Out checkbox


### PR DESCRIPTION
## Description
Fix for Issue #3202 - When selecting the reply all check inside of the Profile tab and pressing save, the checkbox wasn't being saved as checked. This also applied for any record that could had the checkbox checked, but then the user wanted to uncheck the box.

Inclusion of double quote in line 302, appending the name attribute, was breaking the record to not actually handle the form submission properly (due to the association key being wrong, most likely due to the double quote ending the attribute (escaping the attribute, entirely) early) and append or update the record to the system as the result selected by the user.

## Motivation and Context
Issue raised by community member. Broken functionality that should be corrected.

## How To Test This
* Login to SuiteCRM
* Select Profile from the top-right dropdown
* Scroll to the bottom of the profile page.
* Switch the radio (or apply to the radios) for the reply to e-mail.
* Save the changes to the profile
* Go back to the profile to see if the e-mail has been set as the reply e-mail.
* Check the database tables to see if the flag has been set.

Table Structure for checking:

The email_addresses table where email_address is a match to the e-mail you're trying to set
taking it's id from the id column and then using the id to search against the email_addr_bean_rel where email_address_id is a match to the id you took from email_addresses

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.