### PR TITLE
Optimistic Locking not working in some cases

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -3863,7 +3863,7 @@ class SugarBean
 
         global $module, $action;
         //Just to get optimistic locking working for this release
-        if ($this->optimistic_lock && $module == $this->module_dir && $action == 'EditView' && $id == $_REQUEST['record']) {
+        if ($this->optimistic_lock && $module == $this->module_dir && $action == 'EditView' && isset($_REQUEST["record"]) && $id == $_REQUEST['record']) {
             $_SESSION['o_lock_id'] = $id;
             $_SESSION['o_lock_dm'] = $this->date_modified;
             $_SESSION['o_lock_on'] = $this->object_name;

--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -3863,7 +3863,7 @@ class SugarBean
 
         global $module, $action;
         //Just to get optimistic locking working for this release
-        if ($this->optimistic_lock && $module == $this->module_dir && $action == 'EditView') {
+        if ($this->optimistic_lock && $module == $this->module_dir && $action == 'EditView' && $id == $_REQUEST['record']) {
             $_SESSION['o_lock_id'] = $id;
             $_SESSION['o_lock_dm'] = $this->date_modified;
             $_SESSION['o_lock_on'] = $this->object_name;


### PR DESCRIPTION
In some cases sugar retrieves more object of the edited type. This leads to that the optimistic locking id is not the one thats in the edit view, but some other (maybe from relation).
So if someone saves the same record in a different session, the one that saves later simply overwrites the first changes, and does not show the dialog for conflicting saves.
This change makes sure the id from the request is stored in the session, not the id from the last fetched record that maybe from a related bean.

## Motivation and Context
On conflicting saves under specific circumstances the conflict dialog is not shown.

## How To Test This
Not quite sure about the exact requirements for this bug. I assume it is some custom relationships, that relate to the same module, or to an other module and then to the same module again.

Expected:
When saving a record and someone else changed the record within the same time a dialog about that conflicting change should show.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.
