### PR TITLE
Add parameter required for Google Maps Geocoding API.

### DIFF
--- a/modules/Campaigns/SubPanelViewer.php
+++ b/modules/Campaigns/SubPanelViewer.php
@@ -87,7 +87,7 @@ if(!empty($_REQUEST['layout_def_key'])){
 
 $subpanel_object = new SubPanel($module, $record, $subpanel,null, $layout_def_key);
 
-$subpanel_object->setTemplateFile('include/SubPanel/SubPanelDynamic.html');
+$subpanel_object->setTemplateFile('include/SubPanel/tpls/SubPanelDynamic.tpl');
 
 if(!empty($_REQUEST['mkt_id']) && $_REQUEST['mkt_id'] != 'all') {// bug 32910
     $mkt_id = $_REQUEST['mkt_id'];

--- a/modules/jjwg_Maps/jjwg_Maps.php
+++ b/modules/jjwg_Maps/jjwg_Maps.php
@@ -853,6 +853,7 @@ class jjwg_Maps extends jjwg_Maps_sugar {
         if (!empty($this->settings['geocoding_api_secret'])) {
             $hash = md5($address.$this->settings['geocoding_api_secret']);
             $request_url .= '&hash='.urlencode($hash);
+            $request_url .= '&key='.urlencode($this->settings['geocoding_api_secret']); // Geocoding API requires 'key='.
         }
 
         $GLOBALS['log']->info(__METHOD__.' cURL Request URL: '.$request_url);

--- a/modules/jjwg_Maps/jjwg_Maps.php
+++ b/modules/jjwg_Maps/jjwg_Maps.php
@@ -849,10 +849,8 @@ class jjwg_Maps extends jjwg_Maps_sugar {
         if (!(strpos($base_url, '?') > 0)) $base_url .= '?';
         // Add Address Parameter
         $request_url = $base_url . "&address=" . urlencode($address);
-        // Add Hash Parameter as MD5 of Concatenation of Address and Secret
+        // Add key parameter (Google Maps Geocoding API key)
         if (!empty($this->settings['geocoding_api_secret'])) {
-            //$hash = md5($address.$this->settings['geocoding_api_secret']); //OLD GOOGLE MAPS V3 API
-            //$request_url .= '&hash='.urlencode($hash);    //OLD GOOGLE MAPS V3 API
             $request_url .= '&key='.urlencode($this->settings['geocoding_api_secret']); // Geocoding API requires 'key='.
         }
 

--- a/modules/jjwg_Maps/jjwg_Maps.php
+++ b/modules/jjwg_Maps/jjwg_Maps.php
@@ -851,8 +851,8 @@ class jjwg_Maps extends jjwg_Maps_sugar {
         $request_url = $base_url . "&address=" . urlencode($address);
         // Add Hash Parameter as MD5 of Concatenation of Address and Secret
         if (!empty($this->settings['geocoding_api_secret'])) {
-            $hash = md5($address.$this->settings['geocoding_api_secret']);
-            $request_url .= '&hash='.urlencode($hash);
+            //$hash = md5($address.$this->settings['geocoding_api_secret']); //OLD GOOGLE MAPS V3 API
+            //$request_url .= '&hash='.urlencode($hash);    //OLD GOOGLE MAPS V3 API
             $request_url .= '&key='.urlencode($this->settings['geocoding_api_secret']); // Geocoding API requires 'key='.
         }
 

--- a/modules/jjwg_Maps/language/en_us.lang.php
+++ b/modules/jjwg_Maps/language/en_us.lang.php
@@ -143,6 +143,7 @@ $mod_strings['LBL_CONFIG_GEOCODING_API_URL_TITLE'] = 'Geocoding API URL:';
 $mod_strings['LBL_CONFIG_GEOCODING_API_URL_DESC'] = 'The URL of the Google Maps API V3 or Proxy';
 $mod_strings['LBL_CONFIG_GEOCODING_API_SECRET_TITLE'] = 'Secret Phrase for Proxy:';
 $mod_strings['LBL_CONFIG_GEOCODING_API_SECRET_DESC'] = 'The Secret Phrase to be used with the Proxy MD5 comparison.';
+$mod_strings['LBL_CONFIG_GEOCODING_API_SECRET_GET_A_KEY'] = 'Get a free Google Maps Geocoding API key (to geocode 2500 addresses per day for free).';
 $mod_strings['LBL_CONFIG_GEOCODING_LIMIT_TITLE'] = 'Geocoding Limit:';
 $mod_strings['LBL_CONFIG_GEOCODING_LIMIT_DESC'] = "'geocoding_limit' sets the query limit when selecting records to geocode.";
 $mod_strings['LBL_CONFIG_GOOGLE_GEOCODING_LIMIT_TITLE'] = 'Google Geocoding Limit:';

--- a/modules/jjwg_Maps/language/en_us.lang.php
+++ b/modules/jjwg_Maps/language/en_us.lang.php
@@ -140,10 +140,10 @@ $mod_strings['LBL_CONFIG_GROUP_FIELD_FOR_PROSPECTS'] = 'Group Field for  Prospec
 
 $mod_strings['LBL_CONFIG_GEOCODING_SETTINGS_TITLE'] = 'Geocoding/Google Settings:';
 $mod_strings['LBL_CONFIG_GEOCODING_API_URL_TITLE'] = 'Geocoding API URL:';
-$mod_strings['LBL_CONFIG_GEOCODING_API_URL_DESC'] = 'The URL of the Google Maps API V3 or Proxy';
+$mod_strings['LBL_CONFIG_GEOCODING_API_URL_DESC'] = 'The URL of the Google Maps Geocoding API or Proxy';
 $mod_strings['LBL_CONFIG_GEOCODING_API_SECRET_TITLE'] = 'Secret Phrase for Proxy:';
 $mod_strings['LBL_CONFIG_GEOCODING_API_SECRET_DESC'] = 'The Secret Phrase to be used with the Proxy MD5 comparison.';
-$mod_strings['LBL_CONFIG_GEOCODING_API_SECRET_GET_A_KEY'] = 'Get a free Google Maps Geocoding API key (to geocode 2500 addresses per day for free).';
+$mod_strings['LBL_CONFIG_GEOCODING_API_SECRET_GET_A_KEY'] = 'Get a free Google Maps Geocoding API key (to geocode a generous quota of addresses per day for free).';
 $mod_strings['LBL_CONFIG_GEOCODING_LIMIT_TITLE'] = 'Geocoding Limit:';
 $mod_strings['LBL_CONFIG_GEOCODING_LIMIT_DESC'] = "'geocoding_limit' sets the query limit when selecting records to geocode.";
 $mod_strings['LBL_CONFIG_GOOGLE_GEOCODING_LIMIT_TITLE'] = 'Google Geocoding Limit:';

--- a/modules/jjwg_Maps/views/view.config.php
+++ b/modules/jjwg_Maps/views/view.config.php
@@ -423,14 +423,14 @@ class Jjwg_MapsViewConfig extends SugarView {
             title='' tabindex='140' size="25" maxlength="255">
             &nbsp; <?php echo $GLOBALS['mod_strings']['LBL_CONFIG_DEFAULT']; ?>
                 <?php echo htmlspecialchars($GLOBALS['jjwg_config_defaults']['geocoding_api_secret']) ?>
-            <br/>
-            <a href='https://developers.google.com/maps/documentation/geocoding/get-api-key' target='_blank'>
-                Get a free G Maps Geocoding API key.
-            </a>
         </td>
     </tr>
     <tr>
-        <td colspan="2"><?php echo $GLOBALS['mod_strings']['LBL_CONFIG_GEOCODING_API_SECRET_DESC']; ?></td>
+        <td><?php echo $GLOBALS['mod_strings']['LBL_CONFIG_GEOCODING_API_SECRET_DESC']; ?></td>
+        <td><a href='https://developers.google.com/maps/documentation/geocoding/get-api-key' target='_blank'>
+            <?php echo $GLOBALS['mod_strings']['LBL_CONFIG_GEOCODING_API_SECRET_GET_A_KEY']; ?>
+            </a>
+        </td>
     </tr>
     <tr>
         <td><strong><?php echo $GLOBALS['mod_strings']['LBL_CONFIG_GEOCODING_LIMIT_TITLE']; ?> </strong></td>

--- a/modules/jjwg_Maps/views/view.config.php
+++ b/modules/jjwg_Maps/views/view.config.php
@@ -423,6 +423,10 @@ class Jjwg_MapsViewConfig extends SugarView {
             title='' tabindex='140' size="25" maxlength="255">
             &nbsp; <?php echo $GLOBALS['mod_strings']['LBL_CONFIG_DEFAULT']; ?>
                 <?php echo htmlspecialchars($GLOBALS['jjwg_config_defaults']['geocoding_api_secret']) ?>
+            <br/>
+            <a href='https://developers.google.com/maps/documentation/geocoding/get-api-key' target='_blank'>
+                Get a free G Maps Geocoding API key.
+            </a>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The JJW Design Google Maps was using the old Google Maps v3 "hash" parameter.
The API has changed to Google Maps Geocoding API and requires a "key" parameter instead.

NOTE the Geocoding API is used by the server through cron jobs to periodically obtain geographic coordinates (latitude, longitude) of physical street addresses, for the purposes of later displaying pins on the geographical maps in the SutieCRM user's web browser.  

Google Maps Geocoding API is different from the Google Maps Javascript API which is used to DISPLAY the geographical maps on the SuiteCRM user's web browser.  

Two separate keys, for two separate uses, and two separate daily quotas for free usage.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Add "key" parameter to URL, corresponding to the "secret" field on the Google Maps module's config page.
Add a convenient URL on the Google Maps module's config page to make it easy for user to get a free Google Maps Geocoding API key.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The Google Maps module's usage of Geocoding API has been failing on new IP addresses (new servers) since June 2016.
The parameters have changed.  Old parameter = "hash" = md5 hash of address concatenated with Goole Maps v3 API key.  New parameter = "key" = plaintext Google Maps Geocoding API key.
More details:
https://developers.google.com/maps/documentation/geocoding/get-api-key#specify-a-key-in-your-request

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Install SuiteCRM on a new IP address which has never before used SuiteCRM's JJWG_maps module to Geocode addresses.
2. Try to geocode addresses.  It should fail.
3. Get an API key by going to Admin, Google Maps Config, Get a free API key, Create project, get Geocoding API key, copy/paste it into the SuiteCRM Google Maps Config page.
4. Try to geocode addresses.  It should succeed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->