### PR TITLE
Fix 3275 - Remove extra delimiter at the end of the exported line

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -968,9 +968,11 @@ class AOR_Report extends Basic
             }
             ++$i;
         }
-        //remove last delimiter of the line
-        if($field->display)
-            $csv = substr($csv,0,strlen($csv)-strlen($delimiter));
+
+        // Remove last delimiter of the line
+        if ($field->display) {
+            $csv = substr($csv, 0, strlen($csv) - strlen($delimiter));
+        }
             
         $sql = $this->build_report_query();
         $result = $this->db->query($sql);
@@ -989,8 +991,8 @@ class AOR_Report extends Basic
                     $csv .= $delimiter;
                 }
             }
-            //remove last delimiter of the line
-            $csv = substr($csv,0,strlen($csv)-strlen($delimiter));
+            // Remove last delimiter of the line
+            $csv = substr($csv, 0, strlen($csv) - strlen($delimiter));
         }
 
         $csv = $GLOBALS['locale']->translateCharset($csv, 'UTF-8', $GLOBALS['locale']->getExportCharset());

--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -992,8 +992,6 @@ class AOR_Report extends Basic
             //remove last delimiter of the line
             $csv = substr($csv,0,strlen($csv)-strlen($delimiter));
         }
-        
-        ;
 
         $csv = $GLOBALS['locale']->translateCharset($csv, 'UTF-8', $GLOBALS['locale']->getExportCharset());
 

--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -968,7 +968,10 @@ class AOR_Report extends Basic
             }
             ++$i;
         }
-
+        //remove last delimiter of the line
+        if($field->display)
+            $csv = substr($csv,0,strlen($csv)-strlen($delimiter));
+            
         $sql = $this->build_report_query();
         $result = $this->db->query($sql);
 
@@ -986,7 +989,11 @@ class AOR_Report extends Basic
                     $csv .= $delimiter;
                 }
             }
+            //remove last delimiter of the line
+            $csv = substr($csv,0,strlen($csv)-strlen($delimiter));
         }
+        
+        ;
 
         $csv = $GLOBALS['locale']->translateCharset($csv, 'UTF-8', $GLOBALS['locale']->getExportCharset());
 


### PR DESCRIPTION
## Description
Fix the issue https://github.com/salesagility/SuiteCRM/issues/3275 

## Motivation and Context
At the end of each csv export there is an extra delimiter. For example you have
Field1,Field2,Field3,
Instead of 
Field1,Field2,Field3

## How To Test This
- export any report into CSV

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->