### PR TITLE
Spots needs UNION ALL when selecting data #3304

### DIFF
--- a/modules/Spots/controller.php
+++ b/modules/Spots/controller.php
@@ -565,7 +565,7 @@ EOF;
 EOF;
 
         $mysqlQueryMeetings = <<<EOF
-        UNION
+        UNION ALL
         SELECT
             'meeting' as type
             , meetings.name
@@ -579,7 +579,7 @@ EOF;
 EOF;
 
         $mysqlQueryTasks = <<<EOF
-        UNION
+        UNION ALL
         SELECT
             'task' as type
             , tasks.name
@@ -605,7 +605,7 @@ EOF;
         WHERE calls.deleted = 0
 EOF;
         $mssqlQueryMeetings = <<<EOF
-        UNION
+        UNION ALL
         SELECT
             'meeting' as type
             , meetings.name
@@ -618,7 +618,7 @@ EOF;
         WHERE meetings.deleted = 0
 EOF;
         $mssqlQueryTasks = <<<EOF
-        UNION
+        UNION ALL
         SELECT
             'task' as type
             , tasks.name


### PR DESCRIPTION
This works for MySql and I have also changed the SQL for MSSQL but not able to test it.

<!--- Provide a general summary of your changes in the Title above -->
Change SQL to use UNION ALL when selecting data.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Spots pivot table only shows unique values and the counts are all 1. The pivot table needs the 'duplicates' for the counts to be correct.
## How To Test This
<!--- Please describe in detail how to test your changes. -->
Create pivot table on Activities with many calls in various states. Notice that the count correctly reflects the number of calls in the various states.

MSSQL version not tested but MSSQL syntax seems to require the same UNION ALL.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->