### PR TITLE
Conform to spec. Support for java REST API clients

### DIFF
--- a/service/core/REST/SugarRestJSON.php
+++ b/service/core/REST/SugarRestJSON.php
@@ -117,7 +117,7 @@ class SugarRestJSON extends SugarRest{
 		foreach ($params as $param) {
 			$name = $param->getName();
 			if (!isset($data[$name])) {
-				$result[$name] = "";
+				$result[$name] = $param->getDefaultValue();
 			} else {
 				$result[$name] = $data[$name];
 			}


### PR DESCRIPTION
The REST API spec accepts JSON parameters, which the JSON standard specifies may arrive in any order.  SugarCRM 6.5.x REST API has a bug, it fails when parameters arrive in anything other than one predetermined order, which violates the JSON specification.  This PR fixes that bug.
See https://github.com/sugarcrm/sugarcrm_dev/pull/255

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
A function is added to handle any order of incoming parameters to the REST API.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To properly support the REST JSON specification, which allows for any order for the parameters.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Use a java REST client app, login, and try to read/save data with SuiteCRM before and after this PR is applied.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->