### PR TITLE
Fix #3238 - Hide save and continue button on contacts subpanel

### DIFF
--- a/include/EditView/SubpanelQuickCreate.php
+++ b/include/EditView/SubpanelQuickCreate.php
@@ -85,6 +85,7 @@ class SubpanelQuickCreate{
 
         $this->ev = $this->getEditView();
 		$this->ev->view = $this->viewType;
+		$this->ev->showVCRControl = false;
 		$this->ev->ss = new Sugar_Smarty();
 		//$_REQUEST['return_action'] = 'SubPanelViewer';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Original PR ( #3284 ) was compared off of a community member's branch - instead of opening a PR against his branch to then add to the open PR and also removing the view change, this PR will be for any further adjustments.

-- Original Description --
A fix provided by @imtg-suitecrm in relation to Issue #3238 - Sub panel when you are in quick create shows Save and Continue button at the bottom when it should not as this functionality does nothing currently.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
UI indicates functionality that does not belong/does not work, removing this from the view would enhance user experience and not frustrate users when it does not work as they think it would.

## How To Test This
* Open Contacts module
* Go into the Edit View on a contact
* Scroll down to the sub panel
* Create a new record
* Save and Continue button is removed from the bottom section of the subpanel

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.