### PR TITLE
Give Meeting different colors (patch-2), see github #3273 

### DIFF
--- a/modules/Calendar/CalendarDisplay.php
+++ b/modules/Calendar/CalendarDisplay.php
@@ -228,6 +228,22 @@ class CalendarDisplay {
 
 		}
 		foreach($activity as $key => $activityItem){
+			if(!empty($this->cal->activityList[ $key ])) {
+        			// this is IN the default activity list (i.e. DEFINED in CalendarDisplay.php)
+        			if(isset($GLOBALS['app_list_strings']['moduleList'][ $key ]) && !empty($GLOBALS['app_list_strings']['moduleList'][ $key ]) ){
+          				$activity[ $key ]['label'] = $GLOBALS['app_list_strings']['moduleList'][ $key ];
+        			}else{
+          				unset($activity[ $key ]);
+        			}
+      			} else {
+        			// this is NOT in the default activity list (i.e. NOT defined in CalendarDisplay.php)
+        			if( !isset($GLOBALS['sugar_config']['CalendarColors'][$key]['body']) || $GLOBALS['sugar_config']['CalendarColors'][$key]['body']==''){
+					// not defined in config_override.php, unset it
+          				unset($activity[ $key ]);
+        			} 
+				// the else is implied, if the extra color is defind in config_override.php it will NOT be unset.
+      			}
+
 			if(isset($GLOBALS['app_list_strings']['moduleList'][ $key ]) && !empty($GLOBALS['app_list_strings']['moduleList'][ $key ]) && !empty($this->cal->activityList[ $key ]) ){
 				$activity[ $key ]['label'] = $GLOBALS['app_list_strings']['moduleList'][ $key ];
 			}else{


### PR DESCRIPTION
The only customisation required for this to work is to add a few lines for each meeting status into the config_override.php.

Example here for the standard "Planned" meeting statius (light blue).
$sugar_config['CalendarColors']['Planned']['border']="555555";
$sugar_config['CalendarColors']['Planned']['body']  ="D8EFFF";
$sugar_config['CalendarColors']['Planned']['text']  ="000000";

If this is NOT defined, the standard colors as defined in CalendarDisplay.php (public $activity_colors = array(...) are used.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This is a pull request due to github #3273 
It allows Meeting to have different colow

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Makes the calendar less bland.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
- replace Cal.js (patch-1)
- replace CalendarDisplay.php (patch-2)
- add the changes to config_override.php as shwon above
- load SuiteCRM
- go to the calendar
- create a meeting with "planned"
- instead of being the standard wierd blue its light blue (can be any color)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ x] My change requires a change to the documentation.
- [x ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->