### PR TITLE
Fatal error: Uncaught Error: [] operator not supported in PHP 7.1.0

### DIFF
--- a/include/php-sql-parser.php
+++ b/include/php-sql-parser.php
@@ -923,7 +923,7 @@ EOREGEX
 							$base_expr=$subquery;
 						}
 
-/						if(substr(trim($table),0,1) == '(') {
+						if(substr(trim($table),0,1) == '(') {
 							$base_expr=$this->trimSubquery($table);
 							$join_type = 'JOIN';
 							$sub_tree = $this->process_from($this->split_sql($base_expr));

--- a/include/php-sql-parser.php
+++ b/include/php-sql-parser.php
@@ -588,6 +588,7 @@ EOREGEX
 		private function process_set_list($tokens) {
 			$column="";
 			$expression="";
+			$expr=array();
 			foreach($tokens as $token) {
 				$token=trim($token);
 				if(!$column) {
@@ -922,7 +923,7 @@ EOREGEX
 							$base_expr=$subquery;
 						}
 
-						if(substr(trim($table),0,1) == '(') {
+/						if(substr(trim($table),0,1) == '(') {
 							$base_expr=$this->trimSubquery($table);
 							$join_type = 'JOIN';
 							$sub_tree = $this->process_from($this->split_sql($base_expr));
@@ -982,7 +983,7 @@ EOREGEX
 			$direction="ASC";
 		        $type = "expression";
 			if(!$tokens) return false;
-
+	
 			foreach($tokens as $token) {
 				switch(strtoupper($token)) {
 					case ',':
@@ -1071,7 +1072,7 @@ EOREGEX
 	           processes these sections.  Recursive.
 		*/
 		private function process_expr_list($tokens) {
-			$expr = "";
+			$expr = array();
 			$type = "";
 			$prev_token = "";
 			$skip_next = false;


### PR DESCRIPTION
An uninitialized array will lead to the error of the subject line as PHP > 7.1 will assume it to be a string.
Adding 
  $expr = array();
will stop that error appearing!

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
The detail supplied above is enough,

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is one major part of to get the REST interface to work with PHP 7.1

## How To Test This
<!--- Please describe in detail how to test your changes. -->
You need to run a "get_entry_list" query, "login" and "get_server_info" will just work fine but as soon as you need to work with data the above problem will stop the interface to work!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->