### PR TITLE
Calendar - 1 Hour task consumes 2 Hours of space

### DIFF
--- a/modules/AOW_Actions/actions/actionCreateRecord.php
+++ b/modules/AOW_Actions/actions/actionCreateRecord.php
@@ -215,7 +215,7 @@ class actionCreateRecord extends actionBase {
                                 if($params['value'][$key][0] == 'now'){
                                     $date = gmdate($dformat);
                                 } else if($params['value'][$key][0] == 'field'){
-                                    $date = $record->fetched_row[$params['field'][$key]];
+                                    $date = $bean->$params['value'][$key][0];
                                 } else if ($params['value'][$key][0] == 'today') {
                                     $date = $params['value'][$key][0];
                                 } else {

--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -210,7 +210,13 @@ class AOW_WorkFlow extends Basic {
                 case 'custom':
                     $query['join'][$name] = 'LEFT JOIN '.$module->get_custom_table_name().' '.$name.' ON '.$module->table_name.'.id = '. $name.'.id_c ';
                     break;
-
+                ## START HACK FIBRECRM
+                case 'custom_relationship':
+                    $main_name = str_replace("_cstm", "", $name);
+                    $query['join'][$name] = 'LEFT JOIN '.$module->get_custom_table_name().' '.$name.' ON '.$main_name.'.id = '. $name.'.id_c ';
+                    echo $query['join'][$name];
+                    break;
+                ## END HACK FIBRECRM
                 case 'relationship':
                     if($module->load_relationship($name)){
                         $params['join_type'] = 'LEFT JOIN';
@@ -277,11 +283,17 @@ class AOW_WorkFlow extends Basic {
 
         $condition_module = $module;
         $table_alias = $condition_module->table_name;
+        ## START HACK FIBRECRM
+        $oepl_rel = '';
+        ## END HACK FIBRECRM
         if(isset($path[0]) && $path[0] != $module->module_dir){
             foreach($path as $rel){
                 $query = $this->build_flow_query_join($rel, $condition_module, 'relationship', $query);
                 $condition_module = new $beanList[getRelatedModule($condition_module->module_dir,$rel)];
                 $table_alias = $rel;
+                ## START HACK FIBRECRM
+                $oepl_rel = $rel;
+                ## END HACK FIBRECRM
             }
         }
 
@@ -295,7 +307,13 @@ class AOW_WorkFlow extends Basic {
             }
             if(  (isset($data['source']) && $data['source'] == 'custom_fields')) {
                 $field = $table_alias.'_cstm.'.$condition->field;
-                $query = $this->build_flow_query_join($table_alias.'_cstm', $condition_module, 'custom', $query);
+                ## START HACK FIBRECRM
+                if(!empty($oepl_rel)){
+                    $query = $this->build_flow_query_join($table_alias.'_cstm', $condition_module, 'custom_relationship', $query);
+                }## END HACK FIBRECRM
+                else {
+                    $query = $this->build_flow_query_join($table_alias.'_cstm', $condition_module, 'custom', $query);
+                }
             } else {
                 $field = $table_alias.'.'.$condition->field;
             }

--- a/modules/Calendar/Calendar.php
+++ b/modules/Calendar/Calendar.php
@@ -303,6 +303,25 @@ class Calendar {
 					}else{
 						$item = array_merge($item,CalendarUtils::get_time_data($act->sugar_bean));
 					}
+                    
+                    ## START #DEV-224 HACK for Task Durations
+                    if($act->sugar_bean->module_dir == 'Tasks')
+                    {
+                        #$tmp_date_start
+                        $tmp_date_start = $GLOBALS['timedate']->to_db($act->sugar_bean->date_start);
+                        $tmp_date_due = $GLOBALS['timedate']->to_db($act->sugar_bean->date_due);
+                        
+                        $diff = abs( strtotime( $tmp_date_due ) - strtotime( $tmp_date_start ) );
+
+                        $Days = intval( $diff / 86400 );
+                        $Hours = intval( ( $diff % 86400 ) / 3600) + $Days * 24;
+                        $Mins = intval( ( $diff / 60 ) % 60 );
+                        $Seconds = intval( $diff % 60 );
+                        
+                        $item['duration_hours'] = $Hours;
+                        $item['duration_minutes'] = $Mins;
+                    }
+                    ## END #DEV-224 HACK for Task Durations
 
 
 				$shared_calendar_separate = $GLOBALS['current_user']->getPreference('calendar_display_shared_separate');

--- a/modules/Calendar/CalendarUtils.php
+++ b/modules/Calendar/CalendarUtils.php
@@ -90,7 +90,8 @@ class CalendarUtils {
 				'parent_id',
 				'parent_type',
 				'priority',
-				'date_due'
+				'date_start' ## START #DEV-224 HACK for Task Durations
+				/*'date_due'*/
 			),
 		);
 	}
@@ -103,8 +104,12 @@ class CalendarUtils {
 	static function get_time_data(SugarBean $bean, $start_field = "date_start", $end_field = "date_end"){
 					$arr = array();
 
-					if($bean->object_name == 'Task')
-						$start_field = $end_field = "date_due";
+                    ## START #DEV-224 HACK for Task Durations
+					if($bean->object_name == 'Task'){
+                        $start_field = "date_start"; $end_field = "date_due";
+                        #$start_field = $end_field = "date_due";
+                    }
+                    ## END #DEV-224 HACK for Task Durations
 					if(empty($bean->$start_field))
 						return array();
 					if(empty($bean->$end_field))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When generating a one hour task in the system, in the calendar the task placeholder consumes 2 hours of space instead of 1 hour. So other users would assume the task is for 2 hours when it should only be 1.

## Motivation and Context
Expected Behavior

1 Hour task should only consume the proportionate space on the calendar

Actual Behavior

Consumes 2 hours of space in the calendar

## How To Test This
1. Create a new task with a start date/time of today at 12:00 and an end date/time of today at 13:00
2. Navigate to the calendar module and look at the week view.
3. The task placeholder consumes the space from 12:00 to 14:00

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->