### PR TITLE
Fixed #3295 - SugarEmailAddress->addAddress does not set other addresses to non-primary if $primary parameter is true 

### DIFF
--- a/include/SugarEmailAddress/SugarEmailAddress.php
+++ b/include/SugarEmailAddress/SugarEmailAddress.php
@@ -587,7 +587,7 @@ class SugarEmailAddress extends SugarBean {
                 } elseif ($primary && $address['primary_address'] == '1') {
                     // We should only have one primary. If we are adding a primary but
                     // we find an existing primary, reset this one's primary flag.
-                    $address['primary_address'] = '0';
+                    $this->addresses[$k]['primary_address'] = '0';
                 }
             }
 


### PR DESCRIPTION
## Description
Implements the change proposed in #3295

## Motivation and Context
SugarEmailAddress->addresses will only have the last added primary address marked as such, all previous address will have primary_address set to 0, as the code's original intention was.

## How To Test This
Add several primary email addresses to a bean via $bean->emailAddress->addAddress
Check if only the last added address is marked as primary, either in the address array, or in the email_addr_bean_rel table after $bean->save

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.