### PR TITLE
Email Composer Size Improvement

### DIFF
--- a/include/javascript/tiny_mce/themes/advanced/skins/default/content.css
+++ b/include/javascript/tiny_mce/themes/advanced/skins/default/content.css
@@ -1,4 +1,4 @@
-body, td, pre {color:#000; font-family:Verdana, Arial, Helvetica, sans-serif; font-size:10px; margin:8px;}
+body, td, pre {color:#000; font-family:Verdana, Arial, Helvetica, sans-serif; font-size:15px; letter-spacing: 2px; line-height: 1.5; margin:8px;}
 body {background:#FFF;}
 body.mceForceColors {background:#FFF; color:#000;}
 body.mceBrowserDefaults {background:transparent; color:inherit; font-size:inherit; font-family:inherit;}

--- a/jssource/src_files/include/javascript/quickCompose.js
+++ b/jssource/src_files/include/javascript/quickCompose.js
@@ -105,7 +105,7 @@ SUGAR.quickCompose = function() {
     		var panel_modal = dce_mode ? false : true,
     		    panel_width = '880px',
 			    panel_constrain = dce_mode ? false : true,
-    		    panel_height = dce_mode ? 'auto' : '400px',
+    		    panel_height = dce_mode ? 'auto' : '600px',
     		    panel_shadow = dce_mode ? false : true,
     		    panel_draggable = dce_mode ? false : true,
     		    panel_resize = dce_mode ? false : true,
@@ -136,7 +136,7 @@ SUGAR.quickCompose = function() {
                     handles: ['br'],
                     autoRatio: false,
                     minWidth: 400,
-                    minHeight: 350,
+                    minHeight: 550,
                     status: false
                 });
 
@@ -150,7 +150,7 @@ SUGAR.quickCompose = function() {
                 }, SQ.parentPanel, true);
 			} else {
                 SUGAR.util.doWhen("typeof SE.composeLayout[SE.composeLayout.currentInstanceId] != 'undefined'", function(){
-                    var panelHeight = 400;
+                    var panelHeight = 600;
                     SQ.parentPanel.cfg.setProperty("height", panelHeight + "px");
                     var layout = SE.composeLayout[SE.composeLayout.currentInstanceId];
                     layout.set("height", panelHeight);

--- a/modules/Emails/javascript/EmailUICompose.js
+++ b/modules/Emails/javascript/EmailUICompose.js
@@ -892,7 +892,7 @@ SE.composeLayout = {
 
     	 	YAHOO.util.Event.onAvailable('htmleditordiv' + idx, function() {
     	 		SE.composeLayout._createComposeLayout(idx);
-    	 		SE.composeLayout[idx].set('height', 350);
+    	 		SE.composeLayout[idx].set('height', 550);
 	        	SE.composeLayout[idx].render();
            });
         });
@@ -960,7 +960,7 @@ SE.composeLayout = {
         	parent: SE.complexLayout,
         	border:true,
             hideOnLayout: true,
-            height: 400,
+            height: 600,
 			units: [{
 					position: "center",
 	                animate: false,
@@ -1072,7 +1072,7 @@ SE.composeLayout = {
 		if (!SE.composeLayout.isParentTypeValid(idx)) {
 			return;
 		} // if
-		open_popup(document.getElementById('data_parent_type' + idx).value,600,400,'&tree=ProductsProd',true,false,
+		open_popup(document.getElementById('data_parent_type' + idx).value,600,600,'&tree=ProductsProd',true,false,
 		{
 			call_back_function:"SE.composeLayout.popupAddEmail",
 			form_name:formName,

--- a/modules/Emails/templates/dceMenuQuickCreate.tpl
+++ b/modules/Emails/templates/dceMenuQuickCreate.tpl
@@ -38,7 +38,7 @@
  ********************************************************************************/
 
 *}
-<div id="dccontent" style="width:880px; height:400px; z-index:2;"></div>
+<div id="dccontent" style="width:880px; height:600px; z-index:2;"></div>
 <script type='text/javascript'>
 {literal}
 function closeEmailOverlay() {


### PR DESCRIPTION
I changed some style settings in the email composer that make using it a little easier. 

## Description
1) I increased the font size in the editor since the default was very small. 
2) I increased the quick compose window height since by default it didn't even show the email content without resizing the window.

## Motivation and Context
I have been getting constant complaints about both issues.

## How To Test This
Click compose email in the action tab with a lead, contact or account. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->