### PR TITLE
Fixed #3038 - yui.css missing

### DIFF
--- a/include/SugarTheme/SugarTheme.php
+++ b/include/SugarTheme/SugarTheme.php
@@ -601,7 +601,6 @@ class SugarTheme
         $html = '
             <!-- qtip & suggestion box -->
             <link rel="stylesheet" type="text/css" href="include/javascript/qtip/jquery.qtip.min.css" />';
-        $html .= '<link rel="stylesheet" type="text/css" href="'.$this->getCSSURL('yui.css').'" />';
         $html .= '<link rel="stylesheet" type="text/css" href="include/javascript/jquery/themes/base/jquery.ui.all.css" />';
         $html .= '<link rel="stylesheet" type="text/css" href="'.$this->getCSSURL('deprecated.css').'" />';
         $html .= '<link rel="stylesheet" type="text/css" href="'.$this->getCSSURL('style.css').'" />';

--- a/include/javascript/yui/index.html
+++ b/include/javascript/yui/index.html
@@ -5,7 +5,6 @@
     
 
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
-    	<link rel="stylesheet" type="text/css" href="assets/yui.css" >
 
 <style>
 /*Supplemental CSS for the YUI distribution*/

--- a/modules/UpgradeWizard/uw_main.tpl
+++ b/modules/UpgradeWizard/uw_main.tpl
@@ -75,7 +75,6 @@
     <link rel='stylesheet' type='text/css' href="{sugar_getjspath file='include/javascript/yui/assets/container.css'}" />
         {if $step == 'commit'}
     <link rel='stylesheet' type='text/css' href="{sugar_getjspath file='include/javascript/yui/build/container/assets/container.css'}"/>
-    <link rel='stylesheet' type='text/css' href="{sugar_getjspath file='themes/default/css/yui.css'}"/>
        {/if}
     {/if}
 		{if $showBack}
@@ -181,7 +180,6 @@
     <link rel='stylesheet' type='text/css' href='include/javascript/yui/assets/container.css' />
         {if $step == 'commit'}
     <link rel='stylesheet' type='text/css' href='include/javascript/yui/build/container/assets/container.css'/>
-    <link rel='stylesheet' type='text/css' href='themes/default/css/yui.css'/>
        {/if}
     {/if}
 		{if $showBack}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When logging is set to warn, a yui.css cannot be found warning appears. As yui.css in default/themes/css is not needed I have removed all the references to it so the warning will no longer appear.

Issue reference: #3038

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Activate log on Warn level
2. [WARN] CSS File yui.css not found

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->