### PR TITLE
Fix #3404 local reference in include in WizardMarketing.php

### DIFF
--- a/modules/Campaigns/WizardMarketing.php
+++ b/modules/Campaigns/WizardMarketing.php
@@ -521,7 +521,7 @@ else {
     $steps[$mod_strings['LBL_NAVIGATION_MENU_SUMMARY']] = $summaryURLForProgressBar;
 }
 
-include_once('DotListWizardMenu.php');
+include_once('modules/Campaigns/DotListWizardMenu.php');
 $dotListWizardMenu = new DotListWizardMenu($mod_strings, $steps, true);
 //    array(
 //        $mod_strings['LBL_NAVIGATION_MENU_GEN1'] => $camp_url.'1',


### PR DESCRIPTION
Fixes an error I found while customizing the code, #3404 

Without the full path, the reference works because PHP ends up picking up the file from the local directory. However, if you move this `WizardMarketing.php` to `custom` to customize it, the reference will break.


## How To Test This
Just use the Marketing Wizard to see if it works.
Then copy `WizardMarketing.php` into the custom dir and use the Wizard again.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ X ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ X ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

