### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The Contributor Agreement only needs to be signed once for all pull requests and
 
 Once signed and confirmed, any pull requests will be considered for inclusion in the SuiteCRM project.
 
-### Helpful links for the community###
+### Helpful links for the community ###
 
 The following links offer various ways to view, contribute and collaborate to the SuiteCRM project:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##SuiteCRM 7.8.3
+## SuiteCRM 7.8.3
 
 [![Build Status](https://travis-ci.org/salesagility/SuiteCRM.svg?branch=master)](https://travis-ci.org/salesagility/SuiteCRM)
 
@@ -11,7 +11,7 @@ This repository has been created to allow community members to collaborate and c
 
 ### Contributing to the project ###
 
-#####Important: Please read before developing code intended for inclusion in the SuiteCRM project.#####
+##### Important: Please read before developing code intended for inclusion in the SuiteCRM project. #####
 
 Please read and sign the following [contributor agreement][cont_agrmt]
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
