### PR TITLE
Fixed #3374 – Apply Status to Case Updates

### DIFF
--- a/modules/AOP_Case_Updates/CaseUpdatesHook.php
+++ b/modules/AOP_Case_Updates/CaseUpdatesHook.php
@@ -296,7 +296,7 @@ class CaseUpdatesHook
             return;
         }
         $case = BeanFactory::getBean('Cases', $caseId);
-        if (!empty($case->id)) {
+        if (empty($case->id)) {
             return;
         }
         if (array_key_exists($case->status, $statusMap)) {


### PR DESCRIPTION
At AOP and Case flow.
In the area "Admin>AOP Setting > Case Status Changes" not running.