### PR TITLE
added parms to get_entry and get_entries

### DIFF
--- a/service/core/SugarWebServiceImpl.php
+++ b/service/core/SugarWebServiceImpl.php
@@ -62,7 +62,8 @@ class SugarWebServiceImpl{
 *	     'relationship_list' -- Array - The records link field data. The example is if asked about accounts email address then return data would look like Array ( [0] => Array ( [name] => email_addresses [records] => Array ( [0] => Array ( [0] => Array ( [name] => id [value] => 3fb16797-8d90-0a94-ac12-490b63a6be67 ) [1] => Array ( [name] => email_address [value] => hr.kid.qa@example.com ) [2] => Array ( [name] => opt_out [value] => 0 ) [3] => Array ( [name] => primary_address [value] => 1 ) ) [1] => Array ( [0] => Array ( [name] => id [value] => 403f8da1-214b-6a88-9cef-490b63d43566 ) [1] => Array ( [name] => email_address [value] => kid.hr@example.name ) [2] => Array ( [name] => opt_out [value] => 0 ) [3] => Array ( [name] => primary_address [value] => 0 ) ) ) ) )
 * @exception 'SoapFault' -- The SOAP error, if any
 */
-function get_entry($session, $module_name, $id,$select_fields, $link_name_to_fields_array){
+// added parameter to make it php7 compatible
+function get_entry($session, $module_name, $id,$select_fields, $link_name_to_fields_array, $php7_compatible_parameter){
 	$GLOBALS['log']->info('Begin: SugarWebServiceImpl->get_entry');
 	return self::get_entries($session, $module_name, array($id), $select_fields, $link_name_to_fields_array);
 	$GLOBALS['log']->info('end: SugarWebServiceImpl->get_entry');
@@ -81,7 +82,8 @@ function get_entry($session, $module_name, $id,$select_fields, $link_name_to_fie
 *	     'relationship_list' -- Array - The records link field data. The example is if asked about accounts email address then return data would look like Array ( [0] => Array ( [name] => email_addresses [records] => Array ( [0] => Array ( [0] => Array ( [name] => id [value] => 3fb16797-8d90-0a94-ac12-490b63a6be67 ) [1] => Array ( [name] => email_address [value] => hr.kid.qa@example.com ) [2] => Array ( [name] => opt_out [value] => 0 ) [3] => Array ( [name] => primary_address [value] => 1 ) ) [1] => Array ( [0] => Array ( [name] => id [value] => 403f8da1-214b-6a88-9cef-490b63d43566 ) [1] => Array ( [name] => email_address [value] => kid.hr@example.name ) [2] => Array ( [name] => opt_out [value] => 0 ) [3] => Array ( [name] => primary_address [value] => 0 ) ) ) ) )
 * @exception 'SoapFault' -- The SOAP error, if any
 */
-function get_entries($session, $module_name, $ids, $select_fields, $link_name_to_fields_array){
+// added parameter to make it compatible with php7.X
+function get_entries($session, $module_name, $ids, $select_fields, $link_name_to_fields_array, , $php7_compatible_parameter){
 	$GLOBALS['log']->info('Begin: SugarWebServiceImpl->get_entries');
 	global  $beanList, $beanFiles;
 	$error = new SoapError();


### PR DESCRIPTION
added parms to get_entry and get_entries to make it php7 compatible.
I am not sure this is the correct way to go but it is ONE way.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->