### PR TITLE
Fixed #3316 - Click tracker is truncating the urls after the 30th character

### DIFF
--- a/modules/CampaignTrackers/vardefs.php
+++ b/modules/CampaignTrackers/vardefs.php
@@ -1,11 +1,11 @@
 <?php
-if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
-/*********************************************************************************
+/**
+ *
  * SugarCRM Community Edition is a customer relationship management program developed by
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
-
- * SuiteCRM is an extension to SugarCRM Community Edition developed by Salesagility Ltd.
- * Copyright (C) 2011 - 2014 Salesagility Ltd.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2017 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the
@@ -36,125 +36,131 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
  * reasonably feasible for  technical reasons, the Appropriate Legal Notices must
  * display the words  "Powered by SugarCRM" and "Supercharged by SuiteCRM".
- ********************************************************************************/
+ */
 
-$dictionary['CampaignTracker'] = array('table' => 'campaign_trkrs',
-	'comment' => 'Maintains the Tracker URLs used in campaign emails',
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
 
-'fields' => array (
-    'id' => array (
-        'name' => 'id',
-        'vname' => 'LBL_ID',
-        'type' => 'id',
-        'required'=>true,
-        'reportable'=>false,
-        'comment' => 'Unique identifier'
+$dictionary['CampaignTracker'] = array(
+    'table' => 'campaign_trkrs',
+    'comment' => 'Maintains the Tracker URLs used in campaign emails',
+
+    'fields' => array(
+        'id' => array(
+            'name' => 'id',
+            'vname' => 'LBL_ID',
+            'type' => 'id',
+            'required' => true,
+            'reportable' => false,
+            'comment' => 'Unique identifier'
+        ),
+        'tracker_name' => array(
+            'name' => 'tracker_name',
+            'vname' => 'LBL_TRACKER_NAME',
+            'type' => 'varchar',
+            'len' => '255',
+            'comment' => 'The name of the campaign tracker'
+        ),
+        'tracker_url' => array(
+            'name' => 'tracker_url',
+            'vname' => 'LBL_TRACKER_URL',
+            'type' => 'varchar',
+            'len' => '255',
+            'default' => 'http://',
+            'comment' => 'The URL that represents the landing page when the tracker URL in the campaign email is clicked'
+        ),
+        'tracker_key' => array(
+            'name' => 'tracker_key',
+            'vname' => 'LBL_TRACKER_KEY',
+            'type' => 'int',
+            'len' => '11',
+            'auto_increment' => true,
+            'required' => true,
+            'studio' => array('editview' => false),
+            'comment' => 'Internal key to uniquely identifier the tracker URL'
+        ),
+        'campaign_id' => array(
+            'name' => 'campaign_id',
+            'vname' => 'LBL_CAMPAIGN_ID',
+            'type' => 'id',
+            'required' => false,
+            'reportable' => false,
+            'comment' => 'The ID of the campaign'
+        ),
+        'date_entered' => array(
+            'name' => 'date_entered',
+            'vname' => 'LBL_DATE_ENTERED',
+            'type' => 'datetime',
+            'required' => true,
+            'comment' => 'Date record created'
+        ),
+        'date_modified' => array(
+            'name' => 'date_modified',
+            'vname' => 'LBL_DATE_MODIFIED',
+            'type' => 'datetime',
+            'required' => true,
+            'comment' => 'Date record last modified'
+        ),
+        'modified_user_id' => array(
+            'name' => 'modified_user_id',
+            'vname' => 'LBL_MODIFIED_USER_ID',
+            'dbType' => 'id',
+            'type' => 'id',
+            'comment' => 'User who last modified record'
+        ),
+        'created_by' => array(
+            'name' => 'created_by',
+            'vname' => 'LBL_CREATED_BY',
+            'type' => 'assigned_user_name',
+            'table' => 'users',
+            'isnull' => 'false',
+            'dbType' => 'id',
+            'comment' => 'User ID who created record'
+        ),
+        'is_optout' => array(
+            'name' => 'is_optout',
+            'vname' => 'LBL_OPTOUT',
+            'type' => 'bool',
+            'required' => true,
+            'default' => '0',
+            'reportable' => false,
+            'comment' => 'Indicator whether tracker URL represents an opt-out link'
+        ),
+        'deleted' => array(
+            'name' => 'deleted',
+            'vname' => 'LBL_DELETED',
+            'type' => 'bool',
+            'required' => false,
+            'default' => '0',
+            'reportable' => false,
+            'comment' => 'Record deletion indicator'
+        ),
+        'campaign' => array(
+            'name' => 'campaign',
+            'type' => 'link',
+            'relationship' => 'campaign_campaigntrakers',
+            'source' => 'non-db',
+            'vname' => 'LBL_CAMPAIGN',
+        ),
     ),
-   'tracker_name' => array (
-        'name' => 'tracker_name',
-        'vname' => 'LBL_TRACKER_NAME',
-        'type' => 'varchar',
-        'len' => '255',
-        'comment' => 'The name of the campaign tracker'
-   ),
-  	'tracker_url' => array (
-        'name' => 'tracker_url',
-        'vname' => 'LBL_TRACKER_URL',
-        'type' => 'varchar',
-        'len' => '255',
-        'default' => 'http://',
-        'comment' => 'The URL that represents the landing page when the tracker URL in the campaign email is clicked'
-   	),
-    'tracker_key' => array (
-        'name' => 'tracker_key',
-        'vname' => 'LBL_TRACKER_KEY',
-        'type' => 'int',
-        'len' => '11',
-        'auto_increment' => true,
-        'required'=>true,
-        'studio' => array('editview' => false),
-        'comment' => 'Internal key to uniquely identifier the tracker URL'
-  	),  
-  'campaign_id'=> array(
-    	'name'=>'campaign_id',
-    	'vname'=>'LBL_CAMPAIGN_ID',
-    	'type'=>'id',
-    	'required'=>false,
-    	'reportable'=>false,
-    	'comment' => 'The ID of the campaign'
-  	),
-    'date_entered' => array (
-    	'name' => 'date_entered',
-        'vname' => 'LBL_DATE_ENTERED',
-        'type' => 'datetime',
-		'required' => true,
-		'comment' => 'Date record created'
-  	),
-  	'date_modified' => array (
-    	'name' => 'date_modified',
-    	'vname' => 'LBL_DATE_MODIFIED',
-    	'type' => 'datetime',
-    	'required' => true,
-		'comment' => 'Date record last modified'
-  	),
-    'modified_user_id' => array (
-    	'name' => 'modified_user_id',
-    	'vname' => 'LBL_MODIFIED_USER_ID',
-    	'dbType' => 'id',
-    	'type'=>'id',
-		'comment' => 'User who last modified record'
-  	),
-  	'created_by' => array (
-    	'name' => 'created_by',
-    	'vname' => 'LBL_CREATED_BY',
-    	'type' => 'assigned_user_name',
-    	'table' => 'users',
-    	'isnull' => 'false',
-    	'dbType' => 'id',
-		'comment' => 'User ID who created record'
-  	),
-  	'is_optout' => array (
-    	'name' => 'is_optout',
-    	'vname' => 'LBL_OPTOUT',
-    	'type' => 'bool',
-    	'required' => true,
-    	'default' => '0',
-    	'reportable'=>false,
-    	'comment' => 'Indicator whether tracker URL represents an opt-out link'
-  	),
-  	'deleted' => array (
-    	'name' => 'deleted',
-    	'vname' => 'LBL_DELETED',
-    	'type' => 'bool',
-    	'required' => false,
-    	'default' => '0',
-    	'reportable'=>false,
-    	'comment' => 'Record deletion indicator'
-  	),
-  	'campaign' => array (
-  		'name' => 'campaign',
-    	'type' => 'link',
-    	'relationship' => 'campaign_campaigntrakers',
-    	'source'=>'non-db',
-		'vname'=>'LBL_CAMPAIGN',
-  ),
-),
 
-'relationships'=>array(
+    'relationships' => array(
 
-  'campaign_campaigntrakers' => array(
-		'lhs_module'=> 'Campaigns', 
-		'lhs_table'=> 'campaigns', 
-		'lhs_key' => 'id',
-   		'rhs_module'=> 'CampaignTrackers', 
-		'rhs_table'=> 'campaign_trkrs', 
-		'rhs_key' => 'campaign_id',
-   		'relationship_type'=>'one-to-many'
-  )
-)
-,'indices' => array (
-      array('name' =>'campaign_trackepk', 'type' =>'primary', 'fields'=>array('id')),
-      array('name' => 'campaign_tracker_key_idx', 'type'=>'index', 'fields'=>array('tracker_key')),
- )
+        'campaign_campaigntrakers' => array(
+            'lhs_module' => 'Campaigns',
+            'lhs_table' => 'campaigns',
+            'lhs_key' => 'id',
+            'rhs_module' => 'CampaignTrackers',
+            'rhs_table' => 'campaign_trkrs',
+            'rhs_key' => 'campaign_id',
+            'relationship_type' => 'one-to-many'
+        )
+    )
+,
+    'indices' => array(
+        array('name' => 'campaign_trackepk', 'type' => 'primary', 'fields' => array('id')),
+        array('name' => 'campaign_tracker_key_idx', 'type' => 'index', 'fields' => array('tracker_key')),
+    )
 );
 ?>

--- a/modules/CampaignTrackers/vardefs.php
+++ b/modules/CampaignTrackers/vardefs.php
@@ -40,7 +40,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 
 $dictionary['CampaignTracker'] = array('table' => 'campaign_trkrs',
 	'comment' => 'Maintains the Tracker URLs used in campaign emails',
-          
+
 'fields' => array (
     'id' => array (
         'name' => 'id',
@@ -54,7 +54,7 @@ $dictionary['CampaignTracker'] = array('table' => 'campaign_trkrs',
         'name' => 'tracker_name',
         'vname' => 'LBL_TRACKER_NAME',
         'type' => 'varchar',
-        'len' => '30',
+        'len' => '255',
         'comment' => 'The name of the campaign tracker'
    ),
   	'tracker_url' => array (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Changes the vardef tracker_name length from 30 characters to 255. This fixes click trackers from getting truncated after the 30th character.

Issue reference: #3316 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create a campaign
2. Insert a click tracker with more than 30 characters

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->