### PR TITLE
Fixed #2483 - User profile image not visible on Employee detail page

### DIFF
--- a/download.php
+++ b/download.php
@@ -154,6 +154,7 @@ else {
             $query = "SELECT filename name, file_mime_type FROM notes ";
             $query .= "WHERE notes.id = '" . $db->quote($_REQUEST['id']) ."'";
         } elseif( !isset($_REQUEST['isTempFile']) && !isset($_REQUEST['tempName'] ) && isset($_REQUEST['type']) && $file_type!='temp' && isset($image_field) ) { //make sure not email temp file.
+            $file_type = ($file_type == "employees") ? "users" : $file_type;
             //$query = "SELECT " . $image_field ." FROM " . $file_type . " LEFT JOIN " . $file_type . "_cstm cstm ON cstm.id_c = " . $file_type . ".id ";
 
             // Fix for issue #1195: because the module was created using Module Builder and it does not create any _cstm table,

--- a/download.php
+++ b/download.php
@@ -1,11 +1,11 @@
 <?php
-if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
-/*********************************************************************************
+/**
+ *
  * SugarCRM Community Edition is a customer relationship management program developed by
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
-
- * SuiteCRM is an extension to SugarCRM Community Edition developed by Salesagility Ltd.
- * Copyright (C) 2011 - 2014 Salesagility Ltd.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2017 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the
@@ -36,99 +36,102 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
  * reasonably feasible for  technical reasons, the Appropriate Legal Notices must
  * display the words  "Powered by SugarCRM" and "Supercharged by SuiteCRM".
- ********************************************************************************/
+ */
 
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
 
 global $db;
 
-if((!isset($_REQUEST['isProfile']) && empty($_REQUEST['id'])) || empty($_REQUEST['type']) || !isset($_SESSION['authenticated_user_id'])) {
+if ((!isset($_REQUEST['isProfile']) && empty($_REQUEST['id'])) || empty($_REQUEST['type']) || !isset($_SESSION['authenticated_user_id'])) {
     die("Not a Valid Entry Point");
-}
-else {
+} else {
     require_once("data/BeanFactory.php");
-    $file_type=''; // bug 45896
+    $file_type = ''; // bug 45896
     require_once("data/BeanFactory.php");
-    ini_set('zlib.output_compression','Off');//bug 27089, if use gzip here, the Content-Length in header may be incorrect.
+    ini_set('zlib.output_compression',
+        'Off');//bug 27089, if use gzip here, the Content-Length in header may be incorrect.
     // cn: bug 8753: current_user's preferred export charset not being honored
     $GLOBALS['current_user']->retrieve($_SESSION['authenticated_user_id']);
     $GLOBALS['current_language'] = $_SESSION['authenticated_user_language'];
     $app_strings = return_application_language($GLOBALS['current_language']);
     $mod_strings = return_module_language($GLOBALS['current_language'], 'ACL');
     $file_type = strtolower($_REQUEST['type']);
-    if(!isset($_REQUEST['isTempFile'])) {
+    if (!isset($_REQUEST['isTempFile'])) {
         //Custom modules may have capitalizations anywhere in their names. We should check the passed in format first.
         require('include/modules.php');
         $module = $db->quote($_REQUEST['type']);
-        if(empty($beanList[$module])) {
+        if (empty($beanList[$module])) {
             //start guessing at a module name
             $module = ucfirst($file_type);
-            if(empty($beanList[$module])) {
+            if (empty($beanList[$module])) {
                 die($app_strings['ERROR_TYPE_NOT_VALID']);
             }
         }
         $bean_name = $beanList[$module];
-        if(!file_exists('modules/' . $module . '/' . $bean_name . '.php')) {
+        if (!file_exists('modules/' . $module . '/' . $bean_name . '.php')) {
             die($app_strings['ERROR_TYPE_NOT_VALID']);
         }
 
         $focus = BeanFactory::newBean($module);
         $focus->retrieve($_REQUEST['id']);
-        if(!$focus->ACLAccess('view')){
+        if (!$focus->ACLAccess('view')) {
             die($mod_strings['LBL_NO_ACCESS']);
         } // if
         // Pull up the document revision, if it's of type Document
-        if ( isset($focus->object_name) && $focus->object_name == 'Document' ) {
+        if (isset($focus->object_name) && $focus->object_name == 'Document') {
             // It's a document, get the revision that really stores this file
             $focusRevision = new DocumentRevision();
             $focusRevision->retrieve($_REQUEST['id']);
 
-            if ( empty($focusRevision->id) ) {
+            if (empty($focusRevision->id)) {
                 // This wasn't a document revision id, it's probably actually a document id,
                 // we need to grab the latest revision and use that
                 $focusRevision->retrieve($focus->document_revision_id);
 
-                if ( !empty($focusRevision->id) ) {
+                if (!empty($focusRevision->id)) {
                     $_REQUEST['id'] = $focusRevision->id;
                 }
             }
         }
 
         // See if it is a remote file, if so, send them that direction
-        if ( isset($focus->doc_url) && !empty($focus->doc_url) ) {
-            header('Location: '.$focus->doc_url);
+        if (isset($focus->doc_url) && !empty($focus->doc_url)) {
+            header('Location: ' . $focus->doc_url);
             sugar_die("Remote file detected, location header sent.");
         }
 
-        if ( isset($focusRevision) && isset($focusRevision->doc_url) && !empty($focusRevision->doc_url) ) {
-            header('Location: '.$focusRevision->doc_url);
+        if (isset($focusRevision) && isset($focusRevision->doc_url) && !empty($focusRevision->doc_url)) {
+            header('Location: ' . $focusRevision->doc_url);
             sugar_die("Remote file detected, location header sent.");
         }
 
     } // if
-    $temp = explode ( "_" , $_REQUEST['id'], 2  );
-    if(is_array($temp)){
+    $temp = explode("_", $_REQUEST['id'], 2);
+    if (is_array($temp)) {
         $image_field = $temp[1];
         $image_id = $temp[0];
     }
-    if(isset($_REQUEST['ieId']) && isset($_REQUEST['isTempFile'])) {
+    if (isset($_REQUEST['ieId']) && isset($_REQUEST['isTempFile'])) {
         $local_location = sugar_cached("modules/Emails/{$_REQUEST['ieId']}/attachments/{$_REQUEST['id']}");
-    } elseif(isset($_REQUEST['isTempFile']) && $file_type == "import") {
+    } elseif (isset($_REQUEST['isTempFile']) && $file_type == "import") {
         $local_location = "upload://import/{$_REQUEST['tempName']}";
     } else {
         $local_location = "upload://{$_REQUEST['id']}";
     }
 
-    if(isset($_REQUEST['isTempFile']) && ($_REQUEST['type']=="SugarFieldImage")) {
-        $local_location =  "upload://{$_REQUEST['id']}";
+    if (isset($_REQUEST['isTempFile']) && ($_REQUEST['type'] == "SugarFieldImage")) {
+        $local_location = "upload://{$_REQUEST['id']}";
     }
 
-    if(isset($_REQUEST['isTempFile']) && ($_REQUEST['type']=="SugarFieldImage") && (isset($_REQUEST['isProfile'])) && empty($_REQUEST['id'])) {
+    if (isset($_REQUEST['isTempFile']) && ($_REQUEST['type'] == "SugarFieldImage") && (isset($_REQUEST['isProfile'])) && empty($_REQUEST['id'])) {
         $local_location = "include/images/default-profile.png";
     }
 
-    if(!file_exists( $local_location ) || strpos($local_location, "..")) {
+    if (!file_exists($local_location) || strpos($local_location, "..")) {
 
-        if(isset($image_field)) {
+        if (isset($image_field)) {
             header("Content-Type: image/png");
             header("Content-Disposition: attachment; filename=\"No-Image.png\"");
             header("X-Content-Type-Options: nosniff");
@@ -137,57 +140,59 @@ else {
             set_time_limit(0);
             readfile('include/SugarFields/Fields/Image/no_image.png');
             die();
-        }else {
+        } else {
             die($app_strings['ERR_INVALID_FILE_REFERENCE']);
         }
     } else {
         $doQuery = true;
 
-        if($file_type == 'documents') {
+        if ($file_type == 'documents') {
             // cn: bug 9674 document_revisions table has no 'name' column.
             $query = "SELECT filename name FROM document_revisions INNER JOIN documents ON documents.id = document_revisions.document_id ";
-            $query .= "WHERE document_revisions.id = '".$db->quote($_REQUEST['id'])."' ";
-        } elseif($file_type == 'kbdocuments') {
-            $query="SELECT document_revisions.filename name	FROM document_revisions INNER JOIN kbdocument_revisions ON document_revisions.id = kbdocument_revisions.document_revision_id INNER JOIN kbdocuments ON kbdocument_revisions.kbdocument_id = kbdocuments.id ";
-            $query .= "WHERE document_revisions.id = '" . $db->quote($_REQUEST['id']) ."'";
-        }  elseif($file_type == 'notes') {
+            $query .= "WHERE document_revisions.id = '" . $db->quote($_REQUEST['id']) . "' ";
+        } elseif ($file_type == 'kbdocuments') {
+            $query = "SELECT document_revisions.filename name	FROM document_revisions INNER JOIN kbdocument_revisions ON document_revisions.id = kbdocument_revisions.document_revision_id INNER JOIN kbdocuments ON kbdocument_revisions.kbdocument_id = kbdocuments.id ";
+            $query .= "WHERE document_revisions.id = '" . $db->quote($_REQUEST['id']) . "'";
+        } elseif ($file_type == 'notes') {
             $query = "SELECT filename name, file_mime_type FROM notes ";
-            $query .= "WHERE notes.id = '" . $db->quote($_REQUEST['id']) ."'";
-        } elseif( !isset($_REQUEST['isTempFile']) && !isset($_REQUEST['tempName'] ) && isset($_REQUEST['type']) && $file_type!='temp' && isset($image_field) ) { //make sure not email temp file.
+            $query .= "WHERE notes.id = '" . $db->quote($_REQUEST['id']) . "'";
+        } elseif (!isset($_REQUEST['isTempFile']) && !isset($_REQUEST['tempName']) && isset($_REQUEST['type']) && $file_type != 'temp' && isset($image_field)) { //make sure not email temp file.
             $file_type = ($file_type == "employees") ? "users" : $file_type;
             //$query = "SELECT " . $image_field ." FROM " . $file_type . " LEFT JOIN " . $file_type . "_cstm cstm ON cstm.id_c = " . $file_type . ".id ";
 
             // Fix for issue #1195: because the module was created using Module Builder and it does not create any _cstm table,
             // there is a need to check whether the field has _c extension.
-            $query = "SELECT " . $image_field ." FROM " . $file_type . " ";
-            if(substr($image_field, -2) == "_c" ) $query .= "LEFT JOIN " . $file_type . "_cstm cstm ON cstm.id_c = " . $file_type . ".id ";
+            $query = "SELECT " . $image_field . " FROM " . $file_type . " ";
+            if (substr($image_field, -2) == "_c") {
+                $query .= "LEFT JOIN " . $file_type . "_cstm cstm ON cstm.id_c = " . $file_type . ".id ";
+            }
             $query .= "WHERE " . $file_type . ".id= '" . $db->quote($image_id) . "'";
 
             //$query .= "WHERE " . $file_type . ".id= '" . $db->quote($image_id) . "'";
-        }elseif( !isset($_REQUEST['isTempFile']) && !isset($_REQUEST['tempName'] ) && isset($_REQUEST['type']) && $file_type!='temp' ){ //make sure not email temp file.
-            $query = "SELECT filename name FROM ". $file_type ." ";
-            $query .= "WHERE ". $file_type .".id= '".$db->quote($_REQUEST['id'])."'";
-        }elseif( $file_type == 'temp'){
+        } elseif (!isset($_REQUEST['isTempFile']) && !isset($_REQUEST['tempName']) && isset($_REQUEST['type']) && $file_type != 'temp') { //make sure not email temp file.
+            $query = "SELECT filename name FROM " . $file_type . " ";
+            $query .= "WHERE " . $file_type . ".id= '" . $db->quote($_REQUEST['id']) . "'";
+        } elseif ($file_type == 'temp') {
             $doQuery = false;
         }
 
         // Fix for issue 1506 and issue 1304 : IE11 and Microsoft Edge cannot display generic 'application/octet-stream' (which is defined as "arbitrary binary data" in RFC 2046).
         $mime_type = mime_content_type($local_location);
-        if($mime_type == null || $mime_type == '') {
+        if ($mime_type == null || $mime_type == '') {
             $mime_type = 'application/octet-stream';
         }
-        
-        if($doQuery && isset($query)) {
+
+        if ($doQuery && isset($query)) {
             $rs = $GLOBALS['db']->query($query);
             $row = $GLOBALS['db']->fetchByAssoc($rs);
 
-            if(empty($row)){
+            if (empty($row)) {
                 die($app_strings['ERROR_NO_RECORD']);
             }
 
-            if(isset($image_field)){
+            if (isset($image_field)) {
                 $name = $row[$image_field];
-            }else {
+            } else {
                 $name = $row['name'];
             }
             // expose original mime type only for images, otherwise the content of arbitrary type
@@ -195,40 +200,43 @@ else {
             if (isset($row['file_mime_type']) && strpos($row['file_mime_type'], 'image/') === 0) {
                 $mime_type = $row['file_mime_type'];
             }
-            if(isset($_REQUEST['field'])){
+            if (isset($_REQUEST['field'])) {
                 $id = $row[$id_field];
                 $download_location = "upload://{$id}";
-            }else{
+            } else {
                 $download_location = "upload://{$_REQUEST['id']}";
             }
 
-        } else if(isset(  $_REQUEST['tempName'] ) && isset($_REQUEST['isTempFile']) ){
-            // downloading a temp file (email 2.0)
-            $download_location = $local_location;
-            $name = isset($_REQUEST['tempName'])?$_REQUEST['tempName']:'';
-        } else if(isset($_REQUEST['isTempFile']) && ($_REQUEST['type']=="SugarFieldImage")) {
-            $download_location = $local_location;
-            $name = isset($_REQUEST['tempName'])?$_REQUEST['tempName']:'';
+        } else {
+            if (isset($_REQUEST['tempName']) && isset($_REQUEST['isTempFile'])) {
+                // downloading a temp file (email 2.0)
+                $download_location = $local_location;
+                $name = isset($_REQUEST['tempName']) ? $_REQUEST['tempName'] : '';
+            } else {
+                if (isset($_REQUEST['isTempFile']) && ($_REQUEST['type'] == "SugarFieldImage")) {
+                    $download_location = $local_location;
+                    $name = isset($_REQUEST['tempName']) ? $_REQUEST['tempName'] : '';
+                }
+            }
         }
 
-        if(isset($_SERVER['HTTP_USER_AGENT']) && preg_match("/MSIE/", $_SERVER['HTTP_USER_AGENT']))
-        {
+        if (isset($_SERVER['HTTP_USER_AGENT']) && preg_match("/MSIE/", $_SERVER['HTTP_USER_AGENT'])) {
             $name = urlencode($name);
             $name = str_replace("+", "_", $name);
         }
 
         header("Pragma: public");
         header("Cache-Control: maxage=1, post-check=0, pre-check=0");
-        if(isset($_REQUEST['isTempFile']) && ($_REQUEST['type']=="SugarFieldImage")) {
+        if (isset($_REQUEST['isTempFile']) && ($_REQUEST['type'] == "SugarFieldImage")) {
             $mime = getimagesize($download_location);
-            if(!empty($mime)) {
+            if (!empty($mime)) {
                 header("Content-Type: {$mime['mime']}");
             } else {
                 header("Content-Type: image/png");
             }
         } else {
             header('Content-type: ' . $mime_type);
-            header("Content-Disposition: attachment; filename=\"".$name."\";");
+            header("Content-Disposition: attachment; filename=\"" . $name . "\";");
 
         }
         // disable content type sniffing in MSIE
@@ -237,9 +245,11 @@ else {
         header('Expires: ' . gmdate('D, d M Y H:i:s \G\M\T', time() + 2592000));
         set_time_limit(0);
 
-        // When output_buffering = On, ob_get_level() may return 1 even if ob_end_clean() returns false 
+        // When output_buffering = On, ob_get_level() may return 1 even if ob_end_clean() returns false
         // This happens on some QA stacks. See Bug#64860
-        while (ob_get_level() && @ob_end_clean());
+        while (ob_get_level() && @ob_end_clean()) {
+            ;
+        }
 
         readfile($download_location);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
A photo uploaded to the users profile (edit view / detail view) into the 'photo' field of the 'users' table is visible in the users module only. Within the employees detail view the photo is not found. This fix makes the photo correctly display in both the user profile and employee detail view.

Issue reference: #2483 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Add photo in user profile.
2. Add photo to employee detail view layout in studio.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->