### PR TITLE
Report. The errors caused by the conditions of type "field = ''"

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -1548,7 +1548,8 @@ class AOR_Report extends Basic
                     }
 
                     if ($condition->value_type == 'Value' && !$condition->value && $condition->operator == 'Equal_To') {
-                        $value = "{$value} OR {$field} IS NULL";
+                        $value = "{$value} OR {$field} IS NULL)";
+                        $field = "(".$field;
                     }
 
                     if (!$where_set) {


### PR DESCRIPTION
At AOR_Report, when exist a condition "Equal_To" and empty, the system
add extra condition " OR XXX is null", but this condition has no
parenthesis.