### PR TITLE
Gantt Chart - following tasks should be created the next available working day

### DIFF
--- a/modules/AM_ProjectTemplates/controller.php
+++ b/modules/AM_ProjectTemplates/controller.php
@@ -169,14 +169,14 @@ class AM_ProjectTemplatesController extends SugarController {
             $project_task->estimated_effort = $row['estimated_effort'];
             $project_task->utilization = $row['utilization'];
             
-			if($copy_all == 0 && !in_array( $row['id'],$copy_tasks))
-				$project_task->assigned_user_id = NULL;
+	    if($copy_all == 0 && !in_array( $row['id'],$copy_tasks))
+		$project_task->assigned_user_id = NULL;
             else
-				$project_task->assigned_user_id = $row['assigned_user_id'];
+		$project_task->assigned_user_id = $row['assigned_user_id'];
 
-			$project_task->description = $row['description'];
+	    $project_task->description = $row['description'];
             $project_task->duration = $row['duration'];
-			$project_task->duration_unit = $duration_unit;
+	    $project_task->duration_unit = $duration_unit;
             $project_task->project_task_id = $count;
             //Flag to prevent after save logichook running when project_tasks are created (see custom/modules/ProjectTask/updateProject.php)
             $project_task->set_project_end_date = 0;
@@ -210,8 +210,10 @@ class AM_ProjectTemplatesController extends SugarController {
                 $project_task->date_start = $start;
                 $end = $enddate->format('Y-m-d');
                 $project_task->date_finish = $end;
-                $enddate_array[$count] = $end;
-                $GLOBALS['log']->fatal("DATE:". $end);
+		
+		//add one day to let the next task start on next day of it's finish.
+                $enddate_array[$count] = $enddate->modify('+1 Days')->format('Y-m-d');
+                
             }
             else {
                 $start_date = $count - 1;
@@ -220,8 +222,12 @@ class AM_ProjectTemplatesController extends SugarController {
                 $project_task->date_start = $start;
                 $end = $enddate->format('Y-m-d');
                 $project_task->date_finish = $end;
+
+		$startdate = $enddate;
+		//add one day to let the next task start on next day of it's finish.
+		$enddate_array[$count] = $enddate->modify('+1 Days')->format('Y-m-d'); //$end;		    
                 $enddate = $end;
-                $enddate_array[$count] = $end;
+
             }
             $project_task->save();
             //link tasks to the newly created project

--- a/modules/Project/Project.php
+++ b/modules/Project/Project.php
@@ -608,7 +608,9 @@ class Project extends SugarBean {
 					$project_task->date_start = $start;
 					$end = $enddate->format('Y-m-d');
 					$project_task->date_finish = $end;
-					$enddate_array[$count] = $end;
+
+					//add one day to let the next task start on next day of it's finish.
+					$enddate_array[$count] = $enddate->modify('+1 Days')->format('Y-m-d');
 				}
 				else {
 					$start_date = $count - 1;
@@ -617,8 +619,12 @@ class Project extends SugarBean {
 					$project_task->date_start = $start;
 					$end = $enddate->format('Y-m-d');
 					$project_task->date_finish = $end;
+					
+					$startdate = $enddate;
+					//add one day to let the next task start on next day of it's finish.
+					$enddate_array[$count] = $enddate->modify('+1 Days')->format('Y-m-d');
+					
 					$enddate = $end;
-					$enddate_array[$count] = $end;
 				}
 				
 				$project_task->save();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Requirements.

As a User when I create a Project based on a Template (either via the Project Template's Action Button > Created Project, or from a project's Edit View Related To field to Projects and Save) and copy the Template's Tasks over that the Tasks that follow a preceding task will begin on the next available working day.

Currently these tasks are created with a start date of the same finish date of a preceding tasks - this is incorrect.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->