### PR TITLE
Resolving sorting by unformatted date and default sort by date created

### DIFF
--- a/modules/Emails/include/ListView/ListViewDataEmails.php
+++ b/modules/Emails/include/ListView/ListViewDataEmails.php
@@ -326,9 +326,20 @@ class ListViewDataEmails extends ListViewData
                             'D, d M Y H:i:s O',
                             $date
                         );
+                        if($dateTime  == false){  // @TODO This needs to be more generic to dealing with different formats from IMAP
+                            $dateTime = DateTime::createFromFormat(
+                                'd M Y H:i:s O',
+                                $date
+                            );
+                        }
 
-                        $timeDate = new TimeDate();
-                        $emailRecord[strtoupper($field)] = $timeDate->asUser($dateTime, $current_user);
+                        if($dateTime == false){
+                            $emailRecord[strtoupper($field)] = '';
+                        }
+                        else{
+                            $timeDate = new TimeDate();
+                            $emailRecord[strtoupper($field)] = $timeDate->asUser($dateTime, $current_user);
+                        }
                         break;
                     case 'is_imported':
                         $emailRecord['IS_IMPORTED'] = false;

--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -322,6 +322,7 @@ class InboundEmail extends SugarBean
         // handle sorting
         // Default: to sort the date in descending order
         $sortCriteria = SORTDATE;
+        $sortCRM = 'udate';
         $sortOrder = 1;
         if($order['sortOrder'] == 'ASC') {
             $sortOrder = 0;
@@ -329,16 +330,21 @@ class InboundEmail extends SugarBean
 
         if(stristr($order['orderBy'], 'date') !== false) {
             $sortCriteria = SORTDATE;
+            $sortCRM = 'udate';
         } else if(stristr($order['orderBy'], 'to') !== false) {
             $sortCriteria = SORTTO;
+            $sortCRM = 'to';
         } else if(stristr($order['orderBy'], 'from') !== false) {
             $sortCriteria = SORTFROM;
+            $sortCRM = 'from';
         } else if(stristr($order['orderBy'], 'cc') !== false) {
             $sortCriteria = SORTCC;
         } else if(stristr($order['orderBy'], 'name') !== false) {
             $sortCriteria = SORTSUBJECT;
+            $sortCRM = 'subject';
         } else if(stristr($order['orderBy'], 'subject') !== false) {
             $sortCriteria = SORTSUBJECT;
+            $sortCRM = 'subject';
         }
 
         // handle filtering
@@ -398,23 +404,16 @@ class InboundEmail extends SugarBean
         }
 
 
-        // fix sorting problem
-        $sortMsgNoAscending = function($a, $b) {
-            if($a->msgno === $b->msgno) {
+        usort($emailHeaders, function($a, $b) use($sortCRM){  // defaults to DESC order
+            if($a[$sortCRM] === $b[$sortCRM]) {
                 return 0;
-            } else if($a->msgno >= $b->msgno) {
+            } else if($a[$sortCRM] < $b[$sortCRM]) {
                 return 1;
             } else {
                 return -1;
             }
-        };
-
-        if ($sortOrder === 1) {
-            usort($emailHeaders, $sortMsgNoAscending);
-            $msgnos = array_reverse($emailHeaders);
-        }
-
-
+        });
+        if(!$sortOrder) array_reverse($emailHeaders); // Make it ASC order
 
 
         return array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Resolves issue when clicking sort by Date Created and showing default with emails appearing newest at the top.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->