### PR TITLE
Fixed #3477 - Subtotal Tax

### DIFF
--- a/modules/AOS_Quotes/language/en_us.lang.php
+++ b/modules/AOS_Quotes/language/en_us.lang.php
@@ -202,7 +202,7 @@ $mod_strings = array (
     'LBL_GRAND_TOTAL_USDOLLAR' => 'Grand Total (Default Currency)',
     'LBL_QUOTE_TO' => 'Quote To',
 
-    'LBL_SUBTOTAL_TAX_AMOUNT_USDOLLAR' => 'Subtotal Tax (Default Currency)',
+    'LBL_SUBTOTAL_TAX_AMOUNT_USDOLLAR' => 'Subtotal + Tax (Default Currency)',
     'LBL_AOS_QUOTES_AOS_CONTRACTS' => 'Quotes: Contracts',
     'LBL_AOS_QUOTES_AOS_INVOICES' => 'Quotes: Invoices',
     'LBL_AOS_LINE_ITEM_GROUPS' => 'Line Item Groups',


### PR DESCRIPTION
## Description
Language value edited for consistency and clarity:
`'LBL_SUBTOTAL_TAX_AMOUNT_USDOLLAR' => 'Subtotal + Tax (Default Currency)',`

See issue details: Subtotal Tax - language #3477 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Translation issues

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**]

