### PR TITLE
Fixed #3470 - Export fails when trying to export all records (DB error)

### DIFF
--- a/include/SugarObjects/templates/person/Person.php
+++ b/include/SugarObjects/templates/person/Person.php
@@ -318,7 +318,7 @@ class Person extends Basic
 
         $where_auto = " $table.deleted=0 ";
 
-        if ($where !== '') {
+        if ($where != '') {
             $query .= "WHERE ($where) AND " . $where_auto;
         } else {
             $query .= 'WHERE ' . $where_auto;

--- a/include/SugarObjects/templates/person/Person.php
+++ b/include/SugarObjects/templates/person/Person.php
@@ -318,7 +318,7 @@ class Person extends Basic
 
         $where_auto = " $table.deleted=0 ";
 
-        if ($where != '') {
+        if ($where !== '') {
             $query .= "WHERE ($where) AND " . $where_auto;
         } else {
             $query .= 'WHERE ' . $where_auto;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Issue #3470 
## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Removed extra `=` sign from if clause, where it compares `$where` to blank.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Because of this PR, now we can export all records from leads module.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to `Leads` module.
2. Select all the records.
3. Click on `Export'.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->