### PR TITLE
Fixed: 'required_fields' property missing from SugarBean

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -207,6 +207,7 @@ class SugarBean
     public $custom_fields;
     public $column_fields = array();
     public $list_fields = array();
+    public $required_fields = array();
     public $additional_column_fields = array();
     public $relationship_fields = array();
     public $current_notify_user;


### PR DESCRIPTION
## Description
`required_fields` property may be used without being initialized. By defining it, it also avoid dynamic creation of that property which is beneficial in terms of performance as of PHP >= 7.

## Motivation and Context
Performance/conformance related.

It also enables developers to use magic `__get` and `__set` methods in customized beans.

## How To Test This
By loading a bean?

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.