### PR TITLE
Fixed #3499 - SugarBean - array_seach function doesn't use strict parameter

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -4330,7 +4330,7 @@ class SugarBean
         //find all definitions of type link.
         if (!empty($fieldDefs)) {
             foreach ($fieldDefs as $name => $properties) {
-                if (array_search('relate', $properties) === 'type') {
+                if (array_search('relate', $properties, true) === 'type') {
                     $related_fields[$name] = $properties;
                 }
             }


### PR DESCRIPTION
Added strict parameter to array_search function call to include strict type comparison of field def value

Issue raised when trying to create WorkFlow with Send Email action where TO field was a Related Field and there wasn't expected related field in the dropdown list. The field was skipped because it's checked as Required - since array_search was used without the $strict parameter it would compare string value and boolean true value.
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. In studio mark Relate field to Users module as Required
2. Create WorkFlow with Send Email action.  Set TO as Related Field and in dropdown list of fields there should now be this field.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->