### PR TITLE
Fixing Compose View Related To

### DIFF
--- a/jssource/Minifier.php
+++ b/jssource/Minifier.php
@@ -121,6 +121,12 @@ class Minifier
      */
     static public function minify($js, $options = array())
     {
+        global $sugar_config;
+
+        if(isset($sugar_config['developerMode']) && $sugar_config['developerMode'] === true) {
+            return $js;
+        }
+
         try{
             ob_start();
             $currentOptions = array_merge(self::$defaultOptions, $options);

--- a/jssource/Minifier.php
+++ b/jssource/Minifier.php
@@ -123,7 +123,7 @@ class Minifier
     {
         global $sugar_config;
 
-        if(isset($sugar_config['developerMode']) && $sugar_config['developerMode'] === true) {
+        if(isset($sugar_config['developer_mode_disable_minifier']) && $sugar_config['developer_mode_disable_minifier'] === true) {
             return $js;
         }
 

--- a/modules/Emails/include/ComposeView/ComposeView.tpl
+++ b/modules/Emails/include/ComposeView/ComposeView.tpl
@@ -42,7 +42,7 @@
 {{sugar_include type="smarty" file=$headerTpl}}
 {sugar_include include=$includes}
 {* Compose view has a TEMP ID in case you want to display multi instance of the ComposeView *}
-<form class="compose-view" id="{$TEMP_ID}" name="ComposeView" method="POST" action="index.php?module=Emails&action=send">
+<form class="compose-view" id="ComposeView" name="ComposeView" method="POST" action="index.php?module=Emails&action=send">
     <input type="hidden" name="module" value="Emails">
     <input type="hidden" name="action" value="send">
     <input type="hidden" name="record" value="">
@@ -251,7 +251,7 @@
     <script>
         {* Compose view has a TEMP ID in case you want to display multi instance of the ComposeView *}
       $(document).ready(function() {ldelim}
-          $('#{$TEMP_ID}').EmailsComposeView();
+          $('#ComposeView').EmailsComposeView();
       {rdelim});
     </script>
     {/if}

--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -62,7 +62,7 @@
 
       if (self.attr('id').length === 0) {
         console.warn('EmailsComposeView - expects element to have an id. EmailsComposeView has generated one.');
-        self.attr('id', self.generateID());
+        self.attr('id', 'ComposeView');
       }
 
       if (typeof opts.tinyMceOptions.setup === "undefined") {
@@ -839,7 +839,7 @@
   }
 
   $.fn.EmailsComposeView.onTemplateSelect = function(args) {
-
+    "use strict";
     var confirmed = function(args) {
       $.post('index.php?entryPoint=emailTemplateData', {
         emailTemplateId: args.name_to_value_array.emails_email_templates_idb


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Task: scrm-8

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When the user types in the related to field they are not presented with the auto-completion box.

The issue is due to the id of the compose view being randomised. SQS expects the id of the form to be the name of the view like "EditView", as the sqs_objects array stores each filed by the form id + the name of the field.

Also in this change:
I have added an if statement to the minifier so that when you are in development mode the minifier simply returns the javascript unminified. This helps developers debug client side issues faster, and also speeds up the JS rebuild processes. This will only effect developers and not users.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change corrects the issue.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* Repair and Rebuild
* Repair JS Grouping
* Compose an email
* Type in the relate to field

You should be able to see the auto-completion box. Unless there are no records with a name which matches your input.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->