### PR TITLE
Project Duplicate Problem fixing

### DIFF
--- a/modules/Project/Save.php
+++ b/modules/Project/Save.php
@@ -52,7 +52,7 @@ $sugarbean = populateFromPost('', $sugarbean);
 
 $projectTasks = array();
 if (isset($_REQUEST['duplicateSave']) && $_REQUEST['duplicateSave'] === "true"){
-    $base_project_id = $_REQUEST['relate_id'];
+     $base_project_id = $_REQUEST['duplicateId'];
 }
 else{
     $base_project_id = $sugarbean->id;


### PR DESCRIPTION
When duplicating project, the duplicate is happening but the project tasks related to that particular project is not copying . instead of that some other tasks are copying to duplicated project.  I found that duplicateid is parsed to Save.php but Save.ph is looking for relate_id which is a bug.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Try duplicating a project , it does not duplicate project tasks

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->