### PR TITLE
Adding glyphicon when user email settings are missing

### DIFF
--- a/modules/Emails/include/ListView/ListViewHeader.js
+++ b/modules/Emails/include/ListView/ListViewHeader.js
@@ -42,6 +42,8 @@ $(document).ready(function () {
   var query = JSON.parse($('[name=current_query_by_page]').val());
   if(typeof query.folder === 'undefined' ||  query.folder === '') {
     $('.btn-emails-current-folder').remove();
+  } else if(query.folder === null) {
+    $('.btn-emails-current-folder').html('<span class="glyphicon glyphicon-alert"></span>');
   } else {
     $('.btn-emails-current-folder').text(query.folder);
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When the user first clicks on emails with out any settings i have added a glyphicon in the folder button to mark that there is an issue.

![screenshot_20170519_110005](https://cloud.githubusercontent.com/assets/12231216/26243096/8cd7553a-3c82-11e7-959c-2565a1c041a7.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->