### PR TITLE
Fixing regex for date created

### DIFF
--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -5148,7 +5148,7 @@ class InboundEmail extends SugarBean
             if(empty($email->date_entered)) {
 
                 // find if string has (UTC) in timezone
-                $pattern = '/([\w-+\/]+)/i';
+                $pattern = "/\([\w-+\/]+\)/i";
                 $timezoneTextFound = preg_match($pattern,  $header[0]->date);
 
                 $dateTimeFormat = 'D, d M Y H:i:s O *';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
The regex used to check if the date from the imap server has the timezone string is incorrect.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change corrects the issue.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
View emails.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->