### PR TITLE
Fixed #3617 - Imported emails body field

### DIFF
--- a/modules/AOP_Case_Updates/Case_Updates.php
+++ b/modules/AOP_Case_Updates/Case_Updates.php
@@ -316,8 +316,12 @@ function display_case_attachments($case)
  */
 function quick_edit_case_updates($case)
 {
-    global $action, $app_strings, $mod_strings;
-
+    global $action;
+    global $app_strings;
+    global $currentModule;
+    global $current_language;
+    $mod_strings = return_module_language($current_language, 'Cases');
+    #
     //on DetailView only
     if ($action !== 'DetailView') {
         return;

--- a/modules/Emails/views/view.detail.php
+++ b/modules/Emails/views/view.detail.php
@@ -60,6 +60,7 @@ class EmailsViewDetail extends ViewDetail
         $metadataFile = $this->getMetaDataFile();
         $this->dv = new EmailsDetailView();
         $this->dv->ss =&  $this->ss;
+        $this->dv->populateBean($_REQUEST);
         $this->dv->setup(
             $this->module,
             $this->bean,

--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -4974,15 +4974,15 @@ class InboundEmail extends SugarBean
                 $this->imagePrefix = "cid:";
             }
             // handle multi-part email bodies
-            $email->description_html = $this->getMessageText(
-                $msgNo,
+            $email->description_html = $this->getMessageTextWithUid(
+                $uid,
                 'HTML',
                 $structure,
                 $fullHeader,
                 $clean_email
             ); // runs through handleTranserEncoding() already
-            $email->description = $this->getMessageText(
-                $msgNo,
+            $email->description = $this->getMessageTextWithUid(
+                $uid,
                 'PLAIN',
                 $structure,
                 $fullHeader,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Task: SCRM-581
Issue: #3617

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When user imports email, they are unable to see the body. Updated populate fields to support the newer 
InboundEmail::getMessageTextWithUid method.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes bug

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* Import email
* View imported email

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->