### PR TITLE
do not broke the upgrade process

### DIFF
--- a/modules/UpgradeWizard/systemCheck.php
+++ b/modules/UpgradeWizard/systemCheck.php
@@ -176,8 +176,10 @@ $checks = array(
 	//commenting mbstring overload.
 	//'mbstring.func_overload'	=> $mod_strings['LBL_UW_COMPLIANCE_MBSTRING_FUNC_OVERLOAD'],
 );
-if($result['error_found'] == true) {
-	$stop = true;
+if($result['error_found'] == true || $result['warn_found']) {
+	if($result['error_found']) {
+		$stop = true;
+	}
 	$phpIniLocation = get_cfg_var("cfg_file_path");
 
 	$sysCompliance  = "<a href='javascript:void(0); toggleNwFiles(\"sysComp\");'>{$mod_strings['LBL_UW_SHOW_COMPLIANCE']}</a>";

--- a/modules/UpgradeWizard/uw_utils.php
+++ b/modules/UpgradeWizard/uw_utils.php
@@ -246,7 +246,7 @@ function commitCopyNewFiles($unzip_dir, $zip_from_dir, $path='') {
 
 //On cancel put back the copied files from 500 to 451 state
 function copyFilesOnCancel($step){
-//place hoder for cancel action
+//place holder for cancel action
 
 }
 
@@ -1056,7 +1056,7 @@ function checkSystemCompliance() {
 	if (check_php_version() === 0) {
 		$ret['phpVersion'] = "<b><span class=stop>{$installer_mod_strings['LBL_CURRENT_PHP_VERSION']} ".constant('PHP_VERSION').". ";
 		$ret['phpVersion'] .= $mod_strings['LBL_RECOMMENDED_PHP_VERSION_1'].constant('SUITECRM_PHP_REC_VERSION').$mod_strings['LBL_RECOMMENDED_PHP_VERSION_2'].'</span></b>';
-		$ret['error_found'] = true;
+		$ret['warn_found'] = true;
 	}
 
 	if (check_php_version() === 1) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
UpgradeWizard shows deprecated php version but able to upload the upgrade packs

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
UpgradeWizard doesn't able to upload any upgrade on php 5.5.9 and stop the upgrade process


## How To Test This
<!--- Please describe in detail how to test your changes. -->
Upgrade SuiteCRM on php 5.5.9

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->