### PR TITLE
Fixed Email Templates In Compose View

### DIFF
--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -1121,7 +1121,6 @@
         emailTemplateId: args.name_to_value_array.emails_email_templates_idb
       }, function(resp){
         var r = JSON.parse(resp);
-        debugger;
         tinymce.activeEditor.setContent(r.data.body_from_html, {format: 'html'});
         tinymce.activeEditor.change();
       });

--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -379,6 +379,13 @@
         $(self).find('input#description_html').val(editor.getContent());
         $(self).find('textarea#description').val($(self).find('.html_preview').text());
       });
+
+      editor.on('SetContent', function () {
+        // copy html to plain
+        $(self).find('.html_preview').html(editor.getContent());
+        $(self).find('input#description_html').val(editor.getContent());
+        $(self).find('textarea#description').val($(self).find('.html_preview').text());
+      });
     };
 
     /**
@@ -1114,7 +1121,9 @@
         emailTemplateId: args.name_to_value_array.emails_email_templates_idb
       }, function(resp){
         var r = JSON.parse(resp);
-        tinyMCE.get('description').setContent($('<textarea />').html(r.data.body_html).text());
+        debugger;
+        tinymce.activeEditor.setContent(r.data.body_from_html, {format: 'html'});
+        tinymce.activeEditor.change();
       });
       set_return(args);
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When the users selects an email template in the compose view, the validation prevents them from sending an email. This change corrects this by populating the change into the hidden description field.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes bug

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* Repair js
* compose email with a email template

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->