### PR TITLE
Fixed #3676 - Module builder export and file template.	

### DIFF
--- a/include/SugarObjects/templates/file/views/view.edit.php
+++ b/include/SugarObjects/templates/file/views/view.edit.php
@@ -42,7 +42,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-class <module_name > ViewEdit extends ViewEdit{
+class <module_name>ViewEdit extends ViewEdit{
 
     public function display()
     {

--- a/modules/ModuleBuilder/MB/MBPackage.php
+++ b/modules/ModuleBuilder/MB/MBPackage.php
@@ -1015,7 +1015,7 @@ class MBPackage
      *
      * @return string
      */
-    public function exportProject($package, $export = true, $clean = true)
+    public function exportProject($package = '', $export = true, $clean = true)
     {
         $tmppath = 'custom/modulebuilder/projectTMP/';
         if (file_exists($this->getPackageDir())) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This change fixes modules returning a 500 error when attempting to export on PHP 7.1. This change also fixes modules created with the file template not allowing the user to create a record.

Issue ref: #3684 
Issue ref: #3676 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create a module in module builder based of file template.
2. Attempt to create a record inside this module.
3. Attempt to export a module in module builder on PHP 7.1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->