### PR TITLE
Fix #3698 - Restrict executing testinstall.php to CLI

### DIFF
--- a/testinstall.php
+++ b/testinstall.php
@@ -1,4 +1,9 @@
 <?php
+$sapi_type = php_sapi_name();
+if (substr($sapi_type, 0, 3) != 'cli') {
+    sugar_die("testinstall.php is CLI only.");
+}
+
 /* DEFINE SOME VARIABLES FOR INSTALLER */
 $_SERVER['HTTP_HOST'] = 'localhost';
 $_SERVER['REQUEST_URI'] = 'install.php';


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Restrict executing testinstall.php to CLI as suggested by @sergio91pt. Method copied from cron.php.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Security fix.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Try running testinstall.php from PHP with different interfaces.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->