### PR TITLE
Fix typo preventing creation of security groups

### DIFF
--- a/include/EditView/EditView2.php
+++ b/include/EditView/EditView2.php
@@ -929,7 +929,7 @@ class EditView
             require_once('modules/SecurityGroups/SecurityGroup.php');
             $groupFocus = new SecurityGroup();
             $security_modules = $groupFocus->getSecurityModules();
-            if (array_keys_exists($this->focus->module_dir, $security_modules)) {
+            if (array_key_exists($this->focus->module_dir, $security_modules)) {
                 global $current_user;
 
                 $group_count = $groupFocus->getMembershipCount($current_user->id);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
A typo in a method name was preventing creation of security groups, through the administration interface. The problem was introduced in PR #3596.

Fixes issue #3707. 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->