### PR TITLE
Fix connection to dovecot IMAPS server

### DIFF
--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -2898,7 +2898,6 @@ class InboundEmail extends SugarBean
             if (($errors = imap_last_error()) || ($alerts = imap_alerts())) {
                 // login failure means don't bother trying the rest
                 if ($errors == 'Too many login failures'
-                    || $errors == '[CLOSED] IMAP connection broken (server response)'
                     // @link http://tools.ietf.org/html/rfc5530#section-3
                     || strpos($errors, '[AUTHENTICATIONFAILED]') !== false
                     // MS Exchange 2010


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

Fixes issue #3709.

Removes `[CLOSED] IMAP connection broken (server response)` as a "synonymous" of invalid credentials, as it may lead to false positives in the findOptimumSettings loop of the InboundEmail module.

## Potential impact

I made a cursory google search and couldn't correlate this error message with invalid credentials, however there is a chance that some mail server software does indeed trigger this when presented with a wrong password.
If that happens, this change may trigger fail2ban or similar software, if a user mistypes the password.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->