### PR TITLE
Fixed #3719 - Every user can select all private email folders

### DIFF
--- a/include/SugarFolders/SugarFolders.php
+++ b/include/SugarFolders/SugarFolders.php
@@ -546,6 +546,7 @@ class SugarFolder
         $myEmailTypeString = 'inbound';
         $myDraftsTypeString = 'draft';
         $mySentEmailTypeString = 'sent';
+        $myArchiveTypeString = 'archived';
 
         if (empty($user)) {
             global $current_user;
@@ -568,7 +569,10 @@ class SugarFolder
 
         $found = array();
         while ($a = $this->db->fetchByAssoc($r)) {
-            if ($a['folder_type'] == $myEmailTypeString) {
+            if (!empty($a['folder_type']) &&
+                $a['folder_type'] !== $myArchiveTypeString &&
+                $a['created_by'] === $current_user->id
+            ) {
                 if (!isset($found[$a['id']])) {
                     $found[$a['id']] = true;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This changes fixes the issue where a user can see the folders of other users in the email settings dialog.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* Fixes issue


## How To Test This
<!--- Please describe in detail how to test your changes. -->
* Create a personal email account in one user
* Go into the email settings of an other user.
* Under folder management ensure that it says "none" 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.


<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->