### PR TITLE
Fixed #3725 - Email Signature UTF8

### DIFF
--- a/modules/Emails/Compose.php
+++ b/modules/Emails/Compose.php
@@ -69,7 +69,6 @@ function initFullCompose($ret)
         echo $composeOut;
     } else {
         //For normal full compose screen
-//        include('modules/Emails/index.php');
         echo "<script type='text/javascript' language='javascript'>\ncomposePackage = {$composeOut};\n</script>";
     }
 }

--- a/modules/Emails/Compose.php
+++ b/modules/Emails/Compose.php
@@ -69,7 +69,7 @@ function initFullCompose($ret)
         echo $composeOut;
     } else {
         //For normal full compose screen
-        include('modules/Emails/index.php');
+//        include('modules/Emails/index.php');
         echo "<script type='text/javascript' language='javascript'>\ncomposePackage = {$composeOut};\n</script>";
     }
 }

--- a/modules/Emails/EmailsController.php
+++ b/modules/Emails/EmailsController.php
@@ -197,13 +197,18 @@ class EmailsController extends SugarController
         $data = array();
         foreach ($accounts as $inboundEmailId => $inboundEmail) {
             $storedOptions = unserialize(base64_decode($inboundEmail->stored_options));
+            $isGroupEmailAccount = $inboundEmail->isGroupEmailAccount();
+            $isPersonalEmailAccount = $inboundEmail->isPersonalEmailAccount();
+
             $dataAddress = array(
                 'type' => $inboundEmail->module_name,
                 'id' => $inboundEmail->id,
                 'attributes' => array(
                     'from' => $storedOptions['from_addr']
                 ),
-                'prepend' => $prependSignature
+                'prepend' => $prependSignature,
+                'isPersonalEmailAccount' => $isPersonalEmailAccount,
+                'isGroupEmailAccount' => $isGroupEmailAccount
             );
 
             // Include signature
@@ -220,14 +225,16 @@ class EmailsController extends SugarController
                 $signature['signature'] = '';
             }
             $dataAddress['emailSignatures'] = array(
-                'html' => html_entity_decode($signature['signature_html']),
+                'html' => utf8_encode(html_entity_decode($signature['signature_html'])),
                 'plain' => $signature['signature'],
             );
 
             
             $data[] = $dataAddress;
         }
-        echo json_encode(array('data' => $data));
+
+        $dataEncoded = json_encode(array('data' => $data));
+        echo $dataEncoded;
 
         $this->view = 'ajax';
     }

--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -307,6 +307,40 @@ class InboundEmail extends SugarBean
 
 
     /**
+     * @return bool
+     * @throws Exception
+     */
+    public function isPersonalEmailAccount() {
+        if($this->is_personal === '0') {
+            return false;
+        } else if ($this->is_personal === '1') {
+            return true;
+        } else {
+            throw new Exception(
+                'Cannot tell if the inbound email account is a personal account '.
+                'or a group account.'
+            );
+        }
+    }
+
+    /**
+     * @return bool
+     * @throws Exception
+     */
+    public function isGroupEmailAccount() {
+        if($this->is_personal === '0') {
+            return true;
+        } else if ($this->is_personal === '1') {
+            return false;
+        } else {
+            throw new Exception(
+                'Cannot tell if the inbound email account is a personal account '.
+                'or a group account.'
+            );
+        }
+    }
+
+    /**
      * @param int $offset
      * @param int $pageSize
      * @param array $order

--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -316,6 +316,7 @@ class InboundEmail extends SugarBean
         } else if ($this->is_personal === '1') {
             return true;
         } else {
+            // TODO: TASK UNDEFINED - Standardize the exceptions
             throw new Exception(
                 'Cannot tell if the inbound email account is a personal account '.
                 'or a group account.'
@@ -333,6 +334,7 @@ class InboundEmail extends SugarBean
         } else if ($this->is_personal === '1') {
             return false;
         } else {
+            // TODO: TASK UNDEFINED - Standardize the exceptions
             throw new Exception(
                 'Cannot tell if the inbound email account is a personal account '.
                 'or a group account.'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This change fixes the issue with signatures when unsupported UTF-8 characters break the json_encode method, causing the user to not see their signature.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* Fixes the issue

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* Use a PHP 5.3 environment
* Create a signature
* Set the signature up
* Compose an email

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->