### PR TITLE
Fixed SCRM-590 - Cannot select emails with no subject (list view)

### DIFF
--- a/modules/Emails/templates/displaySubjectField.tpl
+++ b/modules/Emails/templates/displaySubjectField.tpl
@@ -40,12 +40,20 @@
 *}
 <div class="email-subject">
     {if $bean}
-        {if !empty($bean.id) and $bean.status == $APP_LIST_STRINGS.dom_email_status.draft}
-            <a href="index.php?module=Emails&action=DetailDraftView&record={$bean.id}">{$bean.name}</a>
-        {elseif !empty($bean.id) and $bean.status != $APP_LIST_STRINGS.dom_email_status.draft}
-            <a href="index.php?module=Emails&action=DetailView&record={$bean.id}">{$bean.name}</a>
+        {* Handle empty subject *}
+        {if $bean.name == ''}
+            {capture name=subject assign=subject}{$MOD.LBL_NO_SUBJECT}{/capture}
         {else}
-            <a href="index.php?module=Emails&action=DisplayDetailView&folder={$bean.folder}&folder={$bean.folder_type}&inbound_email_record={$bean.inbound_email_record}&uid={$bean.uid}&msgno={$bean.msgno}">{$bean.name}</a>
+            {capture name=subject assign=subject}{$bean.name}{/capture}
+        {/if}
+
+        {* Display Link *}
+        {if !empty($bean.id) and $bean.status == $APP_LIST_STRINGS.dom_email_status.draft}
+            <a href="index.php?module=Emails&action=DetailDraftView&record={$bean.id}">{$subject}</a>
+        {elseif !empty($bean.id) and $bean.status != $APP_LIST_STRINGS.dom_email_status.draft}
+            <a href="index.php?module=Emails&action=DetailView&record={$bean.id}">{$subject}</a>
+        {else}
+            <a href="index.php?module=Emails&action=DisplayDetailView&folder={$bean.folder}&folder={$bean.folder_type}&inbound_email_record={$bean.inbound_email_record}&uid={$bean.uid}&msgno={$bean.msgno}">{$subject}</a>
         {/if}
     {/if}
 </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Task: SCRM-590
Issue: n/a

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
In the list view of the emails module, users cannot select emails which do not have a subject.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* Fixes bug

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* Repair and Rebuild
* As a user Given that I am viewing my emails When an email has no subject i Expect to see a (no subject) link.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->