### PR TITLE
Fixed #3646 - Opening email from GMAIL sent folder opens correspondin…

### DIFF
--- a/modules/Emails/include/DetailView/EmailsNonImportedDetailView.php
+++ b/modules/Emails/include/DetailView/EmailsNonImportedDetailView.php
@@ -74,6 +74,11 @@ class EmailsNonImportedDetailView extends EmailsDetailView
     {
         if (!empty($request['uid']) && !empty($request['inbound_email_record'])&& !empty($request['msgno'])) {
             $inboundEmail = BeanFactory::getBean('InboundEmail', $request['inbound_email_record']);
+
+            if($_REQUEST['folder'] === 'sent') {
+                $inboundEmail->mailbox = $inboundEmail->get_stored_options('sentFolder');
+            }
+
             $email = $inboundEmail->returnNonImportedEmail($_REQUEST['msgno'], $request['uid']);
             $this->focus = $email;
             $this->populateFields();


### PR DESCRIPTION
…g IMAP uid from INBOX

<!--- Provide a general summary of your changes in the Title above -->
task: SCRM-617
issue: #3646

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When user views email in the sent folder (using gmail), they see an email that exists in the inbox folder. This is due to how gmail handles uids. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change fixes the issue by setting the mailbox to the sent folder.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* Set up email  account
* view email from sent folder
* verify contents

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->