### PR TITLE
Fixed scrm-613 - Attach Doc submits form on firefox

### DIFF
--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -687,7 +687,7 @@
      * @event attachDocument
      * @returns {boolean}
      */
-    self.attachDocument = function () {
+    self.attachDocument = function (event) {
       "use strict";
       event.preventDefault();
       $(self).trigger("attachDocument", [self]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When user composes email in firefox, and then attaches a document (not a file), it causes the form to submit.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change fixes the issue by adding the missing event into the method arguments

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* Repair js grouping
* Compose email in firefox
* Attach a document

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->