### PR TITLE
Allow email signature to set to none

### DIFF
--- a/modules/Emails/EmailUIAjax.php
+++ b/modules/Emails/EmailUIAjax.php
@@ -1342,7 +1342,7 @@ eoq;
                     $current_user->setPreference('showFolders', $showStore, 0, 'Emails');
                 }
 
-                if(!empty($_REQUEST['account_signature_id'])){
+                if(isset($_REQUEST['account_signature_id'])){
                     $email_signatures = $current_user->getPreference('account_signatures', 'Emails');
                     $email_signatures = unserialize(base64_decode($email_signatures));
                     if(empty($email_signatures)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
User cannot set the signature in the email account settings to none.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change fixes the issue

## How To Test This
<!--- Please describe in detail how to test your changes. -->
*  Navigate to user profile
*  Click "Settings"
*  Switch to the "Mail Accounts" tab and edit a Mail Account
*  Set the signature as something other than --none–
*  Edit it again and try to set it as --none–

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->