### PR TITLE
Adding better handling for return_{field}} in url

### DIFF
--- a/modules/AOS_PDF_Templates/sendEmail.php
+++ b/modules/AOS_PDF_Templates/sendEmail.php
@@ -50,11 +50,11 @@ require_once('modules/Contacts/Contact.php');
 class sendEmail
 {
     /**
-     * @param $module
-     * @param $module_type
-     * @param $printable
-     * @param $file_name
-     * @param $attach
+     * @param SugarBean $module
+     * @param string $module_type
+     * @param string $printable
+     * @param string $file_name
+     * @param bool $attach
      * @see generatePDF (Entrypoint)
      * @deprecated use EmailController::composeViewFrom
      */
@@ -135,7 +135,7 @@ class sendEmail
             echo "Unable to initiate Email Client";
             exit;
         } else {
-            header('Location: index.php?action=ComposeViewWithPdfTemplate&module=Emails&return_module=' . $module_type . '&return_action=DetailView&return_id=' . $_REQUEST['record'] . '&record=' . $email_id);
+            header('Location: index.php?action=ComposeViewWithPdfTemplate&module=Emails&return_module=' . $module_type . '&return_action=DetailView&return_id=' . $module->id . '&record=' . $email_id);
         }
     }
 }

--- a/modules/AOS_Quotes/templates/showPopupWithTemplates.tpl
+++ b/modules/AOS_Quotes/templates/showPopupWithTemplates.tpl
@@ -50,7 +50,7 @@
             {foreach name=template from=$TEMPLATES key=templateKey item=template}
                 {if empty($template) == false}
                     {capture name=on_click_js assign=on_click_js}
-                        document.getElementById('popupDivBack_ara').style.display='none';document.getElementById('popupDiv_ara').style.display='none';var form=document.getElementById('popupForm');if(form!=null){ldelim}form.templateID.value='"{$template}"';form.submit();{rdelim}else{ldelim}alert('Error!');{rdelim}
+                        document.getElementById('popupDivBack_ara').style.display='none';document.getElementById('popupDiv_ara').style.display='none';var form=document.getElementById('popupForm');if(form!=null){ldelim}form.templateID.value='{$template}';form.submit();{rdelim}else{ldelim}alert('Error!');{rdelim}
                     {/capture}
                     <tr height="20">
                         <td width="17" valign="center"><a href="#" onclick="{$on_click_js}">

--- a/modules/Emails/include/ComposeView/ComposeView.tpl
+++ b/modules/Emails/include/ComposeView/ComposeView.tpl
@@ -50,6 +50,7 @@
     <input type="hidden" name="send" value="1">
     <input type="hidden" name="return_module" value="{$RETURN_MODULE}">
     <input type="hidden" name="return_action" value="{$RETURN_ACTION}">
+    <input type="hidden" name="return_id" value="{$RETURN_ID}">
     <input type="hidden" name="inbound_email_id" value="{$INBOUND_ID}">
 <div id="EditView_tabs">
     {*display tabs*}

--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -551,19 +551,39 @@
 
           // If the user is viewing the form in the standard view
           if ($(self).find('input[type="hidden"][name="return_module"]').val() !== '') {
-            location.href = 'index.php?module=' + $('#' + self.attr('id') + ' input[type="hidden"][name="return_module"]').val() +
-              '&action=' +
-              $(self).find('input[type="hidden"][name="return_action"]').val();
+            mb.on('ok', function() {
+              var url = 'index.php?';
+
+              var module = $('#' + self.attr('id') + ' input[type="hidden"][name="return_module"]').val();
+              if(module !== undefined) {
+                url = url + 'module=' + module;
+              }
+
+              var action =  $('#' + self.attr('id') + ' input[type="hidden"][name="return_action"]').val();
+              if(action !== undefined) {
+                url = url + '&action=' + action;
+              }
+
+              var record =  $('#' + self.attr('id') + ' input[type="hidden"][name="return_id"]').val();
+              if(record !== undefined) {
+                url = url + '&record=' + record;
+              }
+
+              location.href = url;
+            });
           } else {
-            // The user is viewing in the modal view
-            $(self).trigger("sentEmail", [self, data]);
+            mb.on('ok', function() {
+              // The user is viewing in the modal view
+              $(self).trigger("sentEmail", [self, response]);
+            });
+
           }
         }
       }).fail(function (response) {
         "use strict";
         mb.showHeader();
         mb.setBody(response.errors.title);
-        $(self).trigger("sentEmailError", [self, data]);
+        $(self).trigger("sentEmailError", [self, response]);
       }).always(function (data) {
         $(self).trigger("sentEmailAlways", [self, data]);
       });

--- a/modules/Emails/views/view.compose.php
+++ b/modules/Emails/views/view.compose.php
@@ -85,8 +85,9 @@ class EmailsViewCompose extends ViewEdit {
         }
 
         $this->ev->ss->assign('TEMP_ID', create_guid());
-        $this->ev->ss->assign('RETURN_MODULE', isset($_REQUEST['return_module']) ? $_REQUEST['return_module'] : '');
-        $this->ev->ss->assign('RETURN_ACTION', isset($_REQUEST['return_action']) ? $_REQUEST['return_action'] : '');
+        $this->ev->ss->assign('RETURN_MODULE', isset($_GET['return_module']) ? $_GET['return_module'] : '');
+        $this->ev->ss->assign('RETURN_ACTION', isset($_GET['return_action']) ? $_GET['return_action'] : '');
+        $this->ev->ss->assign('RETURN_ID', isset($_GET['return_id']) ? $_GET['return_id'] : '');
         $this->ev->setup(
             $this->module,
             $this->bean,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Task: scrm-604
Issue: #3654 
## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When user send an email after selecting "email quotation", they are presented with a blank screen due to the handling of return_id.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This corrects the issue


## How To Test This
<!--- Please describe in detail how to test your changes. -->

- Repair JS minified
- Repair JS groupings
- select a quote
- select email quotation in the action menu
- Send email

You should be redirected back to quote


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->