### PR TITLE
Fixed #3730 - Email: No way to send plain-text emails

### DIFF
--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -2597,31 +2597,23 @@ class Email extends Basic
     public function handleBody($mail)
     {
         global $current_user;
-        ///////////////////////////////////////////////////////////////////////
-        ////	HANDLE EMAIL FORMAT PREFERENCE
-        // the if() below is HIGHLY dependent on the Javascript unchecking the Send HTML Email box
-        // HTML email
-        if ((isset($_REQUEST['setEditor']) /* from Email EditView navigation */
-                && $_REQUEST['setEditor'] == 1
-                && trim($_REQUEST['description_html']) != '')
-            || trim($this->description_html) != '' /* from email templates */
-            && $current_user->getPreference('email_editor_option',
-                'global') !== 'plain' //user preference is not set to plain text
-        ) {
-            $this->handleBodyInHTMLformat($mail);
-        } else {
+
+        // User preferences should takee precedence over everything else
+        $emailSettings = $current_user->getPreference('emailSettings',  'Emails');
+        $alwaysSendEmailsInPlainText = $emailSettings['sendPlainText'] === '1';
+
+        $sendEmailsInPlainText = false;
+        if(isset($_REQUEST['is_only_plain_text']) && $_REQUEST['is_only_plain_text'] === 'true') {
+            $sendEmailsInPlainText = true;
+        }
+
+        if($alwaysSendEmailsInPlainText === true) {
             // plain text only
-            $this->description_html = '';
-            $mail->IsHTML(false);
-            $plainText = from_html($this->description);
-            $plainText = str_replace("&nbsp;", " ", $plainText);
-            $plainText = str_replace("</p>", "</p><br />", $plainText);
-            $plainText = strip_tags(br2nl($plainText));
-            $plainText = str_replace("&amp;", "&", $plainText);
-            $plainText = str_replace("&#39;", "'", $plainText);
-            $mail->Body = wordwrap($plainText, 996);
-            $mail->Body = $this->decodeDuringSend($mail->Body);
-            $this->description = $mail->Body;
+            $this->handleBodyInPlainTextFormat($mail);
+        } else if($alwaysSendEmailsInPlainText === false && $sendEmailsInPlainText === true) {
+            $this->handleBodyInPlainTextFormat($mail);
+        } else {
+            $this->handleBodyInHTMLformat($mail);
         }
 
         // wp: if plain text version has lines greater than 998, use base64 encoding
@@ -2631,8 +2623,6 @@ class Email extends Basic
                 break;
             }
         }
-        ////	HANDLE EMAIL FORMAT PREFERENCE
-        ///////////////////////////////////////////////////////////////////////
 
         return $mail;
     }
@@ -4168,5 +4158,23 @@ eoq;
     {
         $this->load_relationship('notes');
         $this->notes->addBean($note);
+    }
+
+    /**
+     * @param $mail
+     */
+    protected function handleBodyInPlainTextFormat($mail)
+    {
+        $this->description_html = '';
+        $mail->IsHTML(false);
+        $plainText = from_html($this->description);
+        $plainText = str_replace("&nbsp;", " ", $plainText);
+        $plainText = str_replace("</p>", "</p><br />", $plainText);
+        $plainText = strip_tags(br2nl($plainText));
+        $plainText = str_replace("&amp;", "&", $plainText);
+        $plainText = str_replace("&#39;", "'", $plainText);
+        $mail->Body = wordwrap($plainText, 996);
+        $mail->Body = $this->decodeDuringSend($mail->Body);
+        $this->description = $mail->Body;
     }
 } // end class def

--- a/modules/Emails/include/ComposeView/ComposeView.tpl
+++ b/modules/Emails/include/ComposeView/ComposeView.tpl
@@ -50,6 +50,7 @@
     <input type="hidden" name="send" value="1">
     <input type="hidden" name="return_module" value="{$RETURN_MODULE}">
     <input type="hidden" name="return_action" value="{$RETURN_ACTION}">
+    <input type="hidden" name="return_id" value="{$RETURN_ID}">
     <input type="hidden" name="inbound_email_id" value="{$INBOUND_ID}">
 <div id="EditView_tabs">
     {*display tabs*}

--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -1113,6 +1113,17 @@
 
             }
 
+            if ($('#is_only_plain_text').length === 1) {
+              $('#is_only_plain_text').click(function() {
+                var tinemceToolbar = $(tinymce.EditorManager.activeEditor.getContainer()).find('.mce-toolbar');
+                if ($('#is_only_plain_text').prop('checked')) {
+                  tinemceToolbar.hide();
+                } else {
+                  tinemceToolbar.show();
+                }
+              });
+            }
+
             if (typeof json.errors !== "undefined") {
               var message = '';
               $.each(json.errors, function (i, v) {

--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -1113,8 +1113,8 @@
 
             }
 
-            if ($('#is_only_plain_text').length === 1) {
-              $('#is_only_plain_text').click(function() {
+            if ($(self).find('#is_only_plain_text').length === 1) {
+              $(self).find('#is_only_plain_text').click(function() {
                 var tinemceToolbar = $(tinymce.EditorManager.activeEditor.getContainer()).find('.mce-toolbar');
                 if ($('#is_only_plain_text').prop('checked')) {
                   tinemceToolbar.hide();

--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -529,6 +529,11 @@
         formData.append($(v).attr('name'), $(v).val());
       });
 
+
+      $(this).find('input[type=checkbox]').each(function (i, v) {
+        formData.append($(v).attr('name'), $(v).prop('checked'));
+      })
+
       $.ajax({
         type: "POST",
         data: formData,

--- a/modules/Emails/metadata/composeviewdefs.php
+++ b/modules/Emails/metadata/composeviewdefs.php
@@ -130,6 +130,12 @@ $viewdefs['Emails']['ComposeView'] = array(
                     'label' => 'LBL_BODY',
                 )
             ),
+            array(
+                array(
+                    'name' => 'is_only_plain_text',
+                    'label' => 'LBL_SEND_IN_PLAIN_TEXT'
+                )
+            )
         )
     )
 

--- a/modules/Emails/vardefs.php
+++ b/modules/Emails/vardefs.php
@@ -434,6 +434,16 @@ $dictionary['Email'] = array(
             ),
         ),
 
+        'is_only_plain_text' => array(
+            'name' => 'is_only_plain_text',
+            'type' => 'bool',
+            'default' => false,
+            'massupdate' => 0,
+            'importable' => 'false',
+            'duplicate_merge' => 'disabled',
+            'inline_edit' => false,
+            'source' => 'non-db',
+        ),
         /* relationship collection attributes */
         /* added to support InboundEmail */
         'accounts' => array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
User cannot force emails to send in plain text format.

Note: that selecting Send Plain Text Emails Only in the email settings will override the checkbox in the compose view.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change fixes the issue.
## How To Test This
<!--- Please describe in detail how to test your changes. -->

- Compose Email
- Check send in plain text only

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->