### PR TITLE
Fix #3753 no available themes

### DIFF
--- a/include/SugarTheme/SugarTheme.php
+++ b/include/SugarTheme/SugarTheme.php
@@ -1424,7 +1424,7 @@ class SugarThemeRegistry
         }
         asort($themelist, SORT_STRING);
         if (count($themelist)==0) {
-		$GLOBALS['log']->fatal("availableThemes() is returning empty array! Check disabled_themes in config.php and config_override.php");
+		$GLOBALS['log']->fatal('availableThemes() is returning empty array! Check disabled_themes in config.php and config_override.php');
         }
         return $themelist;
     }

--- a/include/SugarTheme/SugarTheme.php
+++ b/include/SugarTheme/SugarTheme.php
@@ -1424,8 +1424,7 @@ class SugarThemeRegistry
         }
         asort($themelist, SORT_STRING);
         if (count($themelist)==0) {
-		$themelist= array('SuiteP' => 'Suite P');
-		$GLOBALS['log']->error('availableThemes() was returning empty array, SuiteP added! Check disabled_themes in config.php and config_override.php');
+     		$GLOBALS['log']->fatal('availableThemes() is returning an empty array! Check disabled_themes in config.php and config_override.php');
         }
         return $themelist;
     }

--- a/include/SugarTheme/SugarTheme.php
+++ b/include/SugarTheme/SugarTheme.php
@@ -1424,7 +1424,8 @@ class SugarThemeRegistry
         }
         asort($themelist, SORT_STRING);
         if (count($themelist)==0) {
-		$GLOBALS['log']->fatal('availableThemes() is returning empty array! Check disabled_themes in config.php and config_override.php');
+		$themelist= array('SuiteP' => 'Suite P');
+		$GLOBALS['log']->error('availableThemes() was returning empty array, SuiteP added! Check disabled_themes in config.php and config_override.php');
         }
         return $themelist;
     }

--- a/include/SugarTheme/SugarTheme.php
+++ b/include/SugarTheme/SugarTheme.php
@@ -1423,6 +1423,9 @@ class SugarThemeRegistry
             $themelist[$themeobject->dirName] = $themeobject->name;
         }
         asort($themelist, SORT_STRING);
+        if (count($themelist)==0) {
+		$GLOBALS['log']->fatal("availableThemes() is returning empty array! Check disabled_themes in config.php and config_override.php");
+        }
         return $themelist;
     }
 


### PR DESCRIPTION
## Description
This is the minimal fix, just a better message. It would be nice to handle this better in upgrades to 7.9 where SuiteP is disabled.

## Motivation and Context
See issue #3753 

## How To Test This
Disable all themes through config_override.php, for example.
Or disable SuiteP on a 7.8 instance, then upgrade to 7.9

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ X ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ X ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->