### PR TITLE
Make "Attach Document" and "Disregard Draft" NOT send the mail on Fir…

### DIFF
--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -687,7 +687,7 @@
      * @event attachDocument
      * @returns {boolean}
      */
-    self.attachDocument = function () {
+    self.attachDocument = function (event) {
       "use strict";
       event.preventDefault();
       $(self).trigger("attachDocument", [self]);
@@ -929,7 +929,7 @@
      * @event disregardDraft
      * @returns {boolean}
      */
-    self.disregardDraft = function () {
+    self.disregardDraft = function (event) {
       "use strict";
 
       var mb = messageBox();


### PR DESCRIPTION
Make "Attach Document" and "Disregard Draft" NOT send the mail on Firefox

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Handed the event to the functions

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
These two buttons sent the draft without asking. Worst case on Disregard Draft.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Click Attach Document or Disregard Draft on FF

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->