### PR TITLE
Fixed  #3811 - Direct html content gets truncated - incomplete html

### DIFF
--- a/modules/EmailTemplates/vardefs.php
+++ b/modules/EmailTemplates/vardefs.php
@@ -114,13 +114,13 @@ $dictionary['EmailTemplate'] = array(
         'body' => array(
             'name' => 'body',
             'vname' => 'LBL_BODY',
-            'type' => 'text',
+            'type' => 'longtext',
             'comment' => 'Plain text body to be used in resulting email'
         ),
         'body_html' => array(
             'name' => 'body_html',
             'vname' => 'LBL_PLAIN_TEXT',
-            'type' => 'html',
+            'type' => 'longtext',
             'comment' => 'HTML formatted email body to be used in resulting email'
         ),
         'deleted' => array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixes email templates from having a maximum size of 65,535 bytes due to having type TEXT.

Issue reference: #3811

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This allows users to create email templates that are above 65,535 bytes and not have the email template get truncated.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create an email template with a size over 65,535 bytes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->