### PR TITLE
Fixed #3671 - able to customize suite editors

### DIFF
--- a/include/SuiteEditor/SuiteEditorConnector.php
+++ b/include/SuiteEditor/SuiteEditorConnector.php
@@ -74,7 +74,8 @@ class SuiteEditorConnector
                     editor.on('focus', function(e){
                         onClickTemplateBody();
                     });
-                }
+                },
+                plugins: ['code', 'table', 'link'],
             }");
     }
 

--- a/include/SuiteEditor/SuiteEditorConnector.php
+++ b/include/SuiteEditor/SuiteEditorConnector.php
@@ -42,15 +42,14 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-include_once 'include/SuiteEditor/SuiteEditorInterface.php';
-include_once 'include/SuiteEditor/SuiteEditorSettings.php';
-include_once 'include/SuiteEditor/SuiteEditorSettingsForDirectHTML.php';
-include_once 'include/SuiteEditor/SuiteEditorDirectHTML.php';
-include_once 'include/SuiteEditor/SuiteEditorSettingsForTinyMCE.php';
-include_once 'include/SuiteEditor/SuiteEditorTinyMCE.php';
-include_once 'include/SuiteEditor/SuiteEditorSettingsForMozaik.php';
-include_once 'include/SuiteEditor/SuiteEditorMozaik.php';
-include_once 'include/SuiteEditor/SuiteEditorConnector.php';
+include_once get_custom_file_if_exists('include/SuiteEditor/SuiteEditorInterface.php');
+include_once get_custom_file_if_exists('include/SuiteEditor/SuiteEditorSettings.php');
+include_once get_custom_file_if_exists('include/SuiteEditor/SuiteEditorSettingsForDirectHTML.php');
+include_once get_custom_file_if_exists('include/SuiteEditor/SuiteEditorDirectHTML.php');
+include_once get_custom_file_if_exists('include/SuiteEditor/SuiteEditorSettingsForTinyMCE.php');
+include_once get_custom_file_if_exists('include/SuiteEditor/SuiteEditorTinyMCE.php');
+include_once get_custom_file_if_exists('include/SuiteEditor/SuiteEditorSettingsForMozaik.php');
+include_once get_custom_file_if_exists('include/SuiteEditor/SuiteEditorMozaik.php');
 
 /**
  * Class SuiteEditor
@@ -131,7 +130,7 @@ class SuiteEditorConnector
 
         $smarty = new Sugar_Smarty();
         $smarty->assign('editor', $editor->getHtml());
-        return $smarty->fetch('include/SuiteEditor/tpls/SuiteEditorConnector.tpl');
+        return $smarty->fetch(get_custom_file_if_exists('include/SuiteEditor/tpls/SuiteEditorConnector.tpl'));
     }
 
 }

--- a/include/SuiteEditor/SuiteEditorDirectHTML.php
+++ b/include/SuiteEditor/SuiteEditorDirectHTML.php
@@ -71,7 +71,7 @@ class SuiteEditorDirectHTML implements SuiteEditorInterface
     public function getHtml() {
         $smarty = new Sugar_Smarty();
         $smarty->assign((array)$this->settings);
-        return $smarty->fetch('include/SuiteEditor/tpls/SuiteEditorDirectHTML.tpl');
+        return $smarty->fetch(get_custom_file_if_exists('include/SuiteEditor/tpls/SuiteEditorDirectHTML.tpl'));
     }
 
 }

--- a/include/SuiteEditor/SuiteEditorMozaik.php
+++ b/include/SuiteEditor/SuiteEditorMozaik.php
@@ -86,7 +86,7 @@ class SuiteEditorMozaik implements SuiteEditorInterface
             $this->settings->group,
             $this->settings->tinyMCESetup
         ));
-        return $smarty->fetch('include/SuiteEditor/tpls/SuiteEditorMozaik.tpl');
+        return $smarty->fetch(get_custom_file_if_exists('include/SuiteEditor/tpls/SuiteEditorMozaik.tpl'));
     }
 
 }

--- a/include/SuiteEditor/SuiteEditorSettings.php
+++ b/include/SuiteEditor/SuiteEditorSettings.php
@@ -77,13 +77,6 @@ abstract class SuiteEditorSettings
     public $group;
 
     /**
-     * JSON setting for TinyMCE initializer script
-     *
-     * @var string
-     */
-    public $tinyMCESetup = '{}';
-
-    /**
      * Javascript for body click handling
      *
      * @var string

--- a/include/SuiteEditor/SuiteEditorSettingsForMozaik.php
+++ b/include/SuiteEditor/SuiteEditorSettingsForMozaik.php
@@ -49,7 +49,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * in constructor, set the default settings for a mozaik editor
  * and if settings argument exists extends it
  */
-class SuiteEditorSettingsForMozaik extends SuiteEditorSettingsForDirectHTML
+class SuiteEditorSettingsForMozaik extends SuiteEditorSettingsForTinyMCE
 {
 
     /**
@@ -61,10 +61,5 @@ class SuiteEditorSettingsForMozaik extends SuiteEditorSettingsForDirectHTML
      * @var string
      */
     public $group = '';
-
-    /**
-     * @var string
-     */
-    public $tinyMCESetup = '{}';
 
 }

--- a/include/SuiteEditor/SuiteEditorSettingsForTinyMCE.php
+++ b/include/SuiteEditor/SuiteEditorSettingsForTinyMCE.php
@@ -55,4 +55,11 @@ if (!defined('sugarEntry') || !sugarEntry) {
 class SuiteEditorSettingsForTinyMCE extends SuiteEditorSettingsForDirectHTML
 {
 
+    /**
+     * JSON setting for TinyMCE initializer script
+     *
+     * @var string
+     */
+    public $tinyMCESetup = '{}';
+
 }

--- a/include/SuiteEditor/SuiteEditorTinyMCE.php
+++ b/include/SuiteEditor/SuiteEditorTinyMCE.php
@@ -71,7 +71,7 @@ class SuiteEditorTinyMCE implements SuiteEditorInterface
     public function getHtml() {
         $smarty = new Sugar_Smarty();
         $smarty->assign((array)$this->settings);
-        return $smarty->fetch('include/SuiteEditor/tpls/SuiteEditorTinyMCE.tpl');
+        return $smarty->fetch(get_custom_file_if_exists('include/SuiteEditor/tpls/SuiteEditorTinyMCE.tpl'));
     }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

In this PR able to customize code templates and settings of Suite Editors and added some plugin into TinyMCE by default: plugins: ['code', 'table', 'link']

ref: SCRM-608

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

please see in related issue #3671 - When editing an email template with TinyMCE it is not possible to edit the html

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->