### PR TITLE
Fixed #3841 - Saving profile deletes SMTP password

### DIFF
--- a/include/OutboundEmail/OutboundEmail.php
+++ b/include/OutboundEmail/OutboundEmail.php
@@ -78,7 +78,7 @@ class OutboundEmail {
 	var $mail_smtpauth_req; // bool
 	var $mail_smtpssl; // bool
 	var $mail_smtpdisplay; // calculated value, not in DB
-	var $new_with_id = FALSE;
+	var $new_with_id = false;
 
 	/**
 	 * Sole constructor
@@ -134,7 +134,7 @@ class OutboundEmail {
 	{
 	    $ob = $this->getSystemMailerSettings();
 	    $ob->id = create_guid();
-	    $ob->new_with_id = TRUE;
+	    $ob->new_with_id = true;
 	    $ob->user_id = $user_id;
 	    $ob->type = 'system-override';
 	    $ob->mail_smtpuser = $user_name;
@@ -153,7 +153,7 @@ class OutboundEmail {
 	 */
 	function doesUserOverrideAccountRequireCredentials($user_id)
 	{
-	    $userCredentialsReq = FALSE;
+	    $userCredentialsReq = false;
 	    $sys = new OutboundEmail();
 	    $ob = $sys->getSystemMailerSettings(); //Dirties '$this'
 
@@ -163,7 +163,7 @@ class OutboundEmail {
 
 	    $userOverideAccount = $this->getUsersMailerForSystemOverride($user_id);
 	    if( $userOverideAccount == null || empty($userOverideAccount->mail_smtpuser) || empty($userOverideAccount->mail_smtpuser) )
-	       $userCredentialsReq = TRUE;
+	       $userCredentialsReq = true;
 
         return $userCredentialsReq;
 
@@ -172,44 +172,43 @@ class OutboundEmail {
 	/**
 	 * Retrieves name value pairs for opts lists
 	 */
-	function getUserMailers($user) {
-		global $app_strings;
+    function getUserMailers($user)
+    {
+        global $app_strings;
 
-		$q = "SELECT * FROM outbound_email WHERE user_id = '{$user->id}' AND type = 'user' ORDER BY name";
-		$r = $this->db->query($q);
+        $q = "SELECT * FROM outbound_email WHERE user_id = '{$user->id}' AND type = 'user' ORDER BY name";
+        $r = $this->db->query($q);
 
-		$ret = array();
+        $ret = array();
 
-		$system = $this->getSystemMailerSettings();
+        $system = $this->getSystemMailerSettings();
 
-		//Now add the system default or user override default to the response.
-		if(!empty($system->id) )
-		{
-			if ($system->mail_sendtype == 'SMTP')
-			{
-			    $systemErrors = "";
+        //Now add the system default or user override default to the response.
+        if (!empty($system->id)) {
+            if ($system->mail_sendtype == 'SMTP') {
+                $systemErrors = "";
                 $userSystemOverride = $this->getUsersMailerForSystemOverride($user->id);
 
                 //If the user is required to to provide a username and password but they have not done so yet,
-        	    //create the account for them.
-        	     $autoCreateUserSystemOverride = FALSE;
-        		 if( $this->doesUserOverrideAccountRequireCredentials($user->id) )
-        		 {
-        		      $systemErrors = $app_strings['LBL_EMAIL_WARNING_MISSING_USER_CREDS'];
-        		      $autoCreateUserSystemOverride = TRUE;
-        		 }
+                //create the account for them.
+                $autoCreateUserSystemOverride = false;
+                if ($this->doesUserOverrideAccountRequireCredentials($user->id)) {
+                    $systemErrors = $app_strings['LBL_EMAIL_WARNING_MISSING_USER_CREDS'];
+                    $autoCreateUserSystemOverride = true;
+                }
 
                 // Substitute in the users system override if its available.
-                if($userSystemOverride != null) {
+                if ($userSystemOverride != null) {
                     $system = $userSystemOverride;
-                }
-        		else if ($autoCreateUserSystemOverride) {
-                    $system = $this->createUserSystemOverrideAccount($user->id, "", "");
+                } else {
+                    if ($autoCreateUserSystemOverride) {
+                        $system = $this->createUserSystemOverrideAccount($user->id, "", "");
+                    }
                 }
                 // User overrides can be edited.
-                $isEditable = ($system->type == 'system' || $system->type == 'system-override') ? FALSE : TRUE;
+                $isEditable = !($system->type == 'system' || $system->type == 'system-override');
 
-                if( !empty($system->mail_smtpserver) ) {
+                if (!empty($system->mail_smtpserver)) {
                     $ret[] = array(
                         'id' => $system->id,
                         'name' => "$system->name",
@@ -219,42 +218,40 @@ class OutboundEmail {
                         'errors' => $systemErrors
                     );
                 }
-			}
-			else //Sendmail
-			{
-				$ret[] = array(
-				    'id' =>$system->id,
+            } else {
+                // use sendmail
+                $ret[] = array(
+                    'id' => $system->id,
                     'name' => "{$system->name} - sendmail",
                     'mail_smtpserver' => 'sendmail',
-					'is_editable' => false,
+                    'is_editable' => false,
                     'type' => $system->type,
                     'errors' => ''
                 );
-			}
-		}
-
-		while($a = $this->db->fetchByAssoc($r))
-		{
-			$oe = array();
-			if($a['mail_sendtype'] != 'SMTP') {
-				continue;
             }
-			$oe['id'] =$a['id'];
-			$oe['name'] = $a['name'];
-			$oe['type'] = $a['type'];
-			$oe['is_editable'] = true;
-			$oe['errors'] = '';
-			if ( !empty($a['mail_smtptype']) ) {
+        }
+
+        while ($a = $this->db->fetchByAssoc($r)) {
+            $oe = array();
+            if ($a['mail_sendtype'] != 'SMTP') {
+                continue;
+            }
+            $oe['id'] = $a['id'];
+            $oe['name'] = $a['name'];
+            $oe['type'] = $a['type'];
+            $oe['is_editable'] = true;
+            $oe['errors'] = '';
+            if (!empty($a['mail_smtptype'])) {
                 $oe['mail_smtpserver'] = $this->_getOutboundServerDisplay($a['mail_smtptype'], $a['mail_smtpserver']);
             } else {
                 $oe['mail_smtpserver'] = $a['mail_smtpserver'];
             }
 
-			$ret[] = $oe;
-		}
+            $ret[] = $oe;
+        }
 
-		return $ret;
-	}
+        return $ret;
+    }
 
 	/**
 	 * Retrieves a cascading mailer set
@@ -318,6 +315,7 @@ class OutboundEmail {
 
 		return $results;
 	}
+
 	/**
 	 * Retrieves a cascading mailer set
 	 * @param object user
@@ -369,7 +367,7 @@ class OutboundEmail {
 	 */
 	function isAllowUserAccessToSystemDefaultOutbound()
 	{
-	    $allowAccess = FALSE;
+	    $allowAccess = false;
 
 	    // first check that a system default exists
 	    $q = "SELECT id FROM outbound_email WHERE type = 'system'";
@@ -378,10 +376,10 @@ class OutboundEmail {
 		if (!empty($a)) {
 		    // next see if the admin preference for using the system outbound is set
             $admin = new Administration();
-            $admin->retrieveSettings('',TRUE);
+            $admin->retrieveSettings('',true);
             if (isset($admin->settings['notify_allow_default_outbound'])
                 &&  $admin->settings['notify_allow_default_outbound'] == 2 )
-                $allowAccess = TRUE;
+                $allowAccess = true;
         }
 
         return $allowAccess;

--- a/include/OutboundEmail/OutboundEmail.php
+++ b/include/OutboundEmail/OutboundEmail.php
@@ -199,40 +199,56 @@ class OutboundEmail {
         		      $autoCreateUserSystemOverride = TRUE;
         		 }
 
-                //Substitute in the users system override if its available.
-                if($userSystemOverride != null)
-        		   $system = $userSystemOverride;
-        		else if ($autoCreateUserSystemOverride)
-        	       $system = $this->createUserSystemOverrideAccount($user->id,"","");
+                // Substitute in the users system override if its available.
+                if($userSystemOverride != null) {
+                    $system = $userSystemOverride;
+                }
+        		else if ($autoCreateUserSystemOverride) {
+                    $system = $this->createUserSystemOverrideAccount($user->id, "", "");
+                }
+                // User overrides can be edited.
+                $isEditable = ($system->type == 'system' || $system->type == 'system-override') ? FALSE : TRUE;
 
-			    $isEditable = ($system->type == 'system') ? FALSE : TRUE; //User overrides can be edited.
-
-                if( !empty($system->mail_smtpserver) )
-				    $ret[] = array('id' =>$system->id, 'name' => "$system->name", 'mail_smtpserver' => $system->mail_smtpdisplay,
-								   'is_editable' => $isEditable, 'type' => $system->type, 'errors' => $systemErrors);
+                if( !empty($system->mail_smtpserver) ) {
+                    $ret[] = array(
+                        'id' => $system->id,
+                        'name' => "$system->name",
+                        'mail_smtpserver' => $system->mail_smtpdisplay,
+                        'is_editable' => $isEditable,
+                        'type' => $system->type,
+                        'errors' => $systemErrors
+                    );
+                }
 			}
 			else //Sendmail
 			{
-				$ret[] = array('id' =>$system->id, 'name' => "{$system->name} - sendmail", 'mail_smtpserver' => 'sendmail',
-								'is_editable' => false, 'type' => $system->type, 'errors' => '');
+				$ret[] = array(
+				    'id' =>$system->id,
+                    'name' => "{$system->name} - sendmail",
+                    'mail_smtpserver' => 'sendmail',
+					'is_editable' => false,
+                    'type' => $system->type,
+                    'errors' => ''
+                );
 			}
 		}
 
 		while($a = $this->db->fetchByAssoc($r))
 		{
 			$oe = array();
-			if($a['mail_sendtype'] != 'SMTP')
+			if($a['mail_sendtype'] != 'SMTP') {
 				continue;
-
+            }
 			$oe['id'] =$a['id'];
 			$oe['name'] = $a['name'];
 			$oe['type'] = $a['type'];
 			$oe['is_editable'] = true;
 			$oe['errors'] = '';
-			if ( !empty($a['mail_smtptype']) )
-			    $oe['mail_smtpserver'] = $this->_getOutboundServerDisplay($a['mail_smtptype'],$a['mail_smtpserver']);
-			else
-			    $oe['mail_smtpserver'] = $a['mail_smtpserver'];
+			if ( !empty($a['mail_smtptype']) ) {
+                $oe['mail_smtpserver'] = $this->_getOutboundServerDisplay($a['mail_smtptype'], $a['mail_smtpserver']);
+            } else {
+                $oe['mail_smtpserver'] = $a['mail_smtpserver'];
+            }
 
 			$ret[] = $oe;
 		}

--- a/modules/Emails/templates/emailOptions.tpl
+++ b/modules/Emails/templates/emailOptions.tpl
@@ -63,38 +63,5 @@
                 </select>
             </div>
         </div>
-        {if !$HIDE_IF_CAN_USE_DEFAULT_OUTBOUND}
-            <div id="mail_smtpserver_tr">
-                <div  scope="row"><span id="mail_smtpserver_label">{$MOD.LBL_EMAIL_PROVIDER}</span></div>
-                <div  >{$mail_smtpdisplay}<input id='mail_smtpserver' name='mail_smtpserver' type="hidden" value='{$mail_smtpserver}' /></div>
-                <div>&nbsp;</div>
-                <div >&nbsp;</div>
-            </div>
-            {if !empty($mail_smtpauth_req) }
-
-                <div id="mail_smtpuser_tr">
-                    <div  scope="row" nowrap="nowrap"><span id="mail_smtpuser_label">{$MOD.LBL_MAIL_SMTPUSER}</span></div>
-                    <div  ><input type="text" id="mail_smtpuser" name="mail_smtpuser" size="25" maxlength="64" value="{$mail_smtpuser}" tabindex='1' ></div>
-                    <div>&nbsp;</div>
-                    <div >&nbsp;</div>
-                </div>
-                <div id="mail_smtppass_tr">
-                    <div  scope="row" nowrap="nowrap"><span id="mail_smtppass_label">{$MOD.LBL_MAIL_SMTPPASS}</span></div>
-                    <div  >
-                            <input type="password" id="mail_smtppass" name="mail_smtppass" size="25" maxlength="64" value="{$mail_smtppass}" tabindex='1'>
-                            <a href="javascript:void(0)" id='mail_smtppass_link' onClick="SUGAR.util.setEmailPasswordEdit('mail_smtppass')" style="display: none">{$APP.LBL_CHANGE_PASSWORD}</a>
-                        </div>
-                    <div>&nbsp;</div>
-                    <div >&nbsp;</div>
-                </div>
-            {/if}
-
-            <div id="test_outbound_settings_tr">
-                <div  scope="row"><input type="button" class="button" value="{$APP.LBL_EMAIL_TEST_OUTBOUND_SETTINGS}" onclick="startOutBoundEmailSettingsTest();"></div>
-                <div  >&nbsp;</div>
-                <div >&nbsp;</div>
-                <div  >&nbsp;</div>
-            </div>
-        {/if}
     </div>
 </div>

--- a/modules/Users/UserEmailOptions.tpl
+++ b/modules/Users/UserEmailOptions.tpl
@@ -63,32 +63,5 @@
                 </select>
             </div>
         </div>
-        {if !$HIDE_IF_CAN_USE_DEFAULT_OUTBOUND}
-            <div id="mail_smtpserver_tr">
-                <div width="20%" scope="row"><span id="mail_smtpserver_label">{$MOD.LBL_EMAIL_PROVIDER}</span></div>
-                <div width="30%" >{$mail_smtpdisplay}<input id='mail_smtpserver' name='mail_smtpserver' type="hidden" value='{$mail_smtpserver}' /></div>
-                <div>&nbsp;</div>
-                <div >&nbsp;</div>
-            </div>
-            {if !empty($mail_smtpauth_req) }
-
-                <div id="mail_smtpuser_tr">
-                    <div width="20%" scope="row" nowrap="nowrap"><span id="mail_smtpuser_label">{$MOD.LBL_MAIL_SMTPUSER}</span></div>
-                    <div width="30%" ><input type="text" id="mail_smtpuser" name="mail_smtpuser" size="25" maxlength="64" value="{$mail_smtpuser}" tabindex='1' ></div>
-
-                </div>
-                <div id="mail_smtppass_tr">
-                    <div width="20%" scope="row" nowrap="nowrap"><span id="mail_smtppass_label">{$MOD.LBL_MAIL_SMTPPASS}</span></div>
-                    <div width="30%" >
-                            <input type="password" id="mail_smtppass" name="mail_smtppass" size="25" maxlength="64" value="{$mail_smtppass}" tabindex='1'>
-                            <a href="javascript:void(0)" id='mail_smtppass_link' onClick="SUGAR.util.setEmailPasswordEdit('mail_smtppass')" style="display: none">{$APP.LBL_CHANGE_PASSWORD}</a>
-                        </div>
-                </div>
-            {/if}
-
-            <div id="test_outbound_settings_tr">
-                <div  scope="row"><input type="button" class="button" value="{$APP.LBL_EMAIL_TEST_OUTBOUND_SETTINGS}" onclick="startOutBoundEmailSettingsTest();"></div>
-            </div>
-        {/if}
     </div>
 </table>

--- a/modules/Users/UserViewHelper.php
+++ b/modules/Users/UserViewHelper.php
@@ -757,8 +757,6 @@ class UserViewHelper {
             $this->ss->assign('MAIL_SMTPPORT',$mail_smtpport);
             $this->ss->assign('MAIL_SMTPSSL',$mail_smtpssl);
         }
-        $this->ss->assign('HIDE_IF_CAN_USE_DEFAULT_OUTBOUND',$hide_if_can_use_default );
-
     }
 
 

--- a/modules/Users/UserViewHelper.php
+++ b/modules/Users/UserViewHelper.php
@@ -718,7 +718,6 @@ class UserViewHelper {
         /////////////////////////////////////////////
         /// Handle email account selections for users
         /////////////////////////////////////////////
-        $hide_if_can_use_default = true;
         if( !($this->usertype=='GROUP' || $this->usertype=='PORTAL_ONLY') ) {
             // email smtp
             $systemOutboundEmail = new OutboundEmail();

--- a/modules/Users/tpls/EditViewFooter.tpl
+++ b/modules/Users/tpls/EditViewFooter.tpl
@@ -78,39 +78,6 @@
                         </select>
                     </td>
                 </tr>
-                            {if !$HIDE_IF_CAN_USE_DEFAULT_OUTBOUND}
-                            <tr id="mail_smtpserver_tr">
-                                <td width="20%" scope="row"><span id="mail_smtpserver_label">{$MOD.LBL_EMAIL_PROVIDER}</span></td>
-                                <td width="30%" ><slot>{$mail_smtpdisplay}<input id='mail_smtpserver' name='mail_smtpserver' type="hidden" value='{$mail_smtpserver}' /></slot></td>
-                                <td>&nbsp;</td>
-                                <td >&nbsp;</td>
-                            </tr>
-                             {if !empty($mail_smtpauth_req) }
-
-                            <tr id="mail_smtpuser_tr">
-                                <td width="20%" scope="row" nowrap="nowrap"><span id="mail_smtpuser_label">{$MOD.LBL_MAIL_SMTPUSER}</span></td>
-                                <td width="30%" ><slot><input type="text" id="mail_smtpuser" name="mail_smtpuser" size="25" maxlength="64" value="{$mail_smtpuser}" tabindex='1' ></slot></td>
-                                <td>&nbsp;</td>
-                                <td >&nbsp;</td>
-                            </tr>
-                            <tr id="mail_smtppass_tr">
-                                <td width="20%" scope="row" nowrap="nowrap"><span id="mail_smtppass_label">{$MOD.LBL_MAIL_SMTPPASS}</span></td>
-                                <td width="30%" ><slot>
-                                <input type="password" id="mail_smtppass" name="mail_smtppass" size="25" maxlength="64" value="{$mail_smtppass}" tabindex='1'>
-                                <a href="javascript:void(0)" id='mail_smtppass_link' onClick="SUGAR.util.setEmailPasswordEdit('mail_smtppass')" style="display: none">{$APP.LBL_CHANGE_PASSWORD}</a>
-                                </slot></td>
-                                <td>&nbsp;</td>
-                                <td >&nbsp;</td>
-                            </tr>
-                            {/if}
-
-                            <tr id="test_outbound_settings_tr">
-                                <td width="17%" scope="row"><input type="button" class="button" value="{$APP.LBL_EMAIL_TEST_OUTBOUND_SETTINGS}" onclick="startOutBoundEmailSettingsTest();"></td>
-                                <td width="33%" >&nbsp;</td>
-                                <td width="17%">&nbsp;</td>
-                                <td width="33%" >&nbsp;</td>
-                            </tr>
-                            {/if}
                         </table>
                         <button class="button" id="settingsButton" onclick="SUGAR.email2.settings.showSettings(); return false;"><img src="themes/default/images/icon_email_settings.gif" align="absmiddle" border="0"> {$APP.LBL_EMAIL_SETTINGS}</button>
             </div>

--- a/modules/Users/tpls/wizard.tpl
+++ b/modules/Users/tpls/wizard.tpl
@@ -374,11 +374,7 @@
     <div class="nav-buttons">
         <input title="{$MOD.LBL_WIZARD_BACK_BUTTON}"
                class="button" type="button" name="next_tab1" value="  {$MOD.LBL_WIZARD_BACK_BUTTON}  "
-                {if !$HIDE_IF_CAN_USE_DEFAULT_OUTBOUND}
-               onclick="SugarWizard.changeScreen('smtp',true);" id="previous_tab_smtp" />&nbsp;
-        {else}
         onclick="SugarWizard.changeScreen('locale',true);" id="previous_tab_locale" />&nbsp;
-        {/if}
         <input title="{$MOD.LBL_WIZARD_FINISH_BUTTON}" class="button primary"
                type="submit" name="save" value="  {$MOD.LBL_WIZARD_FINISH_BUTTON}  " />&nbsp;
     </div>

--- a/modules/Users/tpls/wizard.tpl
+++ b/modules/Users/tpls/wizard.tpl
@@ -86,13 +86,7 @@
                         </tr>
                         <tr>
                             <td scope="row">
-
-                                {if !$HIDE_IF_CAN_USE_DEFAULT_OUTBOUND}
-                                    <p> {$MOD.LBL_WIZARD_WELCOME}</p>
-                                {else}
-                                    <p> {$MOD.LBL_WIZARD_WELCOME_NOSMTP}</p>
-                                {/if}
-
+                                <p> {$MOD.LBL_WIZARD_WELCOME_NOSMTP}</p>
                                 <div class="userWizWelcome"><img src='include/images/sugar_wizard_welcome.jpg' border='0' alt='{$MOD.LBL_WIZARD_WELCOME_TAB}' width='765px' height='325px'></div>
                             </td>
                         </tr>
@@ -266,68 +260,9 @@
                onclick="SugarWizard.changeScreen('personalinfo',true);" id="previous_tab_personalinfo" />&nbsp;
         <input title="{$MOD.LBL_WIZARD_NEXT_BUTTON}"
                class="button primary" type="button" name="next_tab1" value="  {$MOD.LBL_WIZARD_NEXT_BUTTON}  "
-                {if !$HIDE_IF_CAN_USE_DEFAULT_OUTBOUND}
-               onclick="SugarWizard.changeScreen('smtp',false);" id="next_tab_smtp" />
-        {else}
         onclick="SugarWizard.changeScreen('finish',false);" id="next_tab_finish" />
-        {/if}
     </div>
 </div>
-{if !$HIDE_IF_CAN_USE_DEFAULT_OUTBOUND}
-    <div id="smtp" class="screen">
-        <table width="100%" border="0" cellspacing="0" cellpadding="0">
-            <tr>
-                <td>
-                    <div class="edit view">
-                        <table width="100%" border="0" cellspacing="0" cellpadding="0">
-                            <tr>
-                                <th align="left" scope="row" colspan="4">
-                                    <h2>{$MOD.LBL_WIZARD_SMTP}</h2>
-                                </th>
-                            </tr>
-                            <tr>
-                                <td align="left" scope="row" colspan="4"><i>{$MOD.LBL_WIZARD_SMTP_DESC}</i></td>
-                            </tr>
-                            <tr>
-                                <td width="20%" scope="row"><span id="mail_smtpserver_label">{$MOD.LBL_EMAIL_PROVIDER}</span></td>
-                                <td width="30%" ><span>{$mail_smtpdisplay}<input id='mail_smtpserver' name='mail_smtpserver' type="hidden" value='{$mail_smtpserver}' /></span></td>
-                                <td scope="row">&nbsp;</td>
-                                <td >&nbsp;</td>
-                            </tr>
-                            {if !empty($mail_smtpauth_req)}
-                                <tr>
-                                    <td width="20%" scope="row" nowrap="nowrap"><span id="mail_smtpuser_label">{$MOD.LBL_MAIL_SMTPUSER}</span></td>
-                                    <td width="30%" ><span><input type="text" id="mail_smtpuser" name="mail_smtpuser" size="25" maxlength="64" value="{$mail_smtpuser}" tabindex='1' ></span></td>
-                                    <td scope="row">&nbsp;</td>
-                                    <td >&nbsp;</td>
-                                </tr>
-                                <tr>
-                                    <td width="20%" scope="row" nowrap="nowrap"><span id="mail_smtppass_label">{$MOD.LBL_MAIL_SMTPPASS}</span></td>
-                                    <td width="30%" ><span><input type="password" id="mail_smtppass" name="mail_smtppass" size="25" maxlength="64" value="{$mail_smtppass}" tabindex='1'></span></td>
-                                    <td scope="row">&nbsp;</td>
-                                    <td >&nbsp;</td>
-                                </tr>
-                            {/if}
-                            <tr>
-                                <td width="17%" scope="row"><input type="button" class="button" value="{$APP.LBL_EMAIL_TEST_OUTBOUND_SETTINGS}" onclick="startOutBoundEmailSettingsTest();"></td>
-                                <td width="33%" >&nbsp;</td>
-                                <td width="17%" scope="row">&nbsp;</td>
-                                <td width="33%" >&nbsp;</td>
-                            </tr>
-                        </table>
-                    </div>
-                </td>
-        </table>
-        <div class="nav-buttons">
-            <input title="{$MOD.LBL_WIZARD_BACK_BUTTON}"
-                   class="button" type="button" name="next_tab1" value="  {$MOD.LBL_WIZARD_BACK_BUTTON}  "
-                   onclick="SugarWizard.changeScreen('locale',true);" id="previous_tab_locale" />&nbsp;
-            <input title="{$MOD.LBL_WIZARD_NEXT_BUTTON}"
-                   class="button primary" type="button" name="next_tab1" value="  {$MOD.LBL_WIZARD_NEXT_BUTTON}  "
-                   onclick="SugarWizard.changeScreen('finish',false);" id="next_tab_finish" />
-        </div>
-    </div>
-{/if}
 <div id="finish" class="screen">
     <table width="100%" border="0" cellspacing="0" cellpadding="0">
         <tr>

--- a/modules/Users/views/view.wizard.php
+++ b/modules/Users/views/view.wizard.php
@@ -258,7 +258,6 @@ eoq;
         $this->ss->assign('MAIL_SMTPPORT',$mail_smtpport);
         $this->ss->assign('MAIL_SMTPSSL',$mail_smtpssl);
 
-        $this->ss->assign('HIDE_IF_CAN_USE_DEFAULT_OUTBOUND',$hide_if_can_use_default);
         $this->ss->assign('langHeader', get_language_header());
 		$this->ss->display($this->getCustomFilePathIfExists('modules/Users/tpls/wizard.tpl'));
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Users are able to change the system outbound email account by editing it in their user profile.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* This change removes there ability to change the password in the user profile.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* Repair and Rebuild
* Access user profile
* Attempt to change the system email accounts password


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->