### PR TITLE
Fix scrmbt 21 email check mssql

### DIFF
--- a/include/SugarFolders/SugarFolders.php
+++ b/include/SugarFolders/SugarFolders.php
@@ -536,6 +536,7 @@ class SugarFolder
      * Builds up a metacollection of user/group folders to be passed to processor methods
      * @param object User object, defaults to $current_user
      * @return array Array of abstract folder objects
+     * @throws \SugarFolderEmptyException
      */
     public function retrieveFoldersForProcessing($user, $subscribed = true)
     {

--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -308,38 +308,16 @@ class InboundEmail extends SugarBean
 
     /**
      * @return bool
-     * @throws Exception
      */
     public function isPersonalEmailAccount() {
-        if($this->is_personal === '0') {
-            return false;
-        } else if ($this->is_personal === '1') {
-            return true;
-        } else {
-            // TODO: TASK UNDEFINED - Standardize the exceptions
-            throw new Exception(
-                'Cannot tell if the inbound email account is a personal account '.
-                'or a group account.'
-            );
-        }
+        return (bool)$this->is_personal;
     }
 
     /**
      * @return bool
-     * @throws Exception
      */
     public function isGroupEmailAccount() {
-        if($this->is_personal === '0') {
-            return true;
-        } else if ($this->is_personal === '1') {
-            return false;
-        } else {
-            // TODO: TASK UNDEFINED - Standardize the exceptions
-            throw new Exception(
-                'Cannot tell if the inbound email account is a personal account '.
-                'or a group account.'
-            );
-        }
+        return !$this->isPersonalEmailAccount();
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

This PR contains a fix for Compose Email Popup.
'From' field failed when trying to retrieve options for drop-drown select.
ref: SCRMBT-21


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->


Error log shows up a message: [FATAL] Exception in Controller: Cannot tell if the inbound email account is a personal account or a group account.

@daniel-samson: Can you please look at your two new function in https://github.com/salesagility/SuiteCRM/commit/73d21ca5ffde14256dcda033afdff4b269d3637a#diff-2aadc7f50e2480defbfecef7a0295a66
Problem was the database doesn't store string values in a bool field or mssql driver doesn't retrieve strings when the value is bool in this field: 'inbound_email.is_personal' but the IF condition with '===' check for strings and it's failed in each possible case.
In same time, these function returns are bool typed values (in PHPDoc above) so I assume we have two type of Email Accounts: personal/group. Is that correct?


## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->