### PR TITLE
Fixed #3911 - LDAPAutheticate warnings in log

### DIFF
--- a/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php
+++ b/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php
@@ -282,9 +282,10 @@ class LDAPAuthenticateUser extends SugarAuthenticateUser{
 	 *
 	 * @param STRING $name
 	 * @param STRING $password
-	 * @return boolean
+     * @param STRING $fallback - is this authentication a fallback from a failed authentication
+     * @return boolean
 	 */
-	function loadUserOnLogin($name, $password) {
+	function loadUserOnLogin($name, $password, $fallback = false, $PARAMS = Array()) {
 
 	    global $mod_strings;
 

--- a/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php
+++ b/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php
@@ -1,11 +1,11 @@
 <?php
-if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
-/*********************************************************************************
+/**
+ *
  * SugarCRM Community Edition is a customer relationship management program developed by
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
-
- * SuiteCRM is an extension to SugarCRM Community Edition developed by Salesagility Ltd.
- * Copyright (C) 2011 - 2014 Salesagility Ltd.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2017 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the
@@ -16,7 +16,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
  * details.
  *
  * You should have received a copy of the GNU Affero General Public License along with
@@ -34,12 +34,13 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
  * these Appropriate Legal Notices must retain the display of the "Powered by
  * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
- * reasonably feasible for  technical reasons, the Appropriate Legal Notices must
- * display the words  "Powered by SugarCRM" and "Supercharged by SuiteCRM".
- ********************************************************************************/
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
 
-
-
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
 
 /**
  * This file is where the user authentication occurs. No redirection should happen in this file.
@@ -49,49 +50,53 @@ require_once('modules/Users/authentication/LDAPAuthenticate/LDAPConfigs/default.
 require_once('modules/Users/authentication/SugarAuthenticate/SugarAuthenticateUser.php');
 
 define('DEFAULT_PORT', 389);
-class LDAPAuthenticateUser extends SugarAuthenticateUser{
 
-	/**
-	 * Does the actual authentication of the user and returns an id that will be used
-	 * to load the current user (loadUserOnSession)
-	 *
-	 * @param STRING $name
-	 * @param STRING $password
-	 * @return STRING id - used for loading the user
-	 *
-	 * Contributions by Erik Mitchell erikm@logicpd.com
-	 */
-	function authenticateUser($name, $password) {
+class LDAPAuthenticateUser extends SugarAuthenticateUser
+{
 
-		$server = $GLOBALS['ldap_config']->settings['ldap_hostname'];
-		$port = $GLOBALS['ldap_config']->settings['ldap_port'];
-		if(!$port)
-			$port = DEFAULT_PORT;
-		$GLOBALS['log']->debug("ldapauth: Connecting to LDAP server: $server");
-		$ldapconn = ldap_connect($server, $port);
-		 $error = ldap_errno($ldapconn);
-		if($this->loginError($error)){
-        		return '';
-		}
-		@ldap_set_option($ldapconn, LDAP_OPT_PROTOCOL_VERSION, 3);
-		@ldap_set_option($ldapconn, LDAP_OPT_REFERRALS, 0); // required for AD
-		// If constant is defined, set the timeout (PHP >= 5.3)
-		if (defined('LDAP_OPT_NETWORK_TIMEOUT'))
-		{
-			// Network timeout, lower than PHP and DB timeouts
-			@ldap_set_option($ldapconn, LDAP_OPT_NETWORK_TIMEOUT, 60);
-		}
+    /**
+     * Does the actual authentication of the user and returns an id that will be used
+     * to load the current user (loadUserOnSession)
+     *
+     * @param STRING $name
+     * @param STRING $password
+     * @return STRING id - used for loading the user
+     *
+     * Contributions by Erik Mitchell erikm@logicpd.com
+     */
+    function authenticateUser($name, $password)
+    {
 
-		$bind_user = $this->ldap_rdn_lookup($name, $password);
-		$GLOBALS['log']->debug("ldapauth.ldap_authenticate_user: ldap_rdn_lookup returned bind_user=" . $bind_user);
-		if (!$bind_user) {
-			$GLOBALS['log']->fatal("SECURITY: ldapauth: failed LDAP bind (login) by " .
-									$name . ", could not construct bind_user");
-			return '';
-		}
+        $server = $GLOBALS['ldap_config']->settings['ldap_hostname'];
+        $port = $GLOBALS['ldap_config']->settings['ldap_port'];
+        if (!$port) {
+            $port = DEFAULT_PORT;
+        }
+        $GLOBALS['log']->debug("ldapauth: Connecting to LDAP server: $server");
+        $ldapconn = ldap_connect($server, $port);
+        $error = ldap_errno($ldapconn);
+        if ($this->loginError($error)) {
+            return '';
+        }
+        @ldap_set_option($ldapconn, LDAP_OPT_PROTOCOL_VERSION, 3);
+        @ldap_set_option($ldapconn, LDAP_OPT_REFERRALS, 0); // required for AD
+        // If constant is defined, set the timeout (PHP >= 5.3)
+        if (defined('LDAP_OPT_NETWORK_TIMEOUT')) {
+            // Network timeout, lower than PHP and DB timeouts
+            @ldap_set_option($ldapconn, LDAP_OPT_NETWORK_TIMEOUT, 60);
+        }
 
-		// MRF - Bug #18578 - punctuation was being passed as HTML entities, i.e. &amp;
-		$bind_password = html_entity_decode($password,ENT_QUOTES);
+        $bind_user = $this->ldap_rdn_lookup($name, $password);
+        $GLOBALS['log']->debug("ldapauth.ldap_authenticate_user: ldap_rdn_lookup returned bind_user=" . $bind_user);
+        if (!$bind_user) {
+            $GLOBALS['log']->fatal("SECURITY: ldapauth: failed LDAP bind (login) by " .
+                $name . ", could not construct bind_user");
+
+            return '';
+        }
+
+        // MRF - Bug #18578 - punctuation was being passed as HTML entities, i.e. &amp;
+        $bind_password = html_entity_decode($password, ENT_QUOTES);
 
         $GLOBALS['log']->info("ldapauth: Binding user " . $bind_user);
         $bind = ldap_bind($ldapconn, $bind_user, $bind_password);
@@ -108,18 +113,19 @@ class LDAPAuthenticateUser extends SugarAuthenticateUser{
             }
         }
 
-		$GLOBALS['log']->info("ldapauth: Bind attempt complete.");
+        $GLOBALS['log']->info("ldapauth: Bind attempt complete.");
 
-		if ($bind) {
-			// Authentication succeeded, get info from LDAP directory
-			$attrs = array_keys($GLOBALS['ldapConfig']['users']['fields']);
-			$base_dn = $GLOBALS['ldap_config']->settings['ldap_base_dn'];
-			$name_filter = $this->getUserNameFilter($name);
+        if ($bind) {
+            // Authentication succeeded, get info from LDAP directory
+            $attrs = array_keys($GLOBALS['ldapConfig']['users']['fields']);
+            $base_dn = $GLOBALS['ldap_config']->settings['ldap_base_dn'];
+            $name_filter = $this->getUserNameFilter($name);
 
-			//add the group user attribute that we will compare to the group attribute for membership validation if group membership is turned on
+            //add the group user attribute that we will compare to the group attribute for membership validation if group membership is turned on
             if (!empty($GLOBALS['ldap_config']->settings['ldap_group'])
                 && !empty($GLOBALS['ldap_config']->settings['ldap_group_user_attr'])
-                && !empty($GLOBALS['ldap_config']->settings['ldap_group_attr'])) {
+                && !empty($GLOBALS['ldap_config']->settings['ldap_group_attr'])
+            ) {
 
                 if (!in_array($attrs, $GLOBALS['ldap_config']->settings['ldap_group_user_attr'])) {
                     $attrs[] = $GLOBALS['ldap_config']->settings['ldap_group_user_attr'];
@@ -131,12 +137,12 @@ class LDAPAuthenticateUser extends SugarAuthenticateUser{
                 . $base_dn . ", name_filter: " . $name_filter . ", attrs: " . var_export($attrs, true)
             );
 
-			$result = @ldap_search($ldapconn, $base_dn, $name_filter, $attrs);
-			$error = ldap_errno($ldapconn);
+            $result = @ldap_search($ldapconn, $base_dn, $name_filter, $attrs);
+            $error = ldap_errno($ldapconn);
             if ($this->loginError($error)) {
-        		return '';
-			}
-			$GLOBALS['log']->debug("ldapauth: ldap_search complete.");
+                return '';
+            }
+            $GLOBALS['log']->debug("ldapauth: ldap_search complete.");
 
             $info = @ldap_get_entries($ldapconn, $result);
             $error = ldap_errno($ldapconn);
@@ -145,271 +151,294 @@ class LDAPAuthenticateUser extends SugarAuthenticateUser{
             }
 
 
+            $GLOBALS['log']->debug("ldapauth: User info from Directory fetched.");
 
-			$GLOBALS['log']->debug("ldapauth: User info from Directory fetched.");
+            // some of these don't seem to work
+            $this->ldapUserInfo = array();
+            foreach ($GLOBALS['ldapConfig']['users']['fields'] as $key => $value) {
+                //MRF - BUG:19765
+                $key = strtolower($key);
+                if (isset($info[0]) && isset($info[0][$key]) && isset($info[0][$key][0])) {
+                    $this->ldapUserInfo[$value] = $info[0][$key][0];
+                }
+            }
 
-			// some of these don't seem to work
-			$this->ldapUserInfo = array();
-			foreach($GLOBALS['ldapConfig']['users']['fields'] as $key=>$value){
-				//MRF - BUG:19765
-				$key = strtolower($key);
-				if(isset($info[0]) && isset($info[0][$key]) && isset($info[0][$key][0])){
-					$this->ldapUserInfo[$value] = $info[0][$key][0];
-				}
-			}
+            //we should check that a user is a member of a specific group
+            if (!empty($GLOBALS['ldap_config']->settings['ldap_group'])) {
+                $GLOBALS['log']->debug("LDAPAuth: scanning group for user membership");
+                $group_user_attr = $GLOBALS['ldap_config']->settings['ldap_group_user_attr'];
+                $group_attr = $GLOBALS['ldap_config']->settings['ldap_group_attr'];
+                if (!isset($info[0][$group_user_attr])) {
+                    $GLOBALS['log']->fatal("ldapauth: $group_user_attr not found for user $name cannot authenticate against an LDAP group");
+                    ldap_close($ldapconn);
 
-			//we should check that a user is a member of a specific group
-			if(!empty($GLOBALS['ldap_config']->settings['ldap_group'])){
-				$GLOBALS['log']->debug("LDAPAuth: scanning group for user membership");
-				$group_user_attr = $GLOBALS['ldap_config']->settings['ldap_group_user_attr'];
-				$group_attr = $GLOBALS['ldap_config']->settings['ldap_group_attr'];
-				if(!isset($info[0][$group_user_attr])){
-					$GLOBALS['log']->fatal("ldapauth: $group_user_attr not found for user $name cannot authenticate against an LDAP group");
-					ldap_close($ldapconn);
-					return '';
-				}else{
-					$user_uid = $info[0][$group_user_attr];
-                    if (is_array($user_uid)){
+                    return '';
+                } else {
+                    $user_uid = $info[0][$group_user_attr];
+                    if (is_array($user_uid)) {
                         $user_uid = $user_uid[0];
                     }
                     // If user_uid contains special characters (for LDAP) we need to escape them !
                     $user_uid = str_replace(array("(", ")"), array("\(", "\)"), $user_uid);
 
-				}
+                }
 
-				// build search query and determine if we are searching for a bare id or the full dn path
+                // build search query and determine if we are searching for a bare id or the full dn path
                 $group_name = $GLOBALS['ldap_config']->settings['ldap_group_name'] . ","
                     . $GLOBALS['ldap_config']->settings['ldap_group_dn'];
-				$GLOBALS['log']->debug("ldapauth: Searching for group name: " . $group_name);
-				$user_search = "";
+                $GLOBALS['log']->debug("ldapauth: Searching for group name: " . $group_name);
+                $user_search = "";
                 if (!empty($GLOBALS['ldap_config']->settings['ldap_group_attr_req_dn'])
-                    && $GLOBALS['ldap_config']->settings['ldap_group_attr_req_dn'] == 1) {
+                    && $GLOBALS['ldap_config']->settings['ldap_group_attr_req_dn'] == 1
+                ) {
 
-					$GLOBALS['log']->debug("ldapauth: Checking for group membership using full user dn");
-					$user_search = "($group_attr=" . $group_user_attr . "=" . $user_uid . "," . $base_dn . ")";
-				} else {
-					$user_search = "($group_attr=" . $user_uid . ")";
-				}
-				$GLOBALS['log']->debug("ldapauth: Searching for user: " . $user_search);
+                    $GLOBALS['log']->debug("ldapauth: Checking for group membership using full user dn");
+                    $user_search = "($group_attr=" . $group_user_attr . "=" . $user_uid . "," . $base_dn . ")";
+                } else {
+                    $user_search = "($group_attr=" . $user_uid . ")";
+                }
+                $GLOBALS['log']->debug("ldapauth: Searching for user: " . $user_search);
 
-				//user is not a member of the group if the count is zero get the logs and return no id so it fails login        
+                //user is not a member of the group if the count is zero get the logs and return no id so it fails login
                 if (!isset($user_uid)
-                    || ldap_count_entries($ldapconn, ldap_search($ldapconn, $group_name, $user_search)) ==  0) {
+                    || ldap_count_entries($ldapconn, ldap_search($ldapconn, $group_name, $user_search)) == 0
+                ) {
 
-					$GLOBALS['log']->fatal("ldapauth: User ($name) is not a member of the LDAP group");
-					$user_id = var_export($user_uid, true);
+                    $GLOBALS['log']->fatal("ldapauth: User ($name) is not a member of the LDAP group");
+                    $user_id = var_export($user_uid, true);
                     $GLOBALS['log']->debug(
                         "ldapauth: Group DN:{$GLOBALS['ldap_config']->settings['ldap_group_dn']}"
                         . " Group Name: " . $GLOBALS['ldap_config']->settings['ldap_group_name']
                         . " Group Attribute: $group_attr  User Attribute: $group_user_attr :(" . $user_uid . ")"
                     );
 
-					ldap_close($ldapconn);
-					return '';
-				}
-			}
+                    ldap_close($ldapconn);
+
+                    return '';
+                }
+            }
 
 
+            ldap_close($ldapconn);
+            $dbresult = $GLOBALS['db']->query("SELECT id, status FROM users WHERE user_name='" . $name . "' AND deleted = 0");
 
-			ldap_close($ldapconn);
-			$dbresult = $GLOBALS['db']->query("SELECT id, status FROM users WHERE user_name='" . $name . "' AND deleted = 0");
+            //user already exists use this one
+            if ($row = $GLOBALS['db']->fetchByAssoc($dbresult)) {
+                if ($row['status'] != 'Inactive') {
+                    return $row['id'];
+                } else {
+                    return '';
+                }
+            }
 
-			//user already exists use this one
-			if($row = $GLOBALS['db']->fetchByAssoc($dbresult)){
-				if($row['status'] != 'Inactive')
-					return $row['id'];
-				else
-					return '';
-			}
+            //create a new user and return the user
+            if ($GLOBALS['ldap_config']->settings['ldap_auto_create_users']) {
+                return $this->createUser($name);
 
-			//create a new user and return the user
-			if($GLOBALS['ldap_config']->settings['ldap_auto_create_users']){
-				return $this->createUser($name);
+            }
 
-			}
-			return '';
+            return '';
 
-		} else {
-			$GLOBALS['log']->fatal("SECURITY: failed LDAP bind (login) by $this->user_name using bind_user=$bind_user");
-			$GLOBALS['log']->fatal("ldapauth: failed LDAP bind (login) by $this->user_name using bind_user=$bind_user");
-			ldap_close($ldapconn);
-			return '';
-		}
-	}
+        } else {
+            $GLOBALS['log']->fatal("SECURITY: failed LDAP bind (login) by $this->user_name using bind_user=$bind_user");
+            $GLOBALS['log']->fatal("ldapauth: failed LDAP bind (login) by $this->user_name using bind_user=$bind_user");
+            ldap_close($ldapconn);
 
-	/**
-	 * takes in a name and creates the appropriate search filter for that user name including any additional filters specified in the system settings page
-	 * @param $name
-	 * @return String
-	 */
-	function getUserNameFilter($name){
-			$name_filter = "(" . $GLOBALS['ldap_config']->settings['ldap_login_attr']. "=" . $name . ")";
-			//add the additional user filter if it is specified
-			if(!empty($GLOBALS['ldap_config']->settings['ldap_login_filter'])){
-				$add_filter = $GLOBALS['ldap_config']->settings['ldap_login_filter'];
-				if(substr($add_filter, 0, 1) !== "("){
-					$add_filter = "(" . $add_filter . ")";
-				}
-				$name_filter = "(&" . $name_filter . $add_filter . ")";
-			}
-			return $name_filter;
-	}
+            return '';
+        }
+    }
 
-	/**
-	 * Creates a user with the given User Name and returns the id of that new user
-	 * populates the user with what was set in ldapUserInfo
-	 *
-	 * @param STRING $name
-	 * @return STRING $id
-	 */
-	function createUser($name){
+    /**
+     * takes in a name and creates the appropriate search filter for that user name including any additional filters specified in the system settings page
+     * @param $name
+     * @return String
+     */
+    function getUserNameFilter($name)
+    {
+        $name_filter = "(" . $GLOBALS['ldap_config']->settings['ldap_login_attr'] . "=" . $name . ")";
+        //add the additional user filter if it is specified
+        if (!empty($GLOBALS['ldap_config']->settings['ldap_login_filter'])) {
+            $add_filter = $GLOBALS['ldap_config']->settings['ldap_login_filter'];
+            if (substr($add_filter, 0, 1) !== "(") {
+                $add_filter = "(" . $add_filter . ")";
+            }
+            $name_filter = "(&" . $name_filter . $add_filter . ")";
+        }
 
-			$user = new User();
-			$user->user_name = $name;
-			foreach($this->ldapUserInfo as $key=>$value){
-				$user->$key = $value;
-			}
-			$user->employee_status = 'Active';
-			$user->status = 'Active';
-			$user->is_admin = 0;
-			$user->external_auth_only = 1;
-			$user->save();
-			return $user->id;
+        return $name_filter;
+    }
 
-	}
-	/**
-	 * this is called when a user logs in
-	 *
-	 * @param STRING $name
-	 * @param STRING $password
+    /**
+     * Creates a user with the given User Name and returns the id of that new user
+     * populates the user with what was set in ldapUserInfo
+     *
+     * @param STRING $name
+     * @return STRING $id
+     */
+    function createUser($name)
+    {
+
+        $user = new User();
+        $user->user_name = $name;
+        foreach ($this->ldapUserInfo as $key => $value) {
+            $user->$key = $value;
+        }
+        $user->employee_status = 'Active';
+        $user->status = 'Active';
+        $user->is_admin = 0;
+        $user->external_auth_only = 1;
+        $user->save();
+
+        return $user->id;
+
+    }
+
+    /**
+     * this is called when a user logs in
+     *
+     * @param STRING $name
+     * @param STRING $password
      * @param STRING $fallback - is this authentication a fallback from a failed authentication
      * @return boolean
-	 */
-	function loadUserOnLogin($name, $password, $fallback = false, $PARAMS = Array()) {
+     */
+    function loadUserOnLogin($name, $password, $fallback = false, $PARAMS = Array())
+    {
 
-	    global $mod_strings;
+        global $mod_strings;
 
-	    // Check if the LDAP extensions are loaded
-	    if(!function_exists('ldap_connect')) {
-	       $error = $mod_strings['LBL_LDAP_EXTENSION_ERROR'];
-	       $GLOBALS['log']->fatal($error);
-	       $_SESSION['login_error'] = $error;
-	       return false;
-	    }
+        // Check if the LDAP extensions are loaded
+        if (!function_exists('ldap_connect')) {
+            $error = $mod_strings['LBL_LDAP_EXTENSION_ERROR'];
+            $GLOBALS['log']->fatal($error);
+            $_SESSION['login_error'] = $error;
 
-		global $login_error;
-		$GLOBALS['ldap_config']  = new Administration();
-		$GLOBALS['ldap_config']->retrieveSettings('ldap');
-		$GLOBALS['log']->debug("Starting user load for ". $name);
-		if(empty($name) || empty($password)) return false;
-		checkAuthUserStatus();
+            return false;
+        }
 
-		$user_id = $this->authenticateUser($name, $password);
-		if(empty($user_id)) {
-			//check if the user can login as a normal sugar user
-			$GLOBALS['log']->fatal('SECURITY: User authentication for '.$name.' failed');
-			return false;
-		}
-		$this->loadUserOnSession($user_id);
-		return true;
-	}
+        global $login_error;
+        $GLOBALS['ldap_config'] = new Administration();
+        $GLOBALS['ldap_config']->retrieveSettings('ldap');
+        $GLOBALS['log']->debug("Starting user load for " . $name);
+        if (empty($name) || empty($password)) {
+            return false;
+        }
+        checkAuthUserStatus();
+
+        $user_id = $this->authenticateUser($name, $password);
+        if (empty($user_id)) {
+            //check if the user can login as a normal sugar user
+            $GLOBALS['log']->fatal('SECURITY: User authentication for ' . $name . ' failed');
+
+            return false;
+        }
+        $this->loadUserOnSession($user_id);
+
+        return true;
+    }
 
 
-	/**
-	 * Called with the error number of the last call if the error number is 0
-	 * there was no error otherwise it converts the error to a string and logs it as fatal
-	 *
-	 * @param INT $error
-	 * @return boolean
-	 */
-	function loginError($error){
-		if(empty($error)) return false;
-		$errorstr = ldap_err2str($error);
-		// BEGIN SUGAR INT
-		$_SESSION['login_error'] = $errorstr;
-		/*
-		// END SUGAR INT
-		$_SESSION['login_error'] = translate('ERR_INVALID_PASSWORD', 'Users');
-		// BEGIN SUGAR INT
-		*/
-		// END SUGAR INT
-		$GLOBALS['log']->fatal('[LDAP ERROR]['. $error . ']'.$errorstr);
-		return true;
-	}
+    /**
+     * Called with the error number of the last call if the error number is 0
+     * there was no error otherwise it converts the error to a string and logs it as fatal
+     *
+     * @param INT $error
+     * @return boolean
+     */
+    function loginError($error)
+    {
+        if (empty($error)) {
+            return false;
+        }
+        $errorstr = ldap_err2str($error);
+        // BEGIN SUGAR INT
+        $_SESSION['login_error'] = $errorstr;
+        /*
+        // END SUGAR INT
+        $_SESSION['login_error'] = translate('ERR_INVALID_PASSWORD', 'Users');
+        // BEGIN SUGAR INT
+        */
+        // END SUGAR INT
+        $GLOBALS['log']->fatal('[LDAP ERROR][' . $error . ']' . $errorstr);
 
-	 /**
-    * @return string appropriate value for username when binding to directory server.
-    * @param string $user_name the value provided in login form
-    * @desc Take the login username and return either said username for AD or lookup
+        return true;
+    }
+
+    /**
+     * @return string appropriate value for username when binding to directory server.
+     * @param string $user_name the value provided in login form
+     * @desc Take the login username and return either said username for AD or lookup
      * distinguished name using anonymous credentials for OpenLDAP.
      * Contributions by Erik Mitchell erikm@logicpd.com
-    */
-    function ldap_rdn_lookup($user_name, $password) {
+     */
+    function ldap_rdn_lookup($user_name, $password)
+    {
 
         // MFH BUG# 14547 - Added htmlspecialchars_decode()
         $server = $GLOBALS['ldap_config']->settings['ldap_hostname'];
         $base_dn = htmlspecialchars_decode($GLOBALS['ldap_config']->settings['ldap_base_dn']);
-		if(!empty($GLOBALS['ldap_config']->settings['ldap_authentication'])){
-       		$admin_user = htmlspecialchars_decode($GLOBALS['ldap_config']->settings['ldap_admin_user']);
-        	$admin_password = htmlspecialchars_decode($GLOBALS['ldap_config']->settings['ldap_admin_password']);
-		}else{
-			$admin_user = '';
-        	$admin_password = '';
-		}
+        if (!empty($GLOBALS['ldap_config']->settings['ldap_authentication'])) {
+            $admin_user = htmlspecialchars_decode($GLOBALS['ldap_config']->settings['ldap_admin_user']);
+            $admin_password = htmlspecialchars_decode($GLOBALS['ldap_config']->settings['ldap_admin_password']);
+        } else {
+            $admin_user = '';
+            $admin_password = '';
+        }
         $user_attr = $GLOBALS['ldap_config']->settings['ldap_login_attr'];
         $bind_attr = $GLOBALS['ldap_config']->settings['ldap_bind_attr'];
         $port = $GLOBALS['ldap_config']->settings['ldap_port'];
-		if(!$port)
-			$port = DEFAULT_PORT;
+        if (!$port) {
+            $port = DEFAULT_PORT;
+        }
         $ldapconn = ldap_connect($server, $port);
         $error = ldap_errno($ldapconn);
-        if($this->loginError($error)){
-        	return false;
-		}
+        if ($this->loginError($error)) {
+            return false;
+        }
         ldap_set_option($ldapconn, LDAP_OPT_PROTOCOL_VERSION, 3);
         ldap_set_option($ldapconn, LDAP_OPT_REFERRALS, 0); // required for AD
         //if we are going to connect anonymously lets at least try to connect with the user connecting
-        if(empty($admin_user)){
-			$bind = @ldap_bind($ldapconn, $user_name, $password);
-        	$error = ldap_errno($ldapconn);
+        if (empty($admin_user)) {
+            $bind = @ldap_bind($ldapconn, $user_name, $password);
+            $error = ldap_errno($ldapconn);
         }
-        if(empty($bind)){
-        	$bind = @ldap_bind($ldapconn, $admin_user, $admin_password);
-        	$error = ldap_errno($ldapconn);
+        if (empty($bind)) {
+            $bind = @ldap_bind($ldapconn, $admin_user, $admin_password);
+            $error = ldap_errno($ldapconn);
         }
 
-        if($this->loginError($error)){
-        	return false;
-		}
+        if ($this->loginError($error)) {
+            return false;
+        }
         if (!$bind) {
-        	   $GLOBALS['log']->warn("ldapauth.ldap_rdn_lookup: Could not bind with admin user, trying to bind anonymously");
+            $GLOBALS['log']->warn("ldapauth.ldap_rdn_lookup: Could not bind with admin user, trying to bind anonymously");
             $bind = @ldap_bind($ldapconn);
-             $error = ldap_errno($ldapconn);
+            $error = ldap_errno($ldapconn);
 
-       		 if($this->loginError($error)){
-        		return false;
-			}
+            if ($this->loginError($error)) {
+                return false;
+            }
             if (!$bind) {
-            		$GLOBALS['log']->warn("ldapauth.ldap_rdn_lookup: Could not bind anonymously, returning username");
-            		return $user_name;
+                $GLOBALS['log']->warn("ldapauth.ldap_rdn_lookup: Could not bind anonymously, returning username");
+
+                return $user_name;
             }
         }
 
-		// If we get here we were able to bind somehow
+        // If we get here we were able to bind somehow
         $search_filter = $this->getUserNameFilter($user_name);
 
         $GLOBALS['log']->info("ldapauth.ldap_rdn_lookup: Bind succeeded, searching for $user_attr=$user_name");
         $GLOBALS['log']->debug("ldapauth.ldap_rdn_lookup: base_dn:$base_dn , search_filter:$search_filter");
 
-        $result = @ldap_search($ldapconn, $base_dn , $search_filter, array("dn", $bind_attr));
-         $error = ldap_errno($ldapconn);
-       	 if($this->loginError($error)){
-        	return false;
-		}
+        $result = @ldap_search($ldapconn, $base_dn, $search_filter, array("dn", $bind_attr));
+        $error = ldap_errno($ldapconn);
+        if ($this->loginError($error)) {
+            return false;
+        }
         $info = ldap_get_entries($ldapconn, $result);
-         if($info['count'] == 0){
+        if ($info['count'] == 0) {
 
-        	return false;
+            return false;
 
         }
         ldap_unbind($ldapconn);
@@ -417,9 +446,9 @@ class LDAPAuthenticateUser extends SugarAuthenticateUser{
         $GLOBALS['log']->info("ldapauth.ldap_rdn_lookup: Search result:\nldapauth.ldap_rdn_lookup: " . count($info));
 
         if ($bind_attr == "dn") {
-        		$found_bind_user = $info[0]['dn'];
+            $found_bind_user = $info[0]['dn'];
         } else {
-            	$found_bind_user = $info[0][strtolower($bind_attr)][0];
+            $found_bind_user = $info[0][strtolower($bind_attr)][0];
         }
 
         $GLOBALS['log']->info("ldapauth.ldap_rdn_lookup: found_bind_user=" . $found_bind_user);
@@ -434,13 +463,4 @@ class LDAPAuthenticateUser extends SugarAuthenticateUser{
     }
 
 
-
-
-
-
-
-
-
 }
-
-?>

--- a/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php
+++ b/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php
@@ -64,7 +64,7 @@ class LDAPAuthenticateUser extends SugarAuthenticateUser
      *
      * Contributions by Erik Mitchell erikm@logicpd.com
      */
-    function authenticateUser($name, $password)
+    function authenticateUser($name, $password, $fallback = false)
     {
 
         $server = $GLOBALS['ldap_config']->settings['ldap_hostname'];
@@ -324,7 +324,7 @@ class LDAPAuthenticateUser extends SugarAuthenticateUser
         }
         checkAuthUserStatus();
 
-        $user_id = $this->authenticateUser($name, $password);
+        $user_id = $this->authenticateUser($name, $password, $fallback = false);
         if (empty($user_id)) {
             //check if the user can login as a normal sugar user
             $GLOBALS['log']->fatal('SECURITY: User authentication for ' . $name . ' failed');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Updated loadUserOnLogin($name, $password) to be compatible with SugarAuthenticateUser::loadUserOnLogin($name, $password, $fallback = false, $PARAMS = Array) in order to remove php error logging.

Issue reference: #3911

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->