### PR TITLE
Fixed #3791 - Problems with Umlauts in E-Mail-Client

### DIFF
--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -1185,6 +1185,7 @@ class Email extends Basic
         ) {
 
             // saving a draft OR saving a sent email
+            $decodedFromName = mb_decode_mimeheader($mail->FromName);
             $this->from_addr = "{$decodedFromName} <{$mail->From}>";
             $this->from_addr_name = $this->from_addr;
             $this->to_addrs = $_REQUEST['sendTo'];

--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -1185,7 +1185,6 @@ class Email extends Basic
         ) {
 
             // saving a draft OR saving a sent email
-            $decodedFromName = mb_decode_mimeheader($mail->FromName);
             $this->from_addr = "{$decodedFromName} <{$mail->From}>";
             $this->from_addr_name = $this->from_addr;
             $this->to_addrs = $_REQUEST['sendTo'];
@@ -4018,8 +4017,9 @@ eoq;
             // Strip out name from email address
             // eg Angel Mcmahon <sales.vegan@example.it>
             if (count($matches) > 3) {
-                $display = trim($matches[1]);
                 $email = $matches[2];
+                $display = (str_replace($email, '', $address));
+                $display = (trim(str_replace('"', '', $display)));
             } else {
                 $email = $address;
                 $display = '';
@@ -4033,7 +4033,7 @@ eoq;
 
             $bean->to_addrs_arr[] = array(
                 'email' => $email,
-                'display' => $display,
+                'display' => mb_encode_mimeheader($display, 'UTF-8', 'Q')
             );
         }
 

--- a/modules/Emails/include/ListView/ListViewDataEmails.php
+++ b/modules/Emails/include/ListView/ListViewDataEmails.php
@@ -482,7 +482,7 @@ class ListViewDataEmails extends ListViewData
                 $ret = $emailHeader['from'];
                 break;
             case 'to_addrs_names':
-                $ret = $emailHeader['to'];
+                $ret = mb_decode_mimeheader($emailHeader['to']);
                 break;
             case 'has_attachments':
                 $ret = false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Task: SCRM-663

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Display names with umlauts are broken in the latest sCRM email-client:

The Array "$this->to_addrs_arr" contains:
[0] => Array ( [email] => xyz@abc.de [display] => nig )

Where it should be "König". Strings are broken off after the Umlaut.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #3791

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Receive an email with an umlaut containing name

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->