### PR TITLE
Fixing #3859. Added help field in title tag for every textarea and input generated

### DIFF
--- a/include/SugarFields/Fields/Address/en_us.EditView.tpl
+++ b/include/SugarFields/Fields/Address/en_us.EditView.tpl
@@ -57,9 +57,9 @@
 </td>
 <td width="*">
 {{if $displayParams.maxlength}}
-<textarea id="{{$street}}" name="{{$street}}" maxlength="{{$displayParams.maxlength}}" rows="{{$displayParams.rows|default:4}}" cols="{{$displayParams.cols|default:60}}" tabindex="{{$tabindex}}">{$fields.{{$street}}.value}</textarea>
+<textarea id="{{$street}}" name="{{$street}}" title='{{$vardef.help}}' maxlength="{{$displayParams.maxlength}}" rows="{{$displayParams.rows|default:4}}" cols="{{$displayParams.cols|default:60}}" tabindex="{{$tabindex}}">{$fields.{{$street}}.value}</textarea>
 {{else}}
-<textarea id="{{$street}}" name="{{$street}}" rows="{{$displayParams.rows|default:4}}" cols="{{$displayParams.cols|default:60}}" tabindex="{{$tabindex}}">{$fields.{{$street}}.value}</textarea>
+<textarea id="{{$street}}" name="{{$street}}" title='{{$vardef.help}}' rows="{{$displayParams.rows|default:4}}" cols="{{$displayParams.cols|default:60}}" tabindex="{{$tabindex}}">{$fields.{{$street}}.value}</textarea>
 {{/if}}
 </td>
 </tr>
@@ -73,7 +73,7 @@
 {/if}
 </td>
 <td>
-<input type="text" name="{{$city}}" id="{{$city}}" size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$city}}.value}' tabindex="{{$tabindex}}">
+<input type="text" name="{{$city}}" id="{{$city}}" title='{$fields.{{$city}}.help}' size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$city}}.value}' tabindex="{{$tabindex}}">
 </td>
 </tr>
 
@@ -85,7 +85,7 @@
 {/if}
 </td>
 <td>
-<input type="text" name="{{$state}}" id="{{$state}}" size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$state}}.value}' tabindex="{{$tabindex}}">
+<input type="text" name="{{$state}}" id="{{$state}}" title='{$fields.{{$state}}.help}' size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$state}}.value}' tabindex="{{$tabindex}}">
 </td>
 </tr>
 
@@ -99,7 +99,7 @@
 {/if}
 </td>
 <td>
-<input type="text" name="{{$postalcode}}" id="{{$postalcode}}" size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$postalcode}}.value}' tabindex="{{$tabindex}}">
+<input type="text" name="{{$postalcode}}" id="{{$postalcode}}" title='{$fields.{{$postalcode}}.help}' size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$postalcode}}.value}' tabindex="{{$tabindex}}">
 </td>
 </tr>
 
@@ -113,7 +113,7 @@
 {/if}
 </td>
 <td>
-<input type="text" name="{{$country}}" id="{{$country}}" size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$country}}.value}' tabindex="{{$tabindex}}">
+<input type="text" name="{{$country}}" id="{{$country}}" title='{$fields.{{$country}}.help}' size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$country}}.value}' tabindex="{{$tabindex}}">
 </td>
 </tr>
 

--- a/include/SugarFields/Fields/Address/en_us.EditView.tpl
+++ b/include/SugarFields/Fields/Address/en_us.EditView.tpl
@@ -57,9 +57,9 @@
 </td>
 <td width="*">
 {{if $displayParams.maxlength}}
-<textarea id="{{$street}}" name="{{$street}}" title='{{$vardef.help}}' maxlength="{{$displayParams.maxlength}}" rows="{{$displayParams.rows|default:4}}" cols="{{$displayParams.cols|default:60}}" tabindex="{{$tabindex}}">{$fields.{{$street}}.value}</textarea>
+<textarea id="{{$street}}" name="{{$street}}" maxlength="{{$displayParams.maxlength}}" rows="{{$displayParams.rows|default:4}}" cols="{{$displayParams.cols|default:60}}" tabindex="{{$tabindex}}">{$fields.{{$street}}.value}</textarea>
 {{else}}
-<textarea id="{{$street}}" name="{{$street}}" title='{{$vardef.help}}' rows="{{$displayParams.rows|default:4}}" cols="{{$displayParams.cols|default:60}}" tabindex="{{$tabindex}}">{$fields.{{$street}}.value}</textarea>
+<textarea id="{{$street}}" name="{{$street}}" rows="{{$displayParams.rows|default:4}}" cols="{{$displayParams.cols|default:60}}" tabindex="{{$tabindex}}">{$fields.{{$street}}.value}</textarea>
 {{/if}}
 </td>
 </tr>
@@ -73,7 +73,7 @@
 {/if}
 </td>
 <td>
-<input type="text" name="{{$city}}" id="{{$city}}" title='{$fields.{{$city}}.help}' size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$city}}.value}' tabindex="{{$tabindex}}">
+<input type="text" name="{{$city}}" id="{{$city}}" size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$city}}.value}' tabindex="{{$tabindex}}">
 </td>
 </tr>
 
@@ -85,7 +85,7 @@
 {/if}
 </td>
 <td>
-<input type="text" name="{{$state}}" id="{{$state}}" title='{$fields.{{$state}}.help}' size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$state}}.value}' tabindex="{{$tabindex}}">
+<input type="text" name="{{$state}}" id="{{$state}}" size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$state}}.value}' tabindex="{{$tabindex}}">
 </td>
 </tr>
 
@@ -99,7 +99,7 @@
 {/if}
 </td>
 <td>
-<input type="text" name="{{$postalcode}}" id="{{$postalcode}}" title='{$fields.{{$postalcode}}.help}' size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$postalcode}}.value}' tabindex="{{$tabindex}}">
+<input type="text" name="{{$postalcode}}" id="{{$postalcode}}" size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$postalcode}}.value}' tabindex="{{$tabindex}}">
 </td>
 </tr>
 
@@ -113,7 +113,7 @@
 {/if}
 </td>
 <td>
-<input type="text" name="{{$country}}" id="{{$country}}" title='{$fields.{{$country}}.help}' size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$country}}.value}' tabindex="{{$tabindex}}">
+<input type="text" name="{{$country}}" id="{{$country}}" size="{{$displayParams.size|default:30}}" {{if !empty($vardef.len)}}maxlength='{{$vardef.len}}'{{/if}} value='{$fields.{{$country}}.value}' tabindex="{{$tabindex}}">
 </td>
 </tr>
 

--- a/modules/Home/UnifiedSearch.php
+++ b/modules/Home/UnifiedSearch.php
@@ -93,9 +93,10 @@ if($queryString){
     <input id='searchFieldMain' class='searchField' type='text' size='80' name='query_string' placeholder='<?php echo translate("LBL_SEARCH_QUERY_PLACEHOLDER","AOD_Index");?>' value='<?php echo $queryString;?>'>
     <input type="submit" class="button primary" value="<?php echo translate("LBL_SEARCH_BUTTON","AOD_Index");?>">&nbsp;
 </form>
-<?php 
-    if($hits){ 
-?>
+
+<?php
+	if($hits){
+ ?>
 <table cellpadding='0' cellspacing='0' width='100%' border='0' class='list View'>
     <thead>
     <tr height='20'>
@@ -136,26 +137,26 @@ if($queryString){
             </div>
         </th>
     </tr>
-    <?php getPaginateHTML($queryString, $start,$amount,$total); ?>
+
+<?php getPaginateHTML($queryString, $start,$amount,$total); ?>
+
     </thead>
     <?php
-foreach($hits as $hit){
-    echo "<tr>"
-        ."<td>".$hit->label."</td>"
-        ."<td><a href='index.php?module=".$hit->record_module."&action=DetailView&record=".$hit->record_id."'>".$hit->name."</a></td>"
-        ."<td>".$hit->summary."</td>"
-        ."<td>".$hit->date_entered."</td>"
-        ."<td>".$hit->date_modified."</td>"
-        ."<td>".getScoreDisplay($hit)."</td>"
-        ."</tr>";
-} ?>
-</table>	
-    <?php
+            foreach($hits as $hit){
+                echo "<tr>"
+                    ."<td>".$hit->label."</td>"
+                    ."<td><a href='index.php?module=".$hit->record_module."&action=DetailView&record=".$hit->record_id."'>".$hit->name."</a></td>"
+                    ."<td>".$hit->summary."</td>"
+                    ."<td>".$hit->date_entered."</td>"
+                    ."<td>".$hit->date_modified."</td>"
+                    ."<td>".getScoreDisplay($hit)."</td>"
+                    ."</tr>";
+            }
         }else{
         echo "<p>".translate("LBL_SEARCH_RESULT_EMPTY","AOD_Index")."</p>";
     }
 ?>
-
+</table>
 
 <?php
 function getRecordSummary(SugarBean $bean){
@@ -282,38 +283,40 @@ function getPaginateHTML($queryString, $start, $amount, $total){
         $nextImage = SugarThemeRegistry::current()->getImageURL('next.gif');
     }
     ?>
+
 <tr id="pagination" class="pagination-unique" role="presentation">
-    <td colspan="6">
-        <table border="0" cellpadding="0" cellspacing="0" width="100%" class="paginationTable">
-            <tbody>
-                <tr>
-		    <td nowrap="nowrap" class="paginationActionButtons"> &nbsp; </td>
-                    <td nowrap="nowrap" align="right" class="paginationChangeButtons" width="1%">
-			<form action='index.php'>
-			    <input type="hidden" name="action" value="UnifiedSearch">
-			    <input type="hidden" name="module" value="Home">
-			    <input type="hidden" name="start" value="<?php echo $start;?>">
-			    <input type="hidden" name="total" value="<?php echo $total;?>">
-			    <input type="hidden" name="query_string" value="<?php echo $queryString;?>">
-			    <button type="submit" id="listViewStartButton_top" name="listViewStartButton" title="Start" class="button" <?php echo $first ? 'disabled="disabled"' : ''?>>
-				<img src="<?php echo $startImage;?>" alt="Start" align="absmiddle" border="0">
-			    </button>
-			    <button type="submit" id="listViewPrevButton_top" name="listViewPrevButton" class="button" title="Previous" <?php echo $first ? 'disabled="disabled"' : ''?>>
-				<img src="<?php echo $prevImage;?>" alt="Previous" align="absmiddle" border="0">
-			    </button>
-			    <span class="pageNumbers" style="vertical-align: super;">(<?php echo $total ? $start+1 : 0;?> - <?php echo min($start + $amount,$total);?> of <?php echo $total;?>)</span>
-			    <button type="submit" id="listViewNextButton_top" name="listViewNextButton" title="Next" class="button" <?php echo $last ? 'disabled="disabled"' : ''?>>
-				<img src="<?php echo $nextImage;?>" alt="Next" align="absmiddle" border="0">
-			    </button>
-			    <button type="submit" id="listViewEndButton_top" name="listViewEndButton" title="End" class="button" <?php echo $last ? 'disabled="disabled"' : ''?>>
-				<img src="<?php echo $endImage;?>" alt="End" align="absmiddle" border="0">
-			    </button>
-			</form>
-                    </td>
-                </tr>
-            </tbody>
-	</table>
-    </td>
-</tr>
+		<td colspan="6">
+			<table border="0" cellpadding="0" cellspacing="0" width="100%" class="paginationTable">
+				<tbody><tr>
+					<td nowrap="nowrap" class="paginationActionButtons"> &nbsp; </td>
+					<td nowrap="nowrap" align="right" class="paginationChangeButtons" width="1%">
+
+        <form action='index.php'>
+            <input type="hidden" name="action" value="UnifiedSearch">
+            <input type="hidden" name="module" value="Home">
+            <input type="hidden" name="start" value="<?php echo $start;?>">
+            <input type="hidden" name="total" value="<?php echo $total;?>">
+            <input type="hidden" name="query_string" value="<?php echo $queryString;?>">
+            <button type="submit" id="listViewStartButton_top" name="listViewStartButton" title="Start" class="button" <?php echo $first ? 'disabled="disabled"' : ''?>>
+                <img src="<?php echo $startImage;?>" alt="Start" align="absmiddle" border="0">
+            </button>
+            <button type="submit" id="listViewPrevButton_top" name="listViewPrevButton" class="button" title="Previous" <?php echo $first ? 'disabled="disabled"' : ''?>>
+                <img src="<?php echo $prevImage;?>" alt="Previous" align="absmiddle" border="0">
+            </button>
+            <span class="pageNumbers" style="vertical-align: super;">(<?php echo $total ? $start+1 : 0;?> - <?php echo min($start + $amount,$total);?> of <?php echo $total;?>)</span>
+            <button type="submit" id="listViewNextButton_top" name="listViewNextButton" title="Next" class="button" <?php echo $last ? 'disabled="disabled"' : ''?>>
+                <img src="<?php echo $nextImage;?>" alt="Next" align="absmiddle" border="0">
+            </button>
+            <button type="submit" id="listViewEndButton_top" name="listViewEndButton" title="End" class="button" <?php echo $last ? 'disabled="disabled"' : ''?>>
+                <img src="<?php echo $endImage;?>" alt="End" align="absmiddle" border="0">
+            </button>
+        </form>
+
+
+					</td>
+				</tr>
+			</tbody></table>
+		</td>
+	</tr>
 <?php
 }

--- a/modules/Home/UnifiedSearch.php
+++ b/modules/Home/UnifiedSearch.php
@@ -93,8 +93,10 @@ if($queryString){
     <input id='searchFieldMain' class='searchField' type='text' size='80' name='query_string' placeholder='<?php echo translate("LBL_SEARCH_QUERY_PLACEHOLDER","AOD_Index");?>' value='<?php echo $queryString;?>'>
     <input type="submit" class="button primary" value="<?php echo translate("LBL_SEARCH_BUTTON","AOD_Index");?>">&nbsp;
 </form>
+<?php 
+    if($hits){ 
+?>
 <table cellpadding='0' cellspacing='0' width='100%' border='0' class='list View'>
-    <?php getPaginateHTML($queryString, $start,$amount,$total); ?>
     <thead>
     <tr height='20'>
         <th scope='col' width='10%'data-hide="phone">
@@ -134,9 +136,9 @@ if($queryString){
             </div>
         </th>
     </tr>
+    <?php getPaginateHTML($queryString, $start,$amount,$total); ?>
     </thead>
     <?php
-    if($hits){
 foreach($hits as $hit){
     echo "<tr>"
         ."<td>".$hit->label."</td>"
@@ -146,12 +148,14 @@ foreach($hits as $hit){
         ."<td>".$hit->date_modified."</td>"
         ."<td>".getScoreDisplay($hit)."</td>"
         ."</tr>";
-}
+} ?>
+</table>	
+    <?php
         }else{
-        echo "<tr><td>".translate("LBL_SEARCH_RESULT_EMPTY","AOD_Index")."</td></td>";
+        echo "<p>".translate("LBL_SEARCH_RESULT_EMPTY","AOD_Index")."</p>";
     }
 ?>
-</table>
+
 
 <?php
 function getRecordSummary(SugarBean $bean){
@@ -278,27 +282,38 @@ function getPaginateHTML($queryString, $start, $amount, $total){
         $nextImage = SugarThemeRegistry::current()->getImageURL('next.gif');
     }
     ?>
-    <td class="paginationChangeButtons" align="right" nowrap="nowrap" width="1%">
-        <form action='index.php'>
-            <input type="hidden" name="action" value="UnifiedSearch">
-            <input type="hidden" name="module" value="Home">
-            <input type="hidden" name="start" value="<?php echo $start;?>">
-            <input type="hidden" name="total" value="<?php echo $total;?>">
-            <input type="hidden" name="query_string" value="<?php echo $queryString;?>">
-            <button type="submit" id="listViewStartButton_top" name="listViewStartButton" title="Start" class="button" <?php echo $first ? 'disabled="disabled"' : ''?>>
-                <img src="<?php echo $startImage;?>" alt="Start" align="absmiddle" border="0">
-            </button>
-            <button type="submit" id="listViewPrevButton_top" name="listViewPrevButton" class="button" title="Previous" <?php echo $first ? 'disabled="disabled"' : ''?>>
-                <img src="<?php echo $prevImage;?>" alt="Previous" align="absmiddle" border="0">
-            </button>
-            <span class="pageNumbers">(<?php echo $total ? $start+1 : 0;?> - <?php echo min($start + $amount,$total);?> of <?php echo $total;?>)</span>
-            <button type="submit" id="listViewNextButton_top" name="listViewNextButton" title="Next" class="button" <?php echo $last ? 'disabled="disabled"' : ''?>>
-                <img src="<?php echo $nextImage;?>" alt="Next" align="absmiddle" border="0">
-            </button>
-            <button type="submit" id="listViewEndButton_top" name="listViewEndButton" title="End" class="button" <?php echo $last ? 'disabled="disabled"' : ''?>>
-                <img src="<?php echo $endImage;?>" alt="End" align="absmiddle" border="0">
-            </button>
-        </form>
+<tr id="pagination" class="pagination-unique" role="presentation">
+    <td colspan="6">
+        <table border="0" cellpadding="0" cellspacing="0" width="100%" class="paginationTable">
+            <tbody>
+                <tr>
+		    <td nowrap="nowrap" class="paginationActionButtons"> &nbsp; </td>
+                    <td nowrap="nowrap" align="right" class="paginationChangeButtons" width="1%">
+			<form action='index.php'>
+			    <input type="hidden" name="action" value="UnifiedSearch">
+			    <input type="hidden" name="module" value="Home">
+			    <input type="hidden" name="start" value="<?php echo $start;?>">
+			    <input type="hidden" name="total" value="<?php echo $total;?>">
+			    <input type="hidden" name="query_string" value="<?php echo $queryString;?>">
+			    <button type="submit" id="listViewStartButton_top" name="listViewStartButton" title="Start" class="button" <?php echo $first ? 'disabled="disabled"' : ''?>>
+				<img src="<?php echo $startImage;?>" alt="Start" align="absmiddle" border="0">
+			    </button>
+			    <button type="submit" id="listViewPrevButton_top" name="listViewPrevButton" class="button" title="Previous" <?php echo $first ? 'disabled="disabled"' : ''?>>
+				<img src="<?php echo $prevImage;?>" alt="Previous" align="absmiddle" border="0">
+			    </button>
+			    <span class="pageNumbers" style="vertical-align: super;">(<?php echo $total ? $start+1 : 0;?> - <?php echo min($start + $amount,$total);?> of <?php echo $total;?>)</span>
+			    <button type="submit" id="listViewNextButton_top" name="listViewNextButton" title="Next" class="button" <?php echo $last ? 'disabled="disabled"' : ''?>>
+				<img src="<?php echo $nextImage;?>" alt="Next" align="absmiddle" border="0">
+			    </button>
+			    <button type="submit" id="listViewEndButton_top" name="listViewEndButton" title="End" class="button" <?php echo $last ? 'disabled="disabled"' : ''?>>
+				<img src="<?php echo $endImage;?>" alt="End" align="absmiddle" border="0">
+			    </button>
+			</form>
+                    </td>
+                </tr>
+            </tbody>
+	</table>
     </td>
+</tr>
 <?php
 }


### PR DESCRIPTION
NOTE: Replaces Pull request #3868, not being able to fix the errors in the pull request (I had to remove two files but messed it with git). I hope this unlocks these fix.

Description

Added title='{{$vardef.help}}', title='{$fields.{{$city}}.help}', title='{$fields.{{$state}}.help}'...
You set help for address fields in Studio but then is not displayed when you go into the EditView.

Motivation and Context

Displaying help text in address auto generated fields

How To Test This

You set help for account billing address and billing city. then you go to new account and mouse over billing address and billing city.

Types of changes
[X] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[X] Breaking change (fix or feature that would cause existing functionality to change)

Final checklist
[X] My code follows the code style of this project found here.
[X] My change requires a change to the documentation.
[X] I have read the How to Contribute guidelines.-->