### PR TITLE
Fixed #3331 - Quick Create Lead/Contact/Account not saving email address

### DIFF
--- a/include/SugarEmailAddress/templates/forEditView.tpl
+++ b/include/SugarEmailAddress/templates/forEditView.tpl
@@ -37,7 +37,6 @@
  * reasonably feasible for technical reasons, the Appropriate Legal Notices must
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
-
 *}
 {php}
 global $emailInstances;
@@ -125,21 +124,24 @@ var emailAddressWidgetLoaded = false;
 </div>
 <input type="hidden" name="useEmailWidget" value="true">
 <script type="text/javascript" language="javascript">
-SUGAR_callsInProgress++;
-var eaw = SUGAR.EmailAddressWidget.instances.{$module}{$index} = new SUGAR.EmailAddressWidget("{$module}");
-eaw.emailView = '{$emailView}';
-eaw.emailIsRequired = "{$required}";
-eaw.tabIndex = '{$tabindex}';
-var addDefaultAddress = '{$addDefaultAddress}';
-var prefillEmailAddress = '{$prefillEmailAddresses}';
-var prefillData = {$prefillData};
-if(prefillEmailAddress == 'true') {ldelim}
-	eaw.prefillEmailAddresses('{$module}emailAddressesTable{$index}', prefillData);
-{rdelim} else if(addDefaultAddress == 'true') {ldelim}
-	eaw.addEmailAddress('{$module}emailAddressesTable{$index}', '',true);
-{rdelim}
-if('{$module}_email_widget_id') {ldelim}
-   document.getElementById('{$module}_email_widget_id').value = eaw.count;
-{rdelim}
-SUGAR_callsInProgress--;
+  SUGAR_callsInProgress++;
+  var eaw = SUGAR.EmailAddressWidget.instances.{$module}{$index} = new SUGAR.EmailAddressWidget("{$module}");
+  eaw.emailView = '{$emailView}';
+  eaw.emailIsRequired = "{$required}";
+  eaw.tabIndex = '{$tabindex}';
+  var addDefaultAddress = '{$addDefaultAddress}';
+  var prefillEmailAddress = '{$prefillEmailAddresses}';
+  var prefillData = {$prefillData};
+  debugger;
+  if (prefillEmailAddress === 'true') {ldelim}
+    eaw.prefillEmailAddresses('{$module}emailAddressesTable{$index}', prefillData);
+      {rdelim} else if (addDefaultAddress === 'true') {ldelim}
+    eaw.addEmailAddress('{$module}emailAddressesTable{$index}', '', true);
+    document.getElementById('{$module}{$index}emailAddress{$index}').value = document.getElementById('email_addr').value;
+  {rdelim}
+  if ('{$module}_email_widget_id') {ldelim}
+    document.getElementById('{$module}_email_widget_id').value = eaw.count;
+      {rdelim}
+  SUGAR_callsInProgress--;
 </script>
+

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelTopButtonQuickCreate.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelTopButtonQuickCreate.php
@@ -1,11 +1,11 @@
 <?php
-if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
-/*********************************************************************************
+/**
+ *
  * SugarCRM Community Edition is a customer relationship management program developed by
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
-
- * SuiteCRM is an extension to SugarCRM Community Edition developed by Salesagility Ltd.
- * Copyright (C) 2011 - 2014 Salesagility Ltd.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2017 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the
@@ -16,7 +16,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
  * details.
  *
  * You should have received a copy of the GNU Affero General Public License along with
@@ -34,170 +34,169 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
  * these Appropriate Legal Notices must retain the display of the "Powered by
  * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
- * reasonably feasible for  technical reasons, the Appropriate Legal Notices must
- * display the words  "Powered by SugarCRM" and "Supercharged by SuiteCRM".
- ********************************************************************************/
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
 
-
-
-
-
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
 
 class SugarWidgetSubPanelTopButtonQuickCreate extends SugarWidgetSubPanelTopButton
 {
 
 
-	function &_get_form($defines, $additionalFormFields = null, $asUrl = false)
-	{
-		global $app_strings;
-		global $currentModule;
+    function &_get_form($defines, $additionalFormFields = null, $asUrl = false)
+    {
+        global $app_strings;
+        global $currentModule;
 
-		// Create the additional form fields with real values if they were not passed in
-		if(empty($additionalFormFields) && $this->additional_form_fields)
-		{
-			foreach($this->additional_form_fields as $key=>$value)
-			{
-				if(!empty($defines['focus']->$value))
-				{
-					$additionalFormFields[$key] = $defines['focus']->$value;
-				}
-				else
-				{
-					$additionalFormFields[$key] = '';
-				}
-			}
-		}
-
-		if(!empty($this->module))
-		{
-			$defines['child_module_name'] = $this->module;
-		}
-		else
-		{
-			$defines['child_module_name'] = $defines['module'];
-		}
-
-		$defines['parent_bean_name'] = get_class( $defines['focus']);
-
-		$relationship_name = $this->get_subpanel_relationship_name($defines);
-
-		$form = 'form' . $relationship_name;
-		$button = '<form onsubmit="return SUGAR.subpanelUtils.sendAndRetrieve(this.id, \'subpanel_' . $defines['subpanel_definition']->name . '\', \'' . addslashes($app_strings['LBL_LOADING']) . '\');" action="index.php" method="post" name="form" id="form' . $form . "\">\n";
-
-		//module_button is used to override the value of module name
-		$button .= "<input type='hidden' name='target_module' value='".$defines['child_module_name']."'>\n";
-		$button .= "<input type='hidden' name='".strtolower($defines['parent_bean_name'])."_id' value='".$defines['focus']->id."'>\n";
-
-		if(isset($defines['focus']->name))
-		{
-			$button .= "<input type='hidden' name='".strtolower($defines['parent_bean_name'])."_name' value='".$defines['focus']->name."'>";
-			#26451,add these fields for custom one-to-many relate field.
-            if(!empty($defines['child_module_name'])){
-            	$button .= "<input type='hidden' name='". $relationship_name ."_name' value='".$defines['focus']->name."'>";
-            	$childFocusName = !empty($GLOBALS['beanList'][$defines['child_module_name']]) ? $GLOBALS['beanList'][$defines['child_module_name']] : "";
-            	if(!empty($GLOBALS['dictionary'][ $childFocusName ]["fields"][$relationship_name .'_name']['id_name'])){
-            		$button .= "<input type='hidden' name='". $GLOBALS['dictionary'][ $childFocusName ]["fields"][$relationship_name .'_name']['id_name'] ."' value='".$defines['focus']->id."'>";
-            	}
-            }
-            
-            //Set the return_name form variable that will allow EditView2.php 
-            $additionalFormFields['return_name'] = $defines['focus']->name;
-		}
-		
-		if(!empty($defines['view']))
-		$button .= '<input type="hidden" name="target_view" value="'. $defines['view'] . '" />';
-		$button .= '<input type="hidden" name="to_pdf" value="true" />';
-        $button .= '<input type="hidden" name="tpl" value="QuickCreate.tpl" />';
-		$button .= '<input type="hidden" name="return_module" value="' . $currentModule . "\" />\n";
-		$button .= '<input type="hidden" name="return_action" value="' . $defines['action'] . "\" />\n";
-		$button .= '<input type="hidden" name="return_id" value="' . $defines['focus']->id . "\" />\n";
-		$button .= '<input type="hidden" name="return_relationship" value="' . $relationship_name . "\" />\n";
-		$button .= '<input type="hidden" name="record" value="" />';
-
-		// TODO: move this out and get $additionalFormFields working properly
-		if(empty($additionalFormFields['parent_type']))
-		{
-			if($defines['focus']->object_name=='Contact') {
-				$additionalFormFields['parent_type'] = 'Accounts';
-			}
-			else {
-				$additionalFormFields['parent_type'] = $defines['focus']->module_dir;
-			}
-		}
-		if(empty($additionalFormFields['parent_name']))
-		{
-			if($defines['focus']->object_name=='Contact') {
-				$additionalFormFields['parent_name'] = $defines['focus']->account_name;
-				$additionalFormFields['account_name'] = $defines['focus']->account_name;
-			}
-			else {
-				$additionalFormFields['parent_name'] = $defines['focus']->name;
-			}
-		}
-		if(empty($additionalFormFields['parent_id']))
-		{
-			if($defines['focus']->object_name=='Contact') {
-				$additionalFormFields['parent_id'] = $defines['focus']->account_id;
-				$additionalFormFields['account_id'] = $defines['focus']->account_id;
-			}
-			else {
-				$additionalFormFields['parent_id'] = $defines['focus']->id;
-			}
-		}
-
-        if(strtolower($defines['child_module_name']) =='contracts') {
-            //set variables to account name, or parent account name
-            if(strtolower($defines['parent_bean_name']) == 'account' ){
-                //if account is parent bean, then get focus id/focus name
-                if(isset($defines['focus']->id))$additionalFormFields['account_id'] = $defines['focus']->id;
-                if(isset($defines['focus']->name))$additionalFormFields['account_name'] = $defines['focus']->name;
-            }elseif(strtolower($defines['parent_bean_name']) == 'quote' ){
-                //if quote is parent bean, then get billing_account_id/billing_account_name
-                if(isset($defines['focus']->billing_account_id))$additionalFormFields['account_id'] = $defines['focus']->billing_account_id;
-                if(isset($defines['focus']->billing_account_name))$additionalFormFields['account_name'] = $defines['focus']->billing_account_name;
-            }else{
-                if(isset($defines['focus']->account_id))$additionalFormFields['account_id'] = $defines['focus']->account_id;
-                if(isset($defines['focus']->account_name))$additionalFormFields['account_name'] = $defines['focus']->account_name;
+        // Create the additional form fields with real values if they were not passed in
+        if (empty($additionalFormFields) && $this->additional_form_fields) {
+            foreach ($this->additional_form_fields as $key => $value) {
+                if (!empty($defines['focus']->$value)) {
+                    $additionalFormFields[$key] = $defines['focus']->$value;
+                } else {
+                    $additionalFormFields[$key] = '';
+                }
             }
         }
 
-		$button .= '<input type="hidden" name="action" value="SubpanelCreates" />' . "\n";
-		$button .= '<input type="hidden" name="module" value="Home" />' . "\n";
-		$button .= '<input type="hidden" name="target_action" value="QuickCreate" />' . "\n";
+        if (!empty($this->module)) {
+            $defines['child_module_name'] = $this->module;
+        } else {
+            $defines['child_module_name'] = $defines['module'];
+        }
 
-		// fill in additional form fields for all but action
-		foreach($additionalFormFields as $key => $value)
-		{
-			if($key != 'action')
-			{
-				$button .= '<input type="hidden" name="' . $key . '" value=\'' . $value . '\' />' . "\n";
-			}
-		}
+        $defines['parent_bean_name'] = get_class($defines['focus']);
 
-		return $button;
-	}
+        $relationship_name = $this->get_subpanel_relationship_name($defines);
 
-	/**
-	 * get_subpanel_relationship_name
-	 * Get the relationship name based on the subapnel definition
-	 * @param mixed $defines The subpanel definition
-	 */
-	function get_subpanel_relationship_name($defines) {
-		 $relationship_name = '';
-		 if(!empty($defines)) {
-		 	$relationship_name = isset($defines['module']) ? $defines['module'] : '';
-	     	$dataSource = $defines['subpanel_definition']->get_data_source_name(true);
-         	if (!empty($dataSource)) {
-				$relationship_name = $dataSource;
-				//Try to set the relationship name to the real relationship, not the link.
-				if (!empty($defines['subpanel_definition']->parent_bean->field_defs[$dataSource])
-				 && !empty($defines['subpanel_definition']->parent_bean->field_defs[$dataSource]['relationship']))
-				{
-					$relationship_name = $defines['subpanel_definition']->parent_bean->field_defs[$dataSource]['relationship'];
-				}
-			}
-		 }
-		 return $relationship_name;
-	}
+        $form = 'form' . $relationship_name;
+        $button = '<form onsubmit="return SUGAR.subpanelUtils.sendAndRetrieve(this.id, \'subpanel_' . $defines['subpanel_definition']->name . '\', \'' . addslashes($app_strings['LBL_LOADING']) . '\');" action="index.php" method="post" name="form" id="form' . $form . "\">\n";
+
+        //module_button is used to override the value of module name
+        $button .= "<input type='hidden' name='target_module' value='" . $defines['child_module_name'] . "'>\n";
+        $button .= "<input type='hidden' name='" . strtolower($defines['parent_bean_name']) . "_id' value='" . $defines['focus']->id . "'>\n";
+
+        if (isset($defines['focus']->name)) {
+            $button .= "<input type='hidden' name='" . strtolower($defines['parent_bean_name']) . "_name' value='" . $defines['focus']->name . "'>";
+            #26451,add these fields for custom one-to-many relate field.
+            if (!empty($defines['child_module_name'])) {
+                $button .= "<input type='hidden' name='" . $relationship_name . "_name' value='" . $defines['focus']->name . "'>";
+                $childFocusName = !empty($GLOBALS['beanList'][$defines['child_module_name']]) ? $GLOBALS['beanList'][$defines['child_module_name']] : "";
+                if (!empty($GLOBALS['dictionary'][$childFocusName]["fields"][$relationship_name . '_name']['id_name'])) {
+                    $button .= "<input type='hidden' name='" . $GLOBALS['dictionary'][$childFocusName]["fields"][$relationship_name . '_name']['id_name'] . "' value='" . $defines['focus']->id . "'>";
+                }
+            }
+
+            //Set the return_name form variable that will allow EditView2.php 
+            $additionalFormFields['return_name'] = $defines['focus']->name;
+        }
+
+        if (!empty($defines['view'])) {
+            $button .= '<input type="hidden" name="target_view" value="' . $defines['view'] . '" />';
+        }
+        $button .= '<input type="hidden" name="to_pdf" value="true" />';
+        $button .= '<input type="hidden" name="tpl" value="QuickCreate.tpl" />';
+        $button .= '<input type="hidden" name="return_module" value="' . $currentModule . "\" />\n";
+        $button .= '<input type="hidden" name="return_action" value="' . $defines['action'] . "\" />\n";
+        $button .= '<input type="hidden" name="return_id" value="' . $defines['focus']->id . "\" />\n";
+        $button .= '<input type="hidden" name="return_relationship" value="' . $relationship_name . "\" />\n";
+        $button .= '<input type="hidden" name="email_addr" id="email_addr" value="' . $defines['focus']->from_addr . "\" />\n";
+        $button .= '<input type="hidden" name="record" value="" />';
+
+        // TODO: move this out and get $additionalFormFields working properly
+        if (empty($additionalFormFields['parent_type'])) {
+            if ($defines['focus']->object_name === 'Contact') {
+                $additionalFormFields['parent_type'] = 'Accounts';
+            } else {
+                $additionalFormFields['parent_type'] = $defines['focus']->module_dir;
+            }
+        }
+        if (empty($additionalFormFields['parent_name'])) {
+            if ($defines['focus']->object_name === 'Contact') {
+                $additionalFormFields['parent_name'] = $defines['focus']->account_name;
+                $additionalFormFields['account_name'] = $defines['focus']->account_name;
+            } else {
+                $additionalFormFields['parent_name'] = $defines['focus']->name;
+            }
+        }
+        if (empty($additionalFormFields['parent_id'])) {
+            if ($defines['focus']->object_name === 'Contact') {
+                $additionalFormFields['parent_id'] = $defines['focus']->account_id;
+                $additionalFormFields['account_id'] = $defines['focus']->account_id;
+            } else {
+                $additionalFormFields['parent_id'] = $defines['focus']->id;
+            }
+        }
+
+        if (strtolower($defines['child_module_name']) === 'contracts') {
+            //set variables to account name, or parent account name
+            if (strtolower($defines['parent_bean_name']) === 'account') {
+                //if account is parent bean, then get focus id/focus name
+                if (isset($defines['focus']->id)) {
+                    $additionalFormFields['account_id'] = $defines['focus']->id;
+                }
+                if (isset($defines['focus']->name)) {
+                    $additionalFormFields['account_name'] = $defines['focus']->name;
+                }
+            } elseif (strtolower($defines['parent_bean_name']) === 'quote') {
+                //if quote is parent bean, then get billing_account_id/billing_account_name
+                if (isset($defines['focus']->billing_account_id)) {
+                    $additionalFormFields['account_id'] = $defines['focus']->billing_account_id;
+                }
+                if (isset($defines['focus']->billing_account_name)) {
+                    $additionalFormFields['account_name'] = $defines['focus']->billing_account_name;
+                }
+            } else {
+                if (isset($defines['focus']->account_id)) {
+                    $additionalFormFields['account_id'] = $defines['focus']->account_id;
+                }
+                if (isset($defines['focus']->account_name)) {
+                    $additionalFormFields['account_name'] = $defines['focus']->account_name;
+                }
+            }
+        }
+
+        $button .= '<input type="hidden" name="action" value="SubpanelCreates" />' . "\n";
+        $button .= '<input type="hidden" name="module" value="Home" />' . "\n";
+        $button .= '<input type="hidden" name="target_action" value="QuickCreate" />' . "\n";
+
+        // fill in additional form fields for all but action
+        foreach ($additionalFormFields as $key => $value) {
+            if ($key !== 'action') {
+                $button .= '<input type="hidden" name="' . $key . '" value=\'' . $value . '\' />' . "\n";
+            }
+        }
+
+        return $button;
+    }
+
+    /**
+     * get_subpanel_relationship_name
+     * Get the relationship name based on the subapnel definition
+     * @param mixed $defines The subpanel definition
+     * @return string $relationship_name
+     */
+    function get_subpanel_relationship_name($defines)
+    {
+        $relationship_name = '';
+        if (!empty($defines)) {
+            $relationship_name = isset($defines['module']) ? $defines['module'] : '';
+            $dataSource = $defines['subpanel_definition']->get_data_source_name(true);
+            if (!empty($dataSource)) {
+                $relationship_name = $dataSource;
+                //Try to set the relationship name to the real relationship, not the link.
+                if (!empty($defines['subpanel_definition']->parent_bean->field_defs[$dataSource])
+                    && !empty($defines['subpanel_definition']->parent_bean->field_defs[$dataSource]['relationship'])
+                ) {
+                    $relationship_name = $defines['subpanel_definition']->parent_bean->field_defs[$dataSource]['relationship'];
+                }
+            }
+        }
+
+        return $relationship_name;
+    }
 }
-?>
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When quick creating a Lead/Contact/Account from a sub-panel within an emails detail-view, the email address field will not auto-populate.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #3331 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Open an email in the email module list-view
2. Click "Create" on a sub-panel like "Lead".
3. Check the Email field on the pop-up and full form.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->