### PR TITLE
Fixed - Relationship removal access issue

### DIFF
--- a/include/generic/DeleteRelationship.php
+++ b/include/generic/DeleteRelationship.php
@@ -1,11 +1,11 @@
 <?php
-if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
-/*********************************************************************************
+/**
+ *
  * SugarCRM Community Edition is a customer relationship management program developed by
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
-
- * SuiteCRM is an extension to SugarCRM Community Edition developed by Salesagility Ltd.
- * Copyright (C) 2011 - 2014 Salesagility Ltd.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2017 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the
@@ -16,7 +16,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
  * details.
  *
  * You should have received a copy of the GNU Affero General Public License along with
@@ -34,17 +34,13 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
  * these Appropriate Legal Notices must retain the display of the "Powered by
  * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
- * reasonably feasible for  technical reasons, the Appropriate Legal Notices must
- * display the words  "Powered by SugarCRM" and "Supercharged by SuiteCRM".
- ********************************************************************************/
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
 
-/*********************************************************************************
-
- * Description:  TODO: To be written.
- * Portions created by SugarCRM are Copyright (C) SugarCRM, Inc.
- * All Rights Reserved.
- * Contributor(s): ______________________________________..
- ********************************************************************************/
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
 
 /*
  Removes Relationships, input is a form POST
@@ -66,17 +62,16 @@ ARGS:
 
 require_once('include/formbase.php');
 
- global $beanFiles,$beanList;
- $bean_name = $beanList[$_REQUEST['module']];
- require_once($beanFiles[$bean_name]);
- $focus = new $bean_name();
- if (  empty($_REQUEST['linked_id']) || empty($_REQUEST['linked_field'])  || empty($_REQUEST['record']))
- {
-	die("need linked_field, linked_id and record fields");
- }
- $linked_field = $_REQUEST['linked_field'];
- $record = $_REQUEST['record'];
- $linked_id = $_REQUEST['linked_id'];
+global $beanFiles, $beanList;
+$bean_name = $beanList[$_REQUEST['module']];
+require_once($beanFiles[$bean_name]);
+$focus = new $bean_name();
+if (empty($_REQUEST['linked_id']) || empty($_REQUEST['linked_field']) || empty($_REQUEST['record'])) {
+    die("need linked_field, linked_id and record fields");
+}
+$linked_field = $_REQUEST['linked_field'];
+$record = $_REQUEST['record'];
+$linked_id = $_REQUEST['linked_id'];
 
 if ($linked_field === 'aclroles') {
     if (!ACLController::checkAccess($bean_name, 'edit', true)) {
@@ -85,59 +80,56 @@ if ($linked_field === 'aclroles') {
     }
 }
 
- if($bean_name == 'Team')
- {
- 	$focus->retrieve($record);
- 	$focus->remove_user_from_team($linked_id);
- }
- else
- {
- 	// cut it off:
- 	$focus->load_relationship($linked_field);
- 	if($focus->$linked_field->_relationship->relationship_name == 'quotes_contacts_shipto')
- 		unset($focus->$linked_field->_relationship->relationship_role_column);
- 	$focus->$linked_field->delete($record,$linked_id);
- }
- if ($bean_name == 'Campaign' and $linked_field=='prospectlists' ) {
+if ($bean_name === 'Team') {
+    $focus->retrieve($record);
+    $focus->remove_user_from_team($linked_id);
+} else {
+    // cut it off:
+    $focus->load_relationship($linked_field);
+    if ($focus->$linked_field->_relationship->relationship_name === 'quotes_contacts_shipto') {
+        unset($focus->$linked_field->_relationship->relationship_role_column);
+    }
+    $focus->$linked_field->delete($record, $linked_id);
+}
+if ($bean_name === 'Campaign' and $linked_field === 'prospectlists') {
 
- 	$query="SELECT email_marketing_prospect_lists.id from email_marketing_prospect_lists ";
- 	$query.=" left join email_marketing on email_marketing.id=email_marketing_prospect_lists.email_marketing_id";
-	$query.=" where email_marketing.campaign_id='$record'";
- 	$query.=" and email_marketing_prospect_lists.prospect_list_id='$linked_id'";
+    $query = "SELECT email_marketing_prospect_lists.id from email_marketing_prospect_lists ";
+    $query .= " left join email_marketing on email_marketing.id=email_marketing_prospect_lists.email_marketing_id";
+    $query .= " where email_marketing.campaign_id='$record'";
+    $query .= " and email_marketing_prospect_lists.prospect_list_id='$linked_id'";
 
- 	$result=$focus->db->query($query);
-	while (($row=$focus->db->fetchByAssoc($result)) != null) {
-			$del_query =" update email_marketing_prospect_lists set email_marketing_prospect_lists.deleted=1, email_marketing_prospect_lists.date_modified=".$focus->db->convert("'".TimeDate::getInstance()->nowDb()."'",'datetime');
- 			$del_query.=" WHERE  email_marketing_prospect_lists.id='{$row['id']}'";
-		 	$focus->db->query($del_query);
-	}
- 	$focus->db->query($query);
- }
-if ($bean_name == "Meeting") {
+    $result = $focus->db->query($query);
+    while (($row = $focus->db->fetchByAssoc($result)) != null) {
+        $del_query = " update email_marketing_prospect_lists set email_marketing_prospect_lists.deleted=1, email_marketing_prospect_lists.date_modified=" . $focus->db->convert("'" . TimeDate::getInstance()->nowDb() . "'",
+                'datetime');
+        $del_query .= " WHERE  email_marketing_prospect_lists.id='{$row['id']}'";
+        $focus->db->query($del_query);
+    }
+    $focus->db->query($query);
+}
+if ($bean_name === "Meeting") {
     $focus->retrieve($record);
     $user = new User();
     $user->retrieve($linked_id);
     if (!empty($user->id)) {  //make sure that record exists. we may have a contact on our hands.
 
-    	if($focus->update_vcal)
-    	{
-        	vCal::cache_sugar_vcal($user);
-    	}
+        if ($focus->update_vcal) {
+            vCal::cache_sugar_vcal($user);
+        }
     }
 }
-if ($bean_name == "User" && $linked_field == 'eapm') {
+if ($bean_name === "User" && $linked_field === 'eapm') {
     $eapm = new EAPM();
     $eapm->mark_deleted($linked_id);
 }
 
-if(!empty($_REQUEST['return_url'])){
-	$_REQUEST['return_url'] =urldecode($_REQUEST['return_url']);
+if (!empty($_REQUEST['return_url'])) {
+    $_REQUEST['return_url'] = urldecode($_REQUEST['return_url']);
 }
-$GLOBALS['log']->debug("deleted relationship: bean: $bean_name, linked_field: $linked_field, linked_id:$linked_id" );
-if(empty($_REQUEST['refresh_page'])){
-	handleRedirect();
+$GLOBALS['log']->debug("deleted relationship: bean: $bean_name, linked_field: $linked_field, linked_id:$linked_id");
+if (empty($_REQUEST['refresh_page'])) {
+    handleRedirect();
 }
 
 
 exit;
-?>

--- a/include/generic/DeleteRelationship.php
+++ b/include/generic/DeleteRelationship.php
@@ -77,6 +77,14 @@ require_once('include/formbase.php');
  $linked_field = $_REQUEST['linked_field'];
  $record = $_REQUEST['record'];
  $linked_id = $_REQUEST['linked_id'];
+
+if ($linked_field === 'aclroles') {
+    if (!ACLController::checkAccess($bean_name, 'edit', true)) {
+        ACLController::displayNoAccess();
+        sugar_cleanup(true);
+    }
+}
+
  if($bean_name == 'Team')
  {
  	$focus->retrieve($record);

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButton.php
@@ -1,11 +1,11 @@
 <?php
-if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
-/*********************************************************************************
+/**
+ *
  * SugarCRM Community Edition is a customer relationship management program developed by
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
-
- * SuiteCRM is an extension to SugarCRM Community Edition developed by Salesagility Ltd.
- * Copyright (C) 2011 - 2014 Salesagility Ltd.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2017 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the
@@ -16,7 +16,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
  * details.
  *
  * You should have received a copy of the GNU Affero General Public License along with
@@ -34,94 +34,94 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
  * these Appropriate Legal Notices must retain the display of the "Powered by
  * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
- * reasonably feasible for  technical reasons, the Appropriate Legal Notices must
- * display the words  "Powered by SugarCRM" and "Supercharged by SuiteCRM".
- ********************************************************************************/
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
 
-
-
-
-
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
 
 class SugarWidgetSubPanelRemoveButton extends SugarWidgetField
 {
-	function displayHeaderCell($layout_def)
-	{
-		return '&nbsp;';
-	}
+    function displayHeaderCell($layout_def)
+    {
+        return '&nbsp;';
+    }
 
-	function displayList($layout_def)
-	{
-		
-		global $app_strings;
+    function displayList($layout_def)
+    {
+
+        global $app_strings;
         global $subpanel_item_count;
 
-		$unique_id = $layout_def['subpanel_id']."_remove_".$subpanel_item_count; //bug 51512
-		
-		$parent_record_id = $_REQUEST['record'];
-		$parent_module = $_REQUEST['module'];
+        $unique_id = $layout_def['subpanel_id'] . "_remove_" . $subpanel_item_count; //bug 51512
 
-		$action = 'DeleteRelationship';
-		$record = $layout_def['fields']['ID'];
-		$current_module=$layout_def['module'];
-		//in document revisions subpanel ,users are now allowed to 
-		//delete the latest revsion of a document. this will be tested here
-		//and if the condition is met delete button will be removed.
-		$hideremove=false;
-		if ($current_module=='DocumentRevisions') {
-			if ($layout_def['fields']['ID']==$layout_def['fields']['LATEST_REVISION_ID']) {
-				$hideremove=true;
-			}
-		}
-		// Implicit Team-memberships are not "removeable" 
-		elseif ($_REQUEST['module'] == 'Teams' && $current_module == 'Users') {
-			if($layout_def['fields']['UPLINE'] != translate('LBL_TEAM_UPLINE_EXPLICIT', 'Users')) {
-				$hideremove = true;
-			}	
-			
-			//We also cannot remove the user whose private team is set to the parent_record_id value
-			$user = new User();
-			$user->retrieve($layout_def['fields']['ID']);
-			if($parent_record_id == $user->getPrivateTeamID())
-			{
-			    $hideremove = true;
-			}
-		} elseif ($current_module === 'ACLRoles' && (!ACLController::checkAccess($current_module, 'edit', true))) {
+        $parent_record_id = $_REQUEST['record'];
+        $parent_module = $_REQUEST['module'];
+
+        $action = 'DeleteRelationship';
+        $record = $layout_def['fields']['ID'];
+        $current_module = $layout_def['module'];
+        //in document revisions subpanel ,users are now allowed to
+        //delete the latest revsion of a document. this will be tested here
+        //and if the condition is met delete button will be removed.
+        $hideremove = false;
+        if ($current_module === 'DocumentRevisions') {
+            if ($layout_def['fields']['ID'] == $layout_def['fields']['LATEST_REVISION_ID']) {
+                $hideremove = true;
+            }
+        } // Implicit Team-memberships are not "removeable"
+        elseif ($_REQUEST['module'] === 'Teams' && $current_module === 'Users') {
+            if ($layout_def['fields']['UPLINE'] != translate('LBL_TEAM_UPLINE_EXPLICIT', 'Users')) {
+                $hideremove = true;
+            }
+
+            //We also cannot remove the user whose private team is set to the parent_record_id value
+            $user = new User();
+            $user->retrieve($layout_def['fields']['ID']);
+            if ($parent_record_id == $user->getPrivateTeamID()) {
+                $hideremove = true;
+            }
+        } elseif ($current_module === 'ACLRoles' && (!ACLController::checkAccess($current_module, 'edit', true))) {
             $hideremove = false;
         }
-		
-		
-		$return_module = $_REQUEST['module'];
-		$return_action = 'SubPanelViewer';
-		$subpanel = $layout_def['subpanel_id'];
-		$return_id = $_REQUEST['record'];
-		if (isset($layout_def['linked_field_set']) && !empty($layout_def['linked_field_set'])) {
-			$linked_field= $layout_def['linked_field_set'] ;
-		} else {
-			$linked_field = $layout_def['linked_field'];
-		}
-		$refresh_page = 0;
-		if(!empty($layout_def['refresh_page'])){
-			$refresh_page = 1;
-		}
-		$return_url = "index.php?module=$return_module&action=$return_action&subpanel=$subpanel&record=$return_id&sugar_body_only=1&inline=1";
 
-		$icon_remove_text = $app_strings['LBL_ID_FF_REMOVE'];
-		
-         if($linked_field == 'get_emails_by_assign_or_link')
+
+        $return_module = $_REQUEST['module'];
+        $return_action = 'SubPanelViewer';
+        $subpanel = $layout_def['subpanel_id'];
+        $return_id = $_REQUEST['record'];
+        if (isset($layout_def['linked_field_set']) && !empty($layout_def['linked_field_set'])) {
+            $linked_field = $layout_def['linked_field_set'];
+        } else {
+            $linked_field = $layout_def['linked_field'];
+        }
+        $refresh_page = 0;
+        if (!empty($layout_def['refresh_page'])) {
+            $refresh_page = 1;
+        }
+        $return_url = "index.php?module=$return_module&action=$return_action&subpanel=$subpanel&record=$return_id&sugar_body_only=1&inline=1";
+
+        $icon_remove_text = $app_strings['LBL_ID_FF_REMOVE'];
+
+        if ($linked_field === 'get_emails_by_assign_or_link') {
             $linked_field = 'emails';
-		//based on listview since that lets you select records
-		if($layout_def['ListView'] && !$hideremove) {
-            $retStr = "<a href=\"javascript:sub_p_rem('$subpanel', '$linked_field'" 
-                    .", '$record', $refresh_page);\"" 
-			. ' class="listViewTdToolsS1"'
-            . "id=$unique_id"
-			. " onclick=\"return sp_rem_conf();\""
-			. ">$icon_remove_text</a>";
-        return $retStr;
-            
-		}else{
-			return '';
-		}
-	}
+        }
+        //based on listview since that lets you select records
+        if ($layout_def['ListView'] && !$hideremove) {
+            $retStr = "<a href=\"javascript:sub_p_rem('$subpanel', '$linked_field'"
+                . ", '$record', $refresh_page);\""
+                . ' class="listViewTdToolsS1"'
+                . "id=$unique_id"
+                . " onclick=\"return sp_rem_conf();\""
+                . ">$icon_remove_text</a>";
+
+            return $retStr;
+
+        }
+
+        return '';
+
+    }
 }

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButton.php
@@ -86,7 +86,9 @@ class SugarWidgetSubPanelRemoveButton extends SugarWidgetField
 			{
 			    $hideremove = true;
 			}
-		}
+		} elseif ($current_module === 'ACLRoles' && (!ACLController::checkAccess($current_module, 'edit', true))) {
+            $hideremove = false;
+        }
 		
 		
 		$return_module = $_REQUEST['module'];

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButton.php
@@ -68,19 +68,19 @@ class SugarWidgetSubPanelRemoveButton extends SugarWidgetField
         //and if the condition is met delete button will be removed.
         $hideremove = false;
         if ($current_module === 'DocumentRevisions') {
-            if ($layout_def['fields']['ID'] == $layout_def['fields']['LATEST_REVISION_ID']) {
+            if ($layout_def['fields']['ID'] === $layout_def['fields']['LATEST_REVISION_ID']) {
                 $hideremove = true;
             }
-        } // Implicit Team-memberships are not "removeable"
-        elseif ($_REQUEST['module'] === 'Teams' && $current_module === 'Users') {
-            if ($layout_def['fields']['UPLINE'] != translate('LBL_TEAM_UPLINE_EXPLICIT', 'Users')) {
+        } elseif ($_REQUEST['module'] === 'Teams' && $current_module === 'Users') {
+            // Implicit Team-memberships are not "removeable"
+            if ($layout_def['fields']['UPLINE'] !== translate('LBL_TEAM_UPLINE_EXPLICIT', 'Users')) {
                 $hideremove = true;
             }
 
             //We also cannot remove the user whose private team is set to the parent_record_id value
             $user = new User();
             $user->retrieve($layout_def['fields']['ID']);
-            if ($parent_record_id == $user->getPrivateTeamID()) {
+            if ($parent_record_id === $user->getPrivateTeamID()) {
                 $hideremove = true;
             }
         } elseif ($current_module === 'ACLRoles' && (!ACLController::checkAccess($current_module, 'edit', true))) {

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButton.php
@@ -84,7 +84,7 @@ class SugarWidgetSubPanelRemoveButton extends SugarWidgetField
                 $hideremove = true;
             }
         } elseif ($current_module === 'ACLRoles' && (!ACLController::checkAccess($current_module, 'edit', true))) {
-            $hideremove = false;
+            $hideremove = true;
         }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This change removes the "Remove" button from the roles sub-panel in user profile when a user does not have access to roles. It also ensures that a user cannot remove a role relationship if they do not have access to aclroles.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. As a non-admin user go to user profile
2. Click cancel
3. Check that the "Remove" button does not appear in the roles sub-panel

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->