### PR TITLE
Fix non-matching delaration of relationship methods in ModuleBuilder

### DIFF
--- a/modules/ModuleBuilder/parsers/relationships/ManyToOneRelationship.php
+++ b/modules/ModuleBuilder/parsers/relationships/ManyToOneRelationship.php
@@ -83,7 +83,7 @@ class ManyToOneRelationship extends AbstractRelationship
      * BUILD methods called during the build
      */
 	
-	function buildLabels ()
+	function buildLabels($update = false)
     {
         return $this->one_to_many->buildLabels();
     }
@@ -133,9 +133,9 @@ class ManyToOneRelationship extends AbstractRelationship
     	$this->one_to_many->setname($relationshipName);
     }
     
-    public function setReadonly ()
+    public function setReadonly ($set = true)
     {
-        parent::setReadonly();
+        parent::setReadonly($set);
     	$this->one_to_many->setReadonly();
     }
     


### PR DESCRIPTION
## Description
No issue raised. PHP warnings in module builder due to method declarations not matching the abstract.

## Motivation and Context

```
Warning: Declaration of ManyToOneRelationship::setReadonly() should be compatible with AbstractRelationship::setReadonly($set = true) in /.../modules/ModuleBuilder/parsers/relationships/ManyToOneRelationship.php on line 0

Warning: Declaration of ManyToOneRelationship::buildLabels() should be compatible with AbstractRelationship::buildLabels($update = false) in /.../modules/ModuleBuilder/parsers/relationships/ManyToOneRelationship.php on line 0
```

## How To Test This
Go to ModuleBuilder and create a module.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

There are many nasty code formatting issues in this file and this module as a whole. I have not attempted to fix those as there are other PRs that deal with code formatting.
