### PR TITLE
Fix #3604 - Scheduled reports detail view broken - cannot redeclare padNumbers

### DIFF
--- a/include/SugarFields/Fields/CronSchedule/SugarFieldCronSchedule.php
+++ b/include/SugarFields/Fields/CronSchedule/SugarFieldCronSchedule.php
@@ -38,8 +38,10 @@ class SugarFieldCronSchedule extends SugarFieldBase {
         $this->ss->assign('weekdays',get_select_options($weekdays,''));
         $days = $this->getDays();
         $this->ss->assign('days',get_select_options($days,''));
-        function padNumbers($x){
-            return str_pad($x,2,'0',STR_PAD_LEFT);
+        if (!function_exists('padNumbers')) {
+            function padNumbers($x){
+                return str_pad($x,2,'0',STR_PAD_LEFT);
+            }
         }
         $minutes = array_map('padNumbers',range(0,59));
         $hours = array_map('padNumbers',range(0,23));

--- a/include/SugarFields/Fields/CronSchedule/SugarFieldCronSchedule.php
+++ b/include/SugarFields/Fields/CronSchedule/SugarFieldCronSchedule.php
@@ -42,8 +42,8 @@ class SugarFieldCronSchedule extends SugarFieldBase {
         $this->ss->assign('weekdays',get_select_options($weekdays,''));
         $days = $this->getDays();
         $this->ss->assign('days',get_select_options($days,''));
-        $minutes = array_map('padNumbers',range(0,59));
-        $hours = array_map('padNumbers',range(0,23));
+        $minutes = array_map(array($this, 'padNumbers'), range(0,59));
+        $hours = array_map(array($this, 'padNumbers'), range(0,23));
         $this->ss->assign('minutes',get_select_options($minutes,''));
         $this->ss->assign('hours',get_select_options($hours,''));
     }

--- a/include/SugarFields/Fields/CronSchedule/SugarFieldCronSchedule.php
+++ b/include/SugarFields/Fields/CronSchedule/SugarFieldCronSchedule.php
@@ -28,6 +28,10 @@ class SugarFieldCronSchedule extends SugarFieldBase {
 
     }
 
+    protected function padNumbers($x){
+        return str_pad($x,2,'0',STR_PAD_LEFT);
+    }
+
     function setup($parentFieldArray, $vardef, $displayParams, $tabindex, $twopass = true) {
         global $app_list_strings,$app_strings;
         parent::setup($parentFieldArray, $vardef, $displayParams, $tabindex, $twopass);
@@ -38,11 +42,6 @@ class SugarFieldCronSchedule extends SugarFieldBase {
         $this->ss->assign('weekdays',get_select_options($weekdays,''));
         $days = $this->getDays();
         $this->ss->assign('days',get_select_options($days,''));
-        if (!function_exists('padNumbers')) {
-            function padNumbers($x){
-                return str_pad($x,2,'0',STR_PAD_LEFT);
-            }
-        }
         $minutes = array_map('padNumbers',range(0,59));
         $hours = array_map('padNumbers',range(0,23));
         $this->ss->assign('minutes',get_select_options($minutes,''));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
On setup method of SugarFieldCronSchedule class define padNumbers function only if was not declared previously.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
See the issue #3604 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Detail view of scheduled reports is not working.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Apply this changes and see that detail view of scheduled reports is working fine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->