### PR TITLE
2 enhancements / bugfixes for LDAP and download

### DIFF
--- a/download.php
+++ b/download.php
@@ -236,7 +236,7 @@ if ((!isset($_REQUEST['isProfile']) && empty($_REQUEST['id'])) || empty($_REQUES
             }
         } else {
             header('Content-type: ' . $mime_type);
-            header("Content-Disposition: attachment; filename=\"" . $name . "\";");
+            header("Content-Disposition: attachment; filename*=UTF-8''" . rawurlencode($name) );
 
         }
         // disable content type sniffing in MSIE

--- a/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php
+++ b/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php
@@ -75,6 +75,7 @@ class LDAPAuthenticateUser extends SugarAuthenticateUser{
 		}
 		@ldap_set_option($ldapconn, LDAP_OPT_PROTOCOL_VERSION, 3);
 		@ldap_set_option($ldapconn, LDAP_OPT_REFERRALS, 0); // required for AD
+                @ldap_start_tls($ldapconn);
 		// If constant is defined, set the timeout (PHP >= 5.3)
 		if (defined('LDAP_OPT_NETWORK_TIMEOUT'))
 		{
@@ -367,6 +368,7 @@ class LDAPAuthenticateUser extends SugarAuthenticateUser{
 		}
         ldap_set_option($ldapconn, LDAP_OPT_PROTOCOL_VERSION, 3);
         ldap_set_option($ldapconn, LDAP_OPT_REFERRALS, 0); // required for AD
+        ldap_start_tls($ldapconn);
         //if we are going to connect anonymously lets at least try to connect with the user connecting
         if(empty($admin_user)){
 			$bind = @ldap_bind($ldapconn, $user_name, $password);


### PR DESCRIPTION
## Description
Commit 2e27a82 is for upgrading connection to LDAP server with TLS by default, since most LDAP servers require confidentiality for binding.
Commit b496555 fixes bug of corrupting downloaded file with non-ASCII name.

## Motivation and Context
OpenLDAP server by default needs confidentiality, so SuiteCRM will try to upgrade connection.
HTTP header "Content-Disposition" allows only ASCII symbols, so to return file with UTF-8 name we should return prepared header according to RFC6266

## How To Test This
1. Try to authenticate users with already used ldap:// server
2. Download with non-ASCII symbols

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.