### PR TITLE
Fixed #4213 - Cannot edit Layouts in Module Builder

### DIFF
--- a/modules/ModuleBuilder/parsers/views/UndeployedMetaDataImplementation.php
+++ b/modules/ModuleBuilder/parsers/views/UndeployedMetaDataImplementation.php
@@ -109,7 +109,7 @@ class UndeployedMetaDataImplementation extends AbstractMetaDataImplementation im
         $loaded = null ;
         foreach ( array ( MB_BASEMETADATALOCATION , MB_HISTORYMETADATALOCATION ) as $type )
     	{
-			$this->_sourceFilename = $this->getFileName ( $view, $moduleName, $packageName , $type ) ;
+            $this->_sourceFilename = $this->getFileNameInPackage($view, $moduleName, $packageName, $type);
 			if($view == MB_POPUPSEARCH || $view == MB_POPUPLIST){
 				$layout = $this->_loadFromPopupFile ( $this->_sourceFilename , null, $view);
 			}else{
@@ -129,7 +129,7 @@ class UndeployedMetaDataImplementation extends AbstractMetaDataImplementation im
         }
 
         $this->_viewdefs = $loaded ;
-        $sourceFilename = $this->getFileName ( $view, $moduleName, $packageName, MB_BASEMETADATALOCATION );
+        $sourceFilename = $this->getFileNameInPackage($view, $moduleName, $packageName, MB_BASEMETADATALOCATION);
         if($view == MB_POPUPSEARCH || $view == MB_POPUPLIST){
 			$layout = $this->_loadFromPopupFile ( $sourceFilename , null, $view);
 		}else{
@@ -137,7 +137,7 @@ class UndeployedMetaDataImplementation extends AbstractMetaDataImplementation im
 		}
 		$this->_originalViewdefs = $layout ;
 		$this->_fielddefs = $fielddefs ;
-        $this->_history = new History ( $this->getFileName ( $view, $moduleName, $packageName, MB_HISTORYMETADATALOCATION ) ) ;
+        $this->_history = new History($this->getFileNameInPackage($view, $moduleName, $packageName, MB_HISTORYMETADATALOCATION)) ;
     }
 
     function getLanguage ()
@@ -152,24 +152,40 @@ class UndeployedMetaDataImplementation extends AbstractMetaDataImplementation im
     function deploy ($defs)
     {
         //If we are pulling from the History Location, that means we did a restore, and we need to save the history for the previous file.
-    	if ($this->_sourceFilename == $this->getFileName ( $this->_view, $this->_moduleName, $this->_packageName, MB_HISTORYMETADATALOCATION )
-    	&& file_exists($this->getFileName ( $this->_view, $this->_moduleName, $this->_packageName, MB_BASEMETADATALOCATION ))) {
-        	$this->_history->append ( $this->getFileName ( $this->_view, $this->_moduleName, $this->_packageName, MB_BASEMETADATALOCATION )) ;
+        if ($this->_sourceFilename == $this->getFileName($this->_view, $this->_moduleName, MB_HISTORYMETADATALOCATION)
+        && file_exists($this->getFileName($this->_view, $this->_moduleName, MB_BASEMETADATALOCATION))) {
+            $this->_history->append($this->getFileName($this->_view, $this->_moduleName, MB_BASEMETADATALOCATION));
         } else {
     		$this->_history->append ( $this->_sourceFilename ) ;
         }
-        $filename = $this->getFileName ( $this->_view, $this->_moduleName, $this->_packageName, MB_BASEMETADATALOCATION ) ;
+        $filename = $this->getFileName($this->_view, $this->_moduleName, MB_BASEMETADATALOCATION);
         $GLOBALS [ 'log' ]->debug ( get_class ( $this ) . "->deploy(): writing to " . $filename ) ;
         $this->_saveToFile ( $filename, $defs ) ;
     }
 
-    /*
+    /**
      * Construct a full pathname for the requested metadata
-     * @param string view           The view type, that is, EditView, DetailView etc
-     * @param string modulename     The name of the module that will use this layout
-     * @param string type
+     *
+     * @param string $view           The view type, that is, EditView, DetailView etc
+     * @param string $moduleName     The name of the module that will use this layout
+     * @param string $type
+     * @return string               The file name
      */
-    public function getFileName ($view , $moduleName , $packageName , $type = MB_BASEMETADATALOCATION)
+    public function getFileName($view, $moduleName, $type = MB_BASEMETADATALOCATION)
+    {
+        return $this->getFileNameInPackage($view, $moduleName, $this->_packageName, $type);
+    }
+
+    /**
+     * Construct a full pathname for the requested metadata, in a specific package
+     *
+     * @param string $view           The view type, that is, EditView, DetailView etc
+     * @param string $moduleName     The name of the module that will use this layout
+     * @param string $packageName    The name of the package to use
+     * @param string $type
+     * @return string               The file name
+     */
+    public function getFileNameInPackage($view, $moduleName, $packageName, $type = MB_BASEMETADATALOCATION)
     {
 
         $type = strtolower ( $type ) ;


### PR DESCRIPTION
Fix UndeployedMetaDataImplementation::getFileName() to match the signature of the base class.

<!--- Provide a general summary of your changes in the Title above -->

## Description
The getFileName function in UndeployedMetaDataImplementation is
different from the other implementations, since it allows using
alternate packages. Since it is no longer a static function, separate it
into getFileNameInPackage and change getFileName to assume the
instance's package, so it is compatible with the base class.

This should bring it into line with the usage of getFileName in the
other implementations.

Also, repair the broken phpdoc on getFileName.
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I was unable to add one-to-many relationships in the Module Builder because PHP was generating fatal errors.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
In the module builder, create a package and create a module in the package. Attempt to add a one-to-many or many-to-one relationship to another module. Without this fix, it errors during saving.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->