### PR TITLE
Fixed #4220 -- Layout editor showing incorrect labels in SuiteP.

### DIFF
--- a/themes/SuiteP/modules/ModuleBuilder/tpls/layoutView.tpl
+++ b/themes/SuiteP/modules/ModuleBuilder/tpls/layoutView.tpl
@@ -197,6 +197,7 @@
                         {eval var=$col.label data1=$col assign='label'}
                         {sugar_translate label=$label module=$language}
                     {else}
+                        {assign var='label' value=$col.label}
 		                {if !empty($current_mod_strings[$label])}
 		                    {$current_mod_strings[$label]}
 		                {elseif !empty($mod[$label])}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Due to a missing {assign}, the label was not being assigned properly, causing the layout slots to show the wrong title.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Add missing {assign} as per the default template.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Edit a layout of a custom module while using no translations and the SuiteP theme.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->