### PR TITLE
Attachment form translation

### DIFF
--- a/modules/Cases/language/en_us.lang.php
+++ b/modules/Cases/language/en_us.lang.php
@@ -108,7 +108,7 @@ $mod_strings = array(
     'LBL_CASE_INFORMATION' => 'OVERVIEW',
 
     // SNIP
-    'LBL_UPDATE_TEXT' => 'Update Text',
+    'LBL_UPDATE_TEXT' => 'Updates - Text', //Field for Case updates with text only
     'LBL_INTERNAL' => 'Internal Update',
     'LBL_AOP_CASE_UPDATES' => 'Case Updates',
     'LBL_AOP_CASE_UPDATES_THREADED' => 'Case Updates Threaded',
@@ -126,7 +126,7 @@ $mod_strings = array(
     'LBL_SELECT_EXTERNAL_CASE_DOCUMENT' => 'External file',
     'LBL_CONTACT_CREATED_BY_NAME' => 'Created by contact',
     'LBL_CONTACT_CREATED_BY' => 'Created by',
-    'LBL_CASE_UPDATE_FORM' => 'Update attachment form',
+    'LBL_CASE_UPDATE_FORM' => 'Updates - Attachment form', //Form for attachements on case updates
 );
 
 ?>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
English edits to avoid issues on translations.
"Update Text" to "Updates - Text" - this is a field for Case updates with text only
the english wording causes translations as an "action to update some text"

"Update attachment form" to "Updates - Attachment form" - Form for attachments on case updates
the english wording causes translations as an "action to update the attachment form itself"

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Wrong context translation
Note: no GIT issue created.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.