### PR TITLE
allow custom field templates to be loaded even for predefined types

### DIFF
--- a/modules/DynamicFields/FieldCases.php
+++ b/modules/DynamicFields/FieldCases.php
@@ -1,9 +1,7 @@
 <?php
-if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 /*********************************************************************************
  * SugarCRM Community Edition is a customer relationship management program developed by
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
-
  * SuiteCRM is an extension to SugarCRM Community Edition developed by Salesagility Ltd.
  * Copyright (C) 2011 - 2014 Salesagility Ltd.
  *
@@ -38,7 +36,10 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  * display the words  "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  ********************************************************************************/
 
-
+if (!defined('sugarEntry') || !sugarEntry)
+{
+    die('Not A Valid Entry Point');
+}
 
 require_once('modules/DynamicFields/templates/Fields/TemplateTextArea.php');
 require_once('modules/DynamicFields/templates/Fields/TemplateFloat.php');
@@ -51,7 +52,6 @@ require_once('modules/DynamicFields/templates/Fields/TemplateMultiEnum.php');
 require_once('modules/DynamicFields/templates/Fields/TemplateRadioEnum.php');
 require_once('modules/DynamicFields/templates/Fields/TemplateEmail.php');
 require_once('modules/DynamicFields/templates/Fields/TemplateRelatedTextField.php');
-
 require_once('modules/DynamicFields/templates/Fields/TemplateURL.php');
 require_once('modules/DynamicFields/templates/Fields/TemplateIFrame.php');
 require_once('modules/DynamicFields/templates/Fields/TemplateHTML.php');
@@ -65,89 +65,139 @@ require_once('modules/DynamicFields/templates/Fields/TemplateEncrypt.php');
 require_once('modules/DynamicFields/templates/Fields/TemplateId.php');
 require_once('modules/DynamicFields/templates/Fields/TemplateImage.php');
 require_once('modules/DynamicFields/templates/Fields/TemplateDecimal.php');
+
+/**
+ * @param string $type
+ *
+ * @return mixed
+ */
 function get_widget($type)
 {
-
-	$local_temp = null;
-	switch(strtolower($type)){
-			case 'char':
-			case 'varchar':
-			case 'varchar2':
-						$local_temp = new TemplateText(); break;
-			case 'text':
-			case 'textarea':
-						$local_temp = new TemplateTextArea(); break;
-			case 'double':
-
-			case 'float':
-						$local_temp = new TemplateFloat(); break;
-			case 'decimal':
-						$local_temp = new TemplateDecimal(); break;
-			case 'int':
-						$local_temp = new TemplateInt(); break;
-			case 'date':
-						$local_temp = new TemplateDate(); break;
-			case 'bool':
-						$local_temp = new TemplateBoolean(); break;
-			case 'relate':
-						$local_temp = new TemplateRelatedTextField(); break;
-			case 'enum':
-						$local_temp = new TemplateEnum(); break;
-			case 'multienum':
-						$local_temp = new TemplateMultiEnum(); break;
-			case 'radioenum':
-						$local_temp = new TemplateRadioEnum(); break;
-			case 'email':
-						$local_temp = new TemplateEmail(); break;
-		    case 'url':
-						$local_temp = new TemplateURL(); break;
-			case 'iframe':
-						$local_temp = new TemplateIFrame(); break;
-			case 'html':
-						$local_temp = new TemplateHTML(); break;
-			case 'phone':
-						$local_temp = new TemplatePhone(); break;
-			case 'currency':
-						$local_temp = new TemplateCurrency(); break;
-			case 'parent':
-						$local_temp = new TemplateParent(); break;
-			case 'parent_type':
-						$local_temp = new TemplateParentType(); break;
-			case 'currency_id':
-						$local_temp = new TemplateCurrencyId(); break;
-			case 'address':
-						$local_temp = new TemplateAddress(); break;
-			case 'encrypt':
-						$local_temp = new TemplateEncrypt(); break;
-			case 'id':
-						$local_temp = new TemplateId(); break;
-			case 'datetimecombo':
-			case 'datetime':
-						$local_temp = new TemplateDatetimecombo(); break;
+    
+    $widgetInstance = null;
+    
+    /**
+     * Check for Custom override first
+     */
+    if (file_exists('custom/modules/DynamicFields/templates/Fields/CustomTemplate' . ucfirst($type) . '.php'))
+    {
+        $file = 'custom/modules/DynamicFields/templates/Fields/CustomTemplate' . ucfirst($type) . '.php';
+        if (!empty($file))
+        {
+            require_once($file);
+            $className = 'CustomTemplate' . ucfirst($type);
+            if (class_exists($className))
+            {
+                $widgetInstance = new $className();
+            }
+        }
+    }
+    
+    if (!$widgetInstance)
+    {
+        switch (strtolower($type))
+        {
+            case 'char':
+            case 'varchar':
+            case 'varchar2':
+                $widgetInstance = new TemplateText();
+                break;
+            case 'text':
+            case 'textarea':
+                $widgetInstance = new TemplateTextArea();
+                break;
+            case 'double':
+            
+            case 'float':
+                $widgetInstance = new TemplateFloat();
+                break;
+            case 'decimal':
+                $widgetInstance = new TemplateDecimal();
+                break;
+            case 'int':
+                $widgetInstance = new TemplateInt();
+                break;
+            case 'date':
+                $widgetInstance = new TemplateDate();
+                break;
+            case 'bool':
+                $widgetInstance = new TemplateBoolean();
+                break;
+            case 'relate':
+                $widgetInstance = new TemplateRelatedTextField();
+                break;
+            case 'enum':
+                $widgetInstance = new TemplateEnum();
+                break;
+            case 'multienum':
+                $widgetInstance = new TemplateMultiEnum();
+                break;
+            case 'radioenum':
+                $widgetInstance = new TemplateRadioEnum();
+                break;
+            case 'email':
+                $widgetInstance = new TemplateEmail();
+                break;
+            case 'url':
+                $widgetInstance = new TemplateURL();
+                break;
+            case 'iframe':
+                $widgetInstance = new TemplateIFrame();
+                break;
+            case 'html':
+                $widgetInstance = new TemplateHTML();
+                break;
+            case 'phone':
+                $widgetInstance = new TemplatePhone();
+                break;
+            case 'currency':
+                $widgetInstance = new TemplateCurrency();
+                break;
+            case 'parent':
+                $widgetInstance = new TemplateParent();
+                break;
+            case 'parent_type':
+                $widgetInstance = new TemplateParentType();
+                break;
+            case 'currency_id':
+                $widgetInstance = new TemplateCurrencyId();
+                break;
+            case 'address':
+                $widgetInstance = new TemplateAddress();
+                break;
+            case 'encrypt':
+                $widgetInstance = new TemplateEncrypt();
+                break;
+            case 'id':
+                $widgetInstance = new TemplateId();
+                break;
+            case 'datetimecombo':
+            case 'datetime':
+                $widgetInstance = new TemplateDatetimecombo();
+                break;
             case 'image':
-                        $local_temp = new TemplateImage(); break;
-			default:
-						$file = false;
-						if(file_exists('custom/modules/DynamicFields/templates/Fields/Template'. ucfirst($type) . '.php')){
-							$file  =	'custom/modules/DynamicFields/templates/Fields/Template'. ucfirst($type) . '.php';
-						}else if(file_exists('modules/DynamicFields/templates/Fields/Template'. ucfirst($type) . '.php')){
-							$file  =	'modules/DynamicFields/templates/Fields/Template'. ucfirst($type) . '.php';
-						}
-						if(!empty($file)){
-							require_once($file);
-							$class  = 'Template' . ucfirst($type) ;
-							$customClass = 'Custom' . $class;
-							if(class_exists($customClass)){
-								$local_temp = new $customClass();
-							}else{
-								$local_temp = new $class();
-							}
-							break;
-						}else{
-							$local_temp = new TemplateText(); break;
-						}
-	}
-
-	return $local_temp;
+                $widgetInstance = new TemplateImage();
+                break;
+            default:
+                if (file_exists('modules/DynamicFields/templates/Fields/Template' . ucfirst($type) . '.php'))
+                {
+                    $file = 'modules/DynamicFields/templates/Fields/Template' . ucfirst($type) . '.php';
+                    
+                    require_once($file);
+                    $className = 'Template' . ucfirst($type);
+                    if (class_exists($className))
+                    {
+                        $widgetInstance = new $className();
+                    }
+                }
+                break;
+        }
+    }
+    
+    if (!$widgetInstance)
+    {
+        $widgetInstance = new TemplateText();
+    }
+    
+    return $widgetInstance;
 }
-?>


### PR DESCRIPTION
This change will allow custom field templates to be loaded even for predefined types.

## Description
The original would not load custom field template types for predefined fields making it impossible to customize them.

## How To Test This
Copy any Template class from `modules/DynamicFields/templates/Fields/Forms` to `custom/modules/DynamicFields/templates/Fields/Forms` and make some changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->