### PR TITLE
Add Visual Studio exclusions to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,10 @@ Thumbs.db
 Desktop.ini
 .DS_Store
 .DS_Store?
+# Microsoft Visual Studio
+*.sln
+*.suo
+*.phpproj
 # Disytel
 lang_cmp.php
 .kdev4/


### PR DESCRIPTION
Microsoft Visual Studio is a free IDE that can be used for PHP projects, including SuiteCRM.

This makes the generated project files be excluded from Git, similarly to what is already there for other IDE's.

Note: this was previously done in #3221 where it was already labeled `Assessed` and `Ready to Merge`