### PR TITLE
Fixed #4290 : Unresolved labels in PDF Template samples

### DIFF
--- a/modules/AOS_PDF_Templates/language/en_us.lang.php
+++ b/modules/AOS_PDF_Templates/language/en_us.lang.php
@@ -78,10 +78,17 @@ $mod_strings = array (
   'LBL_PAGE' => 'Page',
   'LBL_PREPARED_FOR' => 'Prepared For',
   'LBL_PREPARED_BY' => 'Prepared By',
+  'LBL_QUOTE_SAMPLE' => 'Quote Sample',
+  'LBL_INVOICE_SAMPLE' => 'Invoice Sample',
+  'LBL_ACCOUNT_SAMPLE' => 'Account Sample',
+  'LBL_CONTACT_SAMPLE' => 'Contact Sample',
+  'LBL_LEAD_SAMPLE' => 'Lead Sample',
   'LBL_ANY_STREET' => 'Any Street',
   'LBL_ANY_TOWN' => 'Any Town',
   'LBL_ANY_WHERE' => 'Any Where',
-  
+
+  'LBL_QUOTE_GROUP_SAMPLE' => 'Quote Group Sample',
+  'LBL_INVOICE_GROUP_SAMPLE' => 'Invoice Group Sample',
   'LBL_MARGIN_LEFT' => 'Margin Left',
   'LBL_MARGIN_RIGHT' => 'Margin Right',
   'LBL_MARGIN_TOP' => 'Margin Top',


### PR DESCRIPTION
## Description
Fixed #4290 - Reinstate strings for PDF templates  - "Samples" dropdown 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Without the fix it contains empty options, though these option actually work well if you select them.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Menu ALL / PDF templates

Before fix: "empty" Load Sample drop-down menu:
![2017-09-20 17_35_07-suitecrm](https://user-images.githubusercontent.com/3055443/30660087-9fe4cd62-9e37-11e7-93d6-66d7f2fbbbf7.png)

====== After fix: fields are visible
![2017-09-20 17_47_45-suitecrm](https://user-images.githubusercontent.com/3055443/30660122-bd3050ee-9e37-11e7-8a49-ed4fbe3ea92b.png)

Note 1: A quick repair (or a logout) is required to make strings visible
Note 2: Crowdin project already fixed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->