### PR TITLE
Fixed #4180 - SuiteP quickcreate forms not visible in mobile

### DIFF
--- a/themes/SuiteP/css/navbar.scss
+++ b/themes/SuiteP/css/navbar.scss
@@ -1489,10 +1489,6 @@
     height: 60px;
   }
 
-  .quickcreate {
-    display: none;
-  }
-
   .searchmobile {
     position: absolute;
     left: 60px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Sub-panel quick create form is not visible while using SuiteP with a mobile browser.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #4180

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Repair & Rebuild.
2. Rebuild SASS.
3. Enter an accounts detail-view.
4. Open the opportunities sub-panel.
5. While in mobile view with a width less than 750px, click "Create".

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->