### PR TITLE
Fixed #3279 - PHP Warning logged for Calendar Dashlet

### DIFF
--- a/modules/Calendar/Dashlets/CalendarDashlet/CalendarDashlet.php
+++ b/modules/Calendar/Dashlets/CalendarDashlet/CalendarDashlet.php
@@ -5,7 +5,7 @@
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
  *
  * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
- * Copyright (C) 2011 - 2017 SalesAgility Ltd.
+ * Copyright (C) 2011 - 2018 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the
@@ -50,7 +50,9 @@ class CalendarDashlet extends Dashlet
     public $view = 'week';
 
     /**
-     * @see Dashlet::__construct()
+     * CalendarDashlet constructor.
+     * @param $id string
+     * @param $def array
      */
     public function __construct($id, $def)
     {
@@ -150,13 +152,14 @@ class CalendarDashlet extends Dashlet
     }
 
     /**
-     * @see Dashlet::saveOptions()
+     * @param $req array
+     * @return array
      */
     public function saveOptions($req)
     {
         $options = array();
-        $options['title'] = $_REQUEST['title'];
-        $options['view'] = $_REQUEST['view'];
+        $options['title'] = $req['title'];
+        $options['view'] = $req['view'];
 
         return $options;
     }

--- a/modules/Calendar/Dashlets/CalendarDashlet/CalendarDashlet.php
+++ b/modules/Calendar/Dashlets/CalendarDashlet/CalendarDashlet.php
@@ -1,11 +1,11 @@
 <?php
-if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
-/*********************************************************************************
+/**
+ *
  * SugarCRM Community Edition is a customer relationship management program developed by
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
-
- * SuiteCRM is an extension to SugarCRM Community Edition developed by Salesagility Ltd.
- * Copyright (C) 2011 - 2014 Salesagility Ltd.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2017 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the
@@ -16,7 +16,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
  * details.
  *
  * You should have received a copy of the GNU Affero General Public License along with
@@ -34,9 +34,13 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
  * these Appropriate Legal Notices must retain the display of the "Powered by
  * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
- * reasonably feasible for  technical reasons, the Appropriate Legal Notices must
- * display the words  "Powered by SugarCRM" and "Supercharged by SuiteCRM".
- ********************************************************************************/
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
 
 require_once ('modules/Calendar/Calendar.php');
 require_once('include/Dashlets/Dashlet.php');
@@ -61,10 +65,10 @@ class CalendarDashlet extends Dashlet {
 		if(!empty($def['view']))
 			$this->view = $def['view'];
 
-		// seedBean is need to set the calendar icon
-		$this->seedBean  = BeanFactory::newBean('Calendar');
+        if (!isset($this->seedBean)) {
+            $this->seedBean = new stdClass();
+		}
 		$this->seedBean->module_name = 'Calendar';
-             
     }
 
     function display(){
@@ -126,5 +130,3 @@ class CalendarDashlet extends Dashlet {
 
 
 }
-
-?>

--- a/modules/Calendar/Dashlets/CalendarDashlet/CalendarDashlet.php
+++ b/modules/Calendar/Dashlets/CalendarDashlet/CalendarDashlet.php
@@ -71,10 +71,12 @@ class CalendarDashlet extends Dashlet
             $this->view = $def['view'];
         }
 
-        if (!isset($this->seedBean)) {
-            $this->seedBean = new stdClass();
+        // seedBean is need to set the calendar icon
+        if ($this->seedBean = BeanFactory::newBean('Calendar')) {
+            $this->seedBean->module_name = 'Calendar';
+        } else {
+            $GLOBALS['log']->warn('Calendar bean not created');
         }
-        $this->seedBean->module_name = 'Calendar';
     }
 
     /**

--- a/modules/Calendar/Dashlets/CalendarDashlet/CalendarDashlet.php
+++ b/modules/Calendar/Dashlets/CalendarDashlet/CalendarDashlet.php
@@ -42,91 +42,125 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-require_once ('modules/Calendar/Calendar.php');
+require_once('modules/Calendar/Calendar.php');
 require_once('include/Dashlets/Dashlet.php');
 
+class CalendarDashlet extends Dashlet
+{
+    public $view = 'week';
 
-class CalendarDashlet extends Dashlet {
-    var $view = 'week';
+    /**
+     * @see Dashlet::__construct()
+     */
+    public function __construct($id, $def)
+    {
+        $this->loadLanguage('CalendarDashlet', 'modules/Calendar/Dashlets/');
 
-    function CalendarDashlet($id, $def) {
-        $this->loadLanguage('CalendarDashlet','modules/Calendar/Dashlets/');
+        parent::__construct($id);
 
-		parent::Dashlet($id); 
-         
-		$this->isConfigurable = true; 
-		$this->hasScript = true;  
-                
-		if(empty($def['title'])) 
-			$this->title = $this->dashletStrings['LBL_TITLE'];
-		else 
-			$this->title = $def['title'];  
-			
-		if(!empty($def['view']))
-			$this->view = $def['view'];
+        $this->isConfigurable = true;
+        $this->hasScript = true;
+
+        if (empty($def['title'])) {
+            $this->title = $this->dashletStrings['LBL_TITLE'];
+        } else {
+            $this->title = $def['title'];
+        }
+
+        if (!empty($def['view'])) {
+            $this->view = $def['view'];
+        }
 
         if (!isset($this->seedBean)) {
             $this->seedBean = new stdClass();
-		}
-		$this->seedBean->module_name = 'Calendar';
+        }
+        $this->seedBean->module_name = 'Calendar';
     }
 
-    function display(){
-		ob_start();
-		
-		if(isset($GLOBALS['cal_strings']))
-			return parent::display() . "Only one Calendar dashlet is allowed.";
-			
-		require_once('modules/Calendar/Calendar.php');
-		require_once('modules/Calendar/CalendarDisplay.php');
-		require_once("modules/Calendar/CalendarGrid.php");
-		
-		global $cal_strings, $current_language;
-		$cal_strings = return_module_language($current_language, 'Calendar');
-		
-		if(!ACLController::checkAccess('Calendar', 'list', true))
-			ACLController::displayNoAccess(true);
-						
-		$cal = new Calendar($this->view);
-		$cal->dashlet = true;
-		$cal->add_activities($GLOBALS['current_user']);
-		$cal->load_activities();
-		
-		$display = new CalendarDisplay($cal,$this->id);
-		$display->display_calendar_header(false);
-
-		$display->display();
-
-		$str = ob_get_contents();
-		ob_end_clean();
-		
-		return parent::display() . $str;
+    /**
+     * @deprecated deprecated since version 7.6, PHP4 Style Constructors are deprecated and will be remove in 7.8,
+     * please update your code, use __construct instead
+     */
+    public function CalendarDashlet($id, $def = null)
+    {
+        $deprecatedMessage = 'PHP4 Style Constructors are deprecated and will be removed in 7.8,
+        please update your code';
+        if (isset($GLOBALS['log'])) {
+            $GLOBALS['log']->deprecated($deprecatedMessage);
+        } else {
+            trigger_error($deprecatedMessage, E_USER_DEPRECATED);
+        }
+        self::__construct($id, $def);
     }
-    
 
-    function displayOptions() {
-        global $app_strings,$mod_strings;        
+    /**
+     * @see Dashlet::display()
+     */
+    public function display()
+    {
+        ob_start();
+
+        if (isset($GLOBALS['cal_strings'])) {
+            return parent::display() . "Only one Calendar dashlet is allowed.";
+        }
+
+        require_once('modules/Calendar/Calendar.php');
+        require_once('modules/Calendar/CalendarDisplay.php');
+        require_once("modules/Calendar/CalendarGrid.php");
+
+        global $cal_strings, $current_language;
+        $cal_strings = return_module_language($current_language, 'Calendar');
+
+        if (!ACLController::checkAccess('Calendar', 'list', true)) {
+            ACLController::displayNoAccess(true);
+        }
+
+        $cal = new Calendar($this->view);
+        $cal->dashlet = true;
+        $cal->add_activities($GLOBALS['current_user']);
+        $cal->load_activities();
+
+        $display = new CalendarDisplay($cal, $this->id);
+        $display->display_calendar_header(false);
+
+        $display->display();
+
+        $str = ob_get_contents();
+        ob_end_clean();
+
+        return parent::display() . $str;
+    }
+
+    /**
+     * @see Dashlet::displayOptions()
+     */
+    public function displayOptions()
+    {
+        global $app_strings, $mod_strings;
         $ss = new Sugar_Smarty();
-        $ss->assign('MOD', $this->dashletStrings);        
+        $ss->assign('MOD', $this->dashletStrings);
         $ss->assign('title', $this->title);
         $ss->assign('view', $this->view);
         $ss->assign('id', $this->id);
 
-        return parent::displayOptions() . $ss->fetch('modules/Calendar/Dashlets/CalendarDashlet/CalendarDashletOptions.tpl');
-    }  
+        return parent::displayOptions() .
+            $ss->fetch('modules/Calendar/Dashlets/CalendarDashlet/CalendarDashletOptions.tpl');
+    }
 
-    function saveOptions($req) {
-        global $sugar_config, $timedate, $current_user, $theme;
+    /**
+     * @see Dashlet::saveOptions()
+     */
+    public function saveOptions($req)
+    {
         $options = array();
-        $options['title'] = $_REQUEST['title']; 
-        $options['view'] = $_REQUEST['view'];       
-         
+        $options['title'] = $_REQUEST['title'];
+        $options['view'] = $_REQUEST['view'];
+
         return $options;
     }
 
-    function displayScript(){
-	return "";
+    public function displayScript()
+    {
+        return '';
     }
-
-
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When a Calendar Dashlet is used a PHP Warning is logged every time the Dashlet reloads.

PHP Warning: Creating default object from empty value in /Calendar/Dashlets/CalendarDashlet/CalendarDashlet.php on line 66

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #3279

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->