### PR TITLE
Fixed #2783 - In the calendar dashlet, right / left week icons are not visible

### DIFF
--- a/themes/SuiteP/modules/Calendar/tpls/header.tpl
+++ b/themes/SuiteP/modules/Calendar/tpls/header.tpl
@@ -1,41 +1,41 @@
 {*
-/**
- *
- * SugarCRM Community Edition is a customer relationship management program developed by
- * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
- *
- * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
- * Copyright (C) 2011 - 2017 SalesAgility Ltd.
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Affero General Public License version 3 as published by the
- * Free Software Foundation with the addition of the following permission added
- * to Section 15 as permitted in Section 7(a): FOR ANY PART OF THE COVERED WORK
- * IN WHICH THE COPYRIGHT IS OWNED BY SUGARCRM, SUGARCRM DISCLAIMS THE WARRANTY
- * OF NON INFRINGEMENT OF THIRD PARTY RIGHTS.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
- * details.
- *
- * You should have received a copy of the GNU Affero General Public License along with
- * this program; if not, see http://www.gnu.org/licenses or write to the Free
- * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301 USA.
- *
- * You can contact SugarCRM, Inc. headquarters at 10050 North Wolfe Road,
- * SW2-130, Cupertino, CA 95014, USA. or at email address contact@sugarcrm.com.
- *
- * The interactive user interfaces in modified source and object code versions
- * of this program must display Appropriate Legal Notices, as required under
- * Section 5 of the GNU Affero General Public License version 3.
- *
- * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
- * these Appropriate Legal Notices must retain the display of the "Powered by
- * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
- * reasonably feasible for technical reasons, the Appropriate Legal Notices must
- * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+/** 
+ * 
+ * SugarCRM Community Edition is a customer relationship management program developed by 
+ * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc. 
+ * 
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd. 
+ * Copyright (C) 2011 - 2018 SalesAgility Ltd. 
+ * 
+ * This program is free software; you can redistribute it and/or modify it under 
+ * the terms of the GNU Affero General Public License version 3 as published by the 
+ * Free Software Foundation with the addition of the following permission added 
+ * to Section 15 as permitted in Section 7(a): FOR ANY PART OF THE COVERED WORK 
+ * IN WHICH THE COPYRIGHT IS OWNED BY SUGARCRM, SUGARCRM DISCLAIMS THE WARRANTY 
+ * OF NON INFRINGEMENT OF THIRD PARTY RIGHTS. 
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT 
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more 
+ * details. 
+ * 
+ * You should have received a copy of the GNU Affero General Public License along with 
+ * this program; if not, see http://www.gnu.org/licenses or write to the Free 
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 
+ * 02110-1301 USA. 
+ * 
+ * You can contact SugarCRM, Inc. headquarters at 10050 North Wolfe Road, 
+ * SW2-130, Cupertino, CA 95014, USA. or at email address contact@sugarcrm.com. 
+ * 
+ * The interactive user interfaces in modified source and object code versions 
+ * of this program must display Appropriate Legal Notices, as required under 
+ * Section 5 of the GNU Affero General Public License version 3. 
+ * 
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3, 
+ * these Appropriate Legal Notices must retain the display of the "Powered by 
+ * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not 
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must 
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM". 
  */
 *}
 

--- a/themes/SuiteP/modules/Calendar/tpls/header.tpl
+++ b/themes/SuiteP/modules/Calendar/tpls/header.tpl
@@ -40,58 +40,58 @@
 *}
 
 {if $controls}
-
-<div class="clear"></div>
-
-<div style='float:left; width: 70%;'>
-{foreach name=tabs from=$tabs key=k item=tab}
-	<input type="button" class="button" {if $view == $k} selected {/if} id="{$tabs_params[$k].id}" title="{$tabs_params[$k].title}" value="{$tabs_params[$k].title}" onclick="{$tabs_params[$k].link}">
-{/foreach}
-</div>
-
-<div style="float:left; text-align: right; width: 30%; font-size: 12px;">
-	{if $view == "sharedWeek" || $view == "sharedMonth"}
-		<input id="userListButtonId" type="button" class="btn btn-info" value="{$MOD.LBL_EDIT_USERLIST}" data-toggle="modal" data-target=".modal-calendar-user-list"">
-	{/if}
-	{if $view != 'year' && !$print}
-	<span class="dateTime">
-					<img border="0" src="{$cal_img}" alt="{$APP.LBL_ENTER_DATE}" id="goto_date_trigger" align="absmiddle">
+    <div class="clear"></div>
+    <div style='float:left; width: 70%;'>
+        {foreach name=tabs from=$tabs key=k item=tab}
+            <input type="button" class="button" {if $view == $k} selected {/if} id="{$tabs_params[$k].id}"
+                   title="{$tabs_params[$k].title}" value="{$tabs_params[$k].title}" onclick="{$tabs_params[$k].link}">
+        {/foreach}
+    </div>
+    <div style="float:left; text-align: right; width: 30%; font-size: 12px;">
+        {if $view == "sharedWeek" || $view == "sharedMonth"}
+            <input id="userListButtonId" type="button" class="btn btn-info" value="{$MOD.LBL_EDIT_USERLIST}"
+                   data-toggle="modal" data-target=".modal-calendar-user-list"
+            ">
+        {/if}
+        {if $view != 'year' && !$print}
+            <span class="dateTime">
+					<img border="0" src="{$cal_img}" alt="{$APP.LBL_ENTER_DATE}" id="goto_date_trigger"
+                         align="absmiddle">
 					<input type="hidden" id="goto_date" name="goto_date" value="{$current_date}">
 					<script type="text/javascript">
-					Calendar.setup ({literal}{{/literal}
-						inputField : "goto_date",
-						ifFormat : "%m/%d/%Y",
-						daFormat : "%m/%d/%Y",
-						button : "goto_date_trigger",
-						singleClick : true,
-						dateStr : "{$current_date}",
-						step : 1,
-						onUpdate: goto_date_call,
-						startWeekday: {$start_weekday},
-						weekNumbers:false
-					{literal}}{/literal});
-					{literal}
-					YAHOO.util.Event.onDOMReady(function(){
-						YAHOO.util.Event.addListener("goto_date","change",goto_date_call);
-					});
-					function goto_date_call(){
-						CAL.goto_date_call();
-					}
-					{/literal}
+					Calendar.setup({literal}{{/literal}
+                      inputField: "goto_date",
+                      ifFormat: "%m/%d/%Y",
+                      daFormat: "%m/%d/%Y",
+                      button: "goto_date_trigger",
+                      singleClick: true,
+                      dateStr: "{$current_date}",
+                      step: 1,
+                      onUpdate: goto_date_call,
+                      startWeekday: {$start_weekday},
+                      weekNumbers: false
+                        {literal}}{/literal});
+                    {literal}
+                    YAHOO.util.Event.onDOMReady(function () {
+                      YAHOO.util.Event.addListener("goto_date", "change", goto_date_call);
+                    });
+                    function goto_date_call() {
+                      CAL.goto_date_call();
+                    }
+                    {/literal}
 					</script>
 	</span>
-	{/if}
-	<input type="button" id="" class="btn btn-info" data-toggle="modal" data-target=".modal-calendar-settings" value="{$MOD.LBL_SETTINGS}">
-</div>
-
-<div style='clear: both;'></div>
-
+        {/if}
+        <input type="button" id="" class="btn btn-info" data-toggle="modal" data-target=".modal-calendar-settings"
+               value="{$MOD.LBL_SETTINGS}">
+    </div>
+    <div style='clear: both;'></div>
 {/if}
 
 
 <div class="row monthHeader">
-	<div class="col-xs-1">{$previous}</div>
-	<div class="col-xs-10 text-center"><h3>{$date_info}</h3></div>
-	<div class="col-xs-1 text-right">{$next}</div>
-	<br>
+    <div class="col-xs-1">{$previous}</div>
+    <div class="col-xs-10 text-center"><h3>{$date_info}</h3></div>
+    <div class="col-xs-1 text-right">{$next}</div>
+    <br>
 </div>

--- a/themes/SuiteP/modules/Calendar/tpls/header.tpl
+++ b/themes/SuiteP/modules/Calendar/tpls/header.tpl
@@ -5,7 +5,7 @@
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
  *
  * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
- * Copyright (C) 2011 - 2016 SalesAgility Ltd.
+ * Copyright (C) 2011 - 2017 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the
@@ -16,7 +16,7 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
  * details.
  *
  * You should have received a copy of the GNU Affero General Public License along with
@@ -34,8 +34,8 @@
  * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
  * these Appropriate Legal Notices must retain the display of the "Powered by
  * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
- * reasonably feasible for  technical reasons, the Appropriate Legal Notices must
- * display the words  "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 *}
 
@@ -89,7 +89,7 @@
 {/if}
 
 
-<div class="row {if $controls}monthHeader{/if}">
+<div class="row monthHeader">
 	<div class="col-xs-1">{$previous}</div>
 	<div class="col-xs-10 text-center"><h3>{$date_info}</h3></div>
 	<div class="col-xs-1 text-right">{$next}</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
In the calendar dashlet, right / left navigation icons are not visible in SuiteP:
![calendar_dashlet_invisible](https://user-images.githubusercontent.com/26431166/30804769-8c79d60c-a1e6-11e7-9757-abad74e0b76b.png)


This change updates the month header to use the same colour as the calendar module:
![month_header](https://user-images.githubusercontent.com/26431166/30804762-8222864a-a1e6-11e7-8372-2990e44076cd.png)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #2783

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Repair and rebuild.
2. Add calendar dashlet to homepage.
3. Check that the left/right navigation icons are visible in all themes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->