### PR TITLE
1 Hour tasks in the calendar consumes 2 spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## SuiteCRM 7.8.5
+## SuiteCRM 7.8 LTS
 
 [![Build Status](https://travis-ci.org/salesagility/SuiteCRM.svg?branch=hotfix)](https://travis-ci.org/salesagility/SuiteCRM)
 

--- a/modules/Calendar/CalendarUtils.php
+++ b/modules/Calendar/CalendarUtils.php
@@ -90,7 +90,8 @@ class CalendarUtils {
 				'parent_id',
 				'parent_type',
 				'priority',
-				'date_due'
+				'date_start' ## START #DEV-224 for Task Durations
+				/*'date_due'*/
 			),
 		);
 	}
@@ -103,8 +104,12 @@ class CalendarUtils {
 	static function get_time_data(SugarBean $bean, $start_field = "date_start", $end_field = "date_end"){
 					$arr = array();
 
-					if($bean->object_name == 'Task')
-						$start_field = $end_field = "date_due";
+                    ## START #DEV-224 for Task Durations
+					if($bean->object_name == 'Task'){
+						$start_field = "date_start"; $end_field = "date_due";
+                        #$start_field = $end_field = "date_due";
+                    }
+                    ## END #DEV-224 for Task Durations
 					if(empty($bean->$start_field))
 						return array();
 					if(empty($bean->$end_field))

--- a/suitecrm_version.php
+++ b/suitecrm_version.php
@@ -3,5 +3,5 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-$suitecrm_version      = '7.8.5';
-$suitecrm_timestamp    = '2017-06-15 17:00';
+$suitecrm_version      = '7.8.6';
+$suitecrm_timestamp    = '2017-09-06 17:00';


### PR DESCRIPTION
It appears a task in the calendar that is for 1 hour duration displays as 2 hours.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We have modified the way a task is displayed in the calendar, now a one hour task will only consume one space in the calendar as opposed to two spaces before.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Create a task that has a duration of 1 hour.

Look for the task in your calendar, it will consume two spaces giving the user the impression that the task is for 2 hours.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->