### PR TITLE
Fixed  #3811 - Direct html content gets truncated - incomplete html

### DIFF
--- a/modules/EmailTemplates/vardefs.php
+++ b/modules/EmailTemplates/vardefs.php
@@ -43,7 +43,8 @@ if (!defined('sugarEntry') || !sugarEntry) {
 }
 
 $dictionary['EmailTemplate'] = array(
-    'table' => 'email_templates', 'comment' => 'Templates used in email processing',
+    'table' => 'email_templates',
+    'comment' => 'Templates used in email processing',
     'fields' => array(
         'id' => array(
             'name' => 'id',
@@ -210,11 +211,18 @@ $dictionary['EmailTemplate'] = array(
     ),
     'relationships' => array(
         'emailtemplates_assigned_user' =>
-            array('lhs_module' => 'Users', 'lhs_table' => 'users', 'lhs_key' => 'id',
-                'rhs_module' => 'EmailTemplates', 'rhs_table' => 'email_templates', 'rhs_key' => 'assigned_user_id',
-                'relationship_type' => 'one-to-many')
+            array(
+                'lhs_module' => 'Users',
+                'lhs_table' => 'users',
+                'lhs_key' => 'id',
+                'rhs_module' => 'EmailTemplates',
+                'rhs_table' => 'email_templates',
+                'rhs_key' => 'assigned_user_id',
+                'relationship_type' => 'one-to-many'
+            )
     ),
 );
 
-VardefManager::createVardef('EmailTemplates', 'EmailTemplate', array('security_groups',
+VardefManager::createVardef('EmailTemplates', 'EmailTemplate', array(
+    'security_groups',
 ));

--- a/modules/EmailTemplates/vardefs.php
+++ b/modules/EmailTemplates/vardefs.php
@@ -1,11 +1,11 @@
 <?php
-if (!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
-/*********************************************************************************
+/**
+ *
  * SugarCRM Community Edition is a customer relationship management program developed by
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
  *
- * SuiteCRM is an extension to SugarCRM Community Edition developed by Salesagility Ltd.
- * Copyright (C) 2011 - 2016 Salesagility Ltd.
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2017 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the
@@ -16,7 +16,7 @@ if (!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
  * details.
  *
  * You should have received a copy of the GNU Affero General Public License along with
@@ -34,9 +34,13 @@ if (!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
  * these Appropriate Legal Notices must retain the display of the "Powered by
  * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
- * reasonably feasible for  technical reasons, the Appropriate Legal Notices must
- * display the words  "Powered by SugarCRM" and "Supercharged by SuiteCRM".
- ********************************************************************************/
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
 
 $dictionary['EmailTemplate'] = array(
     'table' => 'email_templates', 'comment' => 'Templates used in email processing',
@@ -114,13 +118,13 @@ $dictionary['EmailTemplate'] = array(
         'body' => array(
             'name' => 'body',
             'vname' => 'LBL_BODY',
-            'type' => 'text',
+            'type' => 'longtext',
             'comment' => 'Plain text body to be used in resulting email'
         ),
         'body_html' => array(
             'name' => 'body_html',
             'vname' => 'LBL_PLAIN_TEXT',
-            'type' => 'html',
+            'type' => 'longtext',
             'comment' => 'HTML formatted email body to be used in resulting email'
         ),
         'deleted' => array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixes email templates from having a maximum size of 65,535 bytes due to having type TEXT.

Issue reference: #3811

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This allows users to create email templates that are above 65,535 bytes and not have the email template get truncated.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create an email template with a size over 65,535 bytes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->