### PR TITLE
Fixed #4328 - TinyMCE brand name

### DIFF
--- a/include/language/en_us.lang.php
+++ b/include/language/en_us.lang.php
@@ -719,7 +719,7 @@ $app_list_strings = array(
 
     'dom_editor_type' => array(
         'none' => 'Direct HTML',
-        'tinymce' => 'Tiny MCE',
+        'tinymce' => 'TinyMCE',
         'mozaik' => 'Mozaik',
     ),
 


### PR DESCRIPTION

## Description
TinyMCE editor name should be written without a space as in TinyMCE
Fix https://github.com/salesagility/SuiteCRM/issues/4328

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Proper brand name for a 3rd party software
Actual format: Tiny MCE
Brand name, see: https://www.tinymce.com/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->