### PR TITLE
Fixed #3716 - Project templates - Wrong labels

### DIFF
--- a/modules/AM_ProjectTemplates/tpls/ListViewGeneric.tpl
+++ b/modules/AM_ProjectTemplates/tpls/ListViewGeneric.tpl
@@ -43,22 +43,22 @@
 
 
 <script>
-{literal}
-	$(document).ready(function(){
-	    $("ul.clickMenu").each(function(index, node){
-	  		$(node).sugarActionMenu();
-	  	});
+    {literal}
+    $(document).ready(function () {
+      $("ul.clickMenu").each(function (index, node) {
+        $(node).sugarActionMenu();
+      });
 
-        $('.selectActionsDisabled').children().each(function(index) {
-            $(this).attr('onclick','').unbind('click');
-        });
+      $('.selectActionsDisabled').children().each(function (index) {
+        $(this).attr('onclick', '').unbind('click');
+      });
 
-        var selectedTopValue = $("#selectCountTop").attr("value");
-        if(typeof(selectedTopValue) !== "undefined" && selectedTopValue !== "0"){
-        	sugarListView.prototype.toggleSelected();
-        }
-	});
-{/literal}
+      var selectedTopValue = $("#selectCountTop").attr("value");
+      if (typeof(selectedTopValue) !== "undefined" && selectedTopValue !== "0") {
+        sugarListView.prototype.toggleSelected();
+      }
+    });
+    {/literal}
 </script>
 {assign var="currentModule" value = $pageData.bean.moduleDir}
 {assign var="singularModule" value = $moduleListSingular.$currentModule}
@@ -66,222 +66,234 @@
 {assign var="hideTable" value=false}
 
 {if count($data) == 0}
-	{assign var="hideTable" value=true}
-	<div class="list view listViewEmpty">
-		{if $displayEmptyDataMesssages}
-        {if strlen($query) == 0}
-                {capture assign="createLink"}<a href="index.php?module={$pageData.bean.moduleDir}&action=EditView&return_module={$pageData.bean.moduleDir}&return_action=DetailView">{$APP.LBL_CREATE_BUTTON_LABEL}</a>{/capture}
-                {capture assign="importLink"}<a href="index.php?module=Import&action=Step1&import_module={$pageData.bean.moduleDir}&return_module={$pageData.bean.moduleDir}&return_action=index">{$APP.LBL_IMPORT}</a>{/capture}
-                {capture assign="helpLink"}<a target="_blank" href='index.php?module=Administration&action=SupportPortal&view=documentation&version={$sugar_info.sugar_version}&edition={$sugar_info.sugar_flavor}&lang=&help_module={$currentModule}&help_action=&key='>{$APP.LBL_CLICK_HERE}</a>{/capture}
-            <div class="filterContainer">
-                {if $showFilterIcon}
+    {assign var="hideTable" value=true}
+    <div class="list view listViewEmpty">
+        {if $displayEmptyDataMesssages}
+            {if strlen($query) == 0}
+                {capture assign="createLink"}<a
+                    href="index.php?module={$pageData.bean.moduleDir}&action=EditView&return_module={$pageData.bean.moduleDir}&return_action=DetailView">{$APP.LBL_CREATE_BUTTON_LABEL}</a>{/capture}
+                {capture assign="importLink"}<a
+                    href="index.php?module=Import&action=Step1&import_module={$pageData.bean.moduleDir}&return_module={$pageData.bean.moduleDir}&return_action=index">{$APP.LBL_IMPORT}</a>{/capture}
+                {capture assign="helpLink"}<a target="_blank"
+                                              href='index.php?module=Administration&action=SupportPortal&view=documentation&version={$sugar_info.sugar_version}&edition={$sugar_info.sugar_flavor}&lang=&help_module={$currentModule}&help_action=&key='>{$APP.LBL_CLICK_HERE}</a>{/capture}
+                <div class="filterContainer">
+                    {if $showFilterIcon}
+                        {sugar_include type="smarty" file='include/ListView/ListViewSearchLink.tpl'}
+                    {/if}
+                </div>
+                <p class="msg">
+                    {$APP.MSG_EMPTY_LIST_VIEW_NO_RESULTS|replace:"<item2>":$createLink|replace:"<item3>":$importLink}
+                </p>
+            {elseif $query == "-advanced_search"}
+                <p class="msg">
+                    {$APP.MSG_LIST_VIEW_NO_RESULTS_BASIC}
                     {sugar_include type="smarty" file='include/ListView/ListViewSearchLink.tpl'}
-                {/if}
-            </div>
-            <p class="msg">
-                {$APP.MSG_EMPTY_LIST_VIEW_NO_RESULTS|replace:"<item2>":$createLink|replace:"<item3>":$importLink}
-            </p>
-        {elseif $query == "-advanced_search"}
-            <p class="msg">
-                {$APP.MSG_LIST_VIEW_NO_RESULTS_BASIC}
-                {sugar_include type="smarty" file='include/ListView/ListViewSearchLink.tpl'}
-            </p>
+                </p>
+            {else}
+                <p class="msg">
+                    {capture assign="quotedQuery"}"{$query}"{/capture}
+                    {$APP.MSG_LIST_VIEW_NO_RESULTS|replace:"<item1>":$quotedQuery}
+                </p>
+                <p class="submsg">
+                    <a href="index.php?module={$pageData.bean.moduleDir}&action=EditView&return_module={$pageData.bean.moduleDir}&return_action=DetailView">
+                        {$APP.MSG_LIST_VIEW_NO_RESULTS_SUBMSG|replace:"<item1>":$quotedQuery|replace:"<item2>":$singularModule}
+                    </a>
+                    {$APP.MSG_LIST_VIEW_CHANGE_SEARCH}
+                    {if $showFilterIcon}
+                        {sugar_include type="smarty" file='include/ListView/ListViewSearchLink.tpl'}
+                    {/if}
+                </p>
+            {/if}
         {else}
             <p class="msg">
-                {capture assign="quotedQuery"}"{$query}"{/capture}
-                {$APP.MSG_LIST_VIEW_NO_RESULTS|replace:"<item1>":$quotedQuery}
-            </p>
-            <p class = "submsg">
-                <a href="index.php?module={$pageData.bean.moduleDir}&action=EditView&return_module={$pageData.bean.moduleDir}&return_action=DetailView">
-                    {$APP.MSG_LIST_VIEW_NO_RESULTS_SUBMSG|replace:"<item1>":$quotedQuery|replace:"<item2>":$singularModule}
-                </a>
-                {$APP.MSG_LIST_VIEW_CHANGE_SEARCH}
-                {if $showFilterIcon}
-                    {sugar_include type="smarty" file='include/ListView/ListViewSearchLink.tpl'}
-                {/if}
+                {$APP.LBL_NO_DATA}
             </p>
         {/if}
-    {else}
-        <p class="msg">
-            {$APP.LBL_NO_DATA}
-        </p>
-	{/if}
-	</div>
+    </div>
 {/if}
 {$multiSelectData}
 {if $hideTable == false}
-	<table cellpadding='0' cellspacing='0' width='100%' border='0' class='list view table'>
-	<thead>
-	{assign var="link_select_id" value="selectLinkTop"}
-    {assign var="link_action_id" value="actionLinkTop"}
-    {assign var="actionsLink" value=$actionsLinkTop}
-    {assign var="selectLink" value=$selectLinkTop}
-    {assign var="action_menu_location" value="top"}
-	{sugar_include type="smarty" file='include/ListView/ListViewPagination.tpl'}
-	<tr>
-			{if $prerow}
-				<td width='1%' class="td_alt">
-					&nbsp;
-				</td>
-			{/if}
-			{if !empty($quickViewLinks)}
-			<td class='td_alt' width='1%' style="padding: 0;">&nbsp;</td>
-			{/if}
-			{counter start=0 name="colCounter" print=false assign="colCounter"}
+    <table cellpadding='0' cellspacing='0' width='100%' border='0' class='list view table'>
+        <thead>
+        {assign var="link_select_id" value="selectLinkTop"}
+        {assign var="link_action_id" value="actionLinkTop"}
+        {assign var="actionsLink" value=$actionsLinkTop}
+        {assign var="selectLink" value=$selectLinkTop}
+        {assign var="action_menu_location" value="top"}
+        {sugar_include type="smarty" file='include/ListView/ListViewPagination.tpl'}
+        <tr>
+            {if $prerow}
+                <td width='1%' class="td_alt">
+                    &nbsp;
+                </td>
+            {/if}
+            {if !empty($quickViewLinks)}
+                <td class='td_alt' width='1%' style="padding: 0;">&nbsp;</td>
+            {/if}
+            {counter start=0 name="colCounter" print=false assign="colCounter"}
             {assign var='datahide' value="phone"}
-			{foreach from=$displayColumns key=colHeader item=params}
+            {foreach from=$displayColumns key=colHeader item=params}
                 {if $colCounter == '3'}{assign var='datahide' value="phone,phonelandscape"}{/if}
                 {if $colCounter == '5'}{assign var='datahide' value="phone,phonelandscape,tablet"}{/if}
-                {if $colHeader == 'NAME' || $params.bold}<th scope='col' data-toggle="true">
-				{else}<th scope='col' data-hide="{$datahide}">{/if}
-					<div style='white-space: normal; align='{$params.align|default:'left'}'>
-	                {if $params.sortable|default:true}
-	                    {if $params.url_sort}
-                            <a href='{$pageData.urls.orderBy}{$params.orderBy|default:$colHeader|lower}' class='listViewThLinkS1'></a>
-	                    {else}
-	                        {if $params.orderBy|default:$colHeader|lower == $pageData.ordering.orderBy}
-                                <a href='javascript:sListView.order_checks("{$pageData.ordering.sortOrder|default:ASCerror}", "{$params.orderBy|default:$colHeader|lower}" , "{$pageData.bean.moduleDir}{"2_"}{$pageData.bean.objectName|upper}{"_ORDER_BY"}")' class='listViewThLinkS1'></a>
-	                        {else}
-                                <a href='javascript:sListView.order_checks("ASC", "{$params.orderBy|default:$colHeader|lower}" , "{$pageData.bean.moduleDir}{"2_"}{$pageData.bean.objectName|upper}{"_ORDER_BY"}")' class='listViewThLinkS1'></a>
-	                        {/if}
-	                    {/if}
-	                    {sugar_translate label=$params.label module=$pageData.bean.moduleDir}
-						&nbsp;&nbsp;
-						{if $params.orderBy|default:$colHeader|lower == $pageData.ordering.orderBy}
-							{if $pageData.ordering.sortOrder == 'ASC'}
-								{capture assign="imageName"}arrow_down.{$arrowExt}{/capture}
-	                            {capture assign="alt_sort"}{sugar_translate label='LBL_ALT_SORT_DESC'}{/capture}
-								{sugar_getimage name=$imageName attr='align="absmiddle" border="0" ' alt="$alt_sort"}
-							{else}
-								{capture assign="imageName"}arrow_up.{$arrowExt}{/capture}
-	                            {capture assign="alt_sort"}{sugar_translate label='LBL_ALT_SORT_ASC'}{/capture}
-								{sugar_getimage name=$imageName attr='align="absmiddle" border="0" ' alt="$alt_sort"}
-							{/if}
-						{else}
-							{capture assign="imageName"}arrow.{$arrowExt}{/capture}
-	                        {capture assign="alt_sort"}{sugar_translate label='LBL_ALT_SORT'}{/capture}
-							{sugar_getimage name=$imageName attr='align="absmiddle" border="0" ' alt="$alt_sort"}
-						{/if}
-					{else}
-	                    {if !isset($params.noHeader) || $params.noHeader == false}
-						  {sugar_translate label=$params.label module=$pageData.bean.moduleDir}
-	                    {/if}
-					{/if}
-				</th>
-				{counter name="colCounter"}
-			{/foreach}
-
-		</tr>
-	</thead>
-		{counter start=$pageData.offsets.current print=false assign="offset" name="offset"}
-		{foreach name=rowIteration from=$data key=id item=rowData}
-		    {counter name="offset" print=false}
-	        {assign var='scope_row' value=true}
-
-			{if $smarty.foreach.rowIteration.iteration is odd}
-				{assign var='_rowColor' value=$rowColor[0]}
-			{else}
-				{assign var='_rowColor' value=$rowColor[1]}
-			{/if}
-			<tr class='{$_rowColor}S1'>
-				{if $prerow}
-				<td width='1%' class='nowrap'>
-				 {if !$is_admin && is_admin_for_user && $rowData.IS_ADMIN==1}
-						<input type='checkbox' disabled="disabled" class='checkbox' value='{$rowData.ID}'>
-				 {else}
-	                    <input title="{sugar_translate label='LBL_SELECT_THIS_ROW_TITLE'}" onclick='sListView.check_item(this, document.MassUpdate)' type='checkbox' class='checkbox' name='mass[]' value='{$rowData.ID}'>
-				 {/if}
-				</td>
-				{/if}
-				{if !empty($quickViewLinks)}
-	            {capture assign=linkModule}{if $params.dynamic_module}{$rowData[$params.dynamic_module]}{else}{$pageData.bean.moduleDir}{/if}{/capture}
-	            {capture assign=action}{if $act}{$act}{else}EditView{/if}{/capture}
-				<td width='2%' nowrap>
-                    {if $pageData.rowAccess[$id].edit}
-                        <a title='{$editLinkString}' id="edit-{$rowData.ID}"
-                           href="index.php?module={$linkModule}&offset={$offset}&stamp={$pageData.stamp}&return_module={$linkModule}&action={$action}&record={$rowData.ID}"
-                                >
-                            {capture name='tmp1' assign='alt_edit'}{sugar_translate label="LNK_EDIT"}{/capture}
-                            {sugar_getimage name="edit_inline.gif" attr='border="0" ' alt="$alt_edit"}</a>
+                {if $colHeader == 'NAME' || $params.bold}
+                    <th scope='col' data-toggle="true">
+                {else}<th scope='col' data-hide="{$datahide}">{/if}
+                <div style='white-space: normal; align='
+                {$params.align|default:'left'}'>
+                {if $params.sortable|default:true}
+                    {if $params.url_sort}
+                        <a href='{$pageData.urls.orderBy}{$params.orderBy|default:$colHeader|lower}'
+                           class='listViewThLinkS1'></a>
+                    {else}
+                        {if $params.orderBy|default:$colHeader|lower == $pageData.ordering.orderBy}
+                            <a href='javascript:sListView.order_checks("{$pageData.ordering.sortOrder|default:ASCerror}", "{$params.orderBy|default:$colHeader|lower}" , "{$pageData.bean.moduleDir}{"2_"}{$pageData.bean.objectName|upper}{"_ORDER_BY"}")'
+                               class='listViewThLinkS1'></a>
+                        {else}
+                            <a href='javascript:sListView.order_checks("ASC", "{$params.orderBy|default:$colHeader|lower}" , "{$pageData.bean.moduleDir}{"2_"}{$pageData.bean.objectName|upper}{"_ORDER_BY"}")'
+                               class='listViewThLinkS1'></a>
+                        {/if}
                     {/if}
-	            </td>
+                    {sugar_translate label=$params.label module=$pageData.bean.moduleDir}
+                    &nbsp;&nbsp;
+                    {if $params.orderBy|default:$colHeader|lower == $pageData.ordering.orderBy}
+                        {if $pageData.ordering.sortOrder == 'ASC'}
+                            {capture assign="imageName"}arrow_down.{$arrowExt}{/capture}
+                            {capture assign="alt_sort"}{sugar_translate label='LBL_ALT_SORT_DESC'}{/capture}
+                            {sugar_getimage name=$imageName attr='align="absmiddle" border="0" ' alt="$alt_sort"}
+                        {else}
+                            {capture assign="imageName"}arrow_up.{$arrowExt}{/capture}
+                            {capture assign="alt_sort"}{sugar_translate label='LBL_ALT_SORT_ASC'}{/capture}
+                            {sugar_getimage name=$imageName attr='align="absmiddle" border="0" ' alt="$alt_sort"}
+                        {/if}
+                    {else}
+                        {capture assign="imageName"}arrow.{$arrowExt}{/capture}
+                        {capture assign="alt_sort"}{sugar_translate label='LBL_ALT_SORT'}{/capture}
+                        {sugar_getimage name=$imageName attr='align="absmiddle" border="0" ' alt="$alt_sort"}
+                    {/if}
+                {else}
+                    {if !isset($params.noHeader) || $params.noHeader == false}
+                        {sugar_translate label=$params.label module=$pageData.bean.moduleDir}
+                    {/if}
+                {/if}
+                </th>
+                {counter name="colCounter"}
+            {/foreach}
 
-				{/if}
-				{counter start=0 name="colCounter" print=false assign="colCounter"}
-				{foreach from=$displayColumns key=col item=params}
+        </tr>
+        </thead>
+        {counter start=$pageData.offsets.current print=false assign="offset" name="offset"}
+        {foreach name=rowIteration from=$data key=id item=rowData}
+            {counter name="offset" print=false}
+            {assign var='scope_row' value=true}
+
+            {if $smarty.foreach.rowIteration.iteration is odd}
+                {assign var='_rowColor' value=$rowColor[0]}
+            {else}
+                {assign var='_rowColor' value=$rowColor[1]}
+            {/if}
+            <tr class='{$_rowColor}S1'>
+                {if $prerow}
+                    <td width='1%' class='nowrap'>
+                        {if !$is_admin && is_admin_for_user && $rowData.IS_ADMIN==1}
+                            <input type='checkbox' disabled="disabled" class='checkbox' value='{$rowData.ID}'>
+                        {else}
+                            <input title="{sugar_translate label='LBL_SELECT_THIS_ROW_TITLE'}"
+                                   onclick='sListView.check_item(this, document.MassUpdate)' type='checkbox'
+                                   class='checkbox' name='mass[]' value='{$rowData.ID}'>
+                        {/if}
+                    </td>
+                {/if}
+                {if !empty($quickViewLinks)}
+                    {capture assign=linkModule}{if $params.dynamic_module}{$rowData[$params.dynamic_module]}{else}{$pageData.bean.moduleDir}{/if}{/capture}
+                    {capture assign=action}{if $act}{$act}{else}EditView{/if}{/capture}
+                    <td width='2%' nowrap>
+                        {if $pageData.rowAccess[$id].edit}
+                            <a title='{$editLinkString}' id="edit-{$rowData.ID}"
+                               href="index.php?module={$linkModule}&offset={$offset}&stamp={$pageData.stamp}&return_module={$linkModule}&action={$action}&record={$rowData.ID}"
+                            >
+                                {capture name='tmp1' assign='alt_edit'}{sugar_translate label="LNK_EDIT"}{/capture}
+                                {sugar_getimage name="edit_inline.gif" attr='border="0" ' alt="$alt_edit"}</a>
+                        {/if}
+                    </td>
+                {/if}
+                {counter start=0 name="colCounter" print=false assign="colCounter"}
+                {foreach from=$displayColumns key=col item=params}
                     {$displayColumns[type]}
-				    {strip}
-					<td {if $scope_row} scope='row' {/if} align='{$params.align|default:'left'}' valign="top" type="{$displayColumns.$col.type}" field="{$col|lower}" class="{if $inline_edit && ($displayColumns.$col.inline_edit == 1 || !isset($displayColumns.$col.inline_edit))}inlineEdit{/if}{if ($params.type == 'teamset')}nowrap{/if}{if preg_match('/PHONE/', $col)} phone{/if}">
-						{if $col == 'NAME' || $params.bold}<b>{/if}
-					    {if $params.link && !$params.customCode}
-	{capture assign=linkModule}{if $params.dynamic_module}{$rowData[$params.dynamic_module]}{else}{$params.module|default:$pageData.bean.moduleDir}{/if}{/capture}
-	{capture assign=action}{if $act}{$act}{else}view_GanttChart{/if}{/capture}
-	{capture assign=record}{$rowData[$params.id]|default:$rowData.ID}{/capture}
-	{capture assign=url}index.php?module={$linkModule}&offset={$offset}&stamp={$pageData.stamp}&return_module={$linkModule}&action={$action}&record={$record}{/capture}
-	                        <{$pageData.tag.$id[$params.ACLTag]|default:$pageData.tag.$id.MAIN} href="{sugar_ajax_url url=$url}">
-						{/if}
+                    {strip}
+                        <td {if $scope_row} scope='row' {/if} align='{$params.align|default:'left'}' valign="top"
+                                                              type="{$displayColumns.$col.type}" field="{$col|lower}"
+                                                              class="{if $inline_edit && ($displayColumns.$col.inline_edit == 1 || !isset($displayColumns.$col.inline_edit))}inlineEdit{/if}{if ($params.type == 'teamset')}nowrap{/if}{if preg_match('/PHONE/', $col)} phone{/if}">
+                            {if $col == 'NAME' || $params.bold}<b>{/if}
+                                {if $params.link && !$params.customCode}
+                                    {capture assign=linkModule}{if $params.dynamic_module}{$rowData[$params.dynamic_module]}{else}{$params.module|default:$pageData.bean.moduleDir}{/if}{/capture}
+                                    {capture assign=action}{if $act}{$act}{else}view_GanttChart{/if}{/capture}
+                                    {capture assign=record}{$rowData[$params.id]|default:$rowData.ID}{/capture}
+                                    {capture assign=url}index.php?module={$linkModule}&offset={$offset}&stamp={$pageData.stamp}&return_module={$linkModule}&action={$action}&record={$record}{/capture}
+                                    <{$pageData.tag.$id[$params.ACLTag]|default:$pageData.tag.$id.MAIN} href="{sugar_ajax_url url=$url}">
+                                {/if}
 
-						{if $params.customCode}
-							{sugar_evalcolumn_old var=$params.customCode rowData=$rowData}
-						{else}
-	                       {sugar_field parentFieldArray=$rowData vardef=$params displayType=ListView field=$col}
+                                {if $params.customCode}
+                                    {sugar_evalcolumn_old var=$params.customCode rowData=$rowData}
+                                {else}
+                                    {sugar_field parentFieldArray=$rowData vardef=$params displayType=ListView field=$col}
 
-						{/if}
-						{if empty($rowData.$col) && empty($params.customCode)}&nbsp;{/if}
-						{if $params.link && !$params.customCode}
-							</{$pageData.tag.$id[$params.ACLTag]|default:$pageData.tag.$id.MAIN}>
-	                    {/if}
-                        {if $inline_edit && ($displayColumns.$col.inline_edit == 1 || !isset($displayColumns.$col.inline_edit))}<div class="inlineEditIcon">{sugar_getimage name="inline_edit_icon.svg" attr='border="0" ' alt="$alt_edit"}</div>{/if}
-					</td>
-					{/strip}
-	                {assign var='scope_row' value=false}
-					{counter name="colCounter"}
+                                {/if}
+                                {if empty($rowData.$col) && empty($params.customCode)}&nbsp;{/if}
+                                {if $params.link && !$params.customCode}
+                            </{$pageData.tag.$id[$params.ACLTag]|default:$pageData.tag.$id.MAIN}>
+                            {/if}
+                            {if $inline_edit && ($displayColumns.$col.inline_edit == 1 || !isset($displayColumns.$col.inline_edit))}
+                                <div class="inlineEditIcon">{sugar_getimage name="inline_edit_icon.svg" attr='border="0" ' alt="$alt_edit"}</div>{/if}
+                        </td>
+                    {/strip}
+                    {assign var='scope_row' value=false}
+                    {counter name="colCounter"}
 
-				{/foreach}
-				<td align='right'>{$pageData.additionalDetails.$id}</td>
-		    	</tr>
-		{foreachelse}
-		<tr class='{$rowColor[0]}S1'>
-		    <td colspan="{$colCount}">
-		        <em>{$APP.LBL_NO_DATA}</em>
-		    </td>
-		</tr>
-		{/foreach}
-    {assign var="link_select_id" value="selectLinkBottom"}
-    {assign var="link_action_id" value="actionLinkBottom"}
-    {assign var="selectLink" value=$selectLinkBottom}
-    {assign var="actionsLink" value=$actionsLinkBottom}
-    {assign var="action_menu_location" value="bottom"}
-    {sugar_include type="smarty" file='include/ListView/ListViewPagination.tpl'}
-	</table>
+                {/foreach}
+                <td align='right'>{$pageData.additionalDetails.$id}</td>
+            </tr>
+            {foreachelse}
+            <tr class='{$rowColor[0]}S1'>
+                <td colspan="{$colCount}">
+                    <em>{$APP.LBL_NO_DATA}</em>
+                </td>
+            </tr>
+        {/foreach}
+        {assign var="link_select_id" value="selectLinkBottom"}
+        {assign var="link_action_id" value="actionLinkBottom"}
+        {assign var="selectLink" value=$selectLinkBottom}
+        {assign var="actionsLink" value=$actionsLinkBottom}
+        {assign var="action_menu_location" value="bottom"}
+        {sugar_include type="smarty" file='include/ListView/ListViewPagination.tpl'}
+    </table>
 {/if}
 {if $contextMenus}
-<script type="text/javascript">
-{$contextMenuScript}
-{literal}
-function lvg_nav(m,id,act,offset,t){
-    if(t.href.search(/#/) < 0) {
-    }
-    else{
-        if(act==='pte'){
-            act='ProjectTemplatesEditView';
-        }
-        else if(act==='d'){
-            act='DetailView';
-        }else if( act ==='ReportsWizard'){
-            act = 'ReportsWizard';
-        }else{
-            act='EditView';
-        }
-    {/literal}
-        url = 'index.php?module='+m+'&offset=' + offset + '&stamp={$pageData.stamp}&return_module='+m+'&action='+act+'&record='+id;
-        t.href=url;
-    {literal}
-    }
-}{/literal}
-{literal}
-    function lvg_dtails(id){{/literal}
-        return SUGAR.util.getAdditionalDetails( '{$pageData.bean.moduleDir|default:$params.module}',id, 'adspan_'+id);{literal}}{/literal}
-</script>
-<script type="text/javascript" src="include/InlineEditing/inlineEditing.js"></script>
+    <script type="text/javascript">
+        {$contextMenuScript}
+        {literal}
+        function lvg_nav(m, id, act, offset, t) {
+          if (t.href.search(/#/) < 0) {
+          }
+          else {
+            if (act === 'pte') {
+              act = 'ProjectTemplatesEditView';
+            }
+            else if (act === 'd') {
+              act = 'DetailView';
+            } else if (act === 'ReportsWizard') {
+              act = 'ReportsWizard';
+            } else {
+              act = 'EditView';
+            }
+              {/literal}
+            url = 'index.php?module=' + m + '&offset=' + offset + '&stamp={$pageData.stamp}&return_module=' + m + '&action=' + act + '&record=' + id;
+            t.href = url;
+              {literal}
+          }
+        }{/literal}
+        {literal}
+        function lvg_dtails(id) {{/literal}
+          return SUGAR.util.getAdditionalDetails('{$pageData.bean.moduleDir|default:$params.module}', id, 'adspan_' + id);{literal}}{/literal}
+    </script>
+    <script type="text/javascript" src="include/InlineEditing/inlineEditing.js"></script>
 {/if}

--- a/modules/AM_ProjectTemplates/tpls/ListViewGeneric.tpl
+++ b/modules/AM_ProjectTemplates/tpls/ListViewGeneric.tpl
@@ -1,11 +1,11 @@
 {*
-
-/*********************************************************************************
+/**
+ *
  * SugarCRM Community Edition is a customer relationship management program developed by
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
-
- * SuiteCRM is an extension to SugarCRM Community Edition developed by Salesagility Ltd.
- * Copyright (C) 2011 - 2014 Salesagility Ltd.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2017 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the
@@ -16,7 +16,7 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
  * details.
  *
  * You should have received a copy of the GNU Affero General Public License along with
@@ -34,13 +34,9 @@
  * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
  * these Appropriate Legal Notices must retain the display of the "Powered by
  * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
- * reasonably feasible for  technical reasons, the Appropriate Legal Notices must
- * display the words  "Powered by SugarCRM" and "Supercharged by SuiteCRM".
- ********************************************************************************/
-
-
-
-
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
 *}
 
 <script type='text/javascript' src='{sugar_getjspath file='include/javascript/popup_helper.js'}'></script>
@@ -58,7 +54,7 @@
         });
 
         var selectedTopValue = $("#selectCountTop").attr("value");
-        if(typeof(selectedTopValue) != "undefined" && selectedTopValue != "0"){
+        if(typeof(selectedTopValue) !== "undefined" && selectedTopValue !== "0"){
         	sugarListView.prototype.toggleSelected();
         }
 	});
@@ -74,15 +70,21 @@
 	<div class="list view listViewEmpty">
 		{if $displayEmptyDataMesssages}
         {if strlen($query) == 0}
-                {capture assign="createLink"}<a href="?module={$pageData.bean.moduleDir}&action=EditView&return_module={$pageData.bean.moduleDir}&return_action=DetailView">{$APP.LBL_CREATE_BUTTON_LABEL}</a>{/capture}
-                {capture assign="importLink"}<a href="?module=Import&action=Step1&import_module={$pageData.bean.moduleDir}&return_module={$pageData.bean.moduleDir}&return_action=index">{$APP.LBL_IMPORT}</a>{/capture}
-                {capture assign="helpLink"}<a target="_blank" href='?module=Administration&action=SupportPortal&view=documentation&version={$sugar_info.sugar_version}&edition={$sugar_info.sugar_flavor}&lang=&help_module={$currentModule}&help_action=&key='>{$APP.LBL_CLICK_HERE}</a>{/capture}
-                <p class="msg">
-                    {$APP.MSG_EMPTY_LIST_VIEW_NO_RESULTS|replace:"<item2>":$createLink|replace:"<item3>":$importLink}
-                </p>
+                {capture assign="createLink"}<a href="index.php?module={$pageData.bean.moduleDir}&action=EditView&return_module={$pageData.bean.moduleDir}&return_action=DetailView">{$APP.LBL_CREATE_BUTTON_LABEL}</a>{/capture}
+                {capture assign="importLink"}<a href="index.php?module=Import&action=Step1&import_module={$pageData.bean.moduleDir}&return_module={$pageData.bean.moduleDir}&return_action=index">{$APP.LBL_IMPORT}</a>{/capture}
+                {capture assign="helpLink"}<a target="_blank" href='index.php?module=Administration&action=SupportPortal&view=documentation&version={$sugar_info.sugar_version}&edition={$sugar_info.sugar_flavor}&lang=&help_module={$currentModule}&help_action=&key='>{$APP.LBL_CLICK_HERE}</a>{/capture}
+            <div class="filterContainer">
+                {if $showFilterIcon}
+                    {sugar_include type="smarty" file='include/ListView/ListViewSearchLink.tpl'}
+                {/if}
+            </div>
+            <p class="msg">
+                {$APP.MSG_EMPTY_LIST_VIEW_NO_RESULTS|replace:"<item2>":$createLink|replace:"<item3>":$importLink}
+            </p>
         {elseif $query == "-advanced_search"}
             <p class="msg">
                 {$APP.MSG_LIST_VIEW_NO_RESULTS_BASIC}
+                {sugar_include type="smarty" file='include/ListView/ListViewSearchLink.tpl'}
             </p>
         {else}
             <p class="msg">
@@ -90,10 +92,13 @@
                 {$APP.MSG_LIST_VIEW_NO_RESULTS|replace:"<item1>":$quotedQuery}
             </p>
             <p class = "submsg">
-                <a href="?module={$pageData.bean.moduleDir}&action=EditView&return_module={$pageData.bean.moduleDir}&return_action=DetailView">
+                <a href="index.php?module={$pageData.bean.moduleDir}&action=EditView&return_module={$pageData.bean.moduleDir}&return_action=DetailView">
                     {$APP.MSG_LIST_VIEW_NO_RESULTS_SUBMSG|replace:"<item1>":$quotedQuery|replace:"<item2>":$singularModule}
                 </a>
-
+                {$APP.MSG_LIST_VIEW_CHANGE_SEARCH}
+                {if $showFilterIcon}
+                    {sugar_include type="smarty" file='include/ListView/ListViewSearchLink.tpl'}
+                {/if}
             </p>
         {/if}
     {else}
@@ -101,10 +106,6 @@
             {$APP.LBL_NO_DATA}
         </p>
 	{/if}
-		{$APP.MSG_LIST_VIEW_CHANGE_SEARCH}
-		{if $showFilterIcon}
-			{include file='include/ListView/ListViewSearchLink.tpl'}
-		{/if}
 	</div>
 {/if}
 {$multiSelectData}
@@ -116,15 +117,15 @@
     {assign var="actionsLink" value=$actionsLinkTop}
     {assign var="selectLink" value=$selectLinkTop}
     {assign var="action_menu_location" value="top"}
-	{include file='include/ListView/ListViewPagination.tpl'}
-	<tr height='20'>
+	{sugar_include type="smarty" file='include/ListView/ListViewPagination.tpl'}
+	<tr>
 			{if $prerow}
 				<td width='1%' class="td_alt">
 					&nbsp;
 				</td>
 			{/if}
 			{if !empty($quickViewLinks)}
-			<td class='td_alt' width='1%' style="padding: 0px;">&nbsp;</td>
+			<td class='td_alt' width='1%' style="padding: 0;">&nbsp;</td>
 			{/if}
 			{counter start=0 name="colCounter" print=false assign="colCounter"}
             {assign var='datahide' value="phone"}
@@ -133,15 +134,15 @@
                 {if $colCounter == '5'}{assign var='datahide' value="phone,phonelandscape,tablet"}{/if}
                 {if $colHeader == 'NAME' || $params.bold}<th scope='col' data-toggle="true">
 				{else}<th scope='col' data-hide="{$datahide}">{/if}
-					<div style='white-space: normal;'width='100%' align='{$params.align|default:'left'}'>
+					<div style='white-space: normal; align='{$params.align|default:'left'}'>
 	                {if $params.sortable|default:true}
 	                    {if $params.url_sort}
-	                        <a href='{$pageData.urls.orderBy}{$params.orderBy|default:$colHeader|lower}' class='listViewThLinkS1'>
+                            <a href='{$pageData.urls.orderBy}{$params.orderBy|default:$colHeader|lower}' class='listViewThLinkS1'></a>
 	                    {else}
 	                        {if $params.orderBy|default:$colHeader|lower == $pageData.ordering.orderBy}
-	                            <a href='javascript:sListView.order_checks("{$pageData.ordering.sortOrder|default:ASCerror}", "{$params.orderBy|default:$colHeader|lower}" , "{$pageData.bean.moduleDir}{"2_"}{$pageData.bean.objectName|upper}{"_ORDER_BY"}")' class='listViewThLinkS1'>
+                                <a href='javascript:sListView.order_checks("{$pageData.ordering.sortOrder|default:ASCerror}", "{$params.orderBy|default:$colHeader|lower}" , "{$pageData.bean.moduleDir}{"2_"}{$pageData.bean.objectName|upper}{"_ORDER_BY"}")' class='listViewThLinkS1'></a>
 	                        {else}
-	                            <a href='javascript:sListView.order_checks("ASC", "{$params.orderBy|default:$colHeader|lower}" , "{$pageData.bean.moduleDir}{"2_"}{$pageData.bean.objectName|upper}{"_ORDER_BY"}")' class='listViewThLinkS1'>
+                                <a href='javascript:sListView.order_checks("ASC", "{$params.orderBy|default:$colHeader|lower}" , "{$pageData.bean.moduleDir}{"2_"}{$pageData.bean.objectName|upper}{"_ORDER_BY"}")' class='listViewThLinkS1'></a>
 	                        {/if}
 	                    {/if}
 	                    {sugar_translate label=$params.label module=$pageData.bean.moduleDir}
@@ -161,13 +162,11 @@
 	                        {capture assign="alt_sort"}{sugar_translate label='LBL_ALT_SORT'}{/capture}
 							{sugar_getimage name=$imageName attr='align="absmiddle" border="0" ' alt="$alt_sort"}
 						{/if}
-	                    </a>
 					{else}
 	                    {if !isset($params.noHeader) || $params.noHeader == false}
 						  {sugar_translate label=$params.label module=$pageData.bean.moduleDir}
 	                    {/if}
 					{/if}
-					</div>
 				</th>
 				{counter name="colCounter"}
 			{/foreach}
@@ -184,7 +183,7 @@
 			{else}
 				{assign var='_rowColor' value=$rowColor[1]}
 			{/if}
-			<tr height='20' class='{$_rowColor}S1'>
+			<tr class='{$_rowColor}S1'>
 				{if $prerow}
 				<td width='1%' class='nowrap'>
 				 {if !$is_admin && is_admin_for_user && $rowData.IS_ADMIN==1}
@@ -242,7 +241,7 @@
 				<td align='right'>{$pageData.additionalDetails.$id}</td>
 		    	</tr>
 		{foreachelse}
-		<tr height='20' class='{$rowColor[0]}S1'>
+		<tr class='{$rowColor[0]}S1'>
 		    <td colspan="{$colCount}">
 		        <em>{$APP.LBL_NO_DATA}</em>
 		    </td>
@@ -253,7 +252,7 @@
     {assign var="selectLink" value=$selectLinkBottom}
     {assign var="actionsLink" value=$actionsLinkBottom}
     {assign var="action_menu_location" value="bottom"}
-    {include file='include/ListView/ListViewPagination.tpl'}
+    {sugar_include type="smarty" file='include/ListView/ListViewPagination.tpl'}
 	</table>
 {/if}
 {if $contextMenus}
@@ -261,14 +260,15 @@
 {$contextMenuScript}
 {literal}
 function lvg_nav(m,id,act,offset,t){
-    if(t.href.search(/#/) < 0){return;}
+    if(t.href.search(/#/) < 0) {
+    }
     else{
-        if(act=='pte'){
+        if(act==='pte'){
             act='ProjectTemplatesEditView';
         }
-        else if(act=='d'){
+        else if(act==='d'){
             act='DetailView';
-        }else if( act =='ReportsWizard'){
+        }else if( act ==='ReportsWizard'){
             act = 'ReportsWizard';
         }else{
             act='EditView';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixes the wrong labels being displayed in basic/advanced search when in the project templates module.

Issue ref: #3716

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go into project templates.
2. Delete all records or do a basic/advanced search.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->