### PR TITLE
Fixed issue #4346 workflow not working when user using date format is d/m/Y

### DIFF
--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -461,11 +461,14 @@ class AOW_WorkFlow extends Basic {
 
 
         if($this->flow_run_on){
-
-            // database time correction with the user's time-zoneqq
-            $beanDateEnteredTimestamp = strtotime($timedate->asUser(new DateTime($timedate->fromDb($bean->date_entered))));
-            $beanDateModifiedTimestamp = strtotime($timedate->asUser(new DateTime($timedate->fromDb($bean->date_modified))));
-            $thisDateEnteredTimestamp = strtotime($this->date_entered);
+		
+	    // strtotime not working with d/m/Y format, need convert to db format to make sure feature working expected.
+            // Keep db format to stable with strtotime
+            $beanDateEnteredTimestamp = strtotime($bean->date_entered);
+            $beanDateModifiedTimestamp = strtotime($bean->date_modified);
+		
+            // Convert user date format to db format to stable with strtotime
+            $thisDateEnteredTimestamp = strtotime($timedate->fromUser($this->date_entered)->asDb());
 
             switch($this->flow_run_on){
                 case'New_Records':

--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -468,6 +468,9 @@ class AOW_WorkFlow extends Basic {
             $beanDateModifiedTimestamp = strtotime($bean->date_modified);
 		
             // Convert user date format to db format to stable with strtotime
+	    if(empty($this->date_created)) {
+		    return false;
+	    }
             $thisDateEnteredTimestamp = strtotime($timedate->fromUser($this->date_entered)->asDb());
 
             switch($this->flow_run_on){


### PR DESCRIPTION
Fixed issue strtotime not working with d/m/Y format. I keep format as db format of bean date created, date modified and convert workflow date created to db format to make sure all workflow not ignore while condition ok.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Some workflow is not working when user using date format is d/m/Y. I investigated the cause. Because strtotime not working with date format d/m/Y so if day of bean created > 12 (Example: 30/10/2017) then strtotime will return false. And if the day of date created of workflow < 12 (Example: 10/01/2017) then it will return a valid value because it understand 10 is month (sttotime working with m/d/Y format) then if compare 2 value then bean created < workflow date is true => workflow will be ignore while actually bean created > workflow created.
See issue: #4346
## Motivation and Context

-  Make sure workflow always working if condtion ok.

## How To Test This
1.  Go to Profile > Advanced tab > Locale settings > Date format and change to d/m/Y format.
2.  Change date your computer to 10/01/2017 and create new workflow on any module with Run On: New Records and execute any action (Ex: create new record or modify record,...)
3.   Change date your computer to day > 12 (Ex: 20/01/2017) and create new record on module you have configured workflow to check.
4.   Workflow will not working because strtotime (20/01/2017) = false < strtotime(10/01/2017) is valid value.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->