### PR TITLE
Typo: Triple quotes instead of only two

### DIFF
--- a/themes/Suite7/tpls/header.tpl
+++ b/themes/Suite7/tpls/header.tpl
@@ -75,4 +75,4 @@
 
 <main>
     <div id="content" {if !$AUTHENTICATED}class="noLeftColumn" {/if}>
-        <table style=""" id="contentTable"><tr><td>
+        <table style="" id="contentTable"><tr><td>


### PR DESCRIPTION
Typo: Triple quotes instead of only two