### PR TITLE
module="xxx" is not a valid attribute for an a tag

### DIFF
--- a/include/Smarty/plugins/function.sugar_link.php
+++ b/include/Smarty/plugins/function.sugar_link.php
@@ -114,6 +114,6 @@ function smarty_function_sugar_link($params, &$smarty)
 	else
 	    $label = (!empty($GLOBALS['app_list_strings']['moduleList'][$params['module']]))?$GLOBALS['app_list_strings']['moduleList'][$params['module']]:$params['module'];
 
-    $link = '<a href="'.ajaxLink($link_url).'"'.$id.$class.$style.$options.$title.$module.'>'.$label.'</a>';
+    $link = '<a href="'.ajaxLink($link_url).'"'.$id.$class.$style.$options.$title.'>'.$label.'</a>';
     return $link;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Actual links in suite look like:
`<a href="?action=ajaxui#ajaxUILoc=index.php%3Fmodule%3DHome%26action%3Dindex" id="moduleTab_Home" module="Home">Home</a>`
"module=xxxx" is no valid html attribute, so it should be:
`<a href="?action=ajaxui#ajaxUILoc=index.php%3Fmodule%3DHome%26action%3Dindex" id="moduleTab_Home">Home</a>`

## Motivation and Context
Produce valid HTML.

## How To Test This
Look at the source code of the generated site.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [dontknow] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.
