### PR TITLE
Fixed #4380 - 7.9.6 Cannot view account details

### DIFF
--- a/include/ListView/ListViewSubPanel.php
+++ b/include/ListView/ListViewSubPanel.php
@@ -261,7 +261,7 @@
             reset($data);
 
             //GETTING OFFSET
-            $offset = empty($this->getOffset($html_varName)) ? 0 : $this->getOffset($html_varName);
+            $offset = ($this->getOffset($html_varName)) === false ? 0 : $this->getOffset($html_varName);
             //$totaltime = 0;
             $processed_ids = array();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixes an issue with PHP Fatal error:  Can't use method return value in write context when using a PHP version lower than 5.5.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #4380 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Enter a list-view like accounts.
2. Click on a record to enter detail-view.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->