### PR TITLE
Tabcount should count only Tabs and not Panels

### DIFF
--- a/include/EditView/EditView.tpl
+++ b/include/EditView/EditView.tpl
@@ -52,10 +52,10 @@ class="yui-navset"
     {* Generate the Tab headers *}
     {{counter name="tabCount" start=-1 print=false assign="tabCount"}}
     <ul class="yui-nav">
-    {{foreach name=section from=$sectionPanels key=label item=panel}}
-        {{counter name="tabCount" print=false}}
+    {{foreach name=section from=$sectionPanels key=label item=panel}} 
         {{capture name=label_upper assign=label_upper}}{{$label|upper}}{{/capture}}
         {{if (isset($tabDefs[$label_upper].newTab) && $tabDefs[$label_upper].newTab == true)}}
+	{{counter name="tabCount" print=false}}
         <li class="selected"><a id="tab{{$tabCount}}" href="javascript:void({{$tabCount}})"><em>{sugar_translate label='{{$label}}' module='{{$module}}'}</em></a></li>
         {{/if}}
     {{/foreach}}


### PR DESCRIPTION
Tabcount should count only Tabs and not Panels 
In Detailview it is correct:
https://github.com/salesagility/SuiteCRM/blob/e0a0a9cd8ad2f01049ef2d412f024fb435151652/include/DetailView/DetailView.tpl#L52-L59