### PR TITLE
Fixed - #1456 - Dropdown Editor: Display Label with single quotes is cut to save

### DIFF
--- a/modules/ModuleBuilder/javascript/SimpleList.js
+++ b/modules/ModuleBuilder/javascript/SimpleList.js
@@ -290,10 +290,11 @@ if(typeof(SimpleList) == 'undefined'){
         var editSpan = document.getElementById('span_edit_'+id);
         var textbox = document.getElementById('input_'+id);
 
+        var value = escape(val);
         dispSpan.style.display = 'inline';
         editSpan.style.display = 'none';
-        dispSpan.innerHTML = "["+val+"]";
-        document.getElementById('value_'+ id).value = val;
+        dispSpan.innerHTML = "["+value+"]";
+        document.getElementById('value_'+ id).value = value;
         SimpleList.lastEdit = null; // Bug 14662 - clear the last edit point behind us
     },
     undoDeleteDropDown : function(transaction){

--- a/modules/ModuleBuilder/parsers/parser.dropdown.php
+++ b/modules/ModuleBuilder/parsers/parser.dropdown.php
@@ -60,7 +60,9 @@ require_once('modules/ModuleBuilder/parsers/ModuleBuilderParser.php');
 
 		$list_value = str_replace('&quot;&quot;:&quot;&quot;', '&quot;__empty__&quot;:&quot;&quot;', $params['list_value']);
 		//Bug 21362 ENT_QUOTES- convert single quotes to escaped single quotes.
-		$temp = $json->decode(html_entity_decode(rawurldecode($list_value), ENT_QUOTES) );
+		$rawurldecode = rawurldecode($list_value);
+		$htmldecode = html_entity_decode($rawurldecode, ENT_QUOTES);
+		$temp = $json->decode($htmldecode);
 		$dropdown = array () ;
 		// dropdown is received as an array of (name,value) pairs - now extract to name=>value format preserving order
 		// we rely here on PHP to preserve the order of the received name=>value pairs - associative arrays in PHP are ordered
@@ -68,7 +70,9 @@ require_once('modules/ModuleBuilder/parsers/ModuleBuilderParser.php');
         {
             foreach ( $temp as $item )
             {
-                $dropdown[ SugarCleaner::stripTags(from_html($item [ 0 ]), false) ] = SugarCleaner::stripTags(from_html($item [ 1 ]), false) ;
+                $keytemp = SugarCleaner::stripTags(from_html($item [ 0 ]), false);
+                $valuetemp = SugarCleaner::stripTags(from_html($item [ 1 ]), false);
+            	$dropdown[ $keytemp ] =  $valuetemp;
             }
         }
 		if(array_key_exists($emptyMarker, $dropdown)){


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
#1456 - Dropdown Editor: Display Label with single quotes is cut to save
## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->