### PR TITLE
Fixed #4375  - PDF Template Editor Shows Only HTML

### DIFF
--- a/include/SugarFields/Fields/Html/SugarFieldHtml.php
+++ b/include/SugarFields/Fields/Html/SugarFieldHtml.php
@@ -79,7 +79,7 @@ class SugarFieldHtml extends SugarFieldBase
 
         $this->setup($parentFieldArray, $vardef, $displayParams, $tabindex);
 
-        return $this->fetch($this->findTemplate('DetailView'));
+        return $this->fetch($this->findTemplate('EditView'));
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This change corrects an issue with display encoded html inside the tinymce editor, while respecting the security issues.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes the issue.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* Install SuiteCRM / Run Repair And Rebuild
* Create a PDF template or use a field which has an html field.
* Save the PDF template
* Edit the PDF template again

Test Fails if you see encoded html tags in the description.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->