### PR TITLE
Fixing #4399 - Calendar ICAL URL ask for User / Password

### DIFF
--- a/modules/vCals/HTTP_WebDAV_Server_vCal.php
+++ b/modules/vCals/HTTP_WebDAV_Server_vCal.php
@@ -112,14 +112,6 @@ require_once 'include/HTTP_WebDAV_Server/Server.php';
             $current_language = $sugar_config['default_language'];
 
 
-            // check authentication
-            if (!$this->_check_auth()) {
-                $this->http_status('401 Unauthorized');
-                header('WWW-Authenticate: Basic realm="'.($this->http_auth_realm).'"');
-
-                return;
-            }
-
             // set root directory, defaults to webserver document root if not set
             if ($base) {
                 $this->base = realpath($base); // TODO throw if not a directory
@@ -196,24 +188,13 @@ require_once 'include/HTTP_WebDAV_Server/Server.php';
                 print $errorMessage;
             }
 
-            /**
-             * @var User|SugarBean|null $current_user
-             */
-            $current_user = BeanFactory::getBean('Users', $_SESSION['authenticated_user_id']);
 
+            // check authentication
+            if (!$this->_check_auth()) {
+                $this->http_status('401 Unauthorized');
+                header('WWW-Authenticate: Basic realm="'.($this->http_auth_realm).'"');
 
-
-            /**
-             * Fake a response so that it is not different from when a user is found
-             */
-            if($this->user_focus->id === null) {
-                $this->user_focus->last_name = $query_arr['user_name'];
-            } elseif (
-                !$current_user->isAdmin() &&
-                $current_user->user_name !== $this->user_focus->user_name
-            ) {
-                $this->user_focus = BeanFactory::newBean('Users');
-                $this->user_focus->last_name = $query_arr['user_name'];
+                return;
             }
 
             parent::ServeRequest();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removing 'authenticated_user_id' check from vCal.

## Description
See issue #4399
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
Most of our users have synchronized the SuiteCRM calendar with external systems. This external systems doesn't have a SuiteCRM session opened, so it's no possible to get the calendar using iCal.
<!--- Why is this change required? What problem does it solve? -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->