### PR TITLE
AOW Conditions operator failing due to extra space on ID 

### DIFF
--- a/modules/AOW_WorkFlow/controller.php
+++ b/modules/AOW_WorkFlow/controller.php
@@ -134,7 +134,7 @@ class AOW_WorkFlowController extends SugarController {
 
             $app_list_strings['aow_operator_list'];
             if($view == 'EditView'){
-                echo "<select type='text' name='$aow_field' id='$aow_field ' title='' tabindex='116'>". get_select_options_with_id($app_list_strings['aow_operator_list'], $value) ."</select>";
+                echo "<select type='text' name='$aow_field' id='$aow_field' title='' tabindex='116'>". get_select_options_with_id($app_list_strings['aow_operator_list'], $value) ."</select>";
             }else{
                 echo $app_list_strings['aow_operator_list'][$value];
             }

--- a/suitecrm_version.php
+++ b/suitecrm_version.php
@@ -3,5 +3,5 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-$suitecrm_version      = '7.9.6';
-$suitecrm_timestamp    = '2017-10-02 17:00';
+$suitecrm_version      = '7.9.7';
+$suitecrm_timestamp    = '2017-10-18 17:00';

--- a/suitecrm_version.php
+++ b/suitecrm_version.php
@@ -3,5 +3,5 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-$suitecrm_version      = '7.9.7';
-$suitecrm_timestamp    = '2017-10-18 17:00';
+$suitecrm_version      = '7.9.6';
+$suitecrm_timestamp    = '2017-10-02 17:00';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Just removed an extra space on the PHP code that was added to the ID field.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Javascript code was failing on AOW Conditions operator dropdown when the selected option was changed.
## How To Test This
<!--- Please describe in detail how to test your changes. -->

- Edit a Workflow
- Add a condition
- Choose a field
- Change operator

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->