### PR TITLE
Fix variable assignment in AOS_Utils::perform_aos_save()

### DIFF
--- a/modules/AOS_Products_Quotes/AOS_Utils.php
+++ b/modules/AOS_Products_Quotes/AOS_Utils.php
@@ -38,7 +38,7 @@ function perform_aos_save($focus){
             if(!number_empty($focus->field_defs[$field['name']])){
                 $currency = new Currency();
                 $currency->retrieve($focus->currency_id);
-                $focus->$fieldNameDollar = $currency->convertToDollar(unformat_number($fieldName));
+                $focus->$fieldNameDollar = $currency->convertToDollar(unformat_number($focus->$fieldName));
             }
 
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

To unformat_number()  is passed only variable name instead of the variable value from object.
This results that  *_usdollar fields of invoices and quotes don't have values.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It is a bug.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Create invoice or a quote and in DB check if *_usdollar fields have correct values.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->