### PR TITLE
Link for forum in CONTRIBUTING.md is wrong

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,7 +15,7 @@ This project and all community members are expected to uphold the [SuiteCRM Code
 
 * If you're unable to find an open issue that relates to your problem, [open a new one.](https://github.com/salesagility/SuiteCRM/issues/new) Please be sure to follow the issue template as much as possible.
 
-* **Ensure that the bug you are reporting is a core SuiteCRM issue** and not specific to your individual setup. For these types of issues please use the [Community Forum.](https://www.suitecrm.com/forum/suite-forum.)
+* **Ensure that the bug you are reporting is a core SuiteCRM issue** and not specific to your individual setup. For these types of issues please use the [Community Forum.](https://www.suitecrm.com/forum/suite-forum)
 
 #### **Did you fix a bug?**
 

--- a/suitecrm_version.php
+++ b/suitecrm_version.php
@@ -3,5 +3,5 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-$suitecrm_version      = '7.9.6';
-$suitecrm_timestamp    = '2017-10-02 17:00';
+$suitecrm_version      = '7.9.7';
+$suitecrm_timestamp    = '2017-10-18 17:00';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The link for the forum in CONTRIBUTING.md is incorrectly formatted leading to a 404 page

## Motivation and Context

People who would like to contribute may click on this link and it goes to a 404 page

## How To Test This

Try clicking on the link in master versus this branch

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->