### PR TITLE
Fixed #4157 / #4272 - Adding new tab on dashboard using Firefox is not possible

### DIFF
--- a/themes/SuiteP/include/MySugar/javascript/retrievePage.js
+++ b/themes/SuiteP/include/MySugar/javascript/retrievePage.js
@@ -52,8 +52,7 @@ var dashletsPageInit = function() {
                 return;
             }
 
-            $.post($('#addpageform').attr('action'), { dashName: $('#dashName').val(), numColumns: $('[name=numColumns] option:selected').val() } );
-            location.reload();
+	    $.post($('#addpageform').attr('action'), { dashName: $('#dashName').val(), numColumns: $('[name=numColumns] option:selected').val() } ).then(function() { location.reload(); });
 
         })
     })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We apply the fix sugested in [here](https://github.com/salesagility/SuiteCRM/issues/4272#issue-258447993)


## Motivation and Context
It's not possible to Add Tabs to Home Page of SuiteCRM using Firefox

## How To Test This
Open SuiteCRM with Firefox, and try to add a new Tab to Home Page

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->