### PR TITLE
Showing email accounts on compose view and redirecting user to settin…

### DIFF
--- a/modules/Emails/EmailsController.php
+++ b/modules/Emails/EmailsController.php
@@ -374,15 +374,24 @@ class EmailsController extends SugarController
                 $isGroupEmailAccount = $inboundEmail->isGroupEmailAccount();
                 $isPersonalEmailAccount = $inboundEmail->isPersonalEmailAccount();
 
+                $oe = new OutboundEmail();
+                $oe->retrieve($storedOptions['outbound_email']);
+                
                 $dataAddress = array(
                     'type' => $inboundEmail->module_name,
                     'id' => $inboundEmail->id,
                     'attributes' => array(
-                        'from' => $storedOptions['from_addr']
+                        'from' => $storedOptions['from_addr'],
+                        'name' => $inboundEmail->name,
+                        'oe' => $oe->mail_smtpuser,
                     ),
                     'prepend' => $prependSignature,
                     'isPersonalEmailAccount' => $isPersonalEmailAccount,
-                    'isGroupEmailAccount' => $isGroupEmailAccount
+                    'isGroupEmailAccount' => $isGroupEmailAccount,
+                    'outboundEmail' => array(
+                        'id' => $oe->id,
+                        'name' => $oe->name,
+                    ),
                 );
 
                 // Include signature
@@ -643,6 +652,20 @@ class EmailsController extends SugarController
         global $db;
         global $mod_strings;
 
+                
+        global $current_user;
+        $email = new Email();
+        $email->email2init();
+        $ie = new InboundEmail();
+        $ie->email = $email;
+        $accounts = $ieAccountsFull = $ie->retrieveAllByGroupIdWithGroupAccounts($current_user->id);
+        if(!$accounts) {
+            $url = 'index.php?module=Users&action=EditView&record=' . $current_user->id . "&showEmailSettingsPopup=1";
+            SugarApplication::appendErrorMessage(
+                    "You don't have any valid email account settings yet. <a href=\"$url\">Click here to set your email accounts.</a>");
+        }
+        
+        
         if (isset($request['record']) && !empty($request['record'])) {
             $this->bean->retrieve($request['record']);
         } else {

--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -435,6 +435,21 @@
         }
       }
     };
+    
+    self.updateFromInfos = function () {
+      var infos = $('#from_addr_name').find('option:selected').attr('infos');
+      if(infos === undefined) {
+        console.warn('Unable to retrieve selected infos in the "From" field.');
+        return false;
+      } 
+      
+      if(!$('#from_addr_name_infos').length) {
+          $('#from_addr_name').parent().append('<span id="from_addr_name_infos"></span>');
+      }
+      
+      $('#from_addr_name_infos').html(infos);
+      
+    };
 
     /**
      *
@@ -1095,7 +1110,8 @@
               var selectOption = $('<option></option>');
               selectOption.attr('value', v.attributes.from);
               selectOption.attr('inboundId', v.id);
-              selectOption.html(v.attributes.from);
+              selectOption.attr('infos', '(<b>Reply-to:</b> ' + v.attributes.from + ', <b>From:</b> ' + v.attributes.oe + ')');
+              selectOption.html(v.attributes.name);
               selectOption.appendTo(selectFrom);
 
               // include signature for account
@@ -1130,9 +1146,12 @@
             $(selectFrom).change(function (e) {
               $(self).find('[name=inbound_email_id]').val($(this).find('option:selected').attr('inboundId'));
               self.updateSignature();
+              self.updateFromInfos();
             });
 
             $(self).trigger('emailComposeViewGetFromFields');
+            
+            self.updateFromInfos();
 
           }
 

--- a/modules/Users/UserViewHelper.php
+++ b/modules/Users/UserViewHelper.php
@@ -141,6 +141,9 @@ class UserViewHelper {
         $edit_self = $current_user->id == $this->bean->id;
         $admin_edit_self = is_admin($current_user) && $edit_self;
 
+        if(isset($_REQUEST['showEmailSettingsPopup']) && $_REQUEST['showEmailSettingsPopup']) {
+            $this->ss->assign('showEmailSettingsPopup', true);
+        }
 
         $this->ss->assign('IS_FOCUS_ADMIN', is_admin($this->bean));
 

--- a/modules/Users/tpls/EditViewFooter.tpl
+++ b/modules/Users/tpls/EditViewFooter.tpl
@@ -488,3 +488,13 @@ onUserEditView();
         </td>
     </tr>
 </table>
+        
+        {if $showEmailSettingsPopup}
+        <script>
+            {literal}
+            $(function(){
+                SUGAR.email2.settings.showSettings();
+            });
+            {/literal}
+        </script>
+        {/if}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

Showing email accounts on compose view and redirecting user to settings popup.
From field shows email account name instead of email address.
Issue #4111

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->