### PR TITLE
Fix #1532 - Adjusted JS for Condition Line Views

### DIFF
--- a/modules/AOR_Reports/tpls/EditViewFooter.tpl
+++ b/modules/AOR_Reports/tpls/EditViewFooter.tpl
@@ -376,7 +376,8 @@
 {literal}
 <script type="text/javascript">
 
-    setModuleFieldsPendingFinishedCallback(function(){
+    function setModuleFieldsPendingFinishedCallback(){
+        'use strict';
         var parenthesisBtnHtml;
         $( "#aor_conditions_body, #aor_condition_parenthesis_btn" ).sortable({
             handle: '.condition-sortable-handle',
@@ -405,7 +406,7 @@
         ConditionOrderHandler.setConditionOrders();
         ParenthesisHandler.addParenthesisLineIdent();
         FieldLineHandler.makeGroupDisplaySelectOptions();
-    });
+    }
 
     $(function(){
 

--- a/suitecrm_version.php
+++ b/suitecrm_version.php
@@ -3,5 +3,5 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-$suitecrm_version      = '7.9.6';
-$suitecrm_timestamp    = '2017-10-02 17:00';
+$suitecrm_version      = '7.9.7';
+$suitecrm_timestamp    = '2017-10-18 17:00';

--- a/suitecrm_version.php
+++ b/suitecrm_version.php
@@ -3,5 +3,5 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-$suitecrm_version      = '7.9.7';
-$suitecrm_timestamp    = '2017-10-18 17:00';
+$suitecrm_version      = '7.9.6';
+$suitecrm_timestamp    = '2017-10-02 17:00';


### PR DESCRIPTION
## Description
Fixes issue #1532

Originally seemed fine on Chrome, but resulted in broken functionality in Firefox.

## Motivation and Context
Resulted in broken functionality in FireFox on certain scenarios - corrected to enable a fully working experience.

## How To Test This
Taken from the comments on the issue:

* Begin Creating a report by clicking the "Create" button on the right of the screen. On the report, you are unable to change tabs. (i.e, Fields, Conditions, Charts)
* If you have a report in the "Recently Viewed" panel, (Either on the Left of the CRM, or the one found by hovering over "Reports" on the Navigation bar), Click the Pencil icon to go straight to the Editview for this report. Then, you are unable to change tabs. (resolved with provided fix)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->