### PR TITLE
Fixed #4496 - bug wrong SugarDateTime minutes method used

### DIFF
--- a/modules/Schedulers/Scheduler.php
+++ b/modules/Schedulers/Scheduler.php
@@ -399,7 +399,7 @@ class Scheduler extends SugarBean {
 		// derive minutes
 		//$currentMin = date('i');
         	$minName = array();
-		$currentMin = $timedate->getNow()->min*1;
+		$currentMin = (int) $timedate->getNow()->min;
 		if($mins == '*') {
 			$GLOBALS['log']->debug('----->got * mins');
 			for($i=0; $i<60; $i++) {
@@ -411,7 +411,7 @@ class Scheduler extends SugarBean {
 			}
 		} elseif(strstr($mins,'*/')) {
 			$mult = str_replace('*/','',$mins);
-			$startMin = $timedate->fromDb($focus->date_time_start)->min*1;
+			$startMin = (int) $timedate->fromDb($focus->date_time_start)->min;
 			$startFrom = ($startMin % $mult);
 			for($i=$startFrom; $i<=59; $i) {
 				if(($currentMin + $i) > 59) {

--- a/modules/Schedulers/Scheduler.php
+++ b/modules/Schedulers/Scheduler.php
@@ -398,11 +398,8 @@ class Scheduler extends SugarBean {
 		//_pp($hrName);
 		// derive minutes
 		//$currentMin = date('i');
-        $minName = array();
-		$currentMin = $timedate->getNow()->minute;
-		if(substr($currentMin, 0, 1) == '0') {
-			$currentMin = substr($currentMin, 1, 1);
-		}
+        	$minName = array();
+		$currentMin = $timedate->getNow()->min*1;
 		if($mins == '*') {
 			$GLOBALS['log']->debug('----->got * mins');
 			for($i=0; $i<60; $i++) {
@@ -414,7 +411,7 @@ class Scheduler extends SugarBean {
 			}
 		} elseif(strstr($mins,'*/')) {
 			$mult = str_replace('*/','',$mins);
-			$startMin = $timedate->fromDb($focus->date_time_start)->minute;
+			$startMin = $timedate->fromDb($focus->date_time_start)->min*1;
 			$startFrom = ($startMin % $mult);
 			for($i=$startFrom; $i<=59; $i) {
 				if(($currentMin + $i) > 59) {


### PR DESCRIPTION
Additional of the wrong method was being used, also by multiplying the result with 1, it makes sure that that the result is numeric. This was causing warnings on PHP 7.1. Code to reduce leading zeros is not needed anymore.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->