### PR TITLE
Added return instruction to One2MRelationship::add() function

### DIFF
--- a/data/Relationships/One2MRelationship.php
+++ b/data/Relationships/One2MRelationship.php
@@ -158,9 +158,9 @@ class One2MRelationship extends M2MRelationship
             } else { // For non self-referencing, remove all the relationships from the many (RHS) side
             	$this->removeAll($rhs->$rhsLinkName);
             }
-            
+
             // Add relationship
-            parent::add($lhs, $rhs, $additionalFields);
+            return parent::add($lhs, $rhs, $additionalFields);
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
One2MRelationship::add() functions last command is to call parent::add() function but it does not return value which is returned from parent::add(). 
Documentation states that it should return boolean value:
`@return boolean true if successful`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Copy of PR #4228 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->