### PR TITLE
Fixed Bug in Quote to Invoice Conversion

### DIFF
--- a/modules/AOS_Quotes/converToInvoice.php
+++ b/modules/AOS_Quotes/converToInvoice.php
@@ -83,7 +83,9 @@
 	//Setting Group Line Items
 	$sql = "SELECT * FROM aos_line_item_groups WHERE parent_type = 'AOS_Quotes' AND parent_id = '".$quote->id."' AND deleted = 0";
   	$result = $this->bean->db->query($sql);
+  	$quoteToInvoiceGroupIds = array();
 	while ($row = $this->bean->db->fetchByAssoc($result)) {
+        $quoteGroupId = $row['id'];
 		$row['id'] = '';
 		$row['parent_id'] = $invoice->id;
 		$row['parent_type'] = 'AOS_Invoices';
@@ -96,6 +98,7 @@
 		$group_invoice = new AOS_Line_Item_Groups();
 		$group_invoice->populateFromRow($row);
 		$group_invoice->save();
+        $quoteToInvoiceGroupIds[$quoteGroupId] = $group_invoice->id;
 	}
 	
 	//Setting Line Items
@@ -105,6 +108,7 @@
 		$row['id'] = '';
 		$row['parent_id'] = $invoice->id;
 		$row['parent_type'] = 'AOS_Invoices';
+        $row['group_id'] = $quoteToInvoiceGroupIds[$row['group_id']];
 		if($row['product_cost_price'] != null)
 		{
 			$row['product_cost_price'] = format_number($row['product_cost_price']);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Previously, when creating an invoice, it would create new line items for each item in the quote but use the existing group. This meant that if you modified a quote then the totals on the invoice would be wrong. To reproduce bug:
1. Create a quote
2. Convert to invoice
3. Modify quote so that the total is different
4. Look at invoice and see the totals are now wrong

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Copy of PR: #3907 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->