### PR TITLE
Fix error with PHP 5.4 and higher

### DIFF
--- a/modules/AOR_Charts/AOR_Chart.php
+++ b/modules/AOR_Charts/AOR_Chart.php
@@ -222,7 +222,7 @@ class AOR_Chart extends Basic {
             $chartPicture->replaceImageMapTitle("data", $labels);
         }
         ob_start();
-        $chartPicture->render('');
+        $chartPicture->render(null);
         $img = ob_get_clean();
         if($asDataURI){
             return 'data:image/png;base64,'.base64_encode($img);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
render('') generates an error with imagepng function for PHP 5.4 and higher.
Must be replaced by render(NULL)
See http://php.net/manual/fr/function.imagepng.php

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Copy of PR: #3819 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->