### PR TITLE
Fix #4607 - Audit does not record the changes when setting value on a related field that was empty

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -3903,6 +3903,8 @@ class SugarBean
             $field_name = $rel_field_name['name'];
             if (!empty($this->$field_name)) {
                 $this->fetched_rel_row[$rel_field_name['name']] = $this->$field_name;
+            } else {
+                $this->fetched_rel_row[$rel_field_name['name']] = '';
             }
         }
         //make a copy of fields in the relationship_fields array. These field values will be used to


### PR DESCRIPTION
Audit does not record the changes when setting value on a related field that was empty.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When a related field is not informed, is not pushed to `$fetched_rel_row` array. My change pushes this related field to `$fetched_rel_row` as empty.
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
See issue #4607 
<!--- Please link to the issue here unless your commit contains the issue number -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->