### PR TITLE
Fix detail panels on upgrade

### DIFF
--- a/themes/SuiteP/include/DetailView/DetailView.tpl
+++ b/themes/SuiteP/include/DetailView/DetailView.tpl
@@ -265,7 +265,7 @@
                                     </div>
                                 </a>
                             </div>
-                            <div class="panel-body {{$collapse}}" id="{{$panelId}}">
+                            <div class="panel-body {{$collapse}} panelContainer" id="{{$panelId}}"  data-id="{{$label_upper}}">
                                 <div class="tab-content">
                                     <!-- TAB CONTENT -->
                                     {{include file='themes/SuiteP/include/DetailView/tab_panel_content.tpl'}}
@@ -284,7 +284,7 @@
                             </a>
 
                         </div>
-                        <div class="panel-body {{$collapse}}" id="{{$panelId}}">
+                        <div class="panel-body {{$collapse}} panelContainer" id="{{$panelId}}" data-id="{{$label_upper}}">
                             <div class="tab-content">
                                 <!-- TAB CONTENT -->
                                 {{include file='themes/SuiteP/include/DetailView/tab_panel_content.tpl'}}

--- a/themes/SuiteP/include/EditView/EditView.tpl
+++ b/themes/SuiteP/include/EditView/EditView.tpl
@@ -170,7 +170,7 @@
                     </a>
 
                 </div>
-                <div class="panel-body {{$collapse} panelContainer}" id="detailpanel_{{$panelCount}}" data-id="{{$label_upper}}">
+                <div class="panel-body {{$collapse}} panelContainer" id="detailpanel_{{$panelCount}}" data-id="{{$label_upper}}">
                     <div class="tab-content">
                         {{include file='themes/SuiteP/include/EditView/tab_panel_content.tpl'}}
                     </div>

--- a/themes/SuiteP/include/EditView/EditView.tpl
+++ b/themes/SuiteP/include/EditView/EditView.tpl
@@ -170,7 +170,7 @@
                     </a>
 
                 </div>
-                <div class="panel-body {{$collapse}}" id="detailpanel_{{$panelCount}}">
+                <div class="panel-body {{$collapse} panelContainer}" id="detailpanel_{{$panelCount}}" data-id="{{$label_upper}}">
                     <div class="tab-content">
                         {{include file='themes/SuiteP/include/EditView/tab_panel_content.tpl'}}
                     </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When a User upgrades from SugarCRM, any JavaScript customisation break on the panels. This is due the change after SuiteCRM 7.7.x, where the panels in the editview and the detail view were changed from tables to divs.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change adds the old class and a data-id attribute to allow these scripts either continue to work or at least be easy to update.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* Repair and Rebuild

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->