### PR TITLE
Feature/restapi - Application language strings

### DIFF
--- a/lib/SuiteCRM/API/v8/Controller/ModuleController.php
+++ b/lib/SuiteCRM/API/v8/Controller/ModuleController.php
@@ -65,6 +65,7 @@ use SuiteCRM\API\v8\Exception\UnsupportedMediaType;
 use SuiteCRM\API\v8\Library\ModulesLib;
 use SuiteCRM\Enumerator\ExceptionCode;
 use SuiteCRM\Exception\Exception;
+use SuiteCRM\Utility\ApplicationLanguage;
 
 /**
  * Class ModuleController
@@ -710,6 +711,35 @@ class ModuleController extends ApiController
         $moduleLanguageStrings = $moduleLanguage->getModuleLanguageStrings($currentLanguage, $args['module']);
 
         $payload['meta'][$args['module']]['language'] = $moduleLanguageStrings;
+
+        return $this->generateJsonApiResponse($req, $res, $payload);
+    }
+
+
+    /**
+     * GET /api/v8/meta/language
+     *
+     * @param Request $req
+     * @param Response $res
+     * @param array $args
+     * @return Response
+     * @throws \SuiteCRM\API\v8\Exception\InvalidJsonApiResponse
+     * @throws \InvalidArgumentException
+     * @throws \Psr\Container\NotFoundExceptionInterface
+     * @throws \Psr\Container\ContainerExceptionInterface
+     * @throws \SuiteCRM\API\v8\Exception\UnsupportedMediaType
+     * @throws \SuiteCRM\API\v8\Exception\NotAcceptable
+     */
+    public function getApplicationMetaLanguages(Request $req, Response $res, array $args)
+    {
+        $this->negotiatedJsonApiContent($req, $res);
+
+        $currentLanguage = $this->containers->get('CurrentLanguage');
+        /** @var ApplicationLanguage $moduleLanguage */
+        $applicationLanguage = $this->containers->get('ApplicationLanguages');
+
+        $payload['meta']['application']['language'] =
+            $applicationLanguage->getApplicationLanguageStrings($currentLanguage);
 
         return $this->generateJsonApiResponse($req, $res, $payload);
     }

--- a/lib/SuiteCRM/API/v8/container/ApplicationLanguage.php
+++ b/lib/SuiteCRM/API/v8/container/ApplicationLanguage.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * @param \Psr\Container\ContainerInterface $container
+ * @return \SuiteCRM\Utility\ApplicationLanguage
+ */
+$container['ApplicationLanguages'] = function($container) {
+    $applicationLanguage = new \SuiteCRM\Utility\ApplicationLanguage();
+    return $applicationLanguage;
+};
+

--- a/lib/SuiteCRM/API/v8/route/moduleRoutes.php
+++ b/lib/SuiteCRM/API/v8/route/moduleRoutes.php
@@ -46,6 +46,7 @@ $app->group('/v8/modules', function () use ($app) {
         $app->get('/list', 'ModuleController:getModulesMetaList');
         $app->get('/menu/modules', 'ModuleController:getModulesMetaMenuModules');
         $app->get('/menu/filters', 'ModuleController:getModulesMetaMenuFilters');
+        $app->get('/languages', 'ModuleController:getApplicationMetaLanguages');
 
     });
 

--- a/lib/SuiteCRM/Utility/ApplicationLanguage.php
+++ b/lib/SuiteCRM/Utility/ApplicationLanguage.php
@@ -38,41 +38,22 @@
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
-namespace SuiteCRM\API\OAuth2\Repositories;
+namespace SuiteCRM\Utility;
 
-use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
-use SuiteCRM\API\OAuth2\Entities\ClientEntity;
-
-class ClientRepository implements ClientRepositoryInterface
+class ApplicationLanguage
 {
+
     /**
-     * {@inheritdoc}
-     * @return null|ClientEntity
+     * @param CurrentLanguage $currentLanguage
+     * @param string $moduleName
+     * @return array
      */
-    public function getClientEntity($clientIdentifier, $grantType, $clientSecret = null, $mustValidateSecret = true)
-    {
-
-        $client = new \OAuth2Clients();
-        $client->retrieve($clientIdentifier);
-        if(empty($client->id)) {
-            return null;
-        }
-
-        if (
-            $mustValidateSecret === true
-            && (bool)$client->is_confidential === true
-            && password_verify($clientSecret, $client->secret) === false
-        ) {
-            return null;
-        }
-
-        $clientEntity = new ClientEntity();
-        $clientEntity->setIdentifier($clientIdentifier);
-        $clientEntity->setName($client->name);
-
-        $redirect_url = isset($client->redirect_uri) ? $client->redirect_uri : '';
-        $clientEntity->setRedirectUri($redirect_url);
-
-        return $clientEntity;
+    public function getApplicationLanguageStrings(CurrentLanguage $currentLanguage) {
+        $applicationLanguageStrings =  array_merge(
+            return_application_language($currentLanguage->getCurrentLanguage()),
+            return_app_list_strings_language($currentLanguage->getCurrentLanguage())
+        );
+        return $applicationLanguageStrings;
     }
+
 }


### PR DESCRIPTION
Added a route for retrieving the application language strings.

## Description
Adds one new route at /api/v8/modules/meta/languages which returns all the application language strings.

## Motivation and Context

## How To Test This

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->