### PR TITLE
Fixed #4109 - 7.9.4 SQL query error in Reports using custom field fro…

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -1241,12 +1241,18 @@ class AOR_Report extends Basic
         $query = array(),
         SugarBean $rel_module = null
     ) {
-
+        // Alias to keep lines short
+        $db = $this->db;
         if (!isset($query['join'][$alias])) {
 
             switch ($type) {
                 case 'custom':
-                    $query['join'][$alias] = 'LEFT JOIN ' . $this->db->quoteIdentifier($module->get_custom_table_name()) . ' ' . $this->db->quoteIdentifier($name) . ' ON ' . $this->db->quoteIdentifier($parentAlias) . '.id = ' . $this->db->quoteIdentifier($name) . '.id_c ';
+                    $customTable = $module->get_custom_table_name();
+                    $query['join'][$alias] =
+                        'LEFT JOIN ' .
+                        $db->quoteIdentifier($customTable) .' '. $db->quoteIdentifier($alias) .
+                        ' ON ' .
+                        $db->quoteIdentifier($parentAlias) . '.id = ' . $db->quoteIdentifier($name) . '.id_c ';
                     break;
 
                 case 'relationship':
@@ -1254,26 +1260,26 @@ class AOR_Report extends Basic
                         $params['join_type'] = 'LEFT JOIN';
                         if ($module->$name->relationship_type != 'one-to-many') {
                             if ($module->$name->getSide() == REL_LHS) {
-                                $params['right_join_table_alias'] = $this->db->quoteIdentifier($alias);
-                                $params['join_table_alias'] = $this->db->quoteIdentifier($alias);
-                                $params['left_join_table_alias'] = $this->db->quoteIdentifier($parentAlias);
+                                $params['right_join_table_alias'] = $db->quoteIdentifier($alias);
+                                $params['join_table_alias'] = $db->quoteIdentifier($alias);
+                                $params['left_join_table_alias'] = $db->quoteIdentifier($parentAlias);
                             } else {
-                                $params['right_join_table_alias'] = $this->db->quoteIdentifier($parentAlias);
-                                $params['join_table_alias'] = $this->db->quoteIdentifier($alias);
-                                $params['left_join_table_alias'] = $this->db->quoteIdentifier($alias);
+                                $params['right_join_table_alias'] = $db->quoteIdentifier($parentAlias);
+                                $params['join_table_alias'] = $db->quoteIdentifier($alias);
+                                $params['left_join_table_alias'] = $db->quoteIdentifier($alias);
                             }
 
                         } else {
-                            $params['right_join_table_alias'] = $this->db->quoteIdentifier($parentAlias);
-                            $params['join_table_alias'] = $this->db->quoteIdentifier($alias);
-                            $params['left_join_table_alias'] = $this->db->quoteIdentifier($parentAlias);
+                            $params['right_join_table_alias'] = $db->quoteIdentifier($parentAlias);
+                            $params['join_table_alias'] = $db->quoteIdentifier($alias);
+                            $params['left_join_table_alias'] = $db->quoteIdentifier($parentAlias);
                         }
                         $linkAlias = $parentAlias . "|" . $alias;
-                        $params['join_table_link_alias'] = $this->db->quoteIdentifier($linkAlias);
+                        $params['join_table_link_alias'] = $db->quoteIdentifier($linkAlias);
                         $join = $module->$name->getJoin($params, true);
                         $query['join'][$alias] = $join['join'];
                         if($rel_module != null) {
-                            $query['join'][$alias] .= $this->build_report_access_query($rel_module, $this->db->quoteIdentifier($alias));
+                            $query['join'][$alias] .= $this->build_report_access_query($rel_module, $db->quoteIdentifier($alias));
                         }
                         $query['id_select'][$alias] = $join['select'] . " AS '" . $alias . "_id'";
                         $query['id_select_group'][$alias] = $join['select'];
@@ -1292,7 +1298,6 @@ class AOR_Report extends Basic
     function build_report_access_query(SugarBean $module, $alias)
     {
 
-        $module->table_name = $alias;
         $where = '';
         if ($module->bean_implements('ACL') && ACLController::requireOwner($module->module_dir, 'list')) {
             global $current_user;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Users are unable to report on custom fields which are related to a module.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #4109 

## How To Test This
<!--- Please describe in detail how to test your changes. -->

- Create custom field on a module eg accounts
- Create a report related it the same module
- Add custom field into the fields section of the report.
- Click save
- Check suitecrm.log

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->