### PR TITLE
Fixed #4544 - Accounts Summary List not sorted - 7.9.7

### DIFF
--- a/modules/Activities/Popup_picker.php
+++ b/modules/Activities/Popup_picker.php
@@ -394,7 +394,7 @@ class Popup_Picker
 
 
         if (count($summary_list) > 0) {
-            $summary_list = array_csort($summary_list, 'sort_value', SORT_DESC);
+            array_multisort(array_column($summary_list, 'sort_value'), SORT_DESC, $summary_list);
 
             foreach ($summary_list as $list) {
                 if ($list['module'] === 'Tasks') {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixed accounts view summary not sorting

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #4502

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Enter accounts module.
2. Open history sub-panel.
3. Click on the "View Summary" popup.
4. Check that each tab is sorted correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->