### PR TITLE
Fix #4653 Compose Email Modal Language Strings

### DIFF
--- a/modules/Emails/EmailsController.php
+++ b/modules/Emails/EmailsController.php
@@ -132,6 +132,14 @@ class EmailsController extends SugarController
     public function action_ComposeView()
     {
         $this->view = 'compose';
+        // For viewing the Compose as modal from other modules we need to load the Emails language strings
+        if (isset($_REQUEST['in_popup']) && $_REQUEST['in_popup']){
+            if (!is_file('cache/jsLanguage/Emails/' . $GLOBALS['current_language'] . '.js')) {
+                require_once ('include/language/jsLanguage.php');
+                jsLanguage::createModuleStringsCache('Emails', $GLOBALS['current_language']);
+            }
+            echo '<script src="cache/jsLanguage/Emails/'. $GLOBALS['current_language'] . '.js"></script>';
+        }
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added a check to make sure language strings are present and loaded when displaying the Compose modal from other modules such as Contacts or Accounts.

Issue #4653

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The Compose modal was not loading any of the Emails language strings.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
In the Accounts module, from the activities subpanel select Compose Email.
Hover the mouse over any of the buttons in the modal footer and see that the tooltip is not 'undefined'.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->