### PR TITLE
Fix #4667 Make To field in the Email dashlet display address correctly

### DIFF
--- a/modules/Emails/Dashlets/MyEmailsDashlet/MyEmailsDashlet.data.php
+++ b/modules/Emails/Dashlets/MyEmailsDashlet/MyEmailsDashlet.data.php
@@ -58,7 +58,7 @@ $dashletData['MyEmailsDashlet']['columns'] = array(
                                                                    'label'   => 'LBL_SUBJECT',
                                                                    'link'    => true,
                                                                    'default' => true),
-                                                   'to_addrs' => array('width'   => '15',
+                                                   'to_addrs_names' => array('width'   => '15',
                                                                          'label'   => 'LBL_TO_ADDRS',
                                                                          'default' => false),
                                                    'assigned_user_name' => array('width'   => '15',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changed the Email Dashlet vardefs to use the same variable for the To field as the regular listview because the other was not being set.

Issue #4667 

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->