### PR TITLE
aow_operator_list was not loaded when using SOAP requests without login, because  was not defined as global

### DIFF
--- a/include/utils.php
+++ b/include/utils.php
@@ -1025,7 +1025,7 @@ function _mergeCustomAppListStrings($file, $app_list_strings)
  */
 function return_application_language($language)
 {
-    global $app_strings, $sugar_config;
+    global $app_strings, $sugar_config, $app_list_strings;
 
     $cache_key = 'app_strings.'.$language;
 


### PR DESCRIPTION
define $app_list_strings as global before loading language file

## Description
This PR fixes a bug that can be reproduce with the following steps:
1. Create a WF on a certain module with conditions
2. Create custom (or use existing) method through SOAP request **without**  login
3. The conditions of the WF are not checked and the WF will always run.

## Motivation and Context
This happens because on the IF statement:  `if(isset($app_list_strings['aow_sql_operator_list'][$condition->operator]))` - the result is always false, this happens because language file with `aow_operator_list` is loaded using `return_application_language` function, but $app_list_strings is not global.
Unlike this case, when using Login we are also calling `return_app_list_strings_language`- which reload language file but also set variable as global.

## How To Test This
1. Create a WF on a certain module with conditions
2. Create custom (or use existing) method through SOAP request **without**  login
3. The conditions of the WF should be checked and the WF should not run.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines