### PR TITLE
PHP Warning count(): Parameter must be an array in headerModuleList.tpl

### DIFF
--- a/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -779,7 +779,7 @@
                     {foreach from=$moduleTopMenu item=module key=name name=moduleList}
                         {if $name == $MODULE_TAB}
                             <ul>
-                                {if count($shortcutTopMenu.$name) > 0}
+                                {if isset($shortcutTopMenu.$name) && count($shortcutTopMenu.$name) > 0}
                                     <h2 class="recent_h3">{$APP.LBL_LINK_ACTIONS}</h2>
                                     {foreach from=$shortcutTopMenu.$name item=item}
                                         {if $item.URL == "-"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /cache/smarty/templates_c/%%F6^F60^F609237E%%_headerModuleList.tpl.php on line 985

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->