### PR TITLE
Improve non filtered email performance

### DIFF
--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -368,38 +368,89 @@ class InboundEmail extends SugarBean
         $filterCriteria = NULL;
 
 
-        foreach($filter as $filterField => $filterFieldValue) {
-            if(empty($filterFieldValue))
-            {
-                continue;
+        if(!empty($filter)) {
+            foreach($filter as $filterField => $filterFieldValue) {
+                if(empty($filterFieldValue))
+                {
+                    continue;
+                }
+
+                // Convert to a blank string as NULL will break the IMAP request
+                if($filterCriteria == NULL) {
+                    $filterCriteria = '';
+                }
+
+                $filterCriteria .= ' ' . $filterField . ' "' . $filterFieldValue . '" ';
             }
-
-            // Convert to a blank string as NULL will break the IMAP request
-            if($filterCriteria == NULL) {
-                $filterCriteria = '';
-            }
-
-            $filterCriteria .= ' ' . $filterField . ' "' . $filterFieldValue . '" ';
-        }
-        // Returns an array of msgno's which are sorted and filtered
-        $emailSortedHeaders = imap_sort(
-            $this->conn,
-            $sortCriteria,
-            $sortOrder,
-            FT_UID,
-            $filterCriteria
-        );
-
-        $lastSequenceNumber = $mailboxInfo['Nmsgs'] = count($emailSortedHeaders);
-
-        // paginate
-        if($offset === "end") {
-            $offset = $lastSequenceNumber - $pageSize;
-        } else if($offset <= 0) {
-            $offset = 0;
         }
 
-        $uids = array_slice($emailSortedHeaders, $offset, $pageSize);
+        if (empty($filterCriteria) && $sortCriteria === SORTDATE) {
+            // Performance fix when no filters are enabled
+            $totalMsgs = imap_num_msg($this->conn);
+            $mailboxInfo['Nmsgs'] = $totalMsgs;
+
+            if ($sortOrder === 0) {
+                // Ascending order
+                if ($offset === "end") {
+                    $firstMsg = $totalMsgs - (int)$pageSize;
+                    $lastMsg = $totalMsgs;
+                } else if ($offset <= 0) {
+                    $firstMsg = 1;
+                    $lastMsg = $firstMsg + (int)$pageSize;
+                } else {
+                    $firstMsg = (int)$offset;
+                    $lastMsg = $firstMsg + (int)$pageSize;
+                }
+            } else {
+                // Descending order
+                if($offset === "end") {
+                    $firstMsg = 1;
+                    $lastMsg = $firstMsg + (int)$pageSize;
+                } else if($offset <= 0) {
+                    $firstMsg = $totalMsgs - (int)$pageSize;
+                    $lastMsg = $totalMsgs;
+                } else {
+                    $offset = ($totalMsgs - (int)$offset) - (int)$pageSize;
+                    $firstMsg = $offset;
+                    $lastMsg = $firstMsg + (int)$pageSize;
+                }
+            }
+
+            $sequence  = $firstMsg . ':' . $lastMsg;
+            $emailSortedHeaders = imap_fetch_overview(
+                $this->conn,
+                $sequence
+            );
+
+            $uids = array_map(
+                function($x) {
+                    return $x->uid;
+                },
+                $emailSortedHeaders
+            );
+        } else {
+            // Filtered case and other sorting cases
+            // Returns an array of msgno's which are sorted and filtered
+            $emailSortedHeaders = imap_sort(
+                $this->conn,
+                $sortCriteria,
+                $sortOrder,
+                SE_UID,
+                $filterCriteria
+            );
+
+            $uids = array_slice($emailSortedHeaders, $offset, $pageSize);
+
+            $lastSequenceNumber = $mailboxInfo['Nmsgs'] = count($emailSortedHeaders);
+
+            // paginate
+            if($offset === "end") {
+                $offset = $lastSequenceNumber - $pageSize;
+            } else if($offset <= 0) {
+                $offset = 0;
+            }
+        }
+
 
         $uids = implode(',', $uids);
 
@@ -427,16 +478,23 @@ class InboundEmail extends SugarBean
         }
 
 
-        usort($emailHeaders, function($a, $b) use($sortCRM){  // defaults to DESC order
-            if($a[$sortCRM] === $b[$sortCRM]) {
-                return 0;
-            } else if($a[$sortCRM] < $b[$sortCRM]) {
-                return 1;
-            } else {
-                return -1;
+        usort(
+            $emailHeaders,
+            function($a, $b) use($sortCRM) {  // defaults to DESC order
+                if($a[$sortCRM] === $b[$sortCRM]) {
+                    return 0;
+                } else if($a[$sortCRM] < $b[$sortCRM]) {
+                    return 1;
+                } else {
+                    return -1;
+                }
             }
-        });
-        if(!$sortOrder) array_reverse($emailHeaders); // Make it ASC order
+        );
+
+        // Make it ASC order
+        if(!$sortOrder) {
+            array_reverse($emailHeaders);
+        };
 
 
         return array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When a user accesses the emails module. If they have Inbox which have a large number of emails (or greater than 2000 emails), the have to wait in excess of 60 seconds. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change helps to improve the performance by up 12x, when the user is not using a filter. It still takes on average around up to 10 seconds to load, hover this is an improvement on the 60 seconds I mentioned earlier.

I tested these loading times against my inbox which has around 6500 emails in it. I was running this on my local computer.

Due to the limitations that we cannot cache the emails, we can only improve the performance on the sort by date field.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
- Set up emails
- Access emails module
- Measure loading times.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->