### PR TITLE
Fix #3703 Make time use the correct separator

### DIFF
--- a/modules/Campaigns/WizardMarketing.html
+++ b/modules/Campaigns/WizardMarketing.html
@@ -880,6 +880,7 @@
 					<table border="0" cellpadding="0" cellspacing="0" class="dateTime">
 						<tr valign="middle">
 							<td nowrap class="datafield" style="width:150px;">
+								<input type="hidden" id="userTimeFormat" value="{$TIME_FORMAT}">
 								<input autocomplete="off" type="text" id="{$fields.date_start.name}_date" value="{$MRKT_DATE_START}" xxx="{$fields[$fields.date_start.name].value}" size="11" maxlength="10" title='' tabindex="0" onblur="combo_{$fields.date_start.name}.update(); parseDate(this, '{$CALENDAR_DATEFORMAT}');" onchange="combo_{$fields.date_start.name}.update();parseDate(this, '{$CALENDAR_DATEFORMAT}'); "    >
 								{capture assign="other_attributes"}alt="{$APP.LBL_ENTER_DATE}" style="position:relative; top:6px" border="0" id="{$fields.date_start.name}_trigger"{/capture}
 								{sugar_getimage name="jscalendar" ext=".gif" other_attributes="$other_attributes"}&nbsp;
@@ -889,7 +890,7 @@
 								<script type="text/javascript">
 									setInterval(function(){
 										$('input[name="wiz_step3_date_start"]').val($('#date_start_date').val());
-										$('input[name="wiz_step3_time_start"]').val($('#date_start_hours').val() + ':' + $('#date_start_minutes').val());
+										$('input[name="wiz_step3_time_start"]').val($('#date_start_hours').val() + $('#userTimeFormat').val()[3] + $('#date_start_minutes').val());
 										$('select[name="meridiem"]').val($('#date_start_meridiem').val());
 										if(parseInt($('#date_start_hours').val())>12) {
 											$('#date_start_meridiem').val('PM');
@@ -926,7 +927,7 @@
 					<script type="text/javascript">
 						var combo_{$fields.date_start.name} = new Datetimecombo("{$fields[$fields.date_start.name].value}", "{$fields.date_start.name}", "{$TIME_FORMAT}", "0", '1', false, true);
 						//Render the remaining widget fields
-						combo_{$fields.date_start.name}.timeseparator = ':';
+						combo_{$fields.date_start.name}.timeseparator = $('#userTimeFormat').val()[3];
 						text = combo_{$fields.date_start.name}.html('');
 						document.getElementById('{$fields.date_start.name}_time_section').innerHTML = text;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
See issue #3703
Made the Datetimecombo use the correct separator between hours and minutes in a time string, depending on the user settings.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
It was always using the 23:00 format when sending the start time for the campaign, causing the Datetime convert to fail when the user format and expected input was in the 23.00 format.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It should solve #3703 


## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go into the user profile and set the time format to 23.00
2. create a campaign
3. create a template
4. go back to view campaigns
5. select/edit campaign
6. click "next" to go to Marketing
7. enter a date, marketing email name and other required fields

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->