### PR TITLE
Fix Email Template ListView date issues

### DIFF
--- a/modules/EmailTemplates/EmailTemplate.php
+++ b/modules/EmailTemplates/EmailTemplate.php
@@ -323,15 +323,6 @@ class EmailTemplate extends SugarBean
     {
     }
 
-    function get_list_view_data()
-    {
-        global $app_list_strings, $focus, $action, $currentModule;
-        $fields = $this->get_list_view_array();
-        //$fields["DATE_MODIFIED"] = substr($fields["DATE_MODIFIED"], 0, 10);
-        $fields["DATE_MODIFIED"] = isset($fields["DATE_MODIFIED"]) && !empty($fields["DATE_MODIFIED"]) ? substr($fields["DATE_MODIFIED"], 0, 10) : false;
-        return $fields;
-    }
-
 //function all string that match the pattern {.} , also catches the list of found strings.
     //the cache will get refreshed when the template bean instance changes.
     //The found url key patterns are replaced with name value pairs provided as function parameter. $tracked_urls.

--- a/modules/EmailTemplates/vardefs.php
+++ b/modules/EmailTemplates/vardefs.php
@@ -54,14 +54,16 @@ $dictionary['EmailTemplate'] = array(
             'vname' => 'LBL_DATE_ENTERED',
             'type' => 'datetime',
             'required' => true,
-            'comment' => 'Date record created'
+            'comment' => 'Date record created',
+            'inline_edit' => false
         ),
         'date_modified' => array(
             'name' => 'date_modified',
             'vname' => 'LBL_DATE_MODIFIED',
             'type' => 'datetime',
             'required' => true,
-            'comment' => 'Date record last modified'
+            'comment' => 'Date record last modified',
+            'inline_edit' => false
         ),
         'modified_user_id' => array(
             'name' => 'modified_user_id',

--- a/tests/unit/modules/EmailTemplates/EmailTemplateTest.php
+++ b/tests/unit/modules/EmailTemplates/EmailTemplateTest.php
@@ -118,7 +118,6 @@ class EmailTemplateTest extends PHPUnit_Framework_TestCase
         //execute the method and verify that it retunrs expected results
         $expected = array(
                 'DELETED' => 0,
-                'DATE_MODIFIED' => false,
         );
 
         $actual = $emailTemplate->get_list_view_data();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removed the ability to inline edit the DATE_ENTERED and DATE_MODIFIED dates in the ListView (they shouldn't be editable).
Made the DATE_MODIFIED display in full in list view (it was being truncated to only show the date but not the time, which doesn't make much sense and is not consistent with the way the DATE_ENTERED is shown right next to it).
Deleted 2 obsolete lines from the get_list_view_data() function (the globals are not being used and the comment is some old code).
Removed the function entirely as it is now identical to the parent function it extends.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The date fields shouldn't be editable in ListView.
The dates should display in full.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->