### PR TITLE
Feature: Only load Subpanels when they are expanded

### DIFF
--- a/include/SubPanel/SubPanelTiles.php
+++ b/include/SubPanel/SubPanelTiles.php
@@ -357,16 +357,23 @@ class SubPanelTiles
             $tabs_properties[$t]['div_display'] = $div_display;
             $tabs_properties[$t]['opp_display'] = $opp_display;
 
-            // Get Subpanel
-            include_once('include/SubPanel/SubPanel.php');
-            $subpanel_object = new SubPanel($this->module, $_REQUEST['record'], $tab, $thisPanel, $layout_def_key);
+            $tabs_properties[$t]['subpanel_body'] = '';
+            $tabs_properties[$t]['buttons'] = '';
 
-            $arr = array();
-            // TODO: Remove x-template:
-            $tabs_properties[$t]['subpanel_body'] = $subpanel_object->ProcessSubPanelListView('include/SubPanel/tpls/SubPanelDynamic.tpl', $arr);
+            // We only preload this subpanel's contents if it's expanded
+            if ($tabs_properties[$t]['expanded_subpanels']){
+                // Get Subpanel
+                include_once('include/SubPanel/SubPanel.php');
+                $subpanel_object = new SubPanel($this->module, $_REQUEST['record'], $tab, $thisPanel, $layout_def_key);
 
-            // Get subpanel buttons
-            $tabs_properties[$t]['buttons'] = $this->get_buttons($thisPanel,$subpanel_object->subpanel_query);
+                $arr = array();
+                // TODO: Remove x-template:
+                $tabs_properties[$t]['subpanel_body'] = $subpanel_object->ProcessSubPanelListView(
+                    'include/SubPanel/tpls/SubPanelDynamic.tpl', $arr);
+
+                // Get subpanel buttons
+                $tabs_properties[$t]['buttons'] = $this->get_buttons($thisPanel,$subpanel_object->subpanel_query);
+            }
 
             array_push($tab_names, $tab);
         }

--- a/themes/SuiteP/include/SubPanel/tpls/SubPanelTiles.tpl
+++ b/themes/SuiteP/include/SubPanel/tpls/SubPanelTiles.tpl
@@ -12,7 +12,8 @@
             {if $subpanel_tabs_properties.$i.expanded_subpanels == true}
                 <a id="subpanel_title_{$subpanel_tab}" class="in" role="button" data-toggle="collapse" href="#subpanel_{$subpanel_tab}" aria-expanded="false">
             {else}
-                <a id="subpanel_title_{$subpanel_tab}" class="collapsed" role="button" data-toggle="collapse" href="#subpanel_{$subpanel_tab}" aria-expanded="false">
+                    <a id="subpanel_title_{$subpanel_tab}" class="collapsed" role="button" data-toggle="collapse"
+                       href="#subpanel_{$subpanel_tab}" aria-expanded="false" onclick="showSubPanel('{$subpanel_tab}')">
             {/if}
                     <div class="col-xs-10 col-sm-11 col-md-11">
                         <div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In SuiteP when the subpanel is minimised, it still loads the subpanel data.

In previous themes, it would load the contents via ajax when the subpanel is maximised. This can be a huge performance hit, and the functionality should be restored.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When building the subpanels before displaying a record, we check if each subpanel will be shown expanded or collapsed by default, and in the latter case we don't preload the contents.

The expand button has been modified to load the contents of the tab being expanded at that moment.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improves performance.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->