### PR TITLE
Fix: Enable importing Project Templates

### DIFF
--- a/modules/AM_ProjectTemplates/AM_ProjectTemplates_sugar.php
+++ b/modules/AM_ProjectTemplates/AM_ProjectTemplates_sugar.php
@@ -46,7 +46,7 @@ class AM_ProjectTemplates_sugar extends Basic {
 	var $module_dir = 'AM_ProjectTemplates';
 	var $object_name = 'AM_ProjectTemplates';
 	var $table_name = 'am_projecttemplates';
-	var $importable = false;
+	var $importable = true;
 	var $disable_row_level_security = true ; // to ensure that modules created and deployed under CE will continue to function under team security if the instance is upgraded to PRO
 		var $id;
 		var $name;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Enable importing Project Templates

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Clicking on the import button in the Project Templates module presents the user with a popup box that reads:
'Imports are not set up for this module'

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->