### PR TITLE
Fix 7.10 Campaign field - schedule Time/date is out of allignment

### DIFF
--- a/jssource/src_files/include/SugarFields/Fields/Datetimecombo/Datetimecombo.js
+++ b/jssource/src_files/include/SugarFields/Fields/Datetimecombo/Datetimecombo.js
@@ -167,7 +167,7 @@ Datetimecombo.prototype.jsscript = function(callback) {
 Datetimecombo.prototype.html = function(callback) {
 	
 	//Now render the items
-	var text = '<span style="position:relative; top:6px;"><select class="datetimecombo_time" size="1" id="' + this.fieldname + '_hours" tabindex="' + this.tabindex + '" onchange="combo_' + this.fieldname + '.update(); ' + callback + '">';
+	var text = '<span><select class="datetimecombo_time" size="1" id="' + this.fieldname + '_hours" tabindex="' + this.tabindex + '" onchange="combo_' + this.fieldname + '.update(); ' + callback + '">';
 	var h1 = this.has12Hours ? 1 : 0;
 	var h2 = this.has12Hours ? 12 : 23;
 	if(this.allowEmptyHM){


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes the vertical alignment of the Datetimecombo time element in views such as the Campaign Wizard and the New Meeting from calendar dialog. 

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The time not being aligned correctly with the date.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->