### PR TITLE
Fix/meetings reminders saving loop

### DIFF
--- a/modules/Meetings/Meeting.php
+++ b/modules/Meetings/Meeting.php
@@ -278,12 +278,12 @@ class Meeting extends SugarBean {
 		}
 
 		if (isset($_REQUEST['reminders_data']) && empty($this->saving_reminders_data)) {
-            $this->saving_reminders_data = true;
+                    $this->saving_reminders_data = true;
 			$reminderData = json_encode(
 				$this->removeUnInvitedFromReminders(json_decode(html_entity_decode($_REQUEST['reminders_data']), true))
 			);
 			Reminder::saveRemindersDataJson('Meetings', $return_id, $reminderData);
-            $this->saving_reminders_data = false;
+                    $this->saving_reminders_data = false;
 		}
 
 		return $return_id;

--- a/modules/Meetings/Meeting.php
+++ b/modules/Meetings/Meeting.php
@@ -277,13 +277,13 @@ class Meeting extends SugarBean {
 			vCal::cache_sugar_vcal($current_user);
 		}
 
-		if(isset($_REQUEST['reminders_data']) && empty($this->saving_reminders_data)) {
-      $this->saving_reminders_data = true;
+		if (isset($_REQUEST['reminders_data']) && empty($this->saving_reminders_data)) {
+            $this->saving_reminders_data = true;
 			$reminderData = json_encode(
 				$this->removeUnInvitedFromReminders(json_decode(html_entity_decode($_REQUEST['reminders_data']), true))
 			);
 			Reminder::saveRemindersDataJson('Meetings', $return_id, $reminderData);
-      $this->saving_reminders_data = false;
+            $this->saving_reminders_data = false;
 		}
 
 		return $return_id;

--- a/modules/Meetings/Meeting.php
+++ b/modules/Meetings/Meeting.php
@@ -277,13 +277,14 @@ class Meeting extends SugarBean {
 			vCal::cache_sugar_vcal($current_user);
 		}
 
-		if(isset($_REQUEST['reminders_data'])) {
+		if(isset($_REQUEST['reminders_data']) && empty($this->saving_reminders_data)) {
+      $this->saving_reminders_data = true;
 			$reminderData = json_encode(
 				$this->removeUnInvitedFromReminders(json_decode(html_entity_decode($_REQUEST['reminders_data']), true))
 			);
 			Reminder::saveRemindersDataJson('Meetings', $return_id, $reminderData);
+      $this->saving_reminders_data = false;
 		}
-
 
 		return $return_id;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add an extra check when saving a meetings reminders to avoid entering an infinite loop.

Issue #4719

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Avoid entering an infinite loop that happens when changing an existing meetings account to another.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->