### PR TITLE
allow also time format in report for datetimecombo field

### DIFF
--- a/modules/AOR_Fields/fieldLines.js
+++ b/modules/AOR_Fields/fieldLines.js
@@ -128,7 +128,7 @@ function loadFieldLine(field){
 }
 
 function showFieldOptions(field, ln){
-    if(field.field_type == "datetime" || field.field_type == "date"){
+    if(field.field_type == "datetime" || field.field_type == "date" || field.field_type == "datetimecombo"){
         showElem("aor_fields_format" + ln);
     }
 }


### PR DESCRIPTION
Allow format for datetimecombo fields in report's view

## Description
Previously format function were not allowed for date-time fields of type "datetimecombo".

Steps:

1. Create field of type "datetimecombo"
2. Create report and drag the selected field to the "Fields" section
3. Format options are not visible

## Motivation and Context
Allow time format for custom date-time fields

## How To Test This
1. Create field of type "datetimecombo"
2. Create report and drag the selected field to the "Fields" section
3. Format options should be visible

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->