### PR TITLE
Fix/invalid sequence for imap function

### DIFF
--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -415,12 +415,8 @@ class InboundEmail extends SugarBean
                     $lastMsg = $firstMsg + (int)$pageSize;
                 }
             }
-            if ($firstMsg < 1){
-                $firstMsg = 1;
-            }
-            if ($lastMsg < $firstMsg){
-                $lastMsg = $firstMsg;
-            }
+            $firstMsg = $firstMsg < 1 ? 1 : $firstMsg;
+            $lastMsg = $lastMsg < $firstMsg ? $firstMsg : $lastMsg;
 
             $sequence  = $firstMsg . ':' . $lastMsg;
             $emailSortedHeaders = imap_fetch_overview(

--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -415,6 +415,12 @@ class InboundEmail extends SugarBean
                     $lastMsg = $firstMsg + (int)$pageSize;
                 }
             }
+            if ($firstMsg < 1){
+                $firstMsg = 1;
+            }
+            if ($lastMsg < $firstMsg){
+                $lastMsg = $firstMsg;
+            }
 
             $sequence  = $firstMsg . ':' . $lastMsg;
             $emailSortedHeaders = imap_fetch_overview(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Make sure the sequence passed to imap_fetch_overview is not invalid.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sometimes the sequence would contain negative numbers or be otherwise invalid.
Issue #4718 
Issue #4746

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->