### PR TITLE
Fix jquery dialog offset in listview

### DIFF
--- a/jssource/src_files/include/javascript/sugar_3.js
+++ b/jssource/src_files/include/javascript/sugar_3.js
@@ -3363,8 +3363,8 @@ SUGAR.util = function () {
             $dialog.dialog("option", "position", {my: 'left top', at: 'right top', of: $(el)});
           }
 
-          $dialog.dialog('open');
           $(".ui-dialog").appendTo("#content");
+          $dialog.dialog('open');
         }
 
 				success = function (data) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix jquery dialog offset in listview

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Jquery UI docs:
Note: The appendTo option should not be changed while the dialog is open.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
List view tables have an 'i' hover button which revels a text box, this goes off screen.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->