### PR TITLE
Fix #4736 Make Template Sample use absolute Logo URL

### DIFF
--- a/modules/AOS_PDF_Templates/TemplateSampleService.php
+++ b/modules/AOS_PDF_Templates/TemplateSampleService.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ *
+ * SugarCRM Community Edition is a customer relationship management program developed by
+ * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2018 SalesAgility Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License version 3 as published by the
+ * Free Software Foundation with the addition of the following permission added
+ * to Section 15 as permitted in Section 7(a): FOR ANY PART OF THE COVERED WORK
+ * IN WHICH THE COPYRIGHT IS OWNED BY SUGARCRM, SUGARCRM DISCLAIMS THE WARRANTY
+ * OF NON INFRINGEMENT OF THIRD PARTY RIGHTS.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program; if not, see http://www.gnu.org/licenses or write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ *
+ * You can contact SugarCRM, Inc. headquarters at 10050 North Wolfe Road,
+ * SW2-130, Cupertino, CA 95014, USA. or at email address contact@sugarcrm.com.
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "Powered by
+ * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
+
+class TemplateSampleService
+{
+    /**
+     * @return string
+     */
+    public static function getAbsoluteLogoUrl()
+    {
+        global $sugar_config;
+        $baseUrl = $sugar_config['site_url'];
+        $logoUrlArr = explode('?', SugarThemeRegistry::current()->getImageURL('company_logo.png'));
+        return $baseUrl . '/' . $logoUrlArr[0];
+    }
+}

--- a/modules/AOS_PDF_Templates/samples/smpl_Account_Sample.php
+++ b/modules/AOS_PDF_Templates/samples/smpl_Account_Sample.php
@@ -5,13 +5,15 @@ class smpl_Account_Sample{
 		}
 
 		function getBody() {
-		global $locale;
-		$d_image = explode('?',SugarThemeRegistry::current()->getImageURL('company_logo.png'));
+        global $locale, $sugar_config;
+        $baseUrl = $sugar_config['site_url'];
+        $logoUrlArr = explode('?',SugarThemeRegistry::current()->getImageURL('company_logo.png'));
+        $logoUrl = $baseUrl . '/' . $logoUrlArr[0];
 			return '<table style="width: 100%;" border="0" cellspacing="2" cellpadding="2">
 <tbody style="text-align: left;">
 <tr>
 <td valign="top">
-<p><img src="'.$d_image[0].'" style="float: left;"/>&nbsp;</p>
+<p><img src="'. $logoUrl .'" style="float: left;"/>&nbsp;</p>
 </td>
 <td style="font-weight: bold; text-align: right;"><div>'.translate('LBL_BROWSER_TITLE').' Ltd<br />'.translate('LBL_ANY_STREET','AOS_PDF_Templates').'<br />'.translate('LBL_ANY_TOWN','AOS_PDF_Templates').'</span><br />'.translate('LBL_ANY_WHERE','AOS_PDF_Templates').'</div></td>
 </tr>
@@ -33,13 +35,12 @@ class smpl_Account_Sample{
 <p> </p>
 <p>Someone</p>';
 		}
-		
+
 		function getHeader() {
 			return '';
 		}
-		
+
 		function getFooter() {
 			return '';
 		}
 }
-?>

--- a/modules/AOS_PDF_Templates/samples/smpl_Account_Sample.php
+++ b/modules/AOS_PDF_Templates/samples/smpl_Account_Sample.php
@@ -1,19 +1,19 @@
 <?php
+
+require_once __DIR__ . '/../TemplateSampleService.php';
+
 class smpl_Account_Sample{
 		function getType() {
 			return 'Accounts';
 		}
 
 		function getBody() {
-        global $locale, $sugar_config;
-        $baseUrl = $sugar_config['site_url'];
-        $logoUrlArr = explode('?',SugarThemeRegistry::current()->getImageURL('company_logo.png'));
-        $logoUrl = $baseUrl . '/' . $logoUrlArr[0];
+        global $locale;
 			return '<table style="width: 100%;" border="0" cellspacing="2" cellpadding="2">
 <tbody style="text-align: left;">
 <tr>
 <td valign="top">
-<p><img src="'. $logoUrl .'" style="float: left;"/>&nbsp;</p>
+<p><img src="'. TemplateSampleService::getAbsoluteLogoUrl() .'" style="float: left;"/>&nbsp;</p>
 </td>
 <td style="font-weight: bold; text-align: right;"><div>'.translate('LBL_BROWSER_TITLE').' Ltd<br />'.translate('LBL_ANY_STREET','AOS_PDF_Templates').'<br />'.translate('LBL_ANY_TOWN','AOS_PDF_Templates').'</span><br />'.translate('LBL_ANY_WHERE','AOS_PDF_Templates').'</div></td>
 </tr>

--- a/modules/AOS_PDF_Templates/samples/smpl_Contact_Sample.php
+++ b/modules/AOS_PDF_Templates/samples/smpl_Contact_Sample.php
@@ -1,19 +1,19 @@
 <?php
+
+require_once __DIR__ . '/../TemplateSampleService.php';
+
 class smpl_Contact_Sample{
 		function getType() {
 			return 'Contacts';
 		}
 		
 		function getBody() {
-        global $locale, $sugar_config;
-        $baseUrl = $sugar_config['site_url'];
-        $logoUrlArr = explode('?',SugarThemeRegistry::current()->getImageURL('company_logo.png'));
-        $logoUrl = $baseUrl . '/' . $logoUrlArr[0];
+        global $locale;
 			return '<table style="width: 100%;" border="0" cellspacing="2" cellpadding="2">
 <tbody style="text-align: left;">
 <tr>
 <td valign="top">
-<p><img src="'. $logoUrl .'" style="float: left;"/>&nbsp;</p>
+<p><img src="'. TemplateSampleService::getAbsoluteLogoUrl() .'" style="float: left;"/>&nbsp;</p>
 </td>
 <td style="font-weight: bold; text-align: right;"><div>'.translate('LBL_BROWSER_TITLE').' Ltd<br />'.translate('LBL_ANY_STREET','AOS_PDF_Templates').'<br />'.translate('LBL_ANY_TOWN','AOS_PDF_Templates').'</span><br />'.translate('LBL_ANY_WHERE','AOS_PDF_Templates').'</div></td>
 </tr>

--- a/modules/AOS_PDF_Templates/samples/smpl_Contact_Sample.php
+++ b/modules/AOS_PDF_Templates/samples/smpl_Contact_Sample.php
@@ -5,13 +5,15 @@ class smpl_Contact_Sample{
 		}
 		
 		function getBody() {
-		global $locale;
-		$d_image = explode('?',SugarThemeRegistry::current()->getImageURL('company_logo.png'));
+        global $locale, $sugar_config;
+        $baseUrl = $sugar_config['site_url'];
+        $logoUrlArr = explode('?',SugarThemeRegistry::current()->getImageURL('company_logo.png'));
+        $logoUrl = $baseUrl . '/' . $logoUrlArr[0];
 			return '<table style="width: 100%;" border="0" cellspacing="2" cellpadding="2">
 <tbody style="text-align: left;">
 <tr>
 <td valign="top">
-<p><img src="'.$d_image[0].'" style="float: left;"/>&nbsp;</p>
+<p><img src="'. $logoUrl .'" style="float: left;"/>&nbsp;</p>
 </td>
 <td style="font-weight: bold; text-align: right;"><div>'.translate('LBL_BROWSER_TITLE').' Ltd<br />'.translate('LBL_ANY_STREET','AOS_PDF_Templates').'<br />'.translate('LBL_ANY_TOWN','AOS_PDF_Templates').'</span><br />'.translate('LBL_ANY_WHERE','AOS_PDF_Templates').'</div></td>
 </tr>
@@ -34,13 +36,12 @@ class smpl_Contact_Sample{
 <p> </p>
 <p>Someone</p>';
 		}
-		
+
 		function getHeader() {
 			return '';
 		}
-		
+
 		function getFooter() {
 			return '';
 		}
 }
-?>

--- a/modules/AOS_PDF_Templates/samples/smpl_Invoice_Group_Sample.php
+++ b/modules/AOS_PDF_Templates/samples/smpl_Invoice_Group_Sample.php
@@ -5,12 +5,15 @@ class smpl_Invoice_Group_Sample{
     }
 
     function getBody() {
-        $d_image = explode('?',SugarThemeRegistry::current()->getImageURL('company_logo.png'));
+        global $sugar_config;
+        $baseUrl = $sugar_config['site_url'];
+        $logoUrlArr = explode('?',SugarThemeRegistry::current()->getImageURL('company_logo.png'));
+        $logoUrl = $baseUrl . '/' . $logoUrlArr[0];
         return '<table style="width: 100%; font-family: Arial; text-align: center;" border="0" cellpadding="2" cellspacing="2">
 <tbody style="text-align: left;">
 <tr style="text-align: left;">
 <td style="text-align: left;">
-<p><img src="'.$d_image[0].'" style="float: left;"/>&nbsp;</p>
+<p><img src="'. $logoUrl .'" style="float: left;"/>&nbsp;</p>
 </td>
 </tr>
 <tr style="text-align: left;">
@@ -137,4 +140,3 @@ class smpl_Invoice_Group_Sample{
 </table>';
     }
 }
-?>

--- a/modules/AOS_PDF_Templates/samples/smpl_Invoice_Group_Sample.php
+++ b/modules/AOS_PDF_Templates/samples/smpl_Invoice_Group_Sample.php
@@ -1,19 +1,19 @@
 <?php
+
+require_once __DIR__ . '/../TemplateSampleService.php';
+
 class smpl_Invoice_Group_Sample{
     function getType() {
         return 'AOS_Invoices';
     }
 
     function getBody() {
-        global $sugar_config;
-        $baseUrl = $sugar_config['site_url'];
-        $logoUrlArr = explode('?',SugarThemeRegistry::current()->getImageURL('company_logo.png'));
-        $logoUrl = $baseUrl . '/' . $logoUrlArr[0];
+        global $locale;
         return '<table style="width: 100%; font-family: Arial; text-align: center;" border="0" cellpadding="2" cellspacing="2">
 <tbody style="text-align: left;">
 <tr style="text-align: left;">
 <td style="text-align: left;">
-<p><img src="'. $logoUrl .'" style="float: left;"/>&nbsp;</p>
+<p><img src="'. TemplateSampleService::getAbsoluteLogoUrl() .'" style="float: left;"/>&nbsp;</p>
 </td>
 </tr>
 <tr style="text-align: left;">

--- a/modules/AOS_PDF_Templates/samples/smpl_Invoice_Sample.php
+++ b/modules/AOS_PDF_Templates/samples/smpl_Invoice_Sample.php
@@ -5,12 +5,15 @@ class smpl_Invoice_Sample{
 		}
 		
 		function getBody() {
-		$d_image = explode('?',SugarThemeRegistry::current()->getImageURL('company_logo.png'));
+        global $sugar_config;
+        $baseUrl = $sugar_config['site_url'];
+        $logoUrlArr = explode('?',SugarThemeRegistry::current()->getImageURL('company_logo.png'));
+        $logoUrl = $baseUrl . '/' . $logoUrlArr[0];
 			return '<table style="width: 100%; font-family: Arial; text-align: center;" border="0" cellpadding="2" cellspacing="2">
 <tbody style="text-align: left;">
 <tr style="text-align: left;">
 <td style="text-align: left;">
-<p><img src="'.$d_image[0].'" style="float: left;"/>&nbsp;</p>
+<p><img src="'. $logoUrl .'" style="float: left;"/>&nbsp;</p>
 </td>
 </tr>
 <tr style="text-align: left;">
@@ -122,11 +125,11 @@ class smpl_Invoice_Sample{
 </table>
 <p>&nbsp;</p>';
 		}
-		
+
 		function getHeader() {
 			return '';
 		}
-		
+
 		function getFooter() {
 		global $locale;
 			return '<table style="width: 100%; border: 0pt none; border-spacing: 0pt;">
@@ -139,4 +142,3 @@ class smpl_Invoice_Sample{
 </table>';
 		}
 }
-?>

--- a/modules/AOS_PDF_Templates/samples/smpl_Invoice_Sample.php
+++ b/modules/AOS_PDF_Templates/samples/smpl_Invoice_Sample.php
@@ -1,19 +1,19 @@
 <?php
+
+require_once __DIR__ . '/../TemplateSampleService.php';
+
 class smpl_Invoice_Sample{
 		function getType() {
 			return 'AOS_Invoices';
 		}
 		
 		function getBody() {
-        global $sugar_config;
-        $baseUrl = $sugar_config['site_url'];
-        $logoUrlArr = explode('?',SugarThemeRegistry::current()->getImageURL('company_logo.png'));
-        $logoUrl = $baseUrl . '/' . $logoUrlArr[0];
+        global $locale;
 			return '<table style="width: 100%; font-family: Arial; text-align: center;" border="0" cellpadding="2" cellspacing="2">
 <tbody style="text-align: left;">
 <tr style="text-align: left;">
 <td style="text-align: left;">
-<p><img src="'. $logoUrl .'" style="float: left;"/>&nbsp;</p>
+<p><img src="'. TemplateSampleService::getAbsoluteLogoUrl() .'" style="float: left;"/>&nbsp;</p>
 </td>
 </tr>
 <tr style="text-align: left;">

--- a/modules/AOS_PDF_Templates/samples/smpl_Lead_Sample.php
+++ b/modules/AOS_PDF_Templates/samples/smpl_Lead_Sample.php
@@ -1,19 +1,19 @@
 <?php
+
+require_once __DIR__ . '/../TemplateSampleService.php';
+
 class smpl_Lead_Sample{
 		function getType() {
 			return 'Leads';
 		}
 		
 		function getBody() {
-        global $locale, $sugar_config;
-        $baseUrl = $sugar_config['site_url'];
-        $logoUrlArr = explode('?',SugarThemeRegistry::current()->getImageURL('company_logo.png'));
-        $logoUrl = $baseUrl . '/' . $logoUrlArr[0];
+        global $locale;
 			return '<table style="width: 100%;" border="0" cellspacing="2" cellpadding="2">
 <tbody style="text-align: left;">
 <tr>
 <td valign="top">
-<p><img src="'. $logoUrl .'" style="float: left;"/>&nbsp;</p>
+<p><img src="'. TemplateSampleService::getAbsoluteLogoUrl() .'" style="float: left;"/>&nbsp;</p>
 </td>
 <td style="font-weight: bold; text-align: right;"><div>'.translate('LBL_BROWSER_TITLE').' Ltd<br />'.translate('LBL_ANY_STREET','AOS_PDF_Templates').'<br />'.translate('LBL_ANY_TOWN','AOS_PDF_Templates').'</span><br />'.translate('LBL_ANY_WHERE','AOS_PDF_Templates').'</div></td>
 </tr>

--- a/modules/AOS_PDF_Templates/samples/smpl_Lead_Sample.php
+++ b/modules/AOS_PDF_Templates/samples/smpl_Lead_Sample.php
@@ -5,13 +5,15 @@ class smpl_Lead_Sample{
 		}
 		
 		function getBody() {
-		global $locale;
-		$d_image = explode('?',SugarThemeRegistry::current()->getImageURL('company_logo.png'));
+        global $locale, $sugar_config;
+        $baseUrl = $sugar_config['site_url'];
+        $logoUrlArr = explode('?',SugarThemeRegistry::current()->getImageURL('company_logo.png'));
+        $logoUrl = $baseUrl . '/' . $logoUrlArr[0];
 			return '<table style="width: 100%;" border="0" cellspacing="2" cellpadding="2">
 <tbody style="text-align: left;">
 <tr>
 <td valign="top">
-<p><img src="'.$d_image[0].'" style="float: left;"/>&nbsp;</p>
+<p><img src="'. $logoUrl .'" style="float: left;"/>&nbsp;</p>
 </td>
 <td style="font-weight: bold; text-align: right;"><div>'.translate('LBL_BROWSER_TITLE').' Ltd<br />'.translate('LBL_ANY_STREET','AOS_PDF_Templates').'<br />'.translate('LBL_ANY_TOWN','AOS_PDF_Templates').'</span><br />'.translate('LBL_ANY_WHERE','AOS_PDF_Templates').'</div></td>
 </tr>
@@ -42,13 +44,12 @@ class smpl_Lead_Sample{
 </tbody>
 </table>';
 		}
-		
+
 		function getHeader() {
 			return '';
 		}
-		
+
 		function getFooter() {
 			return '';
 		}
 }
-?>

--- a/modules/AOS_PDF_Templates/samples/smpl_Quote_Group_Sample.php
+++ b/modules/AOS_PDF_Templates/samples/smpl_Quote_Group_Sample.php
@@ -1,19 +1,19 @@
 <?php
+
+require_once __DIR__ . '/../TemplateSampleService.php';
+
 class smpl_Quote_Group_Sample{
 		function getType() {
 			return 'AOS_Quotes';
 		}
 		
 		function getBody() {
-        global $locale, $sugar_config;
-        $baseUrl = $sugar_config['site_url'];
-        $logoUrlArr = explode('?',SugarThemeRegistry::current()->getImageURL('company_logo.png'));
-        $logoUrl = $baseUrl . '/' . $logoUrlArr[0];
+        global $locale;
 			return '<table style="width: 100%; font-family: Arial; text-align: center;" border="0" cellpadding="2" cellspacing="2">
 <tbody style="text-align: left;">
 <tr style="text-align: left;">
 <td style="text-align: left;">
-<p><img src="'. $logoUrl .'" style="float: left;"/>&nbsp;</p>
+<p><img src="'. TemplateSampleService::getAbsoluteLogoUrl() .'" style="float: left;"/>&nbsp;</p>
 </td>
 </tr>
 <tr>

--- a/modules/AOS_PDF_Templates/samples/smpl_Quote_Group_Sample.php
+++ b/modules/AOS_PDF_Templates/samples/smpl_Quote_Group_Sample.php
@@ -5,12 +5,15 @@ class smpl_Quote_Group_Sample{
 		}
 		
 		function getBody() {
-		$d_image = explode('?',SugarThemeRegistry::current()->getImageURL('company_logo.png'));
+        global $locale, $sugar_config;
+        $baseUrl = $sugar_config['site_url'];
+        $logoUrlArr = explode('?',SugarThemeRegistry::current()->getImageURL('company_logo.png'));
+        $logoUrl = $baseUrl . '/' . $logoUrlArr[0];
 			return '<table style="width: 100%; font-family: Arial; text-align: center;" border="0" cellpadding="2" cellspacing="2">
 <tbody style="text-align: left;">
 <tr style="text-align: left;">
 <td style="text-align: left;">
-<p><img src="'.$d_image[0].'" style="float: left;"/>&nbsp;</p>
+<p><img src="'. $logoUrl .'" style="float: left;"/>&nbsp;</p>
 </td>
 </tr>
 <tr>
@@ -120,11 +123,11 @@ class smpl_Quote_Group_Sample{
 </table>
 <p>&nbsp;</p>';
 		}
-		
+
 		function getHeader() {
 			return '';
 		}
-		
+
 		function getFooter() {
 		global $locale;
 			return '<table style="width: 100%; border: 0pt none; border-spacing: 0pt;">
@@ -137,4 +140,3 @@ class smpl_Quote_Group_Sample{
 </table>';
 		}
 }
-?>

--- a/modules/AOS_PDF_Templates/samples/smpl_Quote_Sample.php
+++ b/modules/AOS_PDF_Templates/samples/smpl_Quote_Sample.php
@@ -1,19 +1,19 @@
 <?php
+
+require_once __DIR__ . '/../TemplateSampleService.php';
+
 class smpl_Quote_Sample{
 		function getType() {
 			return 'AOS_Quotes';
 		}
 		
 		function getBody() {
-        global $locale, $sugar_config;
-        $baseUrl = $sugar_config['site_url'];
-        $logoUrlArr = explode('?',SugarThemeRegistry::current()->getImageURL('company_logo.png'));
-        $logoUrl = $baseUrl . '/' . $logoUrlArr[0];
+        global $locale;
 			return '<table style="width: 100%; font-family: Arial; text-align: center;" border="0" cellpadding="2" cellspacing="2">
 <tbody style="text-align: left;">
 <tr style="text-align: left;">
 <td style="text-align: left;">
-<p><img src="'. $logoUrl .'" style="float: left;"/>&nbsp;</p>
+<p><img src="'. TemplateSampleService::getAbsoluteLogoUrl() .'" style="float: left;"/>&nbsp;</p>
 </td>
 </tr>
 <tr>

--- a/modules/AOS_PDF_Templates/samples/smpl_Quote_Sample.php
+++ b/modules/AOS_PDF_Templates/samples/smpl_Quote_Sample.php
@@ -5,12 +5,15 @@ class smpl_Quote_Sample{
 		}
 		
 		function getBody() {
-		$d_image = explode('?',SugarThemeRegistry::current()->getImageURL('company_logo.png'));
+        global $locale, $sugar_config;
+        $baseUrl = $sugar_config['site_url'];
+        $logoUrlArr = explode('?',SugarThemeRegistry::current()->getImageURL('company_logo.png'));
+        $logoUrl = $baseUrl . '/' . $logoUrlArr[0];
 			return '<table style="width: 100%; font-family: Arial; text-align: center;" border="0" cellpadding="2" cellspacing="2">
 <tbody style="text-align: left;">
 <tr style="text-align: left;">
 <td style="text-align: left;">
-<p><img src="'.$d_image[0].'" style="float: left;"/>&nbsp;</p>
+<p><img src="'. $logoUrl .'" style="float: left;"/>&nbsp;</p>
 </td>
 </tr>
 <tr>
@@ -122,11 +125,11 @@ class smpl_Quote_Sample{
 </table>
 <p>&nbsp;</p>';
 		}
-		
+
 		function getHeader() {
 			return '';
 		}
-		
+
 		function getFooter() {
 		global $locale;
 			return '<table style="width: 100%; border: 0pt none; border-spacing: 0pt;">
@@ -139,4 +142,3 @@ class smpl_Quote_Sample{
 </table>';
 		}
 }
-?>

--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -1347,6 +1347,9 @@
         italic: {inline: 'i'},
         underline: {inline: 'u'}
       },
+      convert_urls:true,
+      relative_urls:false,
+      remove_script_host:false,
     }
   };
 }(jQuery));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Modified the default template samples for AOS_PDF_Templates module to use the absolute path to the CRM logo instead of the relative path to avoid it not showing up in emails.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #4736

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->