### PR TITLE
Fix/multiple tabs appearing

### DIFF
--- a/modules/Home/AddDashboardPages.php
+++ b/modules/Home/AddDashboardPages.php
@@ -57,9 +57,7 @@ if(!isset($_POST['dashName'])){
     $html .='<option value="2">2</option>';
     $html .='<option value="3">3</option>';
     $html .='</select></td>';
-    $html .='</tr>';
-    $html .='<td></td>';
-    $html .='</tr></table>';
+    $html .='</table>';
     $html .='</form>';
 
     echo $html;

--- a/modules/Home/AddDashboardPages.php
+++ b/modules/Home/AddDashboardPages.php
@@ -57,6 +57,7 @@ if(!isset($_POST['dashName'])){
     $html .='<option value="2">2</option>';
     $html .='<option value="3">3</option>';
     $html .='</select></td>';
+    $html .='</tr>';
     $html .='</table>';
     $html .='</form>';
 

--- a/themes/SuiteP/include/MySugar/javascript/AddRemoveDashboardPages.js
+++ b/themes/SuiteP/include/MySugar/javascript/AddRemoveDashboardPages.js
@@ -51,14 +51,7 @@ function addDashboardForm(page_id){
         type: 'POST',
 
         success : function(data) {
-
-            var form = '<form method="post" name="addpageform" id="addpageform" action="index.php?module=Home&amp;action=AddDashboardPages">' +
-              '<input type="text" name="dashName" id="dashName">' +
-              '<select name="numColumns"><option value="1">1</option><option value="2">2</option><option value="3">3</option></select>' +
-              '</form>';
             var titleval = SUGAR.language.get('app_strings', 'LBL_ADD_DASHBOARD_PAGE');
-            var myButtons = [{ text: SUGAR.language.get('app_strings', 'LBL_SAVE_BUTTON_LABEL'), handler: handleSubmit, isDefault: true },
-                { text: SUGAR.language.get('app_strings', 'LBL_CANCEL_BUTTON_TITLE'), handler:handleCancel }];
             $("#dashName").attr('type', 'text');
             $('.modal-add-dashboard > .modal-dialog > .modal-content > .modal-header .modal-title').html(titleval);
             $('.modal-add-dashboard > .modal-dialog > .modal-content > .modal-body').html(data);

--- a/themes/SuiteP/include/MySugar/javascript/retrievePage.js
+++ b/themes/SuiteP/include/MySugar/javascript/retrievePage.js
@@ -44,18 +44,24 @@ var dashletsPageInit = function() {
         SUGAR.mySugar.showDashletsDialog();
     })
 
-    $('.modal-add-dashboard').on('show.bs.modal', function (e) {
-        addDashboardForm($('ul.nav-dashboard > li').length -1);
-        $('.btn-add-dashboard').click(function() {
-            //validate
-            if($('#dashName').val() == '') {
-                return;
-            }
+  $('.modal-add-dashboard').on('show.bs.modal', function (e) {
 
-	    $.post($('#addpageform').attr('action'), { dashName: $('#dashName').val(), numColumns: $('[name=numColumns] option:selected').val() } ).then(function() { location.reload(); });
+    addDashboardForm($('ul.nav-dashboard > li').length -1);
 
-        })
+    $('.btn-add-dashboard').unbind('click');
+    $('.btn-add-dashboard').click(function() {
+      if($('#dashName').val() == '') {
+        return;
+      }
+
+      $.post($('#addpageform').attr('action'), {
+        dashName: $('#dashName').val(),
+        numColumns: $('[name=numColumns] option:selected').val()
+      }).then(function() {
+        location.reload();
+      });
     })
+  })
 
     $('.modal-edit-dashboard').on('show.bs.modal', function (e) {
         var tabs = $('ul.nav-dashboard > li');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Made sure to unbind an on click handler that was being triggered multiple times if the add dashboard tab was opened and closed before being sent.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When adding tabs in the main screen, is the user cancels adding a tab and then does the adding process again and completes the add, the amount of cancels are also added as tabs. 

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->