### PR TITLE
Removing line breaks in long sentences

### DIFF
--- a/modules/Users/language/en_us.lang.php
+++ b/modules/Users/language/en_us.lang.php
@@ -384,8 +384,7 @@ $mod_strings = array(
     'LBL_WIZARD_FINISH_BUTTON' => 'Finish',
     'LBL_WIZARD_FINISH_TITLE' => 'You are ready to use SuiteCRM!',
 
-    'LBL_WIZARD_FINISH' => 'Click <b>Finish</b>
-below to save your settings and to begin using SuiteCRM. For more information on using SuiteCRM:<br /><br />
+    'LBL_WIZARD_FINISH' => 'Click <b>Finish</b>below to save your settings and to begin using SuiteCRM. For more information on using SuiteCRM:<br /><br />
 <table cellpadding=0 cellspacing=0>
 <tr><td><!--not_in_theme!-->Visit www.suitecrm.com
 <img src=include/images/suitecrm_login.png style="margin-right: 5px;">
@@ -403,15 +402,13 @@ below to save your settings and to begin using SuiteCRM. For more information on
     'LBL_WIZARD_FINISH9' => 'Configure the Application ',
     'LBL_WIZARD_FINISH10' => 'Use Studio to create and manage application fields and layouts.',
     'LBL_WIZARD_FINISH11' => 'Visit SuiteCRM Site ',
-    'LBL_WIZARD_FINISH12' => 'Find training materials and classes that will help you get started as a
-    system administrator or end user of the application.',
+    'LBL_WIZARD_FINISH12' => 'Find training materials and classes that will help you get started as a system administrator or end user of the application.',
     'LBL_WIZARD_FINISH14' => 'Documentation ',
     'LBL_WIZARD_FINISH15' => 'Product Guides and Release Notes ',
     'LBL_WIZARD_FINISH16' => 'Knowledge Base ',
     'LBL_WIZARD_FINISH17' => 'Tips from SuiteCRM',
     'LBL_WIZARD_FINISH18' => 'Forums ',
-    'LBL_WIZARD_FINISH19' => 'Forums dedicated to the SuiteCRM Community
-    to discuss topics of interest with each other and with SuiteCRM Developers ',
+    'LBL_WIZARD_FINISH19' => 'Forums dedicated to the SuiteCRM Community to discuss topics of interest with each other and with SuiteCRM Developers ',
     'LBL_WIZARD_FINISH2DESC' => 'Go directly to the application Home page.',
     'LBL_WIZARD_PERSONALINFO' => 'Your Information',
     'LBL_WIZARD_LOCALE' => 'Your Locale',


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Removing line breaks in long sentences. A sentence should't have a line break unless its stated with formatting tags.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Translations issues as a sentence in different lines is getting indenting spaces. This causes Crowdin alerts to include those spaces when translated a sentence!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.