### PR TITLE
Fix #4742 Make email variables replace correctly in AOP Case Updates

### DIFF
--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -117,7 +117,8 @@ class templateParser
                 $sep = get_number_seperators();
                 $value = rtrim(rtrim(format_number($value), '0'), $sep[1]) . $app_strings['LBL_PERCENTAGE_SYMBOL'];
             }
-            if (strpos($name, 'date') > 0 || strpos($name, 'expiration') > 0) {
+            if ($focus->field_defs[$name][dbType] == 'datetime' &&
+                (strpos($name, 'date') > 0 || strpos($name, 'expiration') > 0) ) {
                 if ($value != '') {
                     $dt = explode(' ', $value);
                     $value = $dt[0];

--- a/modules/AOW_Actions/actions/actionSendEmail.php
+++ b/modules/AOW_Actions/actions/actionSendEmail.php
@@ -357,8 +357,10 @@ class actionSendEmail extends actionBase {
         $template->subject = aowTemplateParser::parse_template($template->subject, $object_arr);
         $template->body_html = aowTemplateParser::parse_template($template->body_html, $object_arr);
         $template->body_html = str_replace("\$url",$url,$template->body_html);
+        $template->body_html = str_replace("\$sugarurl",$cleanUrl,$template->body_html);
         $template->body = aowTemplateParser::parse_template($template->body, $object_arr);
         $template->body = str_replace("\$url",$url,$template->body);
+        $template->body = str_replace("\$sugarurl",$cleanUrl,$template->body);
     }
 
     function getAttachments(EmailTemplate $template){


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The templateParser was identifying any field from the AOP_Case_Updates module as a date field and truncating the content to one word.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #4742

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->