### PR TITLE
fix(Quotes): Remove first empty line from quotes export CSV file

### DIFF
--- a/modules/AOS_Quotes/controller.php
+++ b/modules/AOS_Quotes/controller.php
@@ -100,4 +100,4 @@ class AOS_QuotesController extends SugarController {
 
 }
 
-?> 
+?>


### PR DESCRIPTION
Remove first empty line from quotes export CSV file

## Description
Before:
![image](https://user-images.githubusercontent.com/18328936/34246290-a4670002-e636-11e7-8978-57ceb42e2b61.png)

After:
![image](https://user-images.githubusercontent.com/18328936/34246274-8a17c538-e636-11e7-95a5-574a50e15a1e.png)

## Motivation and Context
This fix quotes export CSV file by remove first empty line

## How To Test This

1. open quotes list view
2. select at least one quote
3. from bulk action menu select "Export"
4. before and after described in "Description" block

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->