### PR TITLE
If there is no google maps API key don't throw php notice

### DIFF
--- a/modules/jjwg_Maps/jjwg_Maps.php
+++ b/modules/jjwg_Maps/jjwg_Maps.php
@@ -353,7 +353,7 @@ class jjwg_Maps extends jjwg_Maps_sugar {
                 $this->settings['geocoding_api_secret'] = $rev['geocoding_api_secret'];
             }
             // Set Google Maps API Key
-            $this->settings['google_maps_api_key'] = $rev['google_maps_api_key'];
+            $this->settings['google_maps_api_key'] = !empty($rev['google_maps_api_key'])?$rev['google_maps_api_key']:"";
         }
 
         // Set for Global Use


### PR DESCRIPTION
If there is no google maps API key don't throw php notice