### PR TITLE
Fix #4766 Make tooltip load language string correctly

### DIFF
--- a/modules/AOR_Reports/AOR_Report_Before.js
+++ b/modules/AOR_Reports/AOR_Report_Before.js
@@ -61,7 +61,11 @@ $(document).ready(function(){
       }
       $('#module-name').html('(<span title="' + module_path_display + '">' + module_name + '</span>)');
       $('#fieldTreeLeafs').remove();
-      $('#detailpanel_fields_select').append('<div id="fieldTreeLeafs" class="dragbox aor_dragbox" title="{/literal}{$MOD.LBL_TOOLTIP_DRAG_DROP_ELEMS}{literal}"></div>');
+      $('#detailpanel_fields_select').append(
+        '<div id="fieldTreeLeafs" class="dragbox aor_dragbox" title="'
+        + SUGAR.language.translate('AOR_Reports', 'LBL_TOOLTIP_DRAG_DROP_ELEMS')
+        + '"></div>'
+      );
       $('#fieldTreeLeafs').tree({
         data: treeDataLeafs,
         dragAndDrop: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Make the tooltip data load from JS instead of Smarty TPL (because it's not a template)

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #4766 

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->