### PR TITLE
Fix #4440 Make Call not crash on missing duration field

### DIFF
--- a/modules/Calls/Call.php
+++ b/modules/Calls/Call.php
@@ -174,18 +174,24 @@ class Call extends SugarBean {
 		}
 		return parent::ACLAccess($view,$is_owner,$in_group);
 	}
+	
     // save date_end by calculating user input
     // this is for calendar
-	function save($check_notify = FALSE) {
-		global $timedate,$current_user;
+    function save($check_notify = false)
+    {
+        global $timedate;
 
-	    if(isset($this->date_start) && isset($this->duration_hours) && isset($this->duration_minutes))
-        {
-    	    $td = $timedate->fromDb($this->date_start);
-    	    if($td)
-    	    {
-	        	$this->date_end = $td->modify("+{$this->duration_hours} hours {$this->duration_minutes} mins")->asDb();
-    	    }
+        if (!empty($this->date_start)) {
+            if (!empty($this->duration_hours) && !empty($this->duration_minutes)) {
+                $td = $timedate->fromDb($this->date_start);
+                if ($td) {
+                    $this->date_end = $td->modify(
+                        "+{$this->duration_hours} hours {$this->duration_minutes} mins"
+                    )->asDb();
+                }
+            } else {
+                $this->date_end = $this->date_start;
+            }
         }
 
 		if(!empty($_REQUEST['send_invites']) && $_REQUEST['send_invites'] == '1') {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Avoid a silent crash when editing a call with no duration.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #4440 

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->