### PR TITLE
Fix issue #3902 reschedule greyed out.

### DIFF
--- a/themes/SuiteP/css/suitep-base/editview.scss
+++ b/themes/SuiteP/css/suitep-base/editview.scss
@@ -5235,6 +5235,7 @@ object {
 
 @media (min-width: 980px) {
   #dialog1_c {
+    z-index: 5;
     margin-top: 100px;
     margin-left: 40%;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Rescheduling a call in the edit view of calls was not possible as the the popup was greyed out.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This was solved by overriding the z-index of the popup panel and bringing the rechedule forward.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1) Create a call
2) Navigate to the edit call view via the dashlet
3) Use the dropdown menu and select Reschedule call
4) The popup should now be accessable

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->