### PR TITLE
Fix undefined notice "LBL_SEARCH" during Module Builder Deploy

### DIFF
--- a/ModuleInstall/ModuleScanner.php
+++ b/ModuleInstall/ModuleScanner.php
@@ -662,7 +662,7 @@ class ModuleScanner{
         static $md5 = array();
         if (empty($md5) && file_exists('files.md5')) {
             include ('files.md5');
-            $md5 = $md5_string;
+            $md5 = isset($md5_string) ? $md5_string : null;
         }
         if ($path[0] != '.' || $path[1] != '/') {
             $path = './' . $path;

--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -3048,7 +3048,10 @@ class Email extends Basic
      */
     public function fill_in_additional_detail_fields()
     {
-        global $app_list_strings, $mod_strings;
+        global $app_list_strings;
+
+        $mod_strings = return_module_language($GLOBALS['current_language'], 'Emails'); //Called from EmailMan as well.
+
         // Fill in the assigned_user_name
         $this->assigned_user_name = get_assigned_user_name($this->assigned_user_id, '');
         //if ($this->parent_type == 'Contacts') {

--- a/modules/ModuleBuilder/MB/MBModule.php
+++ b/modules/ModuleBuilder/MB/MBModule.php
@@ -496,7 +496,7 @@ class MBModule
             $class [ 'requires' ] [] = MB_TEMPLATES . '/' . $template . '/' . ucfirst ( $template ) . '.php' ;
         }
         $class [ 'importable' ] = $this->config [ 'importable' ] ;
-        $class [ 'inline_edit' ] = $this->config [ 'inline_edit' ] ;
+        $class [ 'inline_edit' ] = isset($this->config [ 'inline_edit' ]) ? $this->config [ 'inline_edit' ] : null;
         $this->mbvardefs->updateVardefs () ;
         $class [ 'fields' ] = $this->mbvardefs->vardefs [ 'fields' ] ;
         $class [ 'fields_string' ] = var_export_helper ( $this->mbvardefs->vardef [ 'fields' ] ) ;

--- a/modules/ModuleBuilder/language/en_us.lang.php
+++ b/modules/ModuleBuilder/language/en_us.lang.php
@@ -377,6 +377,7 @@ $mod_strings = array(
     'LBL_SUBPANEL' => 'Subpanel',
     'LBL_SUBPANEL_TITLE' => 'Title:',
     'LBL_SEARCH_FORMS' => 'Filter',
+    'LBL_SEARCH' => 'Search',
     'LBL_FILTER' => 'Filter',
     'LBL_TOOLBOX' => 'Toolbox',
     'LBL_QUICKCREATE' => 'QuickCreate',

--- a/modules/ModuleBuilder/language/en_us.lang.php
+++ b/modules/ModuleBuilder/language/en_us.lang.php
@@ -378,6 +378,7 @@ $mod_strings = array(
     'LBL_SUBPANEL_TITLE' => 'Title:',
     'LBL_SEARCH_FORMS' => 'Filter',
     'LBL_SEARCH' => 'Search',
+    'LBL_SEARCH_BUTTON' => 'Search',
     'LBL_FILTER' => 'Filter',
     'LBL_TOOLBOX' => 'Toolbox',
     'LBL_QUICKCREATE' => 'QuickCreate',

--- a/tests/unit/modules/Emails/EmailTest.php
+++ b/tests/unit/modules/Emails/EmailTest.php
@@ -152,9 +152,9 @@ class EmailTest extends PHPUnit_Framework_TestCase
         $this->markTestIncomplete('Not testing sending email currently');
         /*
     	$email = new Email();
-    	
+
     	$result = $email->sendEmailTest('mail.someserver.com', 25, 425, false, '', '', 'admin@email.com', 'abc@email.com', 'smtp', 'admin');
-    	
+
     	$expected = array( "status"=>false, "errorMessage"=> "Error:SMTP connect() failed. https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting");
     	$this->assertSame($expected, $result);
     	*/
@@ -183,15 +183,15 @@ class EmailTest extends PHPUnit_Framework_TestCase
         $this->markTestIncomplete('Not testing sending email currently');
         /*
     	$email = new Email();
-    	
+
     	$email->to_addrs_arr = array('email' =>'abc@xyz.com', 'display' => 'abc');
     	$email->cc_addrs_arr = array('email' =>'abc@xyz.com', 'display' => 'abc');
     	$email->bcc_addrs_arr = array('email' =>'abc@xyz.com', 'display' => 'abc');
-    	
+
     	$email->from_addr = "abc@xyz.com";
     	$email->from_name = "abc";
     	$email->reply_to_name = "xyz";
-    	
+
     	$result = $email->send();
     	$this->assertEquals(false, $result);
     	*/
@@ -273,7 +273,7 @@ class EmailTest extends PHPUnit_Framework_TestCase
 
         $email->saveEmailAddresses();
 
-        //retrieve and verify that email addresses were saved properly 
+        //retrieve and verify that email addresses were saved properly
         $email->retrieveEmailAddresses();
 
         $this->assertNotSame(false, strpos($email->from_addr, 'from_test@email.com'));
@@ -508,7 +508,7 @@ class EmailTest extends PHPUnit_Framework_TestCase
         $actual = $email->u_get_clear_form_js('', '', '');
         $this->assertSame($expected, $actual);
 
-        //with valid params 
+        //with valid params
         $expected = "\n		<script type=\"text/javascript\" language=\"JavaScript\"><!-- Begin\n			function clear_form(form) {\n				var newLoc = \"index.php?action=\" + form.action.value + \"&module=\" + form.module.value + \"&query=true&clear_query=true&type=out&assigned_user_id=1\";\n				if(typeof(form.advanced) != \"undefined\"){\n					newLoc += \"&advanced=\" + form.advanced.value;\n				}\n				document.location.href= newLoc;\n			}\n		//  End --></script>";
         $actual = $email->u_get_clear_form_js('out', '', '1');
         $this->assertSame($expected, $actual);
@@ -574,7 +574,7 @@ class EmailTest extends PHPUnit_Framework_TestCase
         $email->description_html = 'some html text with <b>sign</b>';
         $email->description = 'some text with sign';
 
-        //test for strings with signature present  
+        //test for strings with signature present
         $sig = array('signature_html' => 'sign', 'signature' => 'sign');
         $result = $email->hasSignatureInBody($sig);
         $this->assertEquals(true, $result);
@@ -746,7 +746,7 @@ class EmailTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('Administrator', $email->created_by_name);
         $this->assertEquals('Administrator', $email->modified_by_name);
-        $this->assertEquals('', $email->type_name);
+        $this->assertEquals('Send Error', $email->type_name);
         $this->assertEquals('', $email->name);
         $this->assertEquals('DetailView', $email->link_action);
     }

--- a/tests/unit/modules/Emails/EmailTest.php
+++ b/tests/unit/modules/Emails/EmailTest.php
@@ -747,7 +747,7 @@ class EmailTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Administrator', $email->created_by_name);
         $this->assertEquals('Administrator', $email->modified_by_name);
         $this->assertEquals('Send Error', $email->type_name);
-        $this->assertEquals('', $email->name);
+        $this->assertEquals('(no subject)', $email->name);
         $this->assertEquals('DetailView', $email->link_action);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Currently deploying from module builder throws the following notice

```
==> ../logs/error_log <==
[Fri Dec 29 10:36:06.733469 2017] [:error] [pid 20671] [client ::1:36681] PHP Notice:  Undefined index: LBL_SEARCH in /srv/suitecrm/modules/ModuleBuilder/MB/MBLanguage.php on line 184, referer: https://suitecrm.localhost/index.php?module=ModuleBuilder&action=index&type=mb
[Fri Dec 29 10:36:06.733494 2017] [:error] [pid 20671] [client ::1:36681] PHP Stack trace:, referer: https://suitecrm.localhost/index.php?module=ModuleBuilder&action=index&type=mb
[Fri Dec 29 10:36:06.733502 2017] [:error] [pid 20671] [client ::1:36681] PHP   1. {main}() /srv/suitecrm/index.php:0, referer: https://suitecrm.localhost/index.php?module=ModuleBuilder&action=index&type=mb
[Fri Dec 29 10:36:06.733506 2017] [:error] [pid 20671] [client ::1:36681] PHP   2. SugarApplication->execute() /srv/suitecrm/index.php:52, referer: https://suitecrm.localhost/index.php?module=ModuleBuilder&action=index&type=mb
[Fri Dec 29 10:36:06.733524 2017] [:error] [pid 20671] [client ::1:36681] PHP   3. SugarController->execute() /srv/suitecrm/include/MVC/SugarApplication.php:105, referer: https://suitecrm.localhost/index.php?module=ModuleBuilder&action=index&type=mb
[Fri Dec 29 10:36:06.733527 2017] [:error] [pid 20671] [client ::1:36681] PHP   4. ModuleBuilderController->process() /srv/suitecrm/include/MVC/Controller/SugarController.php:373, referer: https://suitecrm.localhost/index.php?module=ModuleBuilder&action=index&type=mb
[Fri Dec 29 10:36:06.733531 2017] [:error] [pid 20671] [client ::1:36681] PHP   5. SugarController->process() /srv/suitecrm/modules/ModuleBuilder/controller.php:108, referer: https://suitecrm.localhost/index.php?module=ModuleBuilder&action=index&type=mb
[Fri Dec 29 10:36:06.733534 2017] [:error] [pid 20671] [client ::1:36681] PHP   6. SugarController->handle_action() /srv/suitecrm/include/MVC/Controller/SugarController.php:465, referer: https://suitecrm.localhost/index.php?module=ModuleBuilder&action=index&type=mb
[Fri Dec 29 10:36:06.733537 2017] [:error] [pid 20671] [client ::1:36681] PHP   7. SugarController->do_action() /srv/suitecrm/include/MVC/Controller/SugarController.php:491, referer: https://suitecrm.localhost/index.php?module=ModuleBuilder&action=index&type=mb
[Fri Dec 29 10:36:06.733540 2017] [:error] [pid 20671] [client ::1:36681] PHP   8. ModuleBuilderController->action_SavePackage() /srv/suitecrm/include/MVC/Controller/SugarController.php:523, referer: https://suitecrm.localhost/index.php?module=ModuleBuilder&action=index&type=mb
[Fri Dec 29 10:36:06.733544 2017] [:error] [pid 20671] [client ::1:36681] PHP   9. ModuleBuilder->save() /srv/suitecrm/modules/ModuleBuilder/controller.php:197, referer: https://suitecrm.localhost/index.php?module=ModuleBuilder&action=index&type=mb
[Fri Dec 29 10:36:06.733547 2017] [:error] [pid 20671] [client ::1:36681] PHP  10. MBPackage->save() /srv/suitecrm/modules/ModuleBuilder/MB/ModuleBuilder.php:111, referer: https://suitecrm.localhost/index.php?module=ModuleBuilder&action=index&type=mb
[Fri Dec 29 10:36:06.733553 2017] [:error] [pid 20671] [client ::1:36681] PHP  11. MBPackage->updateModulesMetaData($save = *uninitialized*) /srv/suitecrm/modules/ModuleBuilder/MB/MBPackage.php:294, referer: https://suitecrm.localhost/index.php?module=ModuleBuilder&action=index&type=mb
[Fri Dec 29 10:36:06.733558 2017] [:error] [pid 20671] [client ::1:36681] PHP  12. MBModule->renameLanguageFiles($new_dir = *uninitialized*, $duplicate = *uninitialized*) /srv/suitecrm/modules/ModuleBuilder/MB/MBPackage.php:403, referer: https://suitecrm.localhost/index.php?module=ModuleBuilder&action=index&type=mb
[Fri Dec 29 10:36:06.733564 2017] [:error] [pid 20671] [client ::1:36681] PHP  13. MBLanguage->save($key_name = *uninitialized*, $duplicate = *uninitialized*, $rename = *uninitialized*) /srv/suitecrm/modules/ModuleBuilder/MB/MBModule.php:674, referer: https://suitecrm.localhost/index.php?module=ModuleBuilder&action=index&type=mb
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Trying to get rid of the garbage output so my logs are cleaner for actual issues

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Run deploy of a module from module builder and make sure this notice is gone

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->