### PR TITLE
Fix PHP Warning in Schedulers

### DIFF
--- a/modules/Schedulers/views/view.edit.php
+++ b/modules/Schedulers/views/view.edit.php
@@ -61,7 +61,7 @@ class SchedulersViewEdit extends ViewEdit {
     /**
 	 * @see SugarView::_getModuleTitleListParam()
 	 */
-	protected function _getModuleTitleListParam()
+	protected function _getModuleTitleListParam($browserTitle = false)
 	{
 	    global $mod_strings;
 


### PR DESCRIPTION
## Motivation and Context
PHP Strict Standards warning in logs
` PHP Strict Standards: Declaration of SchedulersViewEdit::_getModuleTitleListParam() should be compatible with SugarView::_getModuleTitleListParam($browserTitle = false) in [...]/modules/Schedulers/views/view.edit.php on line 0`

## How To Test This
I have no idea, I just came across this in the forums and the user that had this error confirmed the fix.
https://suitecrm.com/forum/suitecrm-7-0-discussion/16886-schduler-job-drop-down-field-not-loading-all-jobs

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

