### PR TITLE
FIXED #3560 - Now we log queries in one, and only one, log line

### DIFF
--- a/include/database/DBManager.php
+++ b/include/database/DBManager.php
@@ -4041,7 +4041,7 @@ abstract class DBManager
     abstract public function getGuidSQL();
 
 
-    function removeLineBreaks($sql) {
+    public function removeLineBreaks($sql) {
         return trim(str_replace(array("\r", "\n"), " ", $sql));
     }
 }

--- a/include/database/DBManager.php
+++ b/include/database/DBManager.php
@@ -4039,4 +4039,9 @@ abstract class DBManager
      * @return string
      */
     abstract public function getGuidSQL();
+
+
+    function removeLineBreaks($sql) {
+        return trim(str_replace(array("\r", "\n"), " ", $sql));
+    }
 }

--- a/include/database/MssqlManager.php
+++ b/include/database/MssqlManager.php
@@ -296,7 +296,7 @@ class MssqlManager extends DBManager
 
         $sql = $this->_appendN($sql);
 
-        $GLOBALS['log']->info('Query:' . $sql);
+        $GLOBALS['log']->info('Query:' . $this->removeLineBreaks($sql));
         $this->checkConnection();
         $this->countQuery($sql);
         $this->query_time = microtime(true);

--- a/include/database/MysqlManager.php
+++ b/include/database/MysqlManager.php
@@ -179,7 +179,7 @@ class MysqlManager extends DBManager
 		}
 
 		parent::countQuery($sql);
-		$GLOBALS['log']->info('Query:' . $sql);
+		$GLOBALS['log']->info('Query:' . $this->removeLineBreaks($sql));
 		$this->checkConnection();
 		$this->query_time = microtime(true);
 		$this->lastsql = $sql;

--- a/include/database/MysqliManager.php
+++ b/include/database/MysqliManager.php
@@ -128,7 +128,7 @@ class MysqliManager extends MysqlManager
 		static $queryMD5 = array();
 
 		parent::countQuery($sql);
-		$GLOBALS['log']->info('Query:' . $sql);
+		$GLOBALS['log']->info('Query:' . $this->removeLineBreaks($sql));
 		$this->checkConnection();
 		$this->query_time = microtime(true);
 		$this->lastsql = $sql;
@@ -275,7 +275,7 @@ class MysqliManager extends MysqlManager
 			//mysqli connector has a separate parameter for port.. We need to separate it out from the host name
 			$dbhost=$configOptions['db_host_name'];
             $dbport=isset($configOptions['db_port']) ? ($configOptions['db_port'] == '' ? null : $configOptions['db_port']) : null;
-			
+
 			$pos=strpos($configOptions['db_host_name'],':');
 			if ($pos !== false) {
 				$dbhost=substr($configOptions['db_host_name'],0,$pos);
@@ -311,7 +311,7 @@ class MysqliManager extends MysqlManager
 	    }
 
 		// cn: using direct calls to prevent this from spamming the Logs
-	    
+
 	    $collation = $this->getOption('collation');
 	    if(!empty($collation)) {
 	    	$names = "SET NAMES 'utf8' COLLATE '$collation'";

--- a/include/database/SqlsrvManager.php
+++ b/include/database/SqlsrvManager.php
@@ -214,7 +214,7 @@ class SqlsrvManager extends MssqlManager
         $sql = $this->_appendN($sql);
 
         $this->countQuery($sql);
-        $GLOBALS['log']->info('Query:' . $sql);
+        $GLOBALS['log']->info('Query:' . $this->removeLineBreaks($sql));
         $this->checkConnection();
         $this->query_time = microtime(true);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This pull request fixes #3560
Now each log line represents one (and only one) system action.
Now a log line with a query is recorded this way:


     Tue May 16 09:58:11 2017 [30922][1][INFO] Query: SELECT  alerts.*  , jt0.user_name modified_by_name , jt0.created_by modified_by_name_owner  , 'Users' modified_by_name_mod , jt1.user_name created_by_name , jt1.created_by created_by_name_owner  , 'Users' created_by_name_mod , jt2.user_name assigned_user_name , jt2.created_by assigned_user_name_owner  , 'Users' assigned_user_name_mod FROM alerts   LEFT JOIN  users jt0 ON alerts.modified_user_id=jt0.id AND jt0.deleted=0     AND jt0.deleted=0  LEFT JOIN  users jt1 ON alerts.created_by=jt1.id AND jt1.deleted=0     AND jt1.deleted=0  LEFT JOIN  users jt2 ON alerts.assigned_user_id=jt2.id AND jt2.deleted=0     AND jt2.deleted=0 where (alerts.assigned_user_id = '1' AND is_read != '1') AND alerts.deleted=0

## Motivation and Context

When you are debuging it is **VERY annoying** that the queries (and other system actions) are recorded in the log in several lines.
That's not a style thing it's a productive one... with queries in several lines using unix tools (cat, grep, awk, sort, wc, etc, etc) is a headache


## How To Test This
Run SuiteCRM and watch the log.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
-  [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->