### PR TITLE
Fix/email compose button incomplete

### DIFF
--- a/include/ListView/ListViewDisplay.php
+++ b/include/ListView/ListViewDisplay.php
@@ -415,7 +415,7 @@ class ListViewDisplay {
         if($client == 'sugar') {
 		    require_once 'modules/Emails/EmailUI.php';
 		    $emailUI =  new EmailUI();
-            $script = $emailUI->populateComposeViewFields(). $app_strings['LBL_EMAIL_COMPOSE'];
+            $script = $emailUI->populateComposeViewFields(). $app_strings['LBL_EMAIL_COMPOSE'] . '</a>';
         } else {
             $script = "<a href='javascript:void(0)' " .
                 "class=\"parent-dropdown-action-handler\" id=\"composeemail_listview_". $loc ."\"".

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelTopComposeEmailButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelTopComposeEmailButton.php
@@ -87,7 +87,7 @@ class SugarWidgetSubPanelTopComposeEmailButton extends SugarWidgetSubPanelTopBut
             //Generate the compose package for the quick create options.
             require_once 'modules/Emails/EmailUI.php';
             $emailUI = new EmailUI();
-            $button = $emailUI->populateComposeViewFields() . $app_strings['LBL_COMPOSE_EMAIL_BUTTON_LABEL'];
+            $button = $emailUI->populateComposeViewFields() . $app_strings['LBL_COMPOSE_EMAIL_BUTTON_LABEL'] . '</a>';
         }
 
         return $button;

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelTopComposeEmailButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelTopComposeEmailButton.php
@@ -87,7 +87,8 @@ class SugarWidgetSubPanelTopComposeEmailButton extends SugarWidgetSubPanelTopBut
             //Generate the compose package for the quick create options.
             require_once 'modules/Emails/EmailUI.php';
             $emailUI = new EmailUI();
-            $button = $emailUI->populateComposeViewFields($defines['focus']) . $app_strings['LBL_COMPOSE_EMAIL_BUTTON_LABEL'] . '</a>';
+            $button = $emailUI->populateComposeViewFields($defines['focus'])
+                . $app_strings['LBL_COMPOSE_EMAIL_BUTTON_LABEL'] . '</a>';
         }
 
         return $button;

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelTopComposeEmailButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelTopComposeEmailButton.php
@@ -87,7 +87,7 @@ class SugarWidgetSubPanelTopComposeEmailButton extends SugarWidgetSubPanelTopBut
             //Generate the compose package for the quick create options.
             require_once 'modules/Emails/EmailUI.php';
             $emailUI = new EmailUI();
-            $button = $emailUI->populateComposeViewFields() . $app_strings['LBL_COMPOSE_EMAIL_BUTTON_LABEL'] . '</a>';
+            $button = $emailUI->populateComposeViewFields($defines['focus']) . $app_strings['LBL_COMPOSE_EMAIL_BUTTON_LABEL'] . '</a>';
         }
 
         return $button;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add a missing closing tag to the compose email button.
Also make sure to pass the focus as argument to the function that generates the link because in some cases global focus is not set.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #4826 

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->