### PR TITLE
Fix/survey module not showing

### DIFF
--- a/install/performSetup.php
+++ b/install/performSetup.php
@@ -470,6 +470,7 @@ FP;
     $enabled_tabs[] = 'AOK_KnowledgeBase';
     $enabled_tabs[] = 'AOK_Knowledge_Base_Categories';
     $enabled_tabs[] = 'EmailTemplates';
+    $enabled_tabs[] = 'Surveys';
 
 //Beginning of the scenario implementations
 //We need to load the tabs so that we can remove those which are scenario based and un-selected

--- a/modules/MySettings/TabController.php
+++ b/modules/MySettings/TabController.php
@@ -265,38 +265,10 @@ function get_tabs($user)
 			$display_tabs[$key] = $value;
 	}
 
-    ////////////////////////////////////////////////////////////////////
-    // Jenny - Bug 6286: If someone has "old school roles" defined (before 4.0) and upgrades, 
-    // then they can't remove those old roles through the UI. Also, when new tabs are added, 
-    // users who had any of those "old school roles" defined have no way of being able to see 
-    // those roles. We need to disable role checking.
-	
-    //$roleCheck = query_user_has_roles($user->id);
-    $roleCheck = 0;
-    ////////////////////////////////////////////////////////////////////
-		if($roleCheck)
-		{
-			//grabs modules a user has access to via roles
-			$role_tabs = get_user_allowed_modules($user->id);
-	
-			// adds modules to display_tabs if existant in roles
-			foreach($role_tabs as $key=>$value)
-			{
-				if(!isset($display_tabs[$key]))
-					$display_tabs[$key] = $value;
-			}
-		}
-		
 		// removes tabs from display_tabs if not existant in roles
 		// or exist in the hidden tabs
 		foreach($display_tabs as $key=>$value)
 		{
-			if($roleCheck)
-			{			
-				if(!isset($role_tabs[$key]))
-					unset($display_tabs[$key]);
-			}
-			
 			if(!isset($system_tabs[$key]))
 				unset($display_tabs[$key]);
 			if(isset($hide_tabs[$key]))
@@ -306,12 +278,6 @@ function get_tabs($user)
 		// removes tabs from hide_tabs if not existant in roles
 		foreach($hide_tabs as $key=>$value)
 		{
-			if($roleCheck)
-			{
-				if(!isset($role_tabs[$key]))
-					unset($hide_tabs[$key]);
-			}
-			
 			if(!isset($system_tabs[$key]))
 				unset($hide_tabs[$key]);
 		}

--- a/tests/unit/include/utils/securityUtilsTest.php
+++ b/tests/unit/include/utils/securityUtilsTest.php
@@ -53,7 +53,7 @@ class security_utilsTest extends PHPUnit_Framework_TestCase
                 'AOK_KnowledgeBase' => 'AOK_KnowledgeBase',
                 'AOK_Knowledge_Base_Categories' => 'AOK_Knowledge_Base_Categories',
                 'EmailTemplates' => 'EmailTemplates',
-                'Surveys'
+                'Surveys' => 'Surveys'
 
         );
 

--- a/tests/unit/include/utils/securityUtilsTest.php
+++ b/tests/unit/include/utils/securityUtilsTest.php
@@ -52,7 +52,8 @@ class security_utilsTest extends PHPUnit_Framework_TestCase
                 'AOW_WorkFlow' => 'AOW_WorkFlow',
                 'AOK_KnowledgeBase' => 'AOK_KnowledgeBase',
                 'AOK_Knowledge_Base_Categories' => 'AOK_Knowledge_Base_Categories',
-                'EmailTemplates' => 'EmailTemplates'
+                'EmailTemplates' => 'EmailTemplates',
+                'Surveys'
 
         );
 

--- a/tests/unit/include/utils/securityUtilsTest.php
+++ b/tests/unit/include/utils/securityUtilsTest.php
@@ -93,9 +93,7 @@ class security_utilsTest extends PHPUnit_Framework_TestCase
             'ResourceCalendar' => 'ResourceCalendar',
             'AOBH_BusinessHours' => 'AOBH_BusinessHours',
             'AOR_Scheduled_Reports' => 'AOR_Scheduled_Reports',
-            'SecurityGroups' => 'SecurityGroups',
-            'Surveys' => 'Surveys'
-
+            'SecurityGroups' => 'SecurityGroups'
         );
 
         $allowed = query_module_access_list(new User('1'));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added Surveys to the list of modules enabled by default during install.
Also removed a portion of code that was unreachable and making the methods hard to understand.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Surveys should be visible by default.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->