### PR TITLE
Make subpanels load asynchronously and show a loading screen

### DIFF
--- a/jssource/src_files/include/SubPanel/SubPanelTiles.js
+++ b/jssource/src_files/include/SubPanel/SubPanelTiles.js
@@ -284,7 +284,7 @@ function showSubPanel(child_field, url, force_load, layout_def_key) {
 
     current_subpanel_url = url;
 
-    var loadingImg = '<img src="themes/SuiteP/images/loading.gif">';
+    var loadingImg = '<img src="themes/' + SUGAR.themes.theme_name + '/images/loading.gif">';
     $("#list_subpanel_" + child_field.toLowerCase()).html(loadingImg);
 
     $.ajax({

--- a/jssource/src_files/include/SubPanel/SubPanelTiles.js
+++ b/jssource/src_files/include/SubPanel/SubPanelTiles.js
@@ -283,12 +283,30 @@ function showSubPanel(child_field, url, force_load, layout_def_key) {
     }
 
     current_subpanel_url = url;
-    var returnstuff = http_fetch_sync(url + '&inline=' + inline + '&ajaxSubpanel=true');
-    request_id++;
-    got_data(returnstuff, inline);
-    if ($('#whole_subpanel_' + child_field).hasClass('useFooTable')) {
-      $('#whole_subpanel_' + child_field + ' .table-responsive').footable();
-    }
+
+    var loadingImg = '<img src="themes/SuiteP/images/loading.gif">';
+    $("#list_subpanel_" + child_field.toLowerCase()).html(loadingImg);
+
+    $.ajax({
+      type: "GET",
+      async: true,
+      cache: false,
+      url: url + '&inline=' + inline + '&ajaxSubpanel=true',
+      success: function(data) {
+        request_map[request_id] = child_field;
+        var returnstuff = {
+          "responseText": data,
+          "responseXML": '',
+          "request_id": request_id
+        };
+        got_data(returnstuff, inline);
+        if ($('#whole_subpanel_' + child_field).hasClass('useFooTable')) {
+          $('#whole_subpanel_' + child_field + ' .table-responsive').footable();
+        }
+        request_id++;
+      }
+    });
+
   } else {
 
     var subpanel = document.getElementById('subpanel_' + child_field);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Make subpanels load asynchronously.
Show a loading image to give the user feedback.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Loading subpanels with a lot of content (or over a slow connection) was taking a long time and the user wouldn't know why.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->