### PR TITLE
Fix/hide filter icons basic search

### DIFF
--- a/include/ListView/ListViewPagination.tpl
+++ b/include/ListView/ListViewPagination.tpl
@@ -65,7 +65,9 @@
 						{if $showFilterIcon}
 							{include file='include/ListView/ListViewSearchLink.tpl'}
 						{/if}
-						{include file='include/ListView/ListViewColumnsFilterLink.tpl'}
+                        {if empty($hideColumnFilter)}
+							{include file='include/ListView/ListViewColumnsFilterLink.tpl'}
+                        {/if}
 
 						&nbsp;{$selectedObjectsSpan}
 					</td>

--- a/modules/Home/UnifiedSearchAdvanced.php
+++ b/modules/Home/UnifiedSearchAdvanced.php
@@ -353,7 +353,6 @@ class UnifiedSearchAdvanced {
                 $lv->select = false;
                 $lv->showMassupdateFields = false;
                 $lv->email = false;
-                $lv->showFilterIcon = false;
 
                 $lv->setup($seed, 'include/ListView/ListViewNoMassUpdate.tpl', $where, $params, 0, 10);
                 $lv->ss->assign('showFilterIcon', 0);

--- a/modules/Home/UnifiedSearchAdvanced.php
+++ b/modules/Home/UnifiedSearchAdvanced.php
@@ -353,8 +353,11 @@ class UnifiedSearchAdvanced {
                 $lv->select = false;
                 $lv->showMassupdateFields = false;
                 $lv->email = false;
+                $lv->showFilterIcon = false;
 
                 $lv->setup($seed, 'include/ListView/ListViewNoMassUpdate.tpl', $where, $params, 0, 10);
+                $lv->ss->assign('showFilterIcon', 0);
+                $lv->ss->assign('hideColumnFilter', 1);
 
                 $module_results[$moduleName] = '<br /><br />' . get_form_header($GLOBALS['app_list_strings']['moduleList'][$seed->module_dir] . ' (' . $lv->data['pageData']['offsets']['total'] . ')', '', false);
                 $module_counts[$moduleName] = $lv->data['pageData']['offsets']['total'];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removes the 'Filter' and 'Column Filter' icons from the listview template when viewing Basic Global Search, as they are not functional and only throw js errors when clicked.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Removes unusable buttons
Issue #4827 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->