### PR TITLE
Fix #4781 Change PDF templates field type to allow html tags to be saved

### DIFF
--- a/modules/AOS_PDF_Templates/vardefs.php
+++ b/modules/AOS_PDF_Templates/vardefs.php
@@ -85,7 +85,7 @@ $dictionary['AOS_PDF_Templates'] = array(
             array(
                 'name' => 'description',
                 'vname' => 'LBL_DESCRIPTION',
-                'type' => 'html',
+                'type' => 'longtext',
                 'comment' => 'Full text of the note',
                 'rows' => '6',
                 'cols' => '80',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changed the the type of the ''description" field to allow PDF templated with html tags to be saved.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #4781 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Create a template with any kind of html tag.
It will no longer be removed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->