### PR TITLE
Fix #3925 and Fix #3818 email template attachments & duplicate attachments

### DIFF
--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -513,15 +513,7 @@
       var formData = new FormData(jQueryFormComposeView);
 
       $(this).find('input').each(function (inputIndex, inputValue) {
-        if ($(inputValue).attr('type').toLowerCase() === 'file') {
-          for (var fileIndex = 0; fileIndex < inputValue.files.length; fileIndex++) {
-            var file = inputValue.files[fileIndex];
-            var reader = new FileReader();
-            reader.readAsDataURL(file);
-            formData.append($(inputValue).attr('name'), file);
-            fileCount++;
-          }
-        } else {
+        if ($(inputValue).attr('type').toLowerCase() !== 'file') {
           if ($(inputValue).attr('name') === 'action') {
             formData.append('refer_' + $(inputValue).attr('name'), $(inputValue).val());
             formData.append($(inputValue).attr('name'), 'send');
@@ -534,7 +526,9 @@
       });
 
       $(this).find('select').each(function (i, v) {
-        formData.append($(v).attr('name'), $(v).val());
+        if (typeof $(v).attr('is_file') === 'undefined') {
+          formData.append($(v).attr('name'), $(v).val());
+        }
       });
 
       $(this).find('textarea').each(function (i, v) {
@@ -891,14 +885,6 @@
 
       $(this).find('input').each(function (i, v) {
         if ($(v).attr('type').toLowerCase() === 'file') {
-          for (i = 0; i < v.files.length; i++) {
-            var file = v.files[i];
-            var reader = new FileReader();
-            reader.readAsDataURL(file);
-            formData.append($(v).attr('name'), file);
-            fileCount++;
-          }
-        } else {
           var name = $(v).attr('name');
           if (name === 'action') {
             formData.append(name, 'SaveDraft');
@@ -911,7 +897,9 @@
       });
 
       $(this).find('select').each(function (i, v) {
-        formData.append($(v).attr('name'), $(v).val());
+        if (typeof $(v).attr('is_file') === 'undefined') {
+          formData.append($(v).attr('name'), $(v).val());
+        }
       });
 
       $(this).find('textarea').each(function (i, v) {
@@ -989,14 +977,6 @@
 
         $(this).find('input').each(function (i, v) {
           if ($(v).attr('type').toLowerCase() === 'file') {
-            for (i = 0; i < v.files.length; i++) {
-              var file = v.files[i];
-              var reader = new FileReader();
-              reader.readAsDataURL(file);
-              formData.append($(v).attr('name'), file);
-              fileCount++;
-            }
-          } else {
             var name = $(v).attr('name');
             if (name === 'action') {
               formData.append(name, 'Delete');
@@ -1009,7 +989,9 @@
         });
 
         $(this).find('select').each(function (i, v) {
-          formData.append($(v).attr('name'), $(v).val());
+          if (typeof $(v).attr('is_file') === 'undefined') {
+            formData.append($(v).attr('name'), $(v).val());
+          }
         });
 
         $(this).find('textarea').each(function (i, v) {
@@ -1311,6 +1293,7 @@
           var fileInput = $('<select></select>')
             .attr('style', 'display:none')
             .attr('id', id)
+            .attr('is_file', true)
             .attr('name', 'template_attachment[]')
             .attr('multiple', 'multiple');
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds functionality for loading template attachments into the compose view.
When selecting a template that has attachments it should now correctly load the attachments.
Additionally prevents duplicating the form elements that caused the duplicate attachment bug.

Most of the code is straight from the solution proposed by @KaKite

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #3925
Issue #3818 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Create an email template that has an attachment
Go into compose Email
Load the template
Send
Verify that email arrives with attachments

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->