### PR TITLE
Fix #4842 Only show folders of own email accounts in profile

### DIFF
--- a/include/SugarFolders/SugarFolders.php
+++ b/include/SugarFolders/SugarFolders.php
@@ -609,7 +609,7 @@ class SugarFolder
 
         $grp = array();
 
-        $folders = $this->retrieveFoldersForProcessing($focusUser, false);
+        $folders = $this->retrieveFoldersForProcessing($focusUser, true);
         $subscriptions = $this->getSubscriptions($focusUser);
 
         foreach ($folders as $a) {

--- a/include/SugarFolders/SugarFolders.php
+++ b/include/SugarFolders/SugarFolders.php
@@ -609,7 +609,7 @@ class SugarFolder
 
         $grp = array();
 
-        $folders = $this->retrieveFoldersForProcessing($focusUser, true);
+        $folders = $this->retrieveFoldersForProcessing($focusUser);
         $subscriptions = $this->getSubscriptions($focusUser);
 
         foreach ($folders as $a) {
@@ -652,7 +652,7 @@ class SugarFolder
         );
 
         try {
-            $folders = $this->retrieveFoldersForProcessing($focusUser, false);
+            $folders = $this->retrieveFoldersForProcessing($focusUser);
             $subscriptions = $this->getSubscriptions($focusUser);
 
             foreach ($folders as $a) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Make sure only the own folders are visible to each user in his profile.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #4842 

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Log in as user A
2. In profile, create an inbound email account
3. Make sure it shows in Folder Management
4. Log in as user B
5. In profile, make sure the folder from user A is NOT shown in Folder Management

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
  