### PR TITLE
Include script link for Jquery.qtip in view.ganttchart.php

### DIFF
--- a/modules/AM_ProjectTemplates/views/view.ganttchart.php
+++ b/modules/AM_ProjectTemplates/views/view.ganttchart.php
@@ -40,7 +40,8 @@ class AM_ProjectTemplatesViewGanttChart extends ViewDetail {
         echo '<script type="text/javascript" src="modules/AM_ProjectTemplates/js/splitter.js"></script>';
         echo '<script type="text/javascript" src="modules/AM_ProjectTemplates/js/jquery.blockUI.js"></script>';
         echo '<script type="text/javascript" src="modules/AM_ProjectTemplates/js/jquery.validate.min.js"></script>';
-		echo '<script type="text/javascript" src="modules/AM_ProjectTemplates/js/main_lib.js"></script>';
+	echo '<script type="text/javascript" src="modules/AM_ProjectTemplates/js/main_lib.js"></script>';
+	echo '<script type="text/javascript" src="include/javascript/qtip/jquery.qtip.min.js"></script>';
 
 
         $project_template = new AM_ProjectTemplates();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Jquery.qtip is referenced without being loaded in view.gantchart.php. This produces an error in Chrome: Uncaught TypeError: help.qtip is not a function.  Add link to script in display function to resolve error.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix error in browser and correctly display help tooltip.
## How To Test This
<!--- Please describe in detail how to test your changes. -->
Go to Project Templates -> Use Create Project button.  Check browser console.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->