### PR TITLE
Avoid including cache and upload folder into JS minify path

### DIFF
--- a/jssource/minify_utils.php
+++ b/jssource/minify_utils.php
@@ -54,12 +54,13 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
             $prefix = $prefix . '/';
         }
       //add prefix to key if it was passed in
-      $compress_exempt_files = array(
-            $prefix.sugar_cached('')                => true,
+        $compress_exempt_files = array(
+            rtrim($prefix.sugar_cached(''), '/')  => true,
             $prefix.'include/javascript/tiny_mce'   => true,
             $prefix.'include/javascript/yui'        => true,
             $prefix.'modules/Emails'                => true,
             $prefix.'jssource'                      => true,
+            $prefix.'upload'                        => true,
             $prefix.'modules/ModuleBuilder'         => true,
             $prefix.'include/javascript/jquery'     => true,
             $prefix.'include/javascript/jquery/bootstrap'     => true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updated the list of excluded folders for the JS minify utils.
Added 'upload'
Modified 'cache/' to 'cache'

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Minify JS would fail sometimes if it encountered unexpected contents in the upload folder.
Also the cache folder was not being excluded because of a trailing slash character.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->