### PR TITLE
Fix #4176 Date Picker

### DIFF
--- a/themes/SuiteP/css/editview.scss
+++ b/themes/SuiteP/css/editview.scss
@@ -5435,7 +5435,6 @@ table tr#delegates_search {
 /* popup in studio */
 .masked .yui-simple-dialog {
   // Overridding inline style
-  z-index: 100000!important;
 }
 
 /* popup dialog on home page */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Date picker was showing behind the popup display.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
The z-index was changed to allow the date picker to be accessed and in full display.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1) Have the 'Outcome By Month' dashlet on display
2) Click the edit icon
3) Click on the date icon to select a date

The css will need to be rebuilt for this change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
  