### PR TITLE
Fixed #1449 - Word wrap on $aop_case_updates_description in email tem…

### DIFF
--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -130,14 +130,17 @@ class templateParser
                 $sep = get_number_seperators();
                 $value = rtrim(rtrim(format_number($value), '0'), $sep[1]) . $app_strings['LBL_PERCENTAGE_SYMBOL'];
             }
-            if ($focus->field_defs[$name]['dbType'] == 'datetime' &&
-                (strpos($name, 'date') > 0 || strpos($name, 'expiration') > 0)) {
-                if ($value != '') {
+            if ($focus->field_defs[$name]['dbType'] === 'datetime' &&
+                (strpos($name, 'date') > 0 || strpos($name, 'expiration') > 0)
+            ) {
+                if (strpos($name, 'dates') > 0) {
+                    break;
+                } elseif ($value !== '') {
                     $dt = explode(' ', $value);
                     $value = $dt[0];
-                    if (isset($dt[1]) && $dt[1]!='') {
+                    if (isset($dt[1]) && $dt[1] != '') {
                         if (strpos($dt[1], 'am') > 0 || strpos($dt[1], 'pm') > 0) {
-                            $value = $dt[0].' '.$dt[1];
+                            $value = $dt[0] . ' ' . $dt[1];
                         }
                     }
                 }


### PR DESCRIPTION
…plate

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Variable $aop_case_updates_description is not being parsed correctly in email templates. Only the first word of the description is printed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #1449 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Create workflow for case updates to send email using template and use the variable $aop_case_updates_description

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->