### PR TITLE
Fixed #4942 - Name and address fields labels switched?

### DIFF
--- a/modules/OutboundEmailAccounts/language/en_us.lang.php
+++ b/modules/OutboundEmailAccounts/language/en_us.lang.php
@@ -104,6 +104,6 @@ $mod_strings = array (
     'LBL_TYPE' => 'Type',
     'LBL_MAIL_SENDTYPE' => 'Mail Send Type',
     'LBL_MAIL_SMTPSSL' => 'Mail SMTP/SSL',
-    'LBL_SMTP_FROM_NAME' => '"From" address',
-    'LBL_SMTP_FROM_ADDR' => '"From" name',
+    'LBL_SMTP_FROM_NAME' => '"From" name',
+    'LBL_SMTP_FROM_ADDR' => '"From" address',
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixed typo in outbound email LBL's:

  'LBL_SMTP_FROM_NAME' => '"From" address',
  'LBL_SMTP_FROM_ADDR' => '"From" name',

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #4942

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->