### PR TITLE
Fix/4883 from addr like profile

### DIFF
--- a/modules/Emails/EmailsController.php
+++ b/modules/Emails/EmailsController.php
@@ -401,9 +401,9 @@ class EmailsController extends SugarController
                     'type' => $inboundEmail->module_name,
                     'id' => $inboundEmail->id,
                     'attributes' => array(
-                        'from' => $storedOptions['reply_to_addr'],
+                        'reply_to' => $storedOptions['reply_to_addr'],
                         'name' => $storedOptions['from_name'],
-                        'oe' => $storedOptions['from_addr'],
+                        'from' => $storedOptions['from_addr'],
                     ),
                     'prepend' => $prependSignature,
                     'isPersonalEmailAccount' => $isPersonalEmailAccount,

--- a/modules/Emails/EmailsController.php
+++ b/modules/Emails/EmailsController.php
@@ -401,9 +401,9 @@ class EmailsController extends SugarController
                     'type' => $inboundEmail->module_name,
                     'id' => $inboundEmail->id,
                     'attributes' => array(
-                        'from' => $storedOptions['from_addr'],
-                        'name' => $inboundEmail->name,
-                        'oe' => $oe->mail_smtpuser,
+                        'from' => $storedOptions['reply_to_addr'],
+                        'name' => $storedOptions['from_name'],
+                        'oe' => $storedOptions['from_addr'],
                     ),
                     'prepend' => $prependSignature,
                     'isPersonalEmailAccount' => $isPersonalEmailAccount,

--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -1092,7 +1092,7 @@
               var selectOption = $('<option></option>');
               selectOption.attr('value', v.attributes.from);
               selectOption.attr('inboundId', v.id);
-              selectOption.attr('infos', '(<b>Reply-to:</b> ' + v.attributes.from + ', <b>From:</b> ' + v.attributes.oe + ')');
+              selectOption.attr('infos', '(<b>Reply-to:</b> ' + v.attributes.reply_to + ', <b>From:</b> ' + v.attributes.from + ')');
               selectOption.html(v.attributes.name);
               selectOption.appendTo(selectFrom);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Make the dropdown in compose email view display the same attributes the user sets in his profile for Name, From and Reply To.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #4883

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->