### PR TITLE
Fix/issue206

### DIFF
--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -301,11 +301,19 @@ class AOW_WorkFlow extends Basic
                 switch($this->flow_run_on){
 
                     case'New_Records':
-                        $query['where'][] = $module->table_name . '.' . 'date_entered' . ' > ' . "'" .$this->date_entered."'";
+                        if( $module->table_name === 'campaign_log' ){
+                            $query['where'][] = $module->table_name . '.' . 'activity_date' . ' > ' . "'" . $this->activity_date . "'";
+                        } else {
+                            $query['where'][] = $module->table_name . '.' . 'date_entered' . ' > ' . "'" . $this->date_entered . "'";
+                        }
                         Break;
 
                     case'Modified_Records':
-                        $query['where'][] = $module->table_name . '.' . 'date_modified' . ' > ' . "'" .$this->date_entered."'" . ' AND ' . $module->table_name . '.' . 'date_entered' . ' <> ' . $module->table_name . '.' . 'date_modified';
+                        if( $module->table_name === 'campaign_log' ){
+                            $query['where'][] = $module->table_name . '.' . 'date_modified' . ' > ' . "'" . $this->activity_date . "'" . ' AND ' . $module->table_name . '.' . 'activity_date' . ' <> ' . $module->table_name . '.' . 'date_modified';
+                        } else {
+                            $query['where'][] = $module->table_name . '.' . 'date_modified' . ' > ' . "'" . $this->date_entered . "'" . ' AND ' . $module->table_name . '.' . 'date_entered' . ' <> ' . $module->table_name . '.' . 'date_modified';
+                        }
                         Break;
 
                 }

--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -301,7 +301,7 @@ class AOW_WorkFlow extends Basic
                 switch($this->flow_run_on){
 
                     case'New_Records':
-                        if( $module->table_name === 'campaign_log' ){
+                        if($module->table_name === 'campaign_log'){
                             $query['where'][] = $module->table_name . '.' . 'activity_date' . ' > ' . "'" . $this->activity_date . "'";
                         } else {
                             $query['where'][] = $module->table_name . '.' . 'date_entered' . ' > ' . "'" . $this->date_entered . "'";
@@ -309,7 +309,7 @@ class AOW_WorkFlow extends Basic
                         Break;
 
                     case'Modified_Records':
-                        if( $module->table_name === 'campaign_log' ){
+                        if($module->table_name === 'campaign_log'){
                             $query['where'][] = $module->table_name . '.' . 'date_modified' . ' > ' . "'" . $this->activity_date . "'" . ' AND ' . $module->table_name . '.' . 'activity_date' . ' <> ' . $module->table_name . '.' . 'date_modified';
                         } else {
                             $query['where'][] = $module->table_name . '.' . 'date_modified' . ' > ' . "'" . $this->date_entered . "'" . ' AND ' . $module->table_name . '.' . 'date_entered' . ' <> ' . $module->table_name . '.' . 'date_modified';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Added conditional statement to check if the table_name is campaign_log and if so use activity_date instead of date_entered in the queries for both new and modified records to prevent query failure. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Previously the queries failed when workflows were setup to be triggered by Campaign Logs as the date_entered field does not exist in that table and instead there is an activity_date field.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create an Email Campaign with a tracker URL and send the Campaign.
2. Setup a Workflow that is triggered by either new or modified Campaign Log records. For example to trigger on Campaign click-thrus, set it up for new records and add a condition for activity_type = 'link'. 
3. The Workflow should run without a query failure due to the missing database column 'date_entered'


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->