### PR TITLE
Fix studio popup.

### DIFF
--- a/themes/SuiteP/css/main.scss
+++ b/themes/SuiteP/css/main.scss
@@ -95,7 +95,7 @@ a:hover {
 // Fix ajax loader in the edit view
 // Since the z-index is inline the only way to override it is to use the !important
 .mask {
-  z-index: 3 !important;
+  z-index: 2 !important;
 }
 
 #ajaxloading_c {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Popup after save click on studio edit was not clickable.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
The index of the mask was reduced to allow the popup to be accessible. 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1) Navigate to studio module
2) Select a module to edit
3) Navigate to Edit View inside Layouts
4) Select save

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->