### PR TITLE
Fix/4621 lts email navigation buttons

### DIFF
--- a/modules/Emails/javascript/complexLayout.js
+++ b/modules/Emails/javascript/complexLayout.js
@@ -50,10 +50,16 @@ function complexLayoutInit() {
 	            hideOnLayout: true,
 	            height: 400,
 				units: [{
+					position: "top",
+          	height:'64',
+				    scroll:false,
+				    split:true,
+				    body: "<div id='dt-pag-nav'></div> "
+				},{
 					position: "center",
 				    scroll:false, // grid should autoScroll itself
 				    split:true,
-				    body: "<div id='emailGrid'></div><div id='dt-pag-nav'></div> "
+				    body: "<div id='emailGrid'></div>"
 				},{
 					position: "bottom",
 				    scroll:true,

--- a/modules/Emails/javascript/complexLayout.js
+++ b/modules/Emails/javascript/complexLayout.js
@@ -49,18 +49,18 @@ function complexLayoutInit() {
 	    		border:true,
 	            hideOnLayout: true,
 	            height: 400,
-				units: [{
-					position: "top",
-          	height:'64',
-				    scroll:false,
-				    split:true,
-				    body: "<div id='dt-pag-nav'></div> "
-				},{
-					position: "center",
-				    scroll:false, // grid should autoScroll itself
-				    split:true,
-				    body: "<div id='emailGrid'></div>"
-				},{
+            units: [{
+              position: "top",
+              height: '64',
+              scroll: false,
+              split: true,
+              body: "<div id='dt-pag-nav'></div> "
+            }, {
+              position: "center",
+              scroll: false, // grid should autoScroll itself
+              split: true,
+              body: "<div id='emailGrid'></div>"
+            }, {
 					position: "bottom",
 				    scroll:true,
 				    collapse: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Extracts the navigation buttons for the email list into the top unit of the yui layout, as it was sharing the center one and not being visible when the list contained many emals.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #4621 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to the email module
2. Open a folder that contains more than one page of emails

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->