### PR TITLE
Fix #3626 Decode from address names with special characters

### DIFF
--- a/modules/Emails/include/ListView/ListViewDataEmails.php
+++ b/modules/Emails/include/ListView/ListViewDataEmails.php
@@ -501,7 +501,7 @@ class ListViewDataEmails extends ListViewData
 
         switch ($field) {
             case 'from_addr_name':
-                $ret = $emailHeader['from'];
+                $ret = html_entity_decode($inboundEmail->handleMimeHeaderDecode($emailHeader['from']));
                 break;
             case 'to_addrs_names':
                 $ret = mb_decode_mimeheader($emailHeader['to']);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Solution proposed by @likhobory 
Properly decodes special characters in email from addresses.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #3626 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->