### PR TITLE
Fix #4984 Make my pipeline dashlet not use labels for drilling down URL

### DIFF
--- a/include/SuiteGraphs/RGraphIncludes.php
+++ b/include/SuiteGraphs/RGraphIncludes.php
@@ -75,7 +75,6 @@ $chart = <<<EOD
                 &&  bar['object']['properties']['chart.tooltips']!== undefined
                 &&  bar['object']['properties']['chart.tooltips'][bar[5]] !== undefined)
                 {
-                    var stage = encodeURI(bar['object']['properties']['chart.labels'][bar[5]]);
                     var graphId = bar[0]['id'];
                     var divHolder = $("#"+graphId).parent();
                     var module = $(divHolder).find(".module").val();
@@ -85,6 +84,10 @@ $chart = <<<EOD
                     var userId = $(divHolder).find(".userId").val();
                     var startDate = encodeURI($(divHolder).find(".startDate").val());
                     var endDate = encodeURI($(divHolder).find(".endDate").val());
+                    
+                    var keys = window["chartHBarKeys"+graphId];
+                    var stage = encodeURI(keys[bar[5]]);
+                    
                     window.open('index.php?module='+module+'&action='+action+'&query='+query+'&searchFormTab='+searchFormTab+'&assigned_user_id[]='+userId+'&date_closed_advanced_range_choice=between&start_range_date_closed_advanced='+startDate+'&end_range_date_closed_advanced='+endDate+'&sales_stage_advanced[]='+stage,'_self');
                 }
             }

--- a/modules/Charts/Dashlets/MyPipelineBySalesStageDashlet/MyPipelineBySalesStageDashlet.php
+++ b/modules/Charts/Dashlets/MyPipelineBySalesStageDashlet/MyPipelineBySalesStageDashlet.php
@@ -121,7 +121,7 @@ class MyPipelineBySalesStageDashlet extends DashletGenericChart
         $subtitle = translate('LBL_OPP_SIZE', 'Charts') . " " . $currency_symbol . "1" . translate('LBL_OPP_THOUSANDS', 'Charts');
 
         $query = $this->constructQuery();
-        $data = $this->constructCEChartData($this->getChartData($query));
+        $data = $this->getChartData($query);
 
         $chartReadyData = $this->prepareChartData($data, $currency_symbol, $thousands_symbol);
 
@@ -163,6 +163,7 @@ class MyPipelineBySalesStageDashlet extends DashletGenericChart
         <input type='hidden' class='endDate' value='$endDate' />
              $autoRefresh
          <script>
+        window["chartHBarKeys$canvasId"] = $jsonKey;
            var hbar = new RGraph.HBar({
             id: '$canvasId',
             data:$jsonData,
@@ -362,21 +363,6 @@ EOD;
     }
 
     /**
-     * @param  $dataset array
-     * @return array
-     */
-    private function constructCEChartData(
-        $dataset
-    )
-    {
-        $newData = array();
-        foreach($dataset as $key=>$value){
-            $newData[$value['sales_stage']] = $value['total'];
-        }
-        return $newData;
-    }
-
-    /**
      * @see DashletGenericChart::constructQuery()
      */
     protected function constructQuery()
@@ -409,7 +395,7 @@ EOD;
         return $groupBy;
     }
 
-    protected function prepareChartData($data,$currency_symbol, $thousands_symbol)
+    protected function prepareChartData($dataset,$currency_symbol, $thousands_symbol)
     {
         //Use the  lead_source to categorise the data for the charts
         $chart['labels'] = array();
@@ -419,13 +405,15 @@ EOD;
         $chart['tooltips']= array();
         $chart['total'] = 0;
 
-        foreach($data as $key=>$value)
+        foreach($dataset as $data)
         {
-            $formattedFloat = (float)number_format((float)$value, 2, '.', '');
-            $chart['labels'][] = $key;
+            $formattedFloat = (float)number_format((float)$data['total'], 2, '.', '');
+            $chart['labels'][] = $data['sales_stage'];
+            $chart['key'][] = $data['key'];
             $chart['data'][] = $formattedFloat;
             $chart['total']+=$formattedFloat;
-            $chart['tooltips'][] = "'$key' amounts to $currency_symbol$formattedFloat$thousands_symbol (click bar to drill-through)";
+            $chart['tooltips'][] = "'" . $data['sales_stage']
+                . "' amounts to $currency_symbol$formattedFloat$thousands_symbol (click bar to drill-through)";
         }
         return $chart;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Makes the URL for drilldown filtering use the item name instead of the label.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #4984 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->