### PR TITLE
Fix missing labels in the calendar dashlet.

### DIFF
--- a/modules/Calendar/Dashlets/CalendarDashlet/CalendarDashlet.php
+++ b/modules/Calendar/Dashlets/CalendarDashlet/CalendarDashlet.php
@@ -48,7 +48,7 @@ class CalendarDashlet extends Dashlet {
     function CalendarDashlet($id, $def) {
         $this->loadLanguage('CalendarDashlet','modules/Calendar/Dashlets/');
 
-		parent::Dashlet($id); 
+		parent::Dashlet($id);
          
 		$this->isConfigurable = true; 
 		$this->hasScript = true;  
@@ -106,7 +106,12 @@ class CalendarDashlet extends Dashlet {
     function displayOptions() {
         global $app_strings,$mod_strings;        
         $ss = new Sugar_Smarty();
-        $ss->assign('MOD', $this->dashletStrings);        
+        $ss->assign('titleLbl', $this->dashletStrings['LBL_CONFIGURE_TITLE']);
+        $ss->assign('saveLbl', $app_strings['LBL_SAVE_BUTTON_LABEL']);
+        $ss->assign('configureView', $this->dashletStrings['LBL_CONFIGURE_VIEW']);
+        $ss->assign('viewDay', $this->dashletStrings['LBL_VIEW_DAY']);
+        $ss->assign('viewWeek', $this->dashletStrings['LBL_VIEW_WEEK']);
+        $ss->assign('MOD', $this->dashletStrings);
         $ss->assign('title', $this->title);
         $ss->assign('view', $this->view);
         $ss->assign('id', $this->id);

--- a/modules/Calendar/Dashlets/CalendarDashlet/CalendarDashletOptions.tpl
+++ b/modules/Calendar/Dashlets/CalendarDashlet/CalendarDashletOptions.tpl
@@ -51,23 +51,23 @@
 <input type='hidden' name='configure' value='true'>
 <table width="400" cellpadding="0" cellspacing="0" border="0" class="edit view" align="center">
 <tr>
-    <td valign='top' nowrap class='dataLabel'>{$MOD.LBL_CONFIGURE_TITLE}</td>
+    <td valign='top' nowrap class='dataLabel'>{$titleLbl}</td>
     <td valign='top' class='dataField'>
     <input type="text" class="text" name="title" size='20' value='{$title}'>
     </td>
 </tr>
 <tr>
-    <td valign='top' nowrap class='dataLabel'>{$MOD.LBL_CONFIGURE_VIEW}</td>
+    <td valign='top' nowrap class='dataLabel'>{$configureView}</td>
     <td valign='top' class='dataField'>
     <select name="view">
-    		<option value="agendaDay" {if $view == "agendaDay"} selected {/if}>{$MOD.LBL_VIEW_DAY}</option>
-    		<option value="agendaWeek" {if $view == "agendaWeek"} selected {/if}>{$MOD.LBL_VIEW_WEEK}</option>
+    		<option value="agendaDay" {if $view == "agendaDay"} selected {/if}>{$viewDay}</option>
+    		<option value="agendaWeek" {if $view == "agendaWeek"} selected {/if}>{$viewWeek}</option>
     </select>
     </td>
 </tr>
 <tr>
     <td align="right" colspan="2">
-        <input type='submit' class='button' value='{$MOD.LBL_SAVE_BUTTON_LABEL}'>
+        <input type='submit' class='button' value='{$saveLbl}'>
    	</td>
 </tr>
 </table>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The calendar dhashlet was missing all of the labels related to this view.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
The changes allow for all of the strings within the calendar dashlet to be visible.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1) Add the calendar dashlet to a tab
2) Click the edit icon 
3) View the correctly applied labels.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->