### PR TITLE
Fix default color scheme

### DIFF
--- a/themes/SuiteP/themedef.php
+++ b/themes/SuiteP/themedef.php
@@ -78,5 +78,5 @@ if(!empty($app_strings['LBL_SUBTHEMES'])) {
             'Night' => $app_strings['LBL_SUBTHEME_OPTIONS_NIGHT'],
         ),
     );
-    $themedef['config_options']['sub_themes']['default'] = $app_strings['LBL_SUBTHEME_OPTIONS_DAWN'];
+    $themedef['config_options']['sub_themes']['default'] = 'Dawn';
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Relation to https://suitecrm.com/suitecrm/forum/feedback/17448-suitecrm-7-10rc-no-theme-when-i-switched-the-default-language

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This change corrects the default theme.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Fixes a bug in the new color scheme logic.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
- Install a language pack
- Goto admin
- goto locale
- change language.
- log out

You should still be able to see the theme colors.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->