### PR TITLE
Fixed #1406 - Module install error on filesystems which do not suppor…

### DIFF
--- a/include/utils/sugar_file_utils.php
+++ b/include/utils/sugar_file_utils.php
@@ -77,7 +77,7 @@ function sugar_mkdir($pathname, $mode = null, $recursive = false, $context = nul
     }
 
     if ($result) {
-        if (!sugar_chmod($pathname, $mode)) {
+        if (!sugar_chmod($pathname, $mode)  && !is_writable($pathname)) {
             return false;
         }
         if (!empty($GLOBALS['sugar_config']['default_permissions']['user'])) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

Issue - #1406
Pull request - old #1407

When you are on an hybrid filesystem, for instance, a Windows NTFS mounted on a Linux host, your filesystem may not be chmoddable, but the folder may be still writable. The result with the known error message while trying to install a module:

Specified directory '' for zip file 'file.zip' extraction does not exist.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

To prevent the above error message. 
## How To Test This
<!--- Please describe in detail how to test your changes. -->

Test on a  Windows NTFS mounted on a Linux host, your filesystem is likely  not  chmoddable, but the folder may be still writable. The result with the known error message while trying to install a module

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->