### PR TITLE
Fix missing labels for the directions of the filter

### DIFF
--- a/include/SugarObjects/templates/basic/language/en_us.lang.php
+++ b/include/SugarObjects/templates/basic/language/en_us.lang.php
@@ -58,6 +58,8 @@ $mod_strings = array(
     'LBL_EDIT_BUTTON' => 'Edit',
     'LBL_REMOVE' => 'Remove',
 
+    'LBL_ASCENDING' => 'Ascending',
+    'LBL_DESCENDING' => 'Descending',
     // Emails
     'LBL_OPT_IN' => 'Opt In',
     'LBL_OPT_IN_PENDING_EMAIL_NOT_SENT' => 'Pending Confirm opt in, Confirm opt in not sent',

--- a/themes/SuiteP/modules/SavedSearch/SavedSearchForm.tpl
+++ b/themes/SuiteP/modules/SavedSearch/SavedSearchForm.tpl
@@ -63,12 +63,12 @@
             <div><input id='sort_order_desc_radio' type='radio' name='sortOrder' value='DESC'
                         {if $selectedSortOrder == 'DESC'}checked{/if}>&nbsp;<span
                         onclick='document.getElementById("sort_order_desc_radio").checked = true'
-                        style="cursor: pointer; cursor: hand">{$MOD.LBL_DESCENDING}</span></div>
+                        style="cursor: pointer; cursor: hand" ><label>{sugar_translate label='LBL_DESCENDING' module='SavedSearch'}</label></span></div>
 
             <div><input id='sort_order_asc_radio' type='radio' name='sortOrder' value='ASC'
                         {if $selectedSortOrder == 'ASC'}checked{/if}>&nbsp;<span
                         onclick='document.getElementById("sort_order_asc_radio").checked = true'
-                        style="cursor: pointer; cursor: hand">{$MOD.LBL_ASCENDING}</span>
+                        style="cursor: pointer; cursor: hand"><label>{sugar_translate label='LBL_ASCENDING' module='SavedSearch'}</label></span>
             </div>
         </div>
     </div>

--- a/themes/SuiteP/modules/SavedSearch/SavedSearchForm.tpl
+++ b/themes/SuiteP/modules/SavedSearch/SavedSearchForm.tpl
@@ -63,12 +63,12 @@
             <div><input id='sort_order_desc_radio' type='radio' name='sortOrder' value='DESC'
                         {if $selectedSortOrder == 'DESC'}checked{/if}>&nbsp;<span
                         onclick='document.getElementById("sort_order_desc_radio").checked = true'
-                        style="cursor: pointer; cursor: hand" ><label>{sugar_translate label='LBL_DESCENDING' module='SavedSearch'}</label></span></div>
+                        style="cursor: pointer; cursor: hand">{$MOD.LBL_DESCENDING}</span></div>
 
             <div><input id='sort_order_asc_radio' type='radio' name='sortOrder' value='ASC'
                         {if $selectedSortOrder == 'ASC'}checked{/if}>&nbsp;<span
                         onclick='document.getElementById("sort_order_asc_radio").checked = true'
-                        style="cursor: pointer; cursor: hand"><label>{sugar_translate label='LBL_ASCENDING' module='SavedSearch'}</label></span>
+                        style="cursor: pointer; cursor: hand">{$MOD.LBL_ASCENDING}</span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The direction option was missing corresponding labels which made it unclear which option had a certain impact on the filter.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This fix allows the lables to be displayed so the user can see how the results will be ordered.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1) Navigate to one of the modules (e.g. Emails)
2) Select view on the side navigation
3) Select advanced filter options
4) View the directions radio buttons at the bottom of the page

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->