### PR TITLE
Fix Issue #576

### DIFF
--- a/modules/AOP_Case_Updates/CaseUpdatesHook.php
+++ b/modules/AOP_Case_Updates/CaseUpdatesHook.php
@@ -376,7 +376,7 @@ class CaseUpdatesHook
         $aop_config = $this->getAOPConfig();
         $emailTemplate->retrieve($aop_config['case_closure_email_template_id']);
 
-        if (!$emailTemplate) {
+        if (!$emailTemplate->id) {
             $GLOBALS['log']->warn('CaseUpdatesHook: sendClosureEmail template is empty');
 
             return false;
@@ -525,7 +525,7 @@ class CaseUpdatesHook
 
         $aop_config = $this->getAOPConfig();
         $emailTemplate->retrieve($aop_config['case_creation_email_template_id']);
-        if (!$emailTemplate || !$aop_config['case_creation_email_template_id']) {
+        if (!$emailTemplate->id || !$aop_config['case_creation_email_template_id']) {
             $GLOBALS['log']->warn('CaseUpdatesHook: sendCreationEmail template is empty');
 
             return false;
@@ -620,7 +620,7 @@ class CaseUpdatesHook
                 $email_template = $email_template->retrieve($aop_config['contact_email_template_id']);
                 $signature = $current_user->getDefaultSignature();
             }
-            if ($email_template) {
+            if ($email_template->id) {
                 foreach ($caseUpdate->getContacts() as $contact) {
                     $GLOBALS['log']->info('AOPCaseUpdates: Calling send email');
                     $emails = array();

--- a/modules/AOP_Case_Updates/CaseUpdatesHook.php
+++ b/modules/AOP_Case_Updates/CaseUpdatesHook.php
@@ -525,7 +525,7 @@ class CaseUpdatesHook
 
         $aop_config = $this->getAOPConfig();
         $emailTemplate->retrieve($aop_config['case_creation_email_template_id']);
-        if (!$emailTemplate->id || !$aop_config['case_creation_email_template_id']) {
+        if (!$emailTemplate->id) {
             $GLOBALS['log']->warn('CaseUpdatesHook: sendCreationEmail template is empty');
 
             return false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixed by updating conditional statements to validate against email template id rather than the email template object which will always return true whether or not the template is set. Appears creation update had been fixed previously by validating the config value for the template but still saw fit to update the email template object validation to use the id as it was still present in the condition and removed the config value as it was unnecessary. Emails should no longer be sent when there is no template set in AOP settings.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
AOP emails empty messages when cases are updated and no templates are selected.
Also occurs on case closure and was reported to occur on case creation but had been fixed in that case.
Issue #576 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Ensure you have Outbound Email configured with an smtp account or mailcatcher.
2. Configure AOP settings and set the email templates to 'None' on Case Creation, Update and Closure.
3. Create a Case with a related Contact, Update an existing Case ensuring it has a related Contact and Close and existing Case.
4. Emails should not be sent for each event if there is no template set. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->