### PR TITLE
Fix help popup in security groups manager view.

### DIFF
--- a/themes/SuiteP/css/suitep-base/editview.scss
+++ b/themes/SuiteP/css/suitep-base/editview.scss
@@ -4131,7 +4131,7 @@ hr {
 
 /* fix schedule bar popup on calendar */
 .ui-dialog {
-  z-index: 1100;
+  z-index: 16000;
 }
 
 @media (max-width: 768px) {

--- a/themes/SuiteP/css/suitep-base/editview.scss
+++ b/themes/SuiteP/css/suitep-base/editview.scss
@@ -3186,7 +3186,7 @@ table#lineItems tr td table tfoot tr td span {
 }
 
 .modal {
-  z-index: 16000;
+  z-index: 1100;
 }
 
 .detail-view-row .label.col-2-label {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
In the Security Groups Management, the filter options has a '?' logo that can be clicked to provide the user with some hints and information. Currently the popup is displayed behind the original box.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1) Navigate to the Security Groups Management
2) Select Filter
3) Under the Advanced Filter tab, click on the '?' icon
4) View the popup as the front window

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->