### PR TITLE
Fix Issue #2307

### DIFF
--- a/include/MVC/View/SugarView.php
+++ b/include/MVC/View/SugarView.php
@@ -631,6 +631,9 @@ class SugarView
                     }
                     if (!empty($moduleTab)) {
                         $topTabs[$moduleTab] = $app_list_strings['moduleList'][$moduleTab];
+                        if (count($topTabs) >= $max_tabs - 1) {
+                            $extraTabs[$moduleTab] = $app_list_strings['moduleList'][$moduleTab];
+                        }
                     }
                 }
 
@@ -641,6 +644,12 @@ class SugarView
 
                 $groupTabs[$tabIdx]['modules'] = $topTabs;
                 $groupTabs[$tabIdx]['extra'] = $extraTabs;
+            }
+        }
+
+        foreach($groupTabs as $key => $tabGroup) {
+            if (count($topTabs) >= $max_tabs - 1 && $key !== 'All' && in_array($tabGroup['modules'][$moduleTab], $tabGroup['extra'])) {
+                unset($groupTabs[$key]['modules'][$moduleTab]);
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Ensure the current active module link is displayed at the bottom of any tab group list even when the module list is greater than the max tabs limit.

As the module list is split into two arrays one for the main module list and one for an extra list which gets pushed to the groupTabs array after the main list in which the active module is contained. Added a condition to check if the list is greater than the max tab limit and if so also push the active module to the extra list also.

To ensure the shortcut tab group is still built correctly for the active module, rather than unsetting the current active tab at this point or simply not pushing it into the main list, it is unset after the array used for the shortcut tab functionality is built by looping through the groupTabs array and checking that the tablist is greater than the tab limit, not in the All tab group and present in both the main and extra list arrays.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The max tab limit by default is 10 and this gets set in users' preferences if they do not already have a limit set or if the limit they have set is less than or equal to 0 or greater than 10.

When a group tab list contains more tabs than the max tab limit set by either user preferences and/or the default value in config.php the current active module is not displayed at the bottom of the tab list. Any additional modules after the limit is reached get appended to the bottom of the list as referenced is issue #2307. 

## How To Test This
<!--- Please describe in detail how to test your changes. --> 
1. Navigate to Admin Console and Configure Module Menu Filters.
2. If the max tab limit is 10 as is default, fill up a menu filter list with a number of modules greater than 10 such as the Support filter. 
3. Navigate to a module that is not contained in the list.
4. The current module should now display at the bottom of the support list.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->