### PR TITLE
Typo in variable name dublicate -> duplicate, would break

### DIFF
--- a/modules/Leads/views/view.showduplicates.php
+++ b/modules/Leads/views/view.showduplicates.php
@@ -88,7 +88,7 @@ class ViewShowDuplicates extends SugarView
                     $query .= ' OR ';
                 }
                 $first = false;
-                $duplicateIdQuoted = $db->quote($dublicate_id);
+                $duplicateIdQuoted = $db->quote($duplicate_id);
                 $query .= "id='$duplicateIdQuoted' ";
             }
             $query .= ')';


### PR DESCRIPTION
Breaking because the variable name used does not exist, as it is spelled correctly on definition.
Effects 7.8.11, 7.9.x and 7.10