### PR TITLE
Fixed #4470 - Account address copy feature breaks if address contains…

### DIFF
--- a/modules/Accounts/views/view.detail.php
+++ b/modules/Accounts/views/view.detail.php
@@ -79,26 +79,10 @@ class AccountsViewDetail extends ViewDetail {
 		formLetter::DVPopupHtml('Accounts');
 
 		$this->dv->process();
-		global $mod_strings;
+		
 		if(ACLController::checkAccess('Contacts', 'edit', true)) {
-			$push_billing = '<input class="button" title="' . $mod_strings['LBL_PUSH_CONTACTS_BUTTON_LABEL'] .
-								 '" type="button" onclick=\'open_contact_popup("Contacts", 600, 600, "&account_name=' .
-								 $this->bean->name . '&html=change_address' .
-								 '&primary_address_street=' . str_replace(array("\rn", "\r", "\n"), array('','','<br>'), urlencode($this->bean->billing_address_street)) .
-								 '&primary_address_city=' . $this->bean->billing_address_city .
-								 '&primary_address_state=' . $this->bean->billing_address_state .
-								 '&primary_address_postalcode=' . $this->bean->billing_address_postalcode .
-								 '&primary_address_country=' . $this->bean->billing_address_country .
-								 '", true, false);\' value="' . $mod_strings['LBL_PUSH_CONTACTS_BUTTON_TITLE']. '">';
-			$push_shipping = '<input class="button" title="' . $mod_strings['LBL_PUSH_CONTACTS_BUTTON_LABEL'] .
-								 '" type="button" onclick=\'open_contact_popup("Contacts", 600, 600, "&account_name=' .
-								 $this->bean->name . '&html=change_address' .
-								 '&primary_address_street=' . str_replace(array("\rn", "\r", "\n"), array('','','<br>'), urlencode($this->bean->shipping_address_street)) .
-								 '&primary_address_city=' . $this->bean->shipping_address_city .
-								 '&primary_address_state=' . $this->bean->shipping_address_state .
-								 '&primary_address_postalcode=' . $this->bean->shipping_address_postalcode .
-								 '&primary_address_country=' . $this->bean->shipping_address_country .
-								 '", true, false);\' value="' . $mod_strings['LBL_PUSH_CONTACTS_BUTTON_TITLE'] . '">';
+			$push_billing = $this->generatePushCode('billing');
+			$push_shipping = $this->generatePushCode('shipping');
 		} else {
 			$push_billing = '';
 			$push_shipping = '';
@@ -113,6 +97,24 @@ class AccountsViewDetail extends ViewDetail {
 		}
 		echo $this->dv->display();
  	}
+
+	function generatePushCode($param)
+	{
+	    global $mod_strings;
+	    $address_fields = array('street', 'city', 'state', 'postalcode','country');
+
+	    $html = '<input class="button" title="' . $mod_strings['LBL_PUSH_CONTACTS_BUTTON_LABEL'] .
+		     '" type="button" onclick=\'open_contact_popup("Contacts", 600, 600, "&account_name=' .
+		     $this->bean->name . '&html=change_address';
+
+	    foreach ($address_fields as $value) {
+	    	$field_name = $param.'_address_'.$value;
+	    	$html .= '&primary_address_'.$value.'='.str_replace(array("\rn", "\r", "\n"), array('','','<br>'), urlencode($this->bean->$field_name)) ;
+	    }
+
+	    $html .= '", true, false);\' value="' . $mod_strings['LBL_PUSH_CONTACTS_BUTTON_TITLE']. '">';
+	    return $html;
+	}
 }
 
 ?>


### PR DESCRIPTION
#4470 Issue was, if an account address contains HTML entities, the 'Copy' button on the details view fails to work.

So, to solve this issue, have encoded all address fields of account module.
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I have url encoded all address fields of account module using `urlencode` function. Also, introduced a new function which does all url encoding for all address fields of account module and returns exact output.

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

**Steps to Reproduce**

1. Create an Address
2. Enter King's Lynn Café "> in to each line of the address
3. Save
4. Click 'Copy' in the address field

<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change makes sure that if HTML entities are used in any address fields of Account module, *Copy* button will work with no issues.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Create an Address
2. Enter King's Lynn Café "> in to each line of the address
3. Save
4. Click 'Copy' in the address field

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->