### PR TITLE
Fixed #5027 - Subpanels on legacy themes not showing data on expansion

### DIFF
--- a/include/SubPanel/SubPanelTiles.php
+++ b/include/SubPanel/SubPanelTiles.php
@@ -344,7 +344,7 @@ class SubPanelTiles
                 $tabs_properties[$t]['show_icon_html'] = $show_icon_html;
                 $tabs_properties[$t]['hide_icon_html'] = $hide_icon_html;
 
-                $max_min = "<a name=\"$tab\"> </a><span id=\"show_link_".$tab."\" style=\"display: $opp_display\"><a href='#' class='utilsLink' onclick=\"current_child_field = '".$tab."';showSubPanel('".$tab."',null,null,'".$layout_def_key."');document.getElementById('show_link_".$tab."').style.display='none';document.getElementById('hide_link_".$tab."').style.display='';return false;\">"
+                $max_min = "<a name=\"$tab\"> </a><span id=\"show_link_".$tab."\" style=\"display: $opp_display\"><a href='#' class='utilsLink' onclick=\"current_child_field = '".$tab."';showSubPanel('".$tab."',null,true,'".$layout_def_key."');document.getElementById('show_link_".$tab."').style.display='none';document.getElementById('hide_link_".$tab."').style.display='';return false;\">"
                     . "" . $show_icon_html . "</a></span>";
                 $max_min .= "<span id=\"hide_link_".$tab."\" style=\"display: $div_display\"><a href='#' class='utilsLink' onclick=\"hideSubPanel('".$tab."');document.getElementById('hide_link_".$tab."').style.display='none';document.getElementById('show_link_".$tab."').style.display='';return false;\">"
                     . "" . $hide_icon_html . "</a></span>";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Collapsed subpanels on legacy themes weren't loading on expansion
#5027

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
Change theme to Suite7 or SuiteR
Enable Collapsed subpanels under system settings 
Expand a subpanel and see if it loads.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->