### PR TITLE
Fixed #1288 - Marker legend overlap Toggle Clustering button

### DIFF
--- a/modules/jjwg_Maps/views/view.map_markers.php
+++ b/modules/jjwg_Maps/views/view.map_markers.php
@@ -61,7 +61,7 @@ class Jjwg_MapsViewMap_Markers extends SugarView {
       width: 140px;
       min-width: 140px;
       overflow-x: auto;
-      max-height: 440px;
+      max-height: 320px;
       overflow-y: auto;
       white-space: nowrap;
       font-size: 12px;
@@ -195,7 +195,7 @@ var markerClusterer = null;
 var markerClustererToggle = null;
 var clusterControlDiv = null;
 // Clusterer Images - Protocol Independent
-MarkerClusterer.IMAGE_PATH = "//google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclustererplus/images/m";
+MarkerClusterer.IMAGE_PATH = "https://cdn.rawgit.com/googlemaps/js-marker-clusterer/gh-pages/images/m";
 
 // Drawing Controls
 var drawingManager = null;


### PR DESCRIPTION
## Description
Decrease the Max-height value on the "Legend" on maps, uncovering the "Toggle Clustering Button", and preventing the "Legend" from being pushed off the top of Maps.
Additionally, updated the source for the Cluster icons, so they should now appear.
 
Related to issue #1288

(Alternatively, It seems there is a previous PR regarding clustering images, which may be a more preferred solution to this issue as it adds the images to the repo?: #1777 )

## Motivation and Context
The change corrects the source, so cluster icons now appear.  It also clears up the map view allowing for the user to see the entire Legend, and to toggle clustering.

## How To Test This
Create a Map via "Quick Radius Map" or "Add New Maps" on the Maps module 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->