### PR TITLE
Fixed #2341 - In Campaign view status page, row out of box

### DIFF
--- a/modules/Campaigns/TrackDetailView.tpl
+++ b/modules/Campaigns/TrackDetailView.tpl
@@ -83,14 +83,8 @@
 	</tr><tr>
 	<td width="20%" scope="row"><slot>{$MOD.LBL_CAMPAIGN_STATUS}</slot></td>
 	<td width="30%"><slot>{$STATUS}</slot></td>
-<!-- BEGIN: pro -->
 	<td width="20%" scope="row"><slot>{$MOD.LBL_TEAM}</slot></td>
 	<td width="30%"><slot>{$TEAM_NAME}</slot></td>
-<!-- END: pro -->
-<!-- BEGIN: open_source -->
-	<td width="20%" scope="row"><slot>&nbsp;</slot></td>
-	<td width="30%"><slot>&nbsp;</slot></td>
-<!-- END: open_source -->
 	</tr><tr>
 	<td width="20%" scope="row"><slot>{$MOD.LBL_CAMPAIGN_START_DATE}</slot></td>
 	<td width="30%"><slot>{$START_DATE}</slot></td>


### PR DESCRIPTION
## Description
Change is the same as PR #2345
However, this one is pointed to the correct hotfix branch, whereas the previous PR is not.

Related to issue #2341

## Motivation and Context
Change improves the appearance of Campaign -> View Status on all Themes

## How To Test This
Create a Campaign, and click "View Status"

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->