### PR TITLE
Use getter to access protected field

### DIFF
--- a/modules/ModuleBuilder/parsers/views/DashletMetaDataParser.php
+++ b/modules/ModuleBuilder/parsers/views/DashletMetaDataParser.php
@@ -190,7 +190,7 @@ class DashletMetaDataParser extends ListLayoutMetaDataParser
             $writeTodashletName = $dashletName = $this->implementation->module->key_name . 'Dashlet';
         }
 
-        $this->implementation->_history->append($file);
+        $this->implementation->getHistory()->append($file);
         if ($populate) {
             $this->_populateFromRequest();
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes an error when saving the dashlet layout in Studio.

PHP Fatal error:  Uncaught Error: Cannot access protected property DeployedMetaDataImplementation::$_history

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
See [this forum post](https://suitecrm.com/suitecrm/forum/suitecrm-beta/17411-change-dashlet-error)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->