### PR TITLE
Fixed #2640 - Suite 7 Theme Custom Header Color

### DIFF
--- a/themes/Suite7/css/colourSelector.php
+++ b/themes/Suite7/css/colourSelector.php
@@ -19,7 +19,7 @@ header("Content-type: text/css; charset: UTF-8");
 
 /*custom colour css*/
 
-#header {
+header {
     background: #<?php echo $sugar_config['theme_settings']['Suite7']['menu']; ?>;
     background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iIzMzMzMzMyIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiMxMjEyMTIiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
     background: -moz-linear-gradient(top,  #<?php echo $sugar_config['theme_settings']['Suite7']['menuto']; ?> 0%, #<?php echo $sugar_config['theme_settings']['Suite7']['menufrom']; ?> 100%); /* FF3.6+ */


### PR DESCRIPTION
## Description

The change is the same as the 2nd commit found on the PR #2641
However, this PR has an unrelated commit associated with it.
So, this PR is created to merge in the correct change, to the correct branch, with ease.

This change corrects colorSelector.php to look for the \<header> tag, rather than an element with id "header"
Related to issue #2640

## Motivation and Context
Allows users to change the top menu's colours on Suite7 theme.

## How To Test This
Navigate to the Admin Panel -> Themes
Enter into the Colour Picker for the Suite7 theme
Change the colours for the top menu

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->