### PR TITLE
Fix #5095 Pass parameter that gets modified by reference

### DIFF
--- a/modules/DynamicFields/DynamicField.php
+++ b/modules/DynamicFields/DynamicField.php
@@ -312,7 +312,7 @@ class DynamicField
      *
      * @return array select=>select columns, join=>prebuilt join statement
      */
-    public function getJOIN($expandedList = false, $includeRelates = false, $where = false)
+    public function getJOIN($expandedList = false, $includeRelates = false, &$where = false)
     {
         if (!$this->bean->hasCustomFields()) {
             return array(
@@ -346,7 +346,7 @@ class DynamicField
                     $relateJoinInfo = $this->getRelateJoin($field, $jtAlias . $jtCount);
                     $select .= $relateJoinInfo['select'];
                     $join .= $relateJoinInfo['from'];
-                    //bug 27654 martin
+
                     if ($where) {
                         $pattern = '/' . $field['name'] . '\slike/i';
                         $replacement = $relateJoinInfo['name_field'] . ' like';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A parameter that was being modified inside a function was being passed by value, and therefore the modification lost.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #5095 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create a custom relate field on Contacts
2. Set a filter based on the value. Subpanel shows filtered results.
3. Select a few records
4. Click Bulk Action/Export
5. Observe there is no error in the log

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->