### PR TITLE
Remove linebreak from html string

### DIFF
--- a/modules/Emails/EmailUI.php
+++ b/modules/Emails/EmailUI.php
@@ -430,8 +430,8 @@ eoq;
 
         foreach ($emailFields as $emailField) {
             if (!empty($composeData)) {
-                $emailLink = '<a href="javascript:void(0);"  onclick=" $(document).openComposeViewModal(this);" 
-                    data-module="' . $composeData['parent_type'] . '" ' . 'data-record-id="' .
+                $emailLink = '<a href="javascript:void(0);"  onclick=" $(document).openComposeViewModal(this);" ' .
+                    'data-module="' . $composeData['parent_type'] . '" ' . 'data-record-id="' .
                     $composeData['parent_id'] . '" data-module-name="' . $composeData['parent_name'] .
                     '"  data-email-address="' . $composeData['to_addrs'] . '">';
             } elseif (is_object($myBean) && (property_exists($myBean, $emailField))) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed a stray linebreak in an html string which was causing line editing to fail.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
After inline editing the email would show a garbage html value. The new value would be saved correctly but not displayed right.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Steps to reproduce:
- Enter accounts module list-view
- Inline edit an email address

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->