### PR TITLE
Fix #4197 Make listview remember advanced search parameters when changing columns

### DIFF
--- a/include/ListView/ListViewColumnsFilterDialog.tpl
+++ b/include/ListView/ListViewColumnsFilterDialog.tpl
@@ -187,6 +187,8 @@
                         displayColumns: cols.join('|'),
                         query: 'true',
                         use_stored_query: 'true',
+                        update_stored_query: 'true',
+                        update_stored_query_key: 'displayColumns',
                         last_search_tab: listViewSearchIcon.getLatestSearchDialogType(),
                         save_columns_order: 'true'
                     }, function () {

--- a/include/MVC/View/views/view.list.php
+++ b/include/MVC/View/views/view.list.php
@@ -148,6 +148,13 @@ class ViewList extends SugarView
         if (!isset($_REQUEST['query'])) {
             $this->storeQuery->loadQuery($this->module);
             $this->storeQuery->populateRequest();
+        } elseif (!empty($_REQUEST['update_stored_query'])) {
+            $updateKey = $_REQUEST['update_stored_query_key'];
+            $updateValue = $_REQUEST[$updateKey];
+            $this->storeQuery->loadQuery($this->module);
+            $this->storeQuery->populateRequest();
+            $_REQUEST[$updateKey] = $updateValue;
+            $this->storeQuery->saveFromRequest($this->module);
         } else {
             $this->storeQuery->saveFromRequest($this->module);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Solves the issue where listview filters disappear when displayed columns are changed.
Works only with advanced search.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Adds an extra flag to the request when changing columns, which then loads the stored query (instead of starting with a blank query), then adds the changed columns to the storedQuery object, and saves it back.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #4197 

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Accounts-Listview - do an advanced search
2. use "choose column" to add some columns in listview
3. see the filter is still applied and the columns have changed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->