### PR TITLE
Fix email address seed data for accounts

### DIFF
--- a/include/SugarEmailAddress/SugarEmailAddress.php
+++ b/include/SugarEmailAddress/SugarEmailAddress.php
@@ -98,8 +98,12 @@ class SugarEmailAddress extends SugarBean {
      */
     public function handleLegacySave($bean)
     {
-        if (!isset($_REQUEST) || !isset($_REQUEST[$bean->module_dir . '_email_widget_id'])) {
-            if (empty($this->addresses) || !isset($_REQUEST['massupdate'])) {
+        if (
+            !isset($_REQUEST)
+            || !isset($_REQUEST[$bean->module_dir . '_email_widget_id'])
+            || !isset($_REQUEST['massupdate'])
+        ) {
+            if (empty($this->addresses)) {
                 $this->addresses = array();
                 $optOut = (isset($bean->email_opt_out) && $bean->email_opt_out == '1');
                 $invalid = (isset($bean->invalid_email) && $bean->invalid_email == '1');
@@ -472,7 +476,10 @@ class SugarEmailAddress extends SugarBean {
             ($checknotify) is not implemented. Please pass the correct arguments into SugarEmailAddress::saveEmail()');
         }
 
-        if(empty($this->addresses) || $in_workflow) {
+        if(
+            empty($this->addresses)
+            || $in_workflow === true
+        ) {
             $this->populateAddresses($id, $module, $new_addrs, $primary);
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When user installs SuiteCRM with demo data, the email address in the account module appears to be missing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Fixes bug

## How To Test This
<!--- Please describe in detail how to test your changes. -->
- Install SuiteCRM with demo data
- Go to accounts

You Should be able to see the email addresses next the the demo accounts.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->