### PR TITLE
#4970 modules jjwg doesnt work

### DIFF
--- a/modules/jjwg_Areas/views/view.area_detail_map.php
+++ b/modules/jjwg_Areas/views/view.area_detail_map.php
@@ -60,7 +60,7 @@ class Jjwg_AreasViewArea_Detail_Map extends SugarView {
     }
   </style>
 
-  <script type="text/javascript" src="//maps.google.com/maps/api/js?sensor=false&libraries=drawing"></script>
+  <script type="text/javascript" src="//maps.google.com/maps/api/js?key=<?= $GLOBALS['jjwg_config']['google_maps_api_key']; ?>&sensor=false&libraries=drawing"></script>
 
   <script type="text/javascript">
 

--- a/modules/jjwg_Areas/views/view.area_edit_map.php
+++ b/modules/jjwg_Areas/views/view.area_edit_map.php
@@ -102,7 +102,7 @@ class Jjwg_AreasViewArea_Edit_Map extends SugarView {
     .error { background-color: #ffcdd1; border-top: 2px solid #e10c0c; border-bottom: 2px solid #e10c0c; }
   </style>
 
-  <script type="text/javascript" src="//maps.google.com/maps/api/js?sensor=false&libraries=drawing"></script>
+  <script type="text/javascript" src="//maps.google.com/maps/api/js?key=<?= $GLOBALS['jjwg_config']['google_maps_api_key']; ?>&sensor=false&libraries=drawing"></script>
   <script type="text/javascript" src="modules/jjwg_Areas/javascript/jquery-1.8.0.min.js"></script>
 
   <script type="text/javascript">

--- a/modules/jjwg_Markers/views/view.marker_detail_map.php
+++ b/modules/jjwg_Markers/views/view.marker_detail_map.php
@@ -62,7 +62,7 @@ class Jjwg_MarkersViewMarker_Detail_Map extends SugarView {
     }
   </style>
 
-  <script type="text/javascript" src="//maps.google.com/maps/api/js?sensor=false"></script>
+  <script type="text/javascript" src="//maps.google.com/maps/api/js?key=<?= $GLOBALS['jjwg_config']['google_maps_api_key']; ?>&sensor=false"></script>
 
   <script type="text/javascript">
 

--- a/modules/jjwg_Markers/views/view.marker_edit_map.php
+++ b/modules/jjwg_Markers/views/view.marker_edit_map.php
@@ -71,7 +71,7 @@ class Jjwg_MarkersViewMarker_Edit_Map extends SugarView {
     }
   </style>
 
-  <script type="text/javascript" src="//maps.google.com/maps/api/js?sensor=false"></script>
+  <script type="text/javascript" src="//maps.google.com/maps/api/js?key=<?= $GLOBALS['jjwg_config']['google_maps_api_key']; ?>&sensor=false"></script>
 
   <script type="text/javascript">
 


### PR DESCRIPTION
Fix #4970 Modules jjwg doesn't work


Add google api key to urls for maps in edit modes.

## Description
Added api key to url that pulls js from google maps

On add map area or map marker maps section displays an error stating api key not working

## Motivation and Context
It enables users to use google maps on adding map markers and map areas.

## How To Test This
Add map marker and map area after adding google api key in settings.
If map shows then it works

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->