### PR TITLE
Fix #4482 Do not base height on nonexisting nodes

### DIFF
--- a/modules/Emails/javascript/ajax.js
+++ b/modules/Emails/javascript/ajax.js
@@ -688,20 +688,13 @@ AjaxObject.detailView = {
 				shadow	: true
 			});
 
-            SED.quickCreateDialog.renderEvent.subscribe(function() {
-            	var viewH = YAHOO.util.Dom.getViewportHeight();
-            	var contH = 0;
-            	for (var i in this.body.childNodes) {
-            		if (this.body.childNodes[i].clientHeight) {
-            			contH += this.body.childNodes[i].clientHeight;
-            		} else if (this.body.childNodes[i].offsetHeight) {
-            			contH += this.body.childNodes[i].offsetHeight;
-            		} // if
-            	}
-        		this.body.style.width = "800px";
-        		this.body.style.height = (viewH - 75 > contH ? (contH + 10) : (viewH - 75)) + "px";
-        		this.body.style.overflow = "auto";
-            }, SED.quickCreateDialog);
+      SED.quickCreateDialog.renderEvent.subscribe(function () {
+        var viewH = YAHOO.util.Dom.getViewportHeight();
+        var contH = 500;
+        this.body.style.width = "800px";
+        this.body.style.height = (viewH - 75 > contH ? (contH + 10) : (viewH - 75)) + "px";
+        this.body.style.overflow = "auto";
+      }, SED.quickCreateDialog);
 
             SED.quickCreateDialog.hideEvent.subscribe(function(){
 				var qsFields = YAHOO.util.Dom.getElementsByClassName('.sqsEnabled', null, this.body);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Do not base the height of the quickcreate dialog on the nodes contained in the body because when cancelling and reopening it there are no nodes during the render and the dialog would have 0 height.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #4482

## How To Test This
<!--- Please describe in detail how to test your changes. -->
email list view
click or double-click on email
click Quick Create --> Lead
click cancel
repeat Quick Create --> Lead

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->