### PR TITLE
Fix/1976 dynamicenum import

### DIFF
--- a/modules/Import/Importer.php
+++ b/modules/Import/Importer.php
@@ -436,33 +436,30 @@ class Importer
 
     protected function sanitizeFieldValueByType($rowValue, $fieldDef, $defaultRowValue, $focus, $fieldTranslated)
     {
+        $fieldtype = $fieldDef['type'];
         global $mod_strings, $app_list_strings;
-        switch ($fieldDef['type'])
+        switch ($fieldtype)
         {
             case 'enum':
             case 'dynamicenum':
             case 'multienum':
-                if ( isset($fieldDef['type']) && $fieldDef['type'] == "multienum" )
-                    $returnValue = $this->ifs->multienum($rowValue,$fieldDef);
-                else
-                    $returnValue = $this->ifs->enum($rowValue,$fieldDef);
-                // try the default value on fail
-                if ( !$returnValue && !empty($defaultRowValue) )
-                {
-                    if ( isset($fieldDef['type']) && $fieldDef['type'] == "multienum" )
-                        $returnValue = $this->ifs->multienum($defaultRowValue,$fieldDef);
-                    else
-                        $returnValue = $this->ifs->enum($defaultRowValue,$fieldDef);
-                }
-                if ( $returnValue === FALSE )
-                {
-                    $this->importSource->writeError($mod_strings['LBL_ERROR_NOT_IN_ENUM'] . implode(",",$app_list_strings[$fieldDef['options']]), $fieldTranslated,$rowValue);
-                    return FALSE;
-                }
-                else
-                    return $returnValue;
+                $returnValue = $this->ifs->$fieldtype($rowValue, $fieldDef);
 
-                break;
+                // try the default value on fail
+                if (!$returnValue && !empty($defaultRowValue)) {
+                    $returnValue = $this->ifs->$fieldtype($defaultRowValue, $fieldDef);
+                }
+
+                if ($returnValue === false) {
+                    $this->importSource->writeError(
+                        $mod_strings['LBL_ERROR_NOT_IN_ENUM'] . implode(",", $app_list_strings[$fieldDef['options']]),
+                        $fieldTranslated,
+                        $rowValue
+                    );
+                    return false;
+                }
+                return $returnValue;
+
             case 'relate':
             case 'parent':
                 $returnValue = $this->ifs->relate($rowValue, $fieldDef, $focus, empty($defaultRowValue));
@@ -483,14 +480,13 @@ class Importer
                 return $rowValue;
                 break;
             default:
-                $fieldtype = $fieldDef['type'];
                 $returnValue = $this->ifs->$fieldtype($rowValue, $fieldDef, $focus);
                 // try the default value on fail
                 if ( !$returnValue && !empty($defaultRowValue) )
                     $returnValue = $this->ifs->$fieldtype($defaultRowValue,$fieldDef, $focus);
                 if ( !$returnValue )
                 {
-                    $this->importSource->writeError($mod_strings['LBL_ERROR_INVALID_'.strtoupper($fieldDef['type'])],$fieldTranslated,$rowValue,$focus);
+                    $this->importSource->writeError($mod_strings['LBL_ERROR_INVALID_'.strtoupper($fieldtype)],$fieldTranslated,$rowValue,$focus);
                     return FALSE;
                 }
                 return $returnValue;

--- a/modules/Import/Importer.php
+++ b/modules/Import/Importer.php
@@ -440,6 +440,7 @@ class Importer
         switch ($fieldDef['type'])
         {
             case 'enum':
+            case 'dynamicenum':
             case 'multienum':
                 if ( isset($fieldDef['type']) && $fieldDef['type'] == "multienum" )
                     $returnValue = $this->ifs->multienum($rowValue,$fieldDef);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A notice about a missing language string turned out to be a missing case for dynamicenum type on import.
Dynamic enums should be correctly imported now, and if the value is not in the list of accepted a proper message will be shown.

![screenshot from 2018-02-08 12-08-00](https://user-images.githubusercontent.com/34056696/35972318-3ca53dbc-0cc9-11e8-9d00-1f40f380ecff.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #1976 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Export a record with a dynamic dropdown field (Cases->Status)
Change the value of Status to a non accepted value
Attempt to import back in

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->