### PR TITLE
Fix #5025 Undefined when importing contacts

### DIFF
--- a/include/language/getJSLanguage.php
+++ b/include/language/getJSLanguage.php
@@ -69,13 +69,13 @@ function getJSLanguage()
 
         return;
     }
-    if (empty($_REQUEST['module']) || $_REQUEST['module'] === 'app_strings') {
+    if (empty($_REQUEST['modulename']) || $_REQUEST['modulename'] === 'app_strings') {
         $file = sugar_cached('jsLanguage/').$lang.'.js';
         if (!is_file($file)) {
             jsLanguage::createAppStringsCache($lang);
         }
     } else {
-        $module = clean_path($_REQUEST['module']);
+        $module = clean_path($_REQUEST['modulename']);
         $fullModuleList = array_merge($GLOBALS['moduleList'], $GLOBALS['modInvisList']);
         if (!isset($app_list_strings['moduleList'][$module]) && !in_array($module, $fullModuleList)) {
             echo 'Invalid module specified';

--- a/install/install_utils.php
+++ b/install/install_utils.php
@@ -957,8 +957,8 @@ EOQ;
     Options +FollowSymLinks
     RewriteEngine On
     RewriteBase {$basePath}
-    RewriteRule ^cache/jsLanguage/(.._..).js$ index.php?entryPoint=jslang&module=app_strings&lang=$1 [L,QSA]
-    RewriteRule ^cache/jsLanguage/(\w*)/(.._..).js$ index.php?entryPoint=jslang&module=$1&lang=$2 [L,QSA]
+    RewriteRule ^cache/jsLanguage/(.._..).js$ index.php?entryPoint=jslang&modulename=app_strings&lang=$1 [L,QSA]
+    RewriteRule ^cache/jsLanguage/(\w*)/(.._..).js$ index.php?entryPoint=jslang&modulename=$1&lang=$2 [L,QSA]
 </IfModule>
 <FilesMatch "\.(jpg|png|gif|js|css|ico)$">
         <IfModule mod_headers.c>

--- a/modules/Administration/UpgradeAccess.php
+++ b/modules/Administration/UpgradeAccess.php
@@ -63,8 +63,8 @@ RedirectMatch 403 {$ignoreCase}/+files\.md5\$
     Options +FollowSymLinks
     RewriteEngine On
     RewriteBase {$basePath}
-    RewriteRule ^cache/jsLanguage/(.._..).js$ index.php?entryPoint=jslang&module=app_strings&lang=$1 [L,QSA]
-    RewriteRule ^cache/jsLanguage/(\w*)/(.._..).js$ index.php?entryPoint=jslang&module=$1&lang=$2 [L,QSA]
+    RewriteRule ^cache/jsLanguage/(.._..).js$ index.php?entryPoint=jslang&modulename=app_strings&lang=$1 [L,QSA]
+    RewriteRule ^cache/jsLanguage/(\w*)/(.._..).js$ index.php?entryPoint=jslang&modulename=$1&lang=$2 [L,QSA]
 </IfModule>
 # END SUGARCRM RESTRICTIONS
 EOQ;

--- a/modules/Import/views/ImportView.php
+++ b/modules/Import/views/ImportView.php
@@ -63,6 +63,15 @@ class ImportView extends SugarView
         
     }
 
+    public function preDisplay() {
+        if (!is_file('cache/jsLanguage/Import/' . $GLOBALS['current_language'] . '.js')) {
+            require_once ('include/language/jsLanguage.php');
+            jsLanguage::createModuleStringsCache('Import', $GLOBALS['current_language']);
+        }
+        echo '<script src="cache/jsLanguage/Import/'. $GLOBALS['current_language'] . '.js"></script>';
+        parent::preDisplay();
+    }
+
     /**
      * @see SugarView::getMenu()
      */


### PR DESCRIPTION
Fix #5025 Undefined when importing contacts
Fix all calls to module language file for modules without
load $mod_strings into SUGAR.language.languages and fix .htaccess redirect to entrypoint for generated language file in cache/jsLanguage/
This was causing undefined labels on message boxes and buttons specifically in the Import module. Though this will affect all modules that do not have a bean and therefor have to load the language file manually
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Any entry point with module as parameter will redirect to actual module if module exists. Therefor cannot use parameter module to pass module name to entrypoint function.
Change htaccess generation code to update module to modulename
in .htaccess
 RewriteRule ^cache/jsLanguage/(.._..).js$ index.php?entryPoint=jslang&module=app_strings&lang=$1 [L,QSA]
    RewriteRule ^cache/jsLanguage/(\w*)/(.._..).js$ index.php?entryPoint=jslang&module=$1&lang=$2 [L,QSA]
the first one works as this is not a module but any call to the second one will result in module being loaded instead of entry point function

On Target import
index.php?module=Import&action=Step1&import_module=Prospects&return_module=Prospects&return_action=index

choosing 
Create new records and update existing records 

will create message box with undefined. Any pre-set import records when pressing publish will result in button text replacement with undefined as well.

To test actual problem 

On Target import
index.php?module=Import&action=Step1&import_module=Prospects&return_module=Prospects&return_action=index

in chrome console 
SUGAR.language.languages
will show languages array with objects
app_list_strings
app_strings

this should also have 
Import 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As the language file is not loaded then all ajax replacements or loading using the language file will result in undefined as text

## How To Test This
<!--- Please describe in detail how to test your changes. -->

On Target import
index.php?module=Import&action=Step1&import_module=Prospects&return_module=Prospects&return_action=index

in chrome console 
SUGAR.language.languages
will show languages array with objects
app_list_strings
app_strings

this should also have 
Import 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->