### PR TITLE
Fix/4351 notes contacts relation

### DIFF
--- a/modules/Notes/controller.php
+++ b/modules/Notes/controller.php
@@ -61,8 +61,8 @@
 
         // If Note is related to a Contact, we automatically fill the Contact field
         if ($_REQUEST['parent_type'] === 'Contacts'
-						&& !empty($_REQUEST['parent_id'])
-						&& !empty($_REQUEST['parent_name'])) {
+            && !empty($_REQUEST['parent_id'])
+            && !empty($_REQUEST['parent_name'])) {
             $this->bean->contact_id = $_REQUEST['parent_id'];
             $this->bean->contact_name = $_REQUEST['parent_name'];
         }

--- a/modules/Notes/controller.php
+++ b/modules/Notes/controller.php
@@ -59,7 +59,7 @@
 			$_REQUEST['relate_id'] = false;
 		}
 
-		    // If Note is related to a Contact, we automatically fill the Contact field
+        // If Note is related to a Contact, we automatically fill the Contact field
         if ($_REQUEST['parent_type'] === 'Contacts') {
             $this->bean->contact_id = $_REQUEST['parent_id'];
             $this->bean->contact_name = $_REQUEST['parent_name'];

--- a/modules/Notes/controller.php
+++ b/modules/Notes/controller.php
@@ -58,6 +58,12 @@
 		{
 			$_REQUEST['relate_id'] = false;
 		}
+
+		    // If Note is related to a Contact, we automatically fill the Contact field
+        if ($_REQUEST['parent_type'] === 'Contacts') {
+            $this->bean->contact_id = $_REQUEST['parent_id'];
+            $this->bean->contact_name = $_REQUEST['parent_name'];
+        }
 		
 		$GLOBALS['log']->debug('PERFORMING NOTES SAVE');
 		$upload_file = new UploadFile('uploadfile');

--- a/modules/Notes/controller.php
+++ b/modules/Notes/controller.php
@@ -60,7 +60,9 @@
 		}
 
         // If Note is related to a Contact, we automatically fill the Contact field
-        if ($_REQUEST['parent_type'] === 'Contacts') {
+        if ($_REQUEST['parent_type'] === 'Contacts'
+						&& !empty($_REQUEST['parent_id'])
+						&& !empty($_REQUEST['parent_name'])) {
             $this->bean->contact_id = $_REQUEST['parent_id'];
             $this->bean->contact_name = $_REQUEST['parent_name'];
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Improves handling of Notes which are related to Contacts module and have a different Contact or no Contact set as 'Contact' field.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Currently the relationship is a 1-M, so there shouldn't be Notes which are related to Contacts, and the relationship is defined on the contact_id field, so to be consistent whenever a Note is related to Contacts, it should also have the related Contact's id in the contact_id field, otherwise they don't count as really being related.

![screenshot from 2018-02-08 16-47-09](https://user-images.githubusercontent.com/34056696/35986142-2d0536ce-0cf0-11e8-9a6f-7b7f3a7baaa6.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #4351

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Create a Note which is related to Contacts and fill our related (right side) field but leave Contact (left side) field blank.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->