### PR TITLE
Fixed - #2480 SuiteP Theme - Geocoded Counts Table Header unreadable

### DIFF
--- a/themes/SuiteP/css/listview.scss
+++ b/themes/SuiteP/css/listview.scss
@@ -283,7 +283,7 @@ tr#pagination {
 
 .list tbody tr th{
 	color:$main-font-color;
-	}
+}
 	
 .list tr th {
   font-size: 13px;

--- a/themes/SuiteP/css/listview.scss
+++ b/themes/SuiteP/css/listview.scss
@@ -281,6 +281,10 @@ tr#pagination {
   white-space: nowrap;
 }
 
+.list tbody tr th{
+	color:$main-font-color;
+	}
+	
 .list tr th {
   font-size: 13px;
   padding: 16px 10px 16px 10px;

--- a/themes/SuiteP/css/listview.scss
+++ b/themes/SuiteP/css/listview.scss
@@ -282,7 +282,7 @@ tr#pagination {
 }
 
 .list tbody tr th{
-	color:$main-font-color;
+  color:$main-font-color;
 }
 	
 .list tr th {


### PR DESCRIPTION
## Description
SuiteP Theme - The Heading row on the "Geocoded Counts" table is a very light white, against a very light background, making it hard to read. This PR corrects this.

Replaces PR: #2497 , (Which is outdated, as it was made before the move to Sass.)

Related to issue: #2480


## Motivation and Context
Makes the header row in the Geocoding Table, (along with a few other labels, such as "Related to" when composing an Email), more readable.

## How To Test This
Navigate to the "Geocode Count" table in the Admin panel

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->