### PR TITLE
Fix missing drop down icon on time fields.

### DIFF
--- a/themes/SuiteP/css/suitep-base/forms.scss
+++ b/themes/SuiteP/css/suitep-base/forms.scss
@@ -1394,7 +1394,6 @@ select[size] {
   background: url("../../../../../themes/SuiteP/images/forms/select.ico") no-repeat right $input-select-option;
   background-color: $input-select-option;
   background-size: 52px 52px;
-  background: none;
   overflow-y: hidden;
   color: $main-font-color;
   padding: 0 52px 0 5px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Within the campaigns module, time fields were missing drop down icons.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This change adds in the drop down icons for the time fields within the campaigns module, making it clear that these fields can be changed.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1) Begin to create an email campaign
2) Navigate to the Marketing screen
3) Check the Schedule time and date to see if the boxes have dropdown icons

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->