### PR TITLE
Preventing 2 factor authentication from resending lots of codes

### DIFF
--- a/modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php
+++ b/modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php
@@ -293,8 +293,15 @@ class SugarAuthenticate{
                     } else {
                         $GLOBALS['log']->debug('FACTOR AUTH: User did not sent back the token so we send a new one and redirect to token input form');
 
-                        // if(!$this->userAuthenticate->isFactorTokenSent()) {
-                        //     $GLOBALS['log']->fatal('DEBUG: token is not sent yet, do we send a token to user');
+                        if (
+                            $this->userAuthenticate->isFactorTokenSent()
+                            && $this->userAuthenticate->isUserRequestedResendToken() === false
+                        ) {
+                            $GLOBALS['log']->fatal('DEBUG: token is not sent yet, do we send a token to user');
+                            $this->userAuthenticate->showFactorTokenInput();
+                        } else {
+                            $GLOBALS['log']->fatal('DEBUG: token already sent');
+                        }
 
                         if ($this->userAuthenticate->sendFactorTokenToUser()) {
                             $GLOBALS['log']->debug('FACTOR AUTH: Factor Token sent to User');
@@ -303,8 +310,6 @@ class SugarAuthenticate{
                             self::addFactorMessage($msg);
 
                             $this->userAuthenticate->showFactorTokenInput();
-
-                            //$this->userAuthenticate->redirectToLogout(); // todo : maybe its not needed - just a conflict merge issue...??
                         } else {
                             $GLOBALS['log']->debug('FACTOR AUTH: failed to send factor token to user so just redirect to the logout url and kick off ');
 
@@ -312,10 +317,6 @@ class SugarAuthenticate{
 
                             $this->userAuthenticate->redirectToLogout();
                         }
-
-                        // } else {
-                        //     $GLOBALS['log']->fatal('DEBUG: token already sent');
-                        // }
                     }
                 } else {
                     $GLOBALS['log']->debug('FACTOR AUTH: User factor authenticated already');

--- a/modules/Users/authentication/SugarAuthenticate/SugarAuthenticateUser.php
+++ b/modules/Users/authentication/SugarAuthenticate/SugarAuthenticateUser.php
@@ -143,6 +143,9 @@ class SugarAuthenticateUser
         return false;
     }
 
+    /**
+     * @return bool
+     */
     public function isUserNeedFactorAuthentication()
     {
         global $current_user;
@@ -153,6 +156,9 @@ class SugarAuthenticateUser
         return $ret;
     }
 
+    /**
+     * @return bool
+     */
     public function isUserFactorAuthenticated()
     {
         $ret = true;
@@ -162,6 +168,9 @@ class SugarAuthenticateUser
         return $ret;
     }
 
+    /**
+     * @return bool
+     */
     public function isUserFactorTokenReceived()
     {
         $ret = false;
@@ -181,6 +190,9 @@ class SugarAuthenticateUser
         return $_SESSION['user_factor_authenticated'];
     }
 
+    /**
+     * @global User $current_user
+     */
     public function showFactorTokenInput()
     {
         global $current_user;
@@ -203,6 +215,9 @@ class SugarAuthenticateUser
         die();
     }
 
+    /**
+     * @return bool
+     */
     public function isFactorTokenSent()
     {
         $ret = false;
@@ -212,6 +227,9 @@ class SugarAuthenticateUser
         return $ret;
     }
 
+    /**
+     * @return bool
+     */
     public function sendFactorTokenToUser()
     {
         global $current_user, $sugar_config;
@@ -270,6 +288,9 @@ class SugarAuthenticateUser
         return $ret;
     }
 
+    /**
+     *
+     */
     public function redirectToLogout()
     {
         $GLOBALS['log']->debug('Session destroy and redirect to logout.....');
@@ -279,6 +300,9 @@ class SugarAuthenticateUser
         die();
     }
 
+    /**
+     * @return bool
+     */
     public function isUserLogoutRequest()
     {
         $logout = false;
@@ -289,5 +313,14 @@ class SugarAuthenticateUser
             $logout = true;
         }
         return $logout;
+    }
+
+    /**
+     * Has user has requested to resend the multi/2 factor token?
+     * @return bool true === yes, false === no
+     */
+    public function isUserRequestedResendToken()
+    {
+        return $_REQUEST['action'] && $_REQUEST['action'] === 'Resend';
     }
 }

--- a/modules/Users/authentication/SugarAuthenticate/SugarAuthenticateUser.php
+++ b/modules/Users/authentication/SugarAuthenticate/SugarAuthenticateUser.php
@@ -321,6 +321,6 @@ class SugarAuthenticateUser
      */
     public function isUserRequestedResendToken()
     {
-        return $_REQUEST['action'] && $_REQUEST['action'] === 'Resend';
+        return isset($_REQUEST['action']) && $_REQUEST['action'] === 'Resend';
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When two factor authentication is enabled, and the user enters the code incorrectly, SuiteCRM will send a new code to the users email. Resulting in the user recieving many auth codes.

This pull request changes the 2 factor logic to only resend the code when the user requests the code to be resent.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Corrects the 2 factor functionality to meet software requirements

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* set up email settings
* Go into password management
* set the 2 factor email template
* edit a user
* enable 2 factor authentication
* logout
* login
* enter code incorrectly

You should still only have one email code sent to you.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->