### PR TITLE
Adding not opted in feature to Web To Person

### DIFF
--- a/include/SugarEmailAddress/SugarEmailAddress.php
+++ b/include/SugarEmailAddress/SugarEmailAddress.php
@@ -1902,7 +1902,7 @@ class SugarEmailAddress extends SugarBean
      */
     public function resetOptIn()
     {
-        $this->confirm_opt_in = '';
+        $this->confirm_opt_in = self::COI_STAT_DISABLED;
         parent::save();
     }
 
@@ -2067,6 +2067,11 @@ class SugarEmailAddress extends SugarBean
                 return $ret;
             }
 
+            if ($this->isNotOptIn()) {
+                $ret = self::COI_STAT_DISABLED;
+                return $ret;
+            }
+
             $ret = self::COI_FLAG_UNKNOWN_OPT_IN_STATUS;
 
             if ($this->isConfirmedOptIn()) {
@@ -2164,6 +2169,14 @@ class SugarEmailAddress extends SugarBean
     {
         $ret =  $this->getConfirmedOptInState() === self::COI_STAT_CONFIRMED_OPT_IN;
         return $ret;
+    }
+
+    /**
+     * @return bool
+     */
+    private function isNotOptIn()
+    {
+        return $this->confirm_opt_in === self::COI_STAT_DISABLED;
     }
 
     /**

--- a/modules/Campaigns/WebToLeadFormBuilderOptInCheckbox.tpl
+++ b/modules/Campaigns/WebToLeadFormBuilderOptInCheckbox.tpl
@@ -37,6 +37,7 @@
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  *}
     <div class="col" style="padding-left: 0;">
+        <input type="hidden" name="opt_in_{$fieldName}_default" value="1">
         <label>{$APP.LBL_OPT_IN_TITLE}:</label><input type="checkbox" id="opt_in_{$fieldName}" name="opt_in_{$fieldName}">
     </div>
 

--- a/tests/unit/include/SugarEmailAddress/SugarEmailAddressTest.php
+++ b/tests/unit/include/SugarEmailAddress/SugarEmailAddressTest.php
@@ -1978,7 +1978,7 @@ class SugarEmailAddressTest extends PHPUnit_Framework_TestCase
         $emailAddress->confirm_opt_in_sent_date = '';
 
         $this->assertEquals(
-            SugarEmailAddress::COI_FLAG_UNKNOWN_OPT_IN_STATUS,
+            SugarEmailAddress::COI_STAT_DISABLED,
             $emailAddress->getOptInStatus()
         );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When a targe/contact/account/lead has not selected the checkbox to opt in from a web to person form. The suitecrm should mark the email address as not opted in.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change updates the business logic to match the requirements in the description

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* set up web to person form
* untick opt in
* you should not see an opt in status next to the record in the crm


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->