### PR TITLE
Details as comments to language strings needs to be in the same line

### DIFF
--- a/modules/FP_events/language/en_us.lang.php
+++ b/modules/FP_events/language/en_us.lang.php
@@ -103,8 +103,7 @@ $mod_strings = array(
     'LBL_ERROR_MSG_1' => 'All Linked contacts have already been Invited.',
     'LBL_ERROR_MSG_2' => 'Sending the invite emails has failed! Please check your email settings.',
     'LBL_ERROR_MSG_3' => 'More than 10 emails have failed to send. Please check that all the contacts you are inviting have a valid email address. (See suitecrm.log)',
-    'LBL_ERROR_MSG_4' => ' emails have failed to send. Please check that all the contacts you are inviting have a valid email address. (See suitecrm.log)',
-    //LBL_ERROR_MSG_4 Begins with a number (controller.php line 581) for example 10 emails have failed to send.
+    'LBL_ERROR_MSG_4' => ' emails have failed to send. Please check that all the contacts you are inviting have a valid email address. (See suitecrm.log)', // LBL_ERROR_MSG_4 Begins with a number (controller.php line 581) for example 10 emails have failed to send.
     'LBL_ERROR_MSG_5' => 'Invalid Email Template',
     'LBL_EMAIL_INVITE' => 'Email Invite',
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

Giving details to translators should be done as comments to language strings.
To make them visible in Crowdin system it requires needs to be in the same line so Crowdin displays it to translators (when working that string)
This info is in the hotfix only, not in hotfix 7.8 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
See screen after fix:
![help_infos](https://user-images.githubusercontent.com/3055443/36254522-515b6496-1243-11e8-8e57-0192fbad9881.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [X] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->