### PR TITLE
Fix #5167 avoid duplicate encoding

### DIFF
--- a/modules/Campaigns/WebToLeadFormSave.php
+++ b/modules/Campaigns/WebToLeadFormSave.php
@@ -57,8 +57,6 @@ global $app_strings;
 //-----------begin replacing text input tags that have been marked with text area tags
 //get array of text areas strings to process
 $bodyHTML = html_entity_decode($_REQUEST['body_html'],ENT_QUOTES);
-//Bug53791
-$bodyHTML = str_replace(chr(160), " ", $bodyHTML);
 
 while (strpos($bodyHTML, "ta_replace") !== false){
 

--- a/modules/Campaigns/WebToLeadFormSave.php
+++ b/modules/Campaigns/WebToLeadFormSave.php
@@ -98,8 +98,12 @@ if (stripos($html, "<html") === false) {
     $html = "<html {$langHeader}><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head><body>" . $html . "</body></html>";
 }
 
-$html = str_replace('Â', ' ', utf8_encode($html));
+if (!mb_detect_encoding($str, 'UTF-8')) {
+    $html = utf8_encode($html);
+}
+$html = str_replace('Â', ' ', $html);
 file_put_contents($form_file, $html);
+$html = htmlspecialchars($html, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 
 $xtpl=new XTemplate ('modules/Campaigns/WebToLeadDownloadForm.html');
 $xtpl->assign("MOD", $mod_strings);
@@ -107,7 +111,7 @@ $xtpl->assign("APP", $app_strings);
 $webformlink = "<b>$mod_strings[LBL_DOWNLOAD_TEXT_WEB_TO_LEAD_FORM]</b><br/>";
 $webformlink .= "<a href=\"index.php?entryPoint=download&id={$guid}&isTempFile=1&tempName=WebToLeadForm.html&type=temp\">$mod_strings[LBL_DOWNLOAD_WEB_TO_LEAD_FORM]</a>";
 $xtpl->assign("LINK_TO_WEB_FORM",$webformlink);
-$xtpl->assign("RAW_SOURCE", htmlspecialchars($html, ENT_QUOTES, 'iso8859-1'));
+$xtpl->assign("RAW_SOURCE", $html);
 $xtpl->parse("main.copy_source");
 $xtpl->parse("main");
 $xtpl->out("main");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a small encoding issue on the Web 2 Person form

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
String was being encoded to UTF-8 even though it is a UTF-8 string by default.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #5167 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Create a campaign web2person form
Include some non latin characters in the form HTML (tinymce)
Save the campaign and see the characters are not garbled

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->