### PR TITLE
Fix PHP Strict Standards SugarView::init() in ModuleBuilder/views/view.property.php

### DIFF
--- a/modules/ModuleBuilder/views/view.property.php
+++ b/modules/ModuleBuilder/views/view.property.php
@@ -4,7 +4,7 @@
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
 
  * SuiteCRM is an extension to SugarCRM Community Edition developed by Salesagility Ltd.
- * Copyright (C) 2011 - 2014 Salesagility Ltd.
+ * Copyright (C) 2011 - 2018 Salesagility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the
@@ -77,7 +77,7 @@ class ViewProperty extends SugarView
     }
 
 
-    function init () // pseduo-constuctor - given a well-known name to allow subclasses to call this classes constructor
+    function init($bean = NULL, $view_object_map = Array) // pseudo-constuctor - given a well-known name to allow subclasses to call this classes constructor
     {
         $this->editModule = (! empty($_REQUEST['view_module'])) ? $_REQUEST['view_module'] : null;
         $this->editPackage = (! empty($_REQUEST['view_package'])) ? $_REQUEST['view_package'] : null;


### PR DESCRIPTION
Fixes this error:

`Strict Standards: Declaration of ViewProperty::init() should be compatible with SugarView::init($bean = NULL, $view_object_map = Array) in /modules/ModuleBuilder/views/view.property.php on line 150`

## Description

I didn't create an Issue for this. I am not using an IDE, just editing directly here on GitHub, so forgive me for not tidying up the file.

## Motivation and Context
Error reported in Forums
https://suitecrm.com/suitecrm/forum/developer-help/17775-error-editing-fields-in-studio-layot-view

## How To Test This
Please see Forum thread

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

