### PR TITLE
Adding checks to Advanced_Password_SeedData for upgrade purposes

### DIFF
--- a/install/seed_data/Advanced_Password_SeedData.php
+++ b/install/seed_data/Advanced_Password_SeedData.php
@@ -42,66 +42,85 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-require('config.php');
+require __DIR__ .'/../../config.php';
 global $sugar_config;
 global $timedate;
 global $mod_strings;
 
 //Sent when the admin generate a new password
-$EmailTemp = new EmailTemplate();
-$EmailTemp->name = $mod_strings['advanced_password_new_account_email']['name'];
-$EmailTemp->description = $mod_strings['advanced_password_new_account_email']['description'];
-$EmailTemp->subject = $mod_strings['advanced_password_new_account_email']['subject'];
-$EmailTemp->type = $mod_strings['advanced_password_new_account_email']['type'];
-$EmailTemp->body = $mod_strings['advanced_password_new_account_email']['txt_body'];
-$EmailTemp->body_html = $mod_strings['advanced_password_new_account_email']['body'];
-$EmailTemp->deleted = 0;
-$EmailTemp->published = 'off';
-$EmailTemp->text_only = 0;
-$id =$EmailTemp->save();
-$sugar_config['passwordsetting']['generatepasswordtmpl'] = $id;
+if (
+    !isset($sugar_config['passwordsetting']['generatepasswordtmpl'])
+    && empty($sugar_config['passwordsetting']['generatepasswordtmpl'])
+) {
+    $EmailTemp = new EmailTemplate();
+    $EmailTemp->name = $mod_strings['advanced_password_new_account_email']['name'];
+    $EmailTemp->description = $mod_strings['advanced_password_new_account_email']['description'];
+    $EmailTemp->subject = $mod_strings['advanced_password_new_account_email']['subject'];
+    $EmailTemp->type = $mod_strings['advanced_password_new_account_email']['type'];
+    $EmailTemp->body = $mod_strings['advanced_password_new_account_email']['txt_body'];
+    $EmailTemp->body_html = $mod_strings['advanced_password_new_account_email']['body'];
+    $EmailTemp->deleted = 0;
+    $EmailTemp->published = 'off';
+    $EmailTemp->text_only = 0;
+    $id =$EmailTemp->save();
+    $sugar_config['passwordsetting']['generatepasswordtmpl'] = $id;
+}
+
 
 //User generate a link to set a new password
-$EmailTemp = new EmailTemplate();
-$EmailTemp->name = $mod_strings['advanced_password_forgot_password_email']['name'];
-$EmailTemp->description = $mod_strings['advanced_password_forgot_password_email']['description'];
-$EmailTemp->subject = $mod_strings['advanced_password_forgot_password_email']['subject'];
-$EmailTemp->type = $mod_strings['advanced_password_new_account_email']['type'];
-$EmailTemp->body = $mod_strings['advanced_password_forgot_password_email']['txt_body'];
-$EmailTemp->body_html = $mod_strings['advanced_password_forgot_password_email']['body'];
-$EmailTemp->deleted = 0;
-$EmailTemp->published = 'off';
-$EmailTemp->text_only = 0;
-$id =$EmailTemp->save();
-$sugar_config['passwordsetting']['lostpasswordtmpl'] = $id;
+if (
+    !isset($sugar_config['passwordsetting']['lostpasswordtmpl'])
+    && empty($sugar_config['passwordsetting']['lostpasswordtmpl'])
+) {
+    $EmailTemp = new EmailTemplate();
+    $EmailTemp->name = $mod_strings['advanced_password_forgot_password_email']['name'];
+    $EmailTemp->description = $mod_strings['advanced_password_forgot_password_email']['description'];
+    $EmailTemp->subject = $mod_strings['advanced_password_forgot_password_email']['subject'];
+    $EmailTemp->type = $mod_strings['advanced_password_new_account_email']['type'];
+    $EmailTemp->body = $mod_strings['advanced_password_forgot_password_email']['txt_body'];
+    $EmailTemp->body_html = $mod_strings['advanced_password_forgot_password_email']['body'];
+    $EmailTemp->deleted = 0;
+    $EmailTemp->published = 'off';
+    $EmailTemp->text_only = 0;
+    $id =$EmailTemp->save();
+    $sugar_config['passwordsetting']['lostpasswordtmpl'] = $id;
+}
 
 
 //Two Factor Authentication code template
-$EmailTemp = new EmailTemplate();
-$EmailTemp->name = $mod_strings['two_factor_auth_email']['name'];
-$EmailTemp->description = $mod_strings['two_factor_auth_email']['description'];
-$EmailTemp->subject = $mod_strings['two_factor_auth_email']['subject'];
-$EmailTemp->type = $mod_strings['two_factor_auth_email']['type'];
-$EmailTemp->body = $mod_strings['two_factor_auth_email']['txt_body'];
-$EmailTemp->body_html = $mod_strings['two_factor_auth_email']['body'];
-$EmailTemp->deleted = 0;
-$EmailTemp->published = 'off';
-$EmailTemp->text_only = 0;
-$id =$EmailTemp->save();
-$sugar_config['passwordsetting']['factoremailtmpl'] = $id;
+if (
+    !isset($sugar_config['passwordsetting']['factoremailtmpl'])
+    && empty($sugar_config['passwordsetting']['factoremailtmpl'])
+) {
+    $EmailTemp = new EmailTemplate();
+    $EmailTemp->name = $mod_strings['two_factor_auth_email']['name'];
+    $EmailTemp->description = $mod_strings['two_factor_auth_email']['description'];
+    $EmailTemp->subject = $mod_strings['two_factor_auth_email']['subject'];
+    $EmailTemp->type = $mod_strings['two_factor_auth_email']['type'];
+    $EmailTemp->body = $mod_strings['two_factor_auth_email']['txt_body'];
+    $EmailTemp->body_html = $mod_strings['two_factor_auth_email']['body'];
+    $EmailTemp->deleted = 0;
+    $EmailTemp->published = 'off';
+    $EmailTemp->text_only = 0;
+    $id = $EmailTemp->save();
+    $sugar_config['passwordsetting']['factoremailtmpl'] = $id;
+}
 
 // set all other default settings
-$sugar_config['passwordsetting']['forgotpasswordON'] = true;
-$sugar_config['passwordsetting']['SystemGeneratedPasswordON'] = true;
-$sugar_config['passwordsetting']['systexpirationtime'] = 7;
-$sugar_config['passwordsetting']['systexpiration'] = 1;
-$sugar_config['passwordsetting']['linkexpiration'] = true;
-$sugar_config['passwordsetting']['linkexpirationtime'] = 24;
-$sugar_config['passwordsetting']['linkexpirationtype'] = 60;
-$sugar_config['passwordsetting']['minpwdlength'] = 6;
-$sugar_config['passwordsetting']['oneupper'] = false;
-$sugar_config['passwordsetting']['onelower'] = false;
-$sugar_config['passwordsetting']['onenumber'] = false;
-$sugar_config['passwordsetting']['onespecial'] = false;
+if (!isset($sugar_config['passwordsetting'])) {
+    $sugar_config['passwordsetting']['forgotpasswordON'] = true;
+    $sugar_config['passwordsetting']['SystemGeneratedPasswordON'] = true;
+    $sugar_config['passwordsetting']['systexpirationtime'] = 7;
+    $sugar_config['passwordsetting']['systexpiration'] = 1;
+    $sugar_config['passwordsetting']['linkexpiration'] = true;
+    $sugar_config['passwordsetting']['linkexpirationtime'] = 24;
+    $sugar_config['passwordsetting']['linkexpirationtype'] = 60;
+    $sugar_config['passwordsetting']['minpwdlength'] = 6;
+    $sugar_config['passwordsetting']['oneupper'] = false;
+    $sugar_config['passwordsetting']['onelower'] = false;
+    $sugar_config['passwordsetting']['onenumber'] = false;
+    $sugar_config['passwordsetting']['onespecial'] = false;
+}
+
 
 write_array_to_file( "sugar_config", $sugar_config, "config.php");

--- a/install/seed_data/Advanced_Password_SeedData.php
+++ b/install/seed_data/Advanced_Password_SeedData.php
@@ -44,6 +44,8 @@ if (!defined('sugarEntry') || !sugarEntry) {
 
 require __DIR__ . '/../../config.php';
 
+global $current_language;
+
 if (file_exists(__DIR__ . '/../language/' . $current_language . '.lang.php')) {
     require_once __DIR__ . '/../language/' . $current_language . '.lang.php';
 } else {

--- a/install/seed_data/Advanced_Password_SeedData.php
+++ b/install/seed_data/Advanced_Password_SeedData.php
@@ -43,9 +43,10 @@ if (!defined('sugarEntry') || !sugarEntry) {
 }
 
 require __DIR__ .'/../../config.php';
+require_once __DIR__ .'/../language/en_us.lang.php';
 global $sugar_config;
 global $timedate;
-global $mod_strings;
+
 
 //Sent when the admin generate a new password
 if (

--- a/install/seed_data/Advanced_Password_SeedData.php
+++ b/install/seed_data/Advanced_Password_SeedData.php
@@ -131,5 +131,8 @@ if (!isset($sugar_config['passwordsetting'])) {
     $sugar_config['passwordsetting']['onespecial'] = false;
 }
 
+if ($sugar_config['passwordsetting']['systexpirationtype'] === '0') {
+    $sugar_config['passwordsetting']['systexpirationtype'] = 1;
+}
 
 write_array_to_file("sugar_config", $sugar_config, "config.php");

--- a/install/seed_data/Advanced_Password_SeedData.php
+++ b/install/seed_data/Advanced_Password_SeedData.php
@@ -43,7 +43,15 @@ if (!defined('sugarEntry') || !sugarEntry) {
 }
 
 require __DIR__ .'/../../config.php';
-require_once __DIR__ .'/../language/en_us.lang.php';
+
+if(file_exists(__DIR__ .'/../language/'.$current_language.'.lang.php'))
+{
+    require_once __DIR__ .'/../language/'.$current_language.'.lang.php';
+}
+else {
+    require_once __DIR__ .'/../language/en_us.lang.php';
+}
+
 global $sugar_config;
 global $timedate;
 

--- a/install/seed_data/Advanced_Password_SeedData.php
+++ b/install/seed_data/Advanced_Password_SeedData.php
@@ -42,14 +42,12 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-require __DIR__ .'/../../config.php';
+require __DIR__ . '/../../config.php';
 
-if(file_exists(__DIR__ .'/../language/'.$current_language.'.lang.php'))
-{
-    require_once __DIR__ .'/../language/'.$current_language.'.lang.php';
-}
-else {
-    require_once __DIR__ .'/../language/en_us.lang.php';
+if (file_exists(__DIR__ . '/../language/' . $current_language . '.lang.php')) {
+    require_once __DIR__ . '/../language/' . $current_language . '.lang.php';
+} else {
+    require_once __DIR__ . '/../language/en_us.lang.php';
 }
 
 global $sugar_config;
@@ -71,7 +69,7 @@ if (
     $EmailTemp->deleted = 0;
     $EmailTemp->published = 'off';
     $EmailTemp->text_only = 0;
-    $id =$EmailTemp->save();
+    $id = $EmailTemp->save();
     $sugar_config['passwordsetting']['generatepasswordtmpl'] = $id;
 }
 
@@ -91,7 +89,7 @@ if (
     $EmailTemp->deleted = 0;
     $EmailTemp->published = 'off';
     $EmailTemp->text_only = 0;
-    $id =$EmailTemp->save();
+    $id = $EmailTemp->save();
     $sugar_config['passwordsetting']['lostpasswordtmpl'] = $id;
 }
 
@@ -132,4 +130,4 @@ if (!isset($sugar_config['passwordsetting'])) {
 }
 
 
-write_array_to_file( "sugar_config", $sugar_config, "config.php");
+write_array_to_file("sugar_config", $sugar_config, "config.php");

--- a/install/seed_data/Advanced_Password_SeedData.php
+++ b/install/seed_data/Advanced_Password_SeedData.php
@@ -59,7 +59,7 @@ global $timedate;
 //Sent when the admin generate a new password
 if (
     !isset($sugar_config['passwordsetting']['generatepasswordtmpl'])
-    && empty($sugar_config['passwordsetting']['generatepasswordtmpl'])
+    || empty($sugar_config['passwordsetting']['generatepasswordtmpl'])
 ) {
     $EmailTemp = new EmailTemplate();
     $EmailTemp->name = $mod_strings['advanced_password_new_account_email']['name'];
@@ -79,7 +79,7 @@ if (
 //User generate a link to set a new password
 if (
     !isset($sugar_config['passwordsetting']['lostpasswordtmpl'])
-    && empty($sugar_config['passwordsetting']['lostpasswordtmpl'])
+    || empty($sugar_config['passwordsetting']['lostpasswordtmpl'])
 ) {
     $EmailTemp = new EmailTemplate();
     $EmailTemp->name = $mod_strings['advanced_password_forgot_password_email']['name'];
@@ -99,7 +99,7 @@ if (
 //Two Factor Authentication code template
 if (
     !isset($sugar_config['passwordsetting']['factoremailtmpl'])
-    && empty($sugar_config['passwordsetting']['factoremailtmpl'])
+    || empty($sugar_config['passwordsetting']['factoremailtmpl'])
 ) {
     $EmailTemp = new EmailTemplate();
     $EmailTemp->name = $mod_strings['two_factor_auth_email']['name'];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This change adds a check to the Advanced_Password_SeedData so that we can call it from the upgrade packages. So that it the existing templates and settings are preserved on upgrade.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Preserves settings
- Makes upgrade packages easier to build

## How To Test This
<!--- Please describe in detail how to test your changes. -->
- Make installer and upgrade packages

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->