### PR TITLE
Make email addresses display work in subpanels and inline edit

### DIFF
--- a/include/SugarEmailAddress/templates/optInStatusTick.tpl
+++ b/include/SugarEmailAddress/templates/optInStatusTick.tpl
@@ -38,6 +38,4 @@
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 *}
-<span class="email-opt-in-container">
-    <span class="email-opt-in {$optInFlagClass}" title="{$optInFlagTitle}">{$optInFlagText}</span>
-</span>
+<span class="email-opt-in-container"><span class="email-opt-in {$optInFlagClass}" title="{$optInFlagTitle}">{$optInFlagText}</span></span>

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelEmailLink.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelEmailLink.php
@@ -55,6 +55,7 @@ class SugarWidgetSubPanelEmailLink extends SugarWidgetField
     {
         global $current_user;
         global $sugar_config;
+        global $focus;
 
         if (isset($layout_def['varname'])) {
             $key = strtoupper($layout_def['varname']);
@@ -75,11 +76,14 @@ class SugarWidgetSubPanelEmailLink extends SugarWidgetField
         if ($client == 'sugar') {
             require_once('modules/Emails/EmailUI.php');
             $emailUi = new EmailUI();
-            $link = $emailUi->populateComposeViewFields();
-        } else {
-            $link = '<a href="mailto:' . $value . '" >' . $value . '</a>';
+            if ($focus !== null) {
+                return $emailUi->populateComposeViewFields($focus);
+            }
+            if ($current_user !== null) {
+                return $emailUi->populateComposeViewFields($current_user);
+            }
         }
 
-        return $link;
+        return '<a href="mailto:' . $value . '" >' . $value . '</a>';
     }
 }

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelEmailLink.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelEmailLink.php
@@ -42,84 +42,44 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-class SugarWidgetSubPanelEmailLink extends SugarWidgetField {
+/**
+ * Class SugarWidgetSubPanelEmailLink
+ */
+class SugarWidgetSubPanelEmailLink extends SugarWidgetField
+{
+    /**
+     * @param array $layout_def
+     * @return string
+     */
+    function displayList($layout_def)
+    {
+        global $current_user;
+        global $sugar_config;
 
-	function displayList($layout_def) {
-		global $current_user;
-		global $focus;
-		global $sugar_config;
-		global $locale;
-
-		if(isset($layout_def['varname'])) {
-			$key = strtoupper($layout_def['varname']);
-		} else {
-			$key = $this->_get_column_alias($layout_def);
-			$key = strtoupper($key);
-		}
-		$value = $layout_def['fields'][$key];
-
-
-
-			if(isset($_REQUEST['action'])) $action = $_REQUEST['action'];
-			else $action = '';
-
-			if(isset($_REQUEST['module'])) $module = $_REQUEST['module'];
-			else $module = '';
-
-			if(isset($_REQUEST['record'])) $record = $_REQUEST['record'];
-			else $record = '';
-
-			if (!empty($focus->name)) {
-				$name = $focus->name;
-			} else {
-				if( !empty($focus->first_name) && !empty($focus->last_name)) {
-					$name = $locale->getLocaleFormattedName($focus->first_name, $focus->last_name);
-					}
-				if(empty($name)) {
-					$name = '*';
-				}
-			}
-
-			$userPref = $current_user->getPreference('email_link_type');
-			$defaultPref = $sugar_config['email_default_client'];
-			if($userPref != '') {
-				$client = $userPref;
-			} else {
-				$client = $defaultPref;
-			}
-
-        if ($client == 'sugar') {
-            $composeData = array(
-                'load_id' => $layout_def['fields']['ID'],
-                'load_module' => $this->layout_manager->defs['module_name'],
-                'parent_type' => $this->layout_manager->defs['module_name'],
-                'parent_id' => $layout_def['fields']['ID'],
-                'to_addrs' => $layout_def['fields']['EMAIL1'],
-                'return_module' => $module,
-                'return_action' => $action,
-                'return_id' => $record
-            );
-            if (isset($layout_def['fields']['FULL_NAME'])) {
-                $composeData['parent_name'] = $layout_def['fields']['FULL_NAME'];
-                $composeData['to_email_addrs'] = sprintf("%s <%s>", $layout_def['fields']['FULL_NAME'],
-                    $layout_def['fields']['EMAIL1']);
-            } else {
-                $composeData['to_email_addrs'] = $layout_def['fields']['EMAIL1'];
-            }
-            require_once('modules/Emails/EmailUI.php');
-            $emailUi = new EmailUI();
-            $link = $emailUi->populateComposeViewFields(
-                $bean = null,
-                $emailField = 'email1',
-                $checkAllEmail = true,
-                '',
-                $composeData
-            );
+        if (isset($layout_def['varname'])) {
+            $key = strtoupper($layout_def['varname']);
         } else {
-            $link = '<a href="mailto:' . $value . '" >';
+            $key = $this->_get_column_alias($layout_def);
+            $key = strtoupper($key);
+        }
+        $value = $layout_def['fields'][$key];
+
+        $userPref = $current_user->getPreference('email_link_type');
+        $defaultPref = $sugar_config['email_default_client'];
+        if ($userPref != '') {
+            $client = $userPref;
+        } else {
+            $client = $defaultPref;
         }
 
-        return $link . $value . '</a>';
+        if ($client == 'sugar') {
+            require_once('modules/Emails/EmailUI.php');
+            $emailUi = new EmailUI();
+            $link = $emailUi->populateComposeViewFields();
+        } else {
+            $link = '<a href="mailto:' . $value . '" >' . $value . '</a>';
+        }
 
-	}
-} // end class def
+        return $link;
+    }
+}

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelEmailLink.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelEmailLink.php
@@ -79,6 +79,12 @@ class SugarWidgetSubPanelEmailLink extends SugarWidgetField
             if ($focus !== null) {
                 return $emailUi->populateComposeViewFields($focus);
             }
+            if (!empty($layout_def['module']) && !empty($layout_def['fields']) && !empty($layout_def['fields']['ID'])) {
+                $bean = BeanFactory::getBean($layout_def['module'], $layout_def['fields']['ID']);
+                if (!empty($bean)) {
+                    return $emailUi->populateComposeViewFields($bean);
+                }
+            }
             if ($current_user !== null) {
                 return $emailUi->populateComposeViewFields($current_user);
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removes a duplicate closing tag from the email link in listview after inline editing.
Removes dead code and makes use of the correct function EmailUI->populateComposeViewFields to show emails in subpanels

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #5173 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to Contact or other list view
2. Inline edit email address

1. View emails in subpanels

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->