### PR TITLE
Stop required symbol from wrapping on edit form

### DIFF
--- a/include/Smarty/plugins/block.minify.php
+++ b/include/Smarty/plugins/block.minify.php
@@ -1,0 +1,58 @@
+<?php
+function smarty_block_minify($params, $content, &$smarty, &$repeat) {
+    if (!$repeat) {
+        if (isSet($content)) {
+            // HTML Minifier
+            $input = $content;
+            if(trim($input) === "") return $input;
+            // Remove extra white-space(s) between HTML attribute(s)
+            $input = preg_replace_callback('#<([^\/\s<>!]+)(?:\s+([^<>]*?)\s*|\s*)(\/?)>#s', function($matches) {
+                return '<' . $matches[1] . preg_replace('#([^\s=]+)(\=([\'"]?)(.*?)\3)?(\s+|$)#s', ' $1$2', $matches[2]) . $matches[3] . '>';
+            }, str_replace("\r", "", $input));
+            // Minify inline CSS declaration(s)
+            if(strpos($input, ' style=') !== false) {
+                $input = preg_replace_callback('#<([^<]+?)\s+style=([\'"])(.*?)\2(?=[\/\s>])#s', function($matches) {
+                    return '<' . $matches[1] . ' style=' . $matches[2] . minify_css($matches[3]) . $matches[2];
+                }, $input);
+            }
+            return preg_replace(
+                array(
+                    // t = text
+                    // o = tag open
+                    // c = tag close
+                    // Keep important white-space(s) after self-closing HTML tag(s)
+                    '#<(img|input)(>| .*?>)#s',
+                    // Remove a line break and two or more white-space(s) between tag(s)
+                    '#(<!--.*?-->)|(>)(?:\n*|\s{2,})(<)|^\s*|\s*$#s',
+                    '#(<!--.*?-->)|(?<!\>)\s+(<\/.*?>)|(<[^\/]*?>)\s+(?!\<)#s', // t+c || o+t
+                    '#(<!--.*?-->)|(<[^\/]*?>)\s+(<[^\/]*?>)|(<\/.*?>)\s+(<\/.*?>)#s', // o+o || c+c
+                    '#(<!--.*?-->)|(<\/.*?>)\s+(\s)(?!\<)|(?<!\>)\s+(\s)(<[^\/]*?\/?>)|(<[^\/]*?\/?>)\s+(\s)(?!\<)#s', // c+t || t+o || o+t -- separated by long white-space(s)
+                    '#(<!--.*?-->)|(<[^\/]*?>)\s+(<\/.*?>)#s', // empty tag
+                    '#<(img|input)(>| .*?>)<\/\1\x1A>#s', // reset previous fix
+                    '#(&nbsp;)&nbsp;(?![<\s])#', // clean up ...
+                    // Force line-break with `&#10;` or `&#xa;`
+                    '#&\#(?:10|xa);#',
+                    // Force white-space with `&#32;` or `&#x20;`
+                    '#&\#(?:32|x20);#',
+                    // Remove HTML comment(s) except IE comment(s)
+                    '#\s*<!--(?!\[if\s).*?-->\s*|(?<!\>)\n+(?=\<[^!])#s'
+                ),
+                array(
+                    "<$1$2</$1\x1A>",
+                    '$1$2$3',
+                    '$1$2$3',
+                    '$1$2$3$4$5',
+                    '$1$2$3$4$5$6$7',
+                    '$1$2$3',
+                    '<$1$2',
+                    '$1 ',
+                    "\n",
+                    ' ',
+                    ""
+                ),
+                $input);
+
+            return $input;
+        }
+    }
+}

--- a/themes/SuiteP/include/EditView/tab_panel_content.tpl
+++ b/themes/SuiteP/include/EditView/tab_panel_content.tpl
@@ -32,6 +32,7 @@
                         {{/if}}
 
                                 {*label*}
+                                {minify}
                                 {{if isset($colData.field.customLabel)}}
                                 <label for="{{$fields[$colData.field.name].name}}">{{$colData.field.customLabel}}</label>
                                 {{elseif isset($colData.field.label)}}
@@ -59,6 +60,7 @@
                                     {{/if}}
                                     {sugar_help text=$popupText WIDTH=-1}
                                 {{/if}}
+                                {/minify}
                             </div>
                         {{/if}}
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Currently because of the smarty templating the label text has text around it which is is playing havoc with the CSS which states wrapping behavior.

This could be fixed by changing the css or by cleaning up the outputted html. I chose to go with the latter route.

P.s. as a note you can see this behavior even in [one of the screenshots](https://suitecrm.com/wiki/index.php/File:Release_notes4.png) of [7.10 Release Notes](https://suitecrm.com/wiki/index.php/Release_notes_7.10.0).

### Before

![before](https://user-images.githubusercontent.com/361586/36439499-1f7b188a-163b-11e8-9677-9d78229b9a9d.png)

### After
![after](https://user-images.githubusercontent.com/361586/36439501-2032ada6-163b-11e8-96b6-9613cd929427.png)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The edit form looks bad with the symbol wrapping around and into the label

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Checkout branch
2. Clear template cache

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->