### PR TITLE
Use the subtheme key

### DIFF
--- a/include/SugarTheme/SugarThemeRegistry.php
+++ b/include/SugarTheme/SugarThemeRegistry.php
@@ -422,9 +422,9 @@ class SugarThemeRegistry
         $themeConfig = self::getThemeConfig($current->dirName);
         $subThemes = isset($themeConfig['sub_themes']['options'])
             ? $themeConfig['sub_themes']['options']['Style'] : [];
-        foreach ($subThemes as &$subTheme) {
-            $subTheme = isset($mod_strings['LBL_SUBTHEME_OPTIONS_' . strtoupper($subTheme)]) ?
-                $mod_strings['LBL_SUBTHEME_OPTIONS_' . strtoupper($subTheme)] : $subTheme;
+        foreach ($subThemes as $key => &$subTheme) {
+            $subTheme = isset($mod_strings['LBL_SUBTHEME_OPTIONS_' . strtoupper($key)]) ?
+                $mod_strings['LBL_SUBTHEME_OPTIONS_' . strtoupper($key)] : $subTheme;
         }
         return $subThemes;
     }

--- a/include/SugarTheme/SugarThemeRegistry.php
+++ b/include/SugarTheme/SugarThemeRegistry.php
@@ -421,7 +421,7 @@ class SugarThemeRegistry
         $current = self::current();
         $themeConfig = self::getThemeConfig($current->dirName);
         $subThemes = isset($themeConfig['sub_themes']['options'])
-            ? $themeConfig['sub_themes']['options']['Style'] : [];
+            ? reset($themeConfig['sub_themes']['options']) : [];
         foreach ($subThemes as $key => &$subTheme) {
             $subTheme = isset($mod_strings['LBL_SUBTHEME_OPTIONS_' . strtoupper($key)]) ?
                 $mod_strings['LBL_SUBTHEME_OPTIONS_' . strtoupper($key)] : $subTheme;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a bug where the styles are not selectable when using a default language other than english.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #5281 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Note: you can use english language to login and test!
1- Install a language pack
2- Go to Admin / Locale
3- Set default language to the installed language in 1
4- Go to Administrator menu / Profile/ / Layout options
5- the templates dropdown should be visible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->