### PR TITLE
Fix opt in label in contacts filtering.

### DIFF
--- a/include/language/en_us.lang.php
+++ b/include/language/en_us.lang.php
@@ -477,7 +477,7 @@ $app_list_strings = array(
 
         'Prospects' => 'Target',
 
-        ),
+    ),
     'parent_line_items' => array(
         'AOS_Quotes' => 'Quotes',
         'AOS_Invoices' => 'Invoices',
@@ -3581,7 +3581,7 @@ $app_list_strings['email_settings_opt_in_dom'] = array(
 );
 
 $app_list_strings['email_confirmed_opt_in_dom'] = array(
-    'not-opt-in' => 'Opt Out',
+    'not-opt-in' => 'Not Opt In',
     'opt-in' => 'Opt In',
     'confirmed-opt-in' => 'Confirmed Opt In'
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Display label changed to make it more clear for the user to filter their search.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1) Navigate to the 'Contacts' module
2) Select filter
3) Navigate to the bottom of advanced filter
4) View the labels in 'Opt in Primary Email'

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->