### PR TITLE
Fix emails addresses showing in the side bar.

### DIFF
--- a/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -810,7 +810,7 @@
                         {foreach from=$recentRecords item=item name=lastViewed}
                             {if $smarty.foreach.lastViewed.index < 5}
                             <div class="recently_viewed_link_container_sidebar">
-                                {if $item.module_name != 'Emails' && $item.module_name != 'InboundEmail'}<!--Check to ensure that recently viewed emails/email addresses are not displayed in the recently viewed panel.-->
+                                {if $item.module_name != 'Emails' && $item.module_name != 'InboundEmail'}<!--Check to ensure that recently viewed emails or email addresses are not displayed in the recently viewed panel.-->
                                 <li class="recentlinks" role="presentation">
                                     <a title="{$item.module_name}" accessKey="{$smarty.foreach.lastViewed.iteration}" href="{sugar_link module=$item.module_name action='DetailView' record=$item.item_id link_only=1}" class="recent-links-detail">
                                         <img src="{sugar_getimagepath directory='sidebar/modules'  file_name=$item.module_name file_extension="svg" file='sidebar/modules/'.$item.module_name.".svg"}"/><span>{$item.item_summary_short}</span>

--- a/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -810,11 +810,13 @@
                         {foreach from=$recentRecords item=item name=lastViewed}
                             {if $smarty.foreach.lastViewed.index < 5}
                             <div class="recently_viewed_link_container_sidebar">
+                                {if $item.module_name != 'Emails'}<!--Check to ensure that recently viewed emails/email addresses are not displayed in the recently viewed panel.-->
                                 <li class="recentlinks" role="presentation">
                                     <a title="{$item.module_name}" accessKey="{$smarty.foreach.lastViewed.iteration}" href="{sugar_link module=$item.module_name action='DetailView' record=$item.item_id link_only=1}" class="recent-links-detail">
                                         <img src="{sugar_getimagepath directory='sidebar/modules'  file_name=$item.module_name file_extension="svg" file='sidebar/modules/'.$item.module_name.".svg"}"/><span>{$item.item_summary_short}</span>
                                     </a>
                                 </li>
+                                {/if}
                             </div>
                             {/if}
                         {/foreach}

--- a/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -810,7 +810,7 @@
                         {foreach from=$recentRecords item=item name=lastViewed}
                             {if $smarty.foreach.lastViewed.index < 5}
                             <div class="recently_viewed_link_container_sidebar">
-                                {if $item.module_name != 'Emails'}<!--Check to ensure that recently viewed emails/email addresses are not displayed in the recently viewed panel.-->
+                                {if $item.module_name != 'Emails' && $item.module_name != 'InboundEmail'}<!--Check to ensure that recently viewed emails/email addresses are not displayed in the recently viewed panel.-->
                                 <li class="recentlinks" role="presentation">
                                     <a title="{$item.module_name}" accessKey="{$smarty.foreach.lastViewed.iteration}" href="{sugar_link module=$item.module_name action='DetailView' record=$item.item_id link_only=1}" class="recent-links-detail">
                                         <img src="{sugar_getimagepath directory='sidebar/modules'  file_name=$item.module_name file_extension="svg" file='sidebar/modules/'.$item.module_name.".svg"}"/><span>{$item.item_summary_short}</span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
A check has been put in place to stop email addresses being displayed in the sidebar navigation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fix is put in place as emails should not be visible in recently viewed.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1) Navigate to a contacts email address
2) Click on the email to enter compose
3) Afterwards, check to see if this is visible in the recently viewed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->