### PR TITLE
change survey toggle

### DIFF
--- a/modules/Surveys/javascript/Survey.js
+++ b/modules/Surveys/javascript/Survey.js
@@ -1,0 +1,23 @@
+var Survey = (function ($) {
+    var bindToggle = function (event) {
+        event.preventDefault();
+
+        var clickedElement = $(event.target);
+        var resultTable = $('#' + clickedElement.data('question-id') + 'List');
+
+        resultTable.slideToggle(500, function () {
+            clickedElement.text(resultTable.is(':visible') ? 'Hide responses' : 'Show responses');
+        });
+    };
+
+    var showHide = function (elements) {
+        $(elements).each(function (index, element) {
+            $(element).on('click', bindToggle);
+        });
+    };
+
+    var result = {};
+    result.showHide = showHide;
+
+    return result;
+})(jQuery);

--- a/modules/Surveys/language/en_us.lang.php
+++ b/modules/Surveys/language/en_us.lang.php
@@ -77,7 +77,6 @@ $mod_strings = array(
     'LBL_VIEW_SURVEY_REPORTS'                                => 'View Survey Reports',
     'LBL_CHECKED'                                            => 'Checked',
     'LBL_UNCHECKED'                                          => 'Unchecked',
-    'LBL_SHOW_ALL_RESPONSES'                                 => 'Show all responses',
     'LBL_RESPONSE_ANSWER'                                    => 'Answer',
     'LBL_RESPONSE_CONTACT'                                   => 'Contact',
     'LBL_RESPONSE_TIME'                                      => 'Date',
@@ -89,4 +88,5 @@ $mod_strings = array(
     'LBL_DISSATISFIED_TEXT'                                  => 'Dissatisfied Text',
     'LBL_SURVEYS_SURVEYQUESTIONS_FROM_SURVEYQUESTIONS_TITLE' => 'Survey Questions',
     'LBL_SURVEYS_SURVEYRESPONSES_FROM_SURVEYRESPONSES_TITLE' => 'Survey Responses',
+    'LBL_SHOW_RESPONSES' => 'Show responses',
 );

--- a/modules/Surveys/tpls/Reports/other.tpl
+++ b/modules/Surveys/tpls/Reports/other.tpl
@@ -31,5 +31,5 @@
             </tr>
         {/foreach}
     </table>
-    <a href="#" class="showAllResponsesButton" data-question-id="{$question.id}">{$mod.LBL_SHOW_ALL_RESPONSES}</a>
+    <a href="#" class="showHideResponses" data-question-id="{$question.id}">{$mod.LBL_SHOW_RESPONSES}</a>
 </div>

--- a/modules/Surveys/tpls/reports.tpl
+++ b/modules/Surveys/tpls/reports.tpl
@@ -51,15 +51,11 @@
 <script type='text/javascript' src='include/SuiteGraphs/rgraph/libraries/RGraph.radar.js'></script>
 <script type='text/javascript' src='include/SuiteGraphs/rgraph/libraries/RGraph.hbar.js'></script>
 <script type='text/javascript' src='include/SuiteGraphs/rgraph/libraries/RGraph.rose.js'></script>
+<script type='text/javascript' src='modules/Surveys/javascript/Survey.js'></script>
 <script>
     {literal}
     $(document).ready(function () {
-      $(".showAllResponsesButton").click(function (e) {
-        var target = $(e.target);
-        var id = target.data('question-id');
-        $('#' + id + 'List').show();
-        return false;
-      });
+        Survey.showHide($('.showHideResponses'));
     });
     {/literal}
 </script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When viewing Survey reports the user clicks on the show all responses but it does not toggle the state so this can be confusing to the user. 

Toggle texts have been changed to show/hide responses
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
[if you don't have survey with text field, please, create a new one]
- go to survey report
- click on show responses
- see, if results are shows with the correct link text
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->