### PR TITLE
Fix #5307 Set default pdf body to white

### DIFF
--- a/modules/AOR_Reports/controller.php
+++ b/modules/AOR_Reports/controller.php
@@ -255,6 +255,7 @@ class AOR_ReportsController extends SugarController
             $pdf = new mPDF('en', 'A4', '', 'DejaVuSansCondensed');
             $pdf->SetAutoFont();
             $pdf->WriteHTML($stylesheet, 1);
+            $pdf->SetDefaultBodyCSS('background-color', '#FFFFFF');
             $pdf->WriteHTML($head, 2);
             $pdf->WriteHTML($printable, 3);
             $pdf->Output($this->bean->name . '.pdf', "D");


### PR DESCRIPTION
override theme background background-color with white

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
see: https://github.com/salesagility/SuiteCRM/issues/5307
Reports pdf inherits user theme background-color, for SuiteP it is grey. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
when printing report it uses ink for nothing and report does not look pretty.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

    1- switch to SuiteP theme
    2- run a report
    3- download pdf

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->