### PR TITLE
Fixed: Google Map GeoCoding is not working with proxy server

### DIFF
--- a/modules/jjwg_Maps/jjwg_Maps.php
+++ b/modules/jjwg_Maps/jjwg_Maps.php
@@ -911,6 +911,25 @@ class jjwg_Maps extends jjwg_Maps_sugar {
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 15);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        
+        // Add proxy option if user enabled proxy
+        $admin_config = new Administration();
+        $admin_config->retrieveSettings('proxy');
+        if(!empty($admin_config->settings['proxy_on'])) {
+            $proxy_host = $admin_config->settings['proxy_host'];
+            $proxy_port = $admin_config->settings['proxy_port'];
+
+            curl_setopt($ch, CURLOPT_PROXY, $proxy_host);
+            curl_setopt($ch, CURLOPT_PROXYPORT, $proxy_port);
+
+            // Check if use proxy auth
+            if(!empty($admin_config->settings['proxy_auth'])) {
+                $proxy_userpwd = $admin_config->settings['proxy_username'] . ':' . $admin_config->settings['proxy_password'];
+                curl_setopt($ch, CURLOPT_PROXYUSERPWD, $proxy_userpwd);
+            }
+        }
+        // End
+        
         $json_contents = curl_exec($ch);
 
         // Debug: Error Handling


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Include proxy configuration when call api to geocoding for address if user enabled proxy configuration.

Fixed in getGoogleMapsGeocode function in <root>/modules/jjwg_Maps/jjwg_Maps.php

## Motivation and Context
Support for server have enabled proxy server

## How To Test This
1. Setup proxy for your server.
2. Login as 'admin' > Go to Admin area > System settings > Proxy configuration > Enter proxy infomation > Save
3. Reset any geocoding of any module > click on index.php?module=jjwg_Maps&entryPoint=jjwg_Maps&cron=1 to re-geocoding for just module reset.
Expected:
 - Address of geocoding need updated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->