### PR TITLE
Fix #5327 Subject broken in Notes detail view

### DIFF
--- a/include/SugarObjects/templates/file/File.php
+++ b/include/SugarObjects/templates/file/File.php
@@ -143,7 +143,10 @@ class File extends Basic
     {
         $ret_val = parent::retrieve($id, $encode, $deleted);
 
-        $this->name = $this->document_name;
+        //If statement added to prevent the 'name' from being overwritten with a null value
+        if ($this->document_name !== null) {
+            $this->name = $this->document_name;
+        }
 
         return $ret_val;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This change allows the Subject field to be visible in all views.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
[#5327](https://github.com/salesagility/SuiteCRM/issues/5327)

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1) Create a note with a subject field
2) Select this note to navigate to the Detail view
3) Check to see if the subject field is populated
4) Also, navigate to the edit view
5) View the subject field in this view

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->