### PR TITLE
Fix #5315 Don't cache beans with auto increment fields before saving

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -5541,6 +5541,9 @@ class SugarBean
         }
     }
 
+    /**
+     * @return bool
+     */
     protected function hasAutoIncrementFields()
     {
         foreach ($this->field_defs as $key => $field_def){

--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -1894,8 +1894,10 @@ class SugarBean
         }
 
 
-        require_once("data/BeanFactory.php");
-        BeanFactory::registerBean($this->module_name, $this);
+        if (!$this->hasAutoIncrementFields()) {
+            require_once("data/BeanFactory.php");
+            BeanFactory::registerBean($this->module_name, $this);
+        }
 
         if (empty($GLOBALS['updating_relationships']) && empty($GLOBALS['saving_relationships']) && empty($GLOBALS['resavingRelatedBeans'])) {
             $GLOBALS['saving_relationships'] = true;
@@ -5537,5 +5539,15 @@ class SugarBean
             $this->db->save_audit_records($this, $change);
             $this->fetched_row[$change['field_name']] = $change['after'];
         }
+    }
+
+    protected function hasAutoIncrementFields()
+    {
+        foreach ($this->field_defs as $key => $field_def){
+            if ($field_def['type'] === 'int' && $field_def['auto_increment'] === true) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a bug with new Beans that have auto increment fields and the BeanFactory cache.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
BeanFactory holds a copy of 10 last used beans in memory, but does not take into account auto increment fields that change in the database after saving them for the first time.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Potential bugs with any module that uses auto increment fields (Campaigns, Trackers, Prospects, Cases) as well as any auto increment custom fields.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Set up email template that uses the case number
2. Set up a workflow action to send email on case creation
3. Create a new case
4. Check that the email sent contains the correct case number

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->