### PR TITLE
FIX #5356 - The marker images URLs in Maps were wrong

### DIFF
--- a/modules/jjwg_Maps/views/view.map_markers.php
+++ b/modules/jjwg_Maps/views/view.map_markers.php
@@ -195,7 +195,7 @@ var markerClusterer = null;
 var markerClustererToggle = null;
 var clusterControlDiv = null;
 // Clusterer Images - Protocol Independent
-MarkerClusterer.IMAGE_PATH = "//google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclustererplus/images/m";
+MarkerClusterer.IMAGE_PATH = "//raw.githubusercontent.com/googlemaps/js-marker-clusterer/gh-pages/images/m";
 
 // Drawing Controls
 var drawingManager = null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

The URL of marker images in Maps were wrong

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

See #5356 

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1.- Create a Map.
2.- Show that map 
3.- Verify that marker images are shown



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->