### PR TITLE
Fixed #5174 - Confirmed Opt in tick - Microsoft edge

### DIFF
--- a/include/SugarEmailAddress/SugarEmailAddress.php
+++ b/include/SugarEmailAddress/SugarEmailAddress.php
@@ -2254,27 +2254,28 @@ class SugarEmailAddress extends SugarBean
                     case self::COI_FLAG_OPT_IN:
                         $optInFlagClass = 'email-opt-in-confirmed';
                         $optInFlagTitle = $app_strings['LBL_OPT_IN'];
-                        $optInFlagText = '&#10004;';
+                        $optInFlagText = '<span class="suitepicon suitepicon-action-confirm"></span>';
                         break;
                     case self::COI_FLAG_OPT_IN_PENDING_EMAIL_CONFIRMED:
                         $optInFlagClass = 'email-opt-in-confirmed';
                         $optInFlagTitle = $app_strings['LBL_OPT_IN_CONFIRMED'];
-                        $optInFlagText = '&#10004;&#10004;';
+                        $optInFlagText = '<span class="suitepicon suitepicon-action-confirm">';
+                        $optInFlagText .= '</span><span class="suitepicon suitepicon-action-confirm"></span>';
                         break;
                     case self::COI_FLAG_OPT_IN_PENDING_EMAIL_SENT:
                         $optInFlagClass = 'email-opt-in-sent';
                         $optInFlagTitle = $app_strings['LBL_OPT_IN_PENDING_EMAIL_SENT'];
-                        $optInFlagText = '&#10004;';
+                        $optInFlagText = '<span class="suitepicon suitepicon-action-confirm"></span>';
                         break;
                     case self::COI_FLAG_OPT_IN_PENDING_EMAIL_NOT_SENT:
                         $optInFlagClass = 'email-opt-in-not-sent';
                         $optInFlagTitle = $app_strings['LBL_OPT_IN_PENDING_EMAIL_NOT_SENT'];
-                        $optInFlagText = '&#10004;';
+                        $optInFlagText = '<span class="suitepicon suitepicon-action-confirm"></span>';
                         break;
                     case self::COI_FLAG_OPT_IN_PENDING_EMAIL_FAILED:
                         $optInFlagClass = 'email-opt-in-failed';
                         $optInFlagTitle = $app_strings['LBL_OPT_IN_PENDING_EMAIL_FAILED'];
-                        $optInFlagText = '&#10004;';
+                        $optInFlagText = '<span class="suitepicon suitepicon-action-confirm"></span>';
                         break;
                     case self::COI_FLAG_OPT_OUT:
                         $optInFlagClass = 'email-opt-in-opt-out';

--- a/themes/SuiteP/css/suitep-base/detailview.scss
+++ b/themes/SuiteP/css/suitep-base/detailview.scss
@@ -436,3 +436,7 @@ p.msg {
     @extend  .email-opt-in-confirmed;
   }
 }
+
+.email-opt-in .suitepicon {
+  line-height: inherit;
+}

--- a/themes/SuiteP/css/suitep-base/detailview.scss
+++ b/themes/SuiteP/css/suitep-base/detailview.scss
@@ -392,6 +392,8 @@ p.msg {
   font-size: 14px;
 }
 
+
+
 .email-opt-in-not-sent {
   color: $opt-in-tick-color-not-sent;
 }
@@ -410,4 +412,27 @@ p.msg {
 
 .email-line-through {
   text-decoration: line-through;
+}
+
+// Fix for list view confirm opt in ticks
+.table-responsive.list > tbody > tr > td {
+  .email-opt-in .suitepicon {
+    font-size: $page-font-size;
+  }
+
+  .email-opt-in-not-sent .suitepicon {
+    @extend  .email-opt-in-not-sent;
+  }
+
+  .email-opt-in-failed .suitepicon {
+    @extend  .email-opt-in-failed;
+  }
+
+  .email-opt-in-sent .suitepicon {
+    @extend  .email-opt-in-sent;
+  }
+
+  .email-opt-in-confirmed .suitepicon {
+    @extend  .email-opt-in-confirmed;
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
It seems to be a rendering issue in windows instead of a css issue. Edge is correctly selecting the css selector. other browsers such as Firefox have the same issue on windows. The tick does will always be green regardless of the css.

The solution would be to use an icon instead, so that it is not using the unicode value.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- This ensures that the color of the confirmed opt in tick displays the correct colors in web browsers on Microsoft windows.
- Fixed #5174

## How To Test This
<!--- Please describe in detail how to test your changes. -->
- Rebuild sass
- Clear browser cache
- test the color of confirm opt in on Microsoft edge

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->