### PR TITLE
Fix out of line expand icon.

### DIFF
--- a/themes/SuiteP/css/suitep-base/suitepicon.scss
+++ b/themes/SuiteP/css/suitep-base/suitepicon.scss
@@ -187,5 +187,5 @@
     @extend .suitepicon;
     @extend .suitepicon-action-move-right;
     line-height: 30px;
-    margin-left: 4px;
+    margin-left: 7px;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This fix re positions the expand icon into the middle of the display.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The expand icon was out of alignment.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1) Minimise the side bar,
2) View the expand icon.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->