### PR TITLE
Refactor map function to avoid declaring a function twice

### DIFF
--- a/include/SugarFields/Fields/CronSchedule/SugarFieldCronSchedule.php
+++ b/include/SugarFields/Fields/CronSchedule/SugarFieldCronSchedule.php
@@ -38,14 +38,13 @@ class SugarFieldCronSchedule extends SugarFieldBase {
         $this->ss->assign('weekdays',get_select_options($weekdays,''));
         $days = $this->getDays();
         $this->ss->assign('days',get_select_options($days,''));
-        function padNumbers($x){
-            return str_pad($x,2,'0',STR_PAD_LEFT);
-        }
-        $minutes = array_map('padNumbers',range(0,59));
-        $hours = array_map('padNumbers',range(0,23));
+        $minutes = array_map([$this, 'padNumbers'],range(0,59));
+        $hours = array_map([$this, 'padNumbers'],range(0,23));
         $this->ss->assign('minutes',get_select_options($minutes,''));
         $this->ss->assign('hours',get_select_options($hours,''));
     }
 
-
+    private function padNumbers($x){
+        return str_pad($x,2,'0',STR_PAD_LEFT);
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a small bug with scheduled report where a function redeclaration would cause the module to crash.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Unsure under which circumstances SugarFieldCronSchedule->setup() would be called twice, but it happens sometimes.
1. Create a report
2. Create a scheduled report
3. Go into detail view and see it doesn't crash

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->