### PR TITLE
Fixed #5424 - Missing add product menu while using PL language - 7.10.1

### DIFF
--- a/include/MVC/View/SugarView.php
+++ b/include/MVC/View/SugarView.php
@@ -660,12 +660,6 @@ class SugarView
             }
         }
 
-        foreach($groupTabs as $key => $tabGroup) {
-            if (count($topTabs) >= $max_tabs - 1 && $key !== 'All' && in_array($tabGroup['modules'][$moduleTab], $tabGroup['extra'])) {
-                unset($groupTabs[$key]['modules'][$moduleTab]);
-            }
-        }
-
         if (isset($topTabList) && is_array($topTabList)) {
             // Adding shortcuts array to menu array for displaying shortcuts associated with each module
             $shortcutTopMenu = array();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
While using a language pack certain modules like products do not show the sidebar menu.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #5424 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Install a language pack such as PL.
2. Go into "Products" module.
3. Check that the sidebar displays correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->