### PR TITLE
Fixed #2400 - Language manifest is duplicated and overwritten on each…

### DIFF
--- a/modules/Administration/UpgradeWizard_prepare.php
+++ b/modules/Administration/UpgradeWizard_prepare.php
@@ -1,11 +1,11 @@
 <?php
-if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
-/*********************************************************************************
+/**
+ *
  * SugarCRM Community Edition is a customer relationship management program developed by
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
-
- * SuiteCRM is an extension to SugarCRM Community Edition developed by Salesagility Ltd.
- * Copyright (C) 2011 - 2014 Salesagility Ltd.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2018 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the
@@ -16,7 +16,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
  * details.
  *
  * You should have received a copy of the GNU Affero General Public License along with
@@ -34,13 +34,13 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
  * these Appropriate Legal Notices must retain the display of the "Powered by
  * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
- * reasonably feasible for  technical reasons, the Appropriate Legal Notices must
- * display the words  "Powered by SugarCRM" and "Supercharged by SuiteCRM".
- ********************************************************************************/
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
 
-
-
-
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
 
 require_once('modules/Administration/UpgradeWizardCommon.php');
 
@@ -398,51 +398,56 @@ if( $show_files == true ){
          .SugarThemeRegistry::current()->getImage('basic_search', '', null, null, ".gif", $mod_strings['LBL_BASIC_SEARCH']).$mod_strings['LBL_UW_HIDE_DETAILS'].'</div><br>';
     echo '<input type="checkbox" checked onclick="toggle_these(' . count($new_studio_mod_files) . ',' . count($new_files) . ', this)"> '.$mod_strings['LBL_UW_CHECK_ALL'];
 	echo '<ul>';
-	foreach( $new_sugar_mod_files as $the_file ){
-		$highlight_start    = "";
-		$highlight_end      = "";
-		$checked            = "";
-		$disabled           = "";
-		$unzip_file = "$unzip_dir/$zip_from_dir/$the_file";
-		$new_file   = clean_path( "$zip_to_dir/$the_file" );
-		$forced_copy    = false;
+    foreach ($new_sugar_mod_files as $the_file) {
+        $highlight_start = "";
+        $highlight_end = "";
+        $checked = "";
+        $disabled = "";
+        $unzip_file = "$unzip_dir/$zip_from_dir/$the_file";
+        $new_file = clean_path("$zip_to_dir/$the_file");
+        $forced_copy = false;
 
-		if( $mode == "Install" ){
-			$checked = "checked";
-			foreach( $zip_force_copy as $pattern ){
-				if( preg_match("#" . $pattern . "#", $unzip_file) ){
-					$disabled = "disabled=\"true\"";
-					$forced_copy = true;
-				}
-			}
-			if( !$forced_copy && is_file( $new_file ) && (md5_file( $unzip_file ) == md5_file( $new_file )) ){
-				$disabled = "disabled=\"true\"";
-				//$checked = "";
-			}
-			if( $checked != "" && $disabled != "" ){    // need to put a hidden field
-				print( "<input name=\"copy_$count\" type=\"hidden\" value=\"" . $the_file . "\">\n" );
-			}
-			print( "<li><input id=\"copy_$count\" name=\"copy_$count\" type=\"checkbox\" value=\"" . $the_file . "\" $checked $disabled > " . $highlight_start . $new_file . $highlight_end );
-			if( $checked == "" && $disabled != "" ){    // need to explain this file hasn't changed
-				print( " (no changes)" );
-			}
-			print( "<br>\n" );
-		}
-		else if( $mode == "Uninstall" && file_exists( $new_file ) ){
-			if( md5_file( $unzip_file ) == md5_file( $new_file ) ){
-				$checked = "checked=\"true\"";
-			}
-			else{
-				$highlight_start    = "<font color=red>";
-				$highlight_end      = "</font>";
-			}
-			print( "<li><input name=\"copy_$count\" type=\"checkbox\" value=\"" . $the_file . "\" $checked $disabled > " . $highlight_start . $new_file . $highlight_end . "<br>\n" );
-		}
-		$count++;
-	}
-        print( "</ul>\n" );
+        if ($mode == "Install") {
+            $checked = "checked";
+
+            if ($install_type === 'langpack' && $the_file == "./manifest.php") {
+                $checked = '';
+                $disabled = "disabled=\"true\"";
+            }
+
+            foreach ($zip_force_copy as $pattern) {
+                if (preg_match("#" . $pattern . "#", $unzip_file)) {
+                    $disabled = "disabled=\"true\"";
+                    $forced_copy = true;
+                }
+            }
+            if (!$forced_copy && is_file($new_file) && (md5_file($unzip_file) == md5_file($new_file))) {
+                $disabled = "disabled=\"true\"";
+            }
+            if ($checked != "" && $disabled != "") {    // need to put a hidden field
+                print("<input name=\"copy_$count\" type=\"hidden\" value=\"" . $the_file . "\">\n");
+            }
+            print("<li><input id=\"copy_$count\" name=\"copy_$count\" type=\"checkbox\" value=\"" . $the_file . "\" $checked $disabled > " . $highlight_start . $new_file . $highlight_end);
+            if ($checked == "" && $disabled != "") {    // need to explain this file hasn't changed
+                print(" (no changes)");
+            }
+            print("<br>\n");
+        } else {
+            if ($mode == "Uninstall" && file_exists($new_file)) {
+                if (md5_file($unzip_file) == md5_file($new_file)) {
+                    $checked = "checked=\"true\"";
+                } else {
+                    $highlight_start = "<font color=red>";
+                    $highlight_end = "</font>";
+                }
+                print("<li><input name=\"copy_$count\" type=\"checkbox\" value=\"" . $the_file . "\" $checked $disabled > " . $highlight_start . $new_file . $highlight_end . "<br>\n");
+            }
+        }
+        $count++;
+    }
+    print("</ul>\n");
 }
-//    echo '</div>';
+
 if($mode == "Disable" || $mode == "Enable"){
 	//check to see if any files have been modified
 	$modified_files = getDiffFiles($unzip_dir, $install_file, ($mode == 'Enable'), $previous_version);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Prevents manifest.php from being copied to the root directory when installing a language pack. See original issue for details.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #2400

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Install language pack.
2. Check that manifest.php is only copied to the upload/upgrades/langpack directory

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->