### PR TITLE
Fix Windows cron instructions for cases where a Drive change is required

### DIFF
--- a/install/ready.php
+++ b/install/ready.php
@@ -270,7 +270,7 @@ if(is_windows()) {
         }
     }
     $cronString = '<p><b>'.$mod_strings_scheduler['LBL_CRON_WINDOWS_DESC'].'</b><br>
-						cd '.realpath('./').'<br>
+						cd /D '.realpath('./').'<br>
 						php.exe -f cron.php
 						<br>'.$error.'</p>
 			   ';

--- a/modules/Schedulers/Scheduler.php
+++ b/modules/Schedulers/Scheduler.php
@@ -790,7 +790,7 @@ class Scheduler extends SugarBean {
 				<tr class="evenListRowS1">
 					<td scope="row" valign="top" width="70%"><slot>
 						'.$mod_strings['LBL_CRON_WINDOWS_DESC'].'<br>
-						<b>cd '.realpath('./').'<br>
+						<b>cd /D '.realpath('./').'<br>
 						php.exe -f cron.php</b>
 					</slot></td>
 				</tr>


### PR DESCRIPTION
## Description
This fixes text instructing how to set up Scheduler jobs on Windows.

## Motivation and Context
If a user has SuiteCRM on a different drive than the working directory of the batch file, the `cd` command would fail to change the drive.

So, if you're on `C:` and you type `cd E:\Suite` you're still left at `C:`.

You could either type two commands, `E:`, them  `cd \Suite`, or use the `/D` switch on  `cd`, which is what I propose.

## How To Test This
Run Admin / Schedulers on Windows, see text is different at the bottom of the page.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

I guess this is as low priority as it gets. :-)

But it does fool a few people, and they have to go ask in the forums...