### PR TITLE
Fixed #4717 - XTemplate doesn't support output escaping

### DIFF
--- a/modules/InboundEmail/language/en_us.lang.php
+++ b/modules/InboundEmail/language/en_us.lang.php
@@ -93,9 +93,7 @@ $mod_strings = array(
 	'LBL_FOUND_MAILBOXES'	=> 'Found the following usable folders.<br>Click one to choose it:',
 	'LBL_FOUND_OPTIMUM_MSG'	=> '<br>Found optimum settings. Press the button below to apply them to your mail account.',
 	'LBL_FROM_ADDR'			=> '"From" Address',
-    // as long as XTemplate doesn't support output escaping, transform
-    // quotes to html-entities right here (bug #48913)
-    'LBL_FROM_ADDR_DESC'    => "The email address provided here might not appear in the &quot;From&quot; address section of the email sent due to restrictions imposed by the mail service provider. In these circumstances, the email address defined in the outgoing mail server will be used.",
+    'LBL_FROM_ADDR_DESC'    => 'The email address provided here might not appear in the "From" address section of the email sent due to restrictions imposed by the mail service provider. In these circumstances, the email address defined in the outgoing mail server will be used.',
 	'LBL_FROM_NAME_ADDR'	=> 'From Name/Email',
 	'LBL_FROM_NAME'			=> '"From" Name',
 	'LBL_GROUP_QUEUE'		=> 'Assign To Group',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Removed unnecessary &quot

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #4717 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->