### PR TITLE
Fix/close decoration

### DIFF
--- a/modules/Calls/Call.php
+++ b/modules/Calls/Call.php
@@ -502,9 +502,9 @@ class Call extends SugarBean {
 			if(empty($action))
 			    $action = "index";
 
-            $setCompleteUrl = "<a id='{$this->id}' class='list-view-data-icon' title='".translate('LBL_CLOSEINLINE')."' onclick='SUGAR.util.closeActivityPanel.show(\"{$this->module_dir}\",\"{$this->id}\",\"Held\",\"listview\",\"1\");'>";
+            $setCompleteUrl = "<b><a id='{$this->id}' class='list-view-data-icon' title='".translate('LBL_CLOSEINLINE')."' onclick='SUGAR.util.closeActivityPanel.show(\"{$this->module_dir}\",\"{$this->id}\",\"Held\",\"listview\",\"1\");'>";
 			if ($this->ACLAccess('edit')) {
-                $call_fields['SET_COMPLETE'] = $setCompleteUrl ."<span class='suitepicon suitepicon-action-clear'></span></a>";
+                $call_fields['SET_COMPLETE'] = $setCompleteUrl ."<span class='suitepicon suitepicon-action-clear'></span></a></b>";
             } else {
                 $call_fields['SET_COMPLETE'] = '';
             }

--- a/modules/Meetings/Meeting.php
+++ b/modules/Meetings/Meeting.php
@@ -546,9 +546,9 @@ class Meeting extends SugarBean {
 			//cn: added this if() to deal with sequential Closes in Meetings.	this is a hack to a hack(formbase.php->handleRedirect)
 			if(empty($action))
 			     $action = "index";
-            $setCompleteUrl = "<a id='{$this->id}' class='list-view-data-icon' title='".translate('LBL_CLOSEINLINE')."' onclick='SUGAR.util.closeActivityPanel.show(\"{$this->module_dir}\",\"{$this->id}\",\"Held\",\"listview\",\"1\");'>";
-			if ($this->ACLAccess('edit')) {
-                $meeting_fields['SET_COMPLETE'] = $setCompleteUrl . "<span class='suitepicon suitepicon-action-clear'></span></a>";
+            $setCompleteUrl = "<b><a id='{$this->id}' class='list-view-data-icon' title='".translate('LBL_CLOSEINLINE')."' onclick='SUGAR.util.closeActivityPanel.show(\"{$this->module_dir}\",\"{$this->id}\",\"Held\",\"listview\",\"1\");'>";
+            if ($this->ACLAccess('edit')) {
+                $meeting_fields['SET_COMPLETE'] = $setCompleteUrl . "<span class='suitepicon suitepicon-action-clear'></span></a></b>";
             } else {
                 $meeting_fields['SET_COMPLETE'] = '';
             }

--- a/modules/Tasks/Task.php
+++ b/modules/Tasks/Task.php
@@ -313,8 +313,8 @@ class Task extends SugarBean {
 			$task_fields['PARENT_MODULE'] = $this->parent_type;
 		if ($this->status != "Completed" && $this->status != "Deferred" )
 		{
-			$setCompleteUrl = "<a id='{$this->id}' class='list-view-data-icon' title='".translate('LBL_LIST_CLOSE','Tasks')."' onclick='SUGAR.util.closeActivityPanel.show(\"{$this->module_dir}\",\"{$this->id}\",\"Completed\",\"listview\",\"1\");'>";
-		    $task_fields['SET_COMPLETE'] = $setCompleteUrl . "<span class='suitepicon suitepicon-action-clear'></span></a>";
+            $setCompleteUrl = "<b><a id='{$this->id}' class='list-view-data-icon' title='".translate('LBL_LIST_CLOSE','Tasks')."' onclick='SUGAR.util.closeActivityPanel.show(\"{$this->module_dir}\",\"{$this->id}\",\"Completed\",\"listview\",\"1\");'>";
+            $task_fields['SET_COMPLETE'] = $setCompleteUrl . "<span class='suitepicon suitepicon-action-clear'></span></a></b>";
 		}
 
         // make sure we grab the localized version of the contact name, if a contact is provided

--- a/tests/unit/modules/Calls/CallTest.php
+++ b/tests/unit/modules/Calls/CallTest.php
@@ -153,7 +153,7 @@ class CallTest extends PHPUnit_Framework_TestCase
                 'EMAIL_REMINDER_TIME' => '-1',
                 'EMAIL_REMINDER_SENT' => '0',
                 'REPEAT_INTERVAL' => '1',
-                'SET_COMPLETE' => '<a id=\'\' class=\'list-view-data-icon\' title=\'Close\' onclick=\'SUGAR.util.closeActivityPanel.show("Calls","","Held","listview","1");\'><span class=\'suitepicon suitepicon-action-clear\'></span></a>',
+                'SET_COMPLETE' => '<b><a id=\'\' class=\'list-view-data-icon\' title=\'Close\' onclick=\'SUGAR.util.closeActivityPanel.show("Calls","","Held","listview","1");\'><span class=\'suitepicon suitepicon-action-clear\'></span></a></b>',
                 'DATE_START' => '<font class=\'overdueTask\'></font>',
                 'CONTACT_ID' => null,
                 'CONTACT_NAME' => null,

--- a/tests/unit/modules/Tasks/TaskTest.php
+++ b/tests/unit/modules/Tasks/TaskTest.php
@@ -145,7 +145,7 @@ class TaskTest extends PHPUnit_Framework_TestCase
                 'CONTACT_PHONE' => '1234567',
                 'PRIORITY' => 'Medium',
                 'PARENT_MODULE' => 'Accounts',
-                'SET_COMPLETE' => '<a id=\'\' class=\'list-view-data-icon\' title=\'Close\' onclick=\'SUGAR.util.closeActivityPanel.show("Tasks","","Completed","listview","1");\'><span class=\'suitepicon suitepicon-action-clear\'></span></a>',
+                'SET_COMPLETE' => '<b><a id=\'\' class=\'list-view-data-icon\' title=\'Close\' onclick=\'SUGAR.util.closeActivityPanel.show("Tasks","","Completed","listview","1");\'><span class=\'suitepicon suitepicon-action-clear\'></span></a></b>',
                 'TITLE' => ": test\nAccount: test",
         );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This change is used to remove the dashed underline from the 'close' icon beside a meeting or task.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1) Load the Tasks module
2) Select 'View Tasks' from the side navigation
3) View the 'Close/X' icon beside each row to ensure there is no dashed underline

4) Load the Meetings module
5) Select 'View Meetings' from the side navigation
6) View the 'Close/X' icon beside each row to ensure there is no dashed underline

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->