### PR TITLE
Preview documents

### DIFF
--- a/download.php
+++ b/download.php
@@ -236,8 +236,11 @@ if ((!isset($_REQUEST['isProfile']) && empty($_REQUEST['id'])) || empty($_REQUES
             }
         } else {
             header('Content-type: ' . $mime_type);
-            header("Content-Disposition: attachment; filename=\"" . $name . "\";");
-
+            if($_REQUEST['preview'] === "yes"){ 
+                header( "Content-Disposition: inline; filename=\"".$name."\";"); }
+            else{
+                header("Content-Disposition: attachment; filename=\"" . $name . "\";");
+            }
         }
         // disable content type sniffing in MSIE
         header("X-Content-Type-Options: nosniff");

--- a/include/SugarFields/Fields/File/DetailView.tpl
+++ b/include/SugarFields/Fields/File/DetailView.tpl
@@ -40,6 +40,10 @@
 *}
 <span class="sugar_field" id="{{if empty($displayParams.idName)}}{{sugarvar key='name'}}{{else}}{{$displayParams.idName}}{{/if}}">
 <a href="index.php?entryPoint=download&id={$fields.{{$vardef.fileId}}.value}&type={{$vardef.linkModule}}" class="tabDetailViewDFLink" target='_blank'>{{sugarvar key='value'}}</a>
+&nbsp;
+<a href="index.php?preview=yes&entryPoint=download&id={$fields.{{$vardef.fileId}}.value}&type={{$vardef.linkModule}}" class="tabDetailViewDFLink" target='_blank' style="border-bottom: 0px;">
+	<i class="glyphicon glyphicon-eye-open"></i>
+</a>
 </span>
 {{if isset($vardef) && isset($vardef.allowEapm) && $vardef.allowEapm}}
 {if isset($fields.{{$vardef.docType}}) && !empty($fields.{{$vardef.docType}}.value) && $fields.{{$vardef.docType}}.value != 'SugarCRM' && !empty($fields.{{$vardef.docUrl}}.value) }

--- a/include/SugarFields/Fields/File/ListView.tpl
+++ b/include/SugarFields/Fields/File/ListView.tpl
@@ -48,4 +48,7 @@
 {/capture}
 {if strlen($imageURL)>1}{sugar_getimage name=$imageName alt=$imageName other_attributes='border="0" '}{/if}
 {/if}
+</a>&nbsp;
+<a href="index.php?preview=yes&entryPoint=download&id={$parentFieldArray.ID}&type={$displayParams.module}{$vardef.displayParams.module}" class="tabDetailViewDFLink" target='_blank' style="border-bottom: 0px;">
+	<i class="fas fa-eye"></i>
 </a>

--- a/include/SugarFields/Fields/File/ListView.tpl
+++ b/include/SugarFields/Fields/File/ListView.tpl
@@ -50,5 +50,5 @@
 {/if}
 </a>&nbsp;
 <a href="index.php?preview=yes&entryPoint=download&id={$parentFieldArray.ID}&type={$displayParams.module}{$vardef.displayParams.module}" class="tabDetailViewDFLink" target='_blank' style="border-bottom: 0px;">
-	<i class="fas fa-eye"></i>
+	<i class="glyphicon glyphicon-eye-open"></i>
 </a>


### PR DESCRIPTION
I provide a link to preview documents.

## Description
include/SugarFields/Fields/File/ListView.tpl: Added an eye icon besides filename field to enable preview. This links to download entrypoint with preview=yes parameter.
![image](https://user-images.githubusercontent.com/23360/37414979-496100ec-27a2-11e8-9675-ffe2394ef186.png)

download.php: Added header( "Content-Disposition: inline" if $_REQUEST['preview'] === "yes"

## Motivation and Context
You don't always want to download PDFs or JPGs documents.

## How To Test This
Go to documents list, look for a PDF or JPG file and click in the eye.
A new tab is opened instead of downloading the document.

## Types of changes
Small new feature
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [X ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->