### PR TITLE
Fixed #5093 - Emails sent from within SuiteCRM have mis-matched bound…

### DIFF
--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -969,7 +969,10 @@ class Email extends SugarBean {
 			if (isset($ie->id) && !$ie->isPop3Protocol() && $mail->oe->mail_smtptype != 'gmail') {
 				$sentFolder = $ie->get_stored_options("sentFolder");
 				if (!empty($sentFolder)) {
-					$data = $mail->CreateHeader() . "\r\n" . $mail->CreateBody() . "\r\n";
+					// Call CreateBody() before CreateHeader() as that is where boundary IDs are generated.
+					$emailbody = $mail->CreateBody();
+					$emailheader = $mail->CreateHeader();
+					$data = $emailheader . "\r\n" . $emailbody . "\r\n";
 					$ie->mailbox = $sentFolder;
 					if ($ie->connectMailserver() == 'true') {
 						$connectString = $ie->getConnectString($ie->getServiceString(), $ie->mailbox);


### PR DESCRIPTION
…ary ids on copy in sent folder.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Call CreateBody() before CreateHeader() when building an email message to save to an IMAP sent folder.
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
MIME Boundary IDs are generated within phpMailer in the CreateBody function and then referenced in the CreateHeader function. These functions need to be called in this order when generating a valid email message. Calling them in the opposite order results in a saved sent message that cannot be parsed by most mail agents.
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
Configure SuiteCRM to use your sent folder on an IMAP server and then send a message (preferably with an attachment, but it's not necessary) from any module within SuiteCRM. The message should appear in your sent folder properly formatted with text & html parts and the source will have boundary IDs that match the one specified in the email header.
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->