### PR TITLE
Change misleading message in install_utils.php

### DIFF
--- a/install/install_utils.php
+++ b/install/install_utils.php
@@ -63,7 +63,7 @@ function installerHook($function_name, $options = array()){
             $GLOBALS['customInstallHooksExist'] = true;
         }
         else{
-            installLog("installerHook: Could not find custom/install/install_hooks.php");
+            installLog("installerHook: Info: custom/install/install_hooks.php not present, no custom hooks to execute");
             $GLOBALS['customInstallHooksExist'] = false;
         }
     }


### PR DESCRIPTION
## Description
When troubleshooting in the forums, we often ask people to check for any errors in their `install.log`.
 
There's one particular message they always report about, which is 

`installerHook: Could not find custom/install/install_hooks.php`

That looks like an error, but it isn't. They say that file isn't there, where can they get it, etc.

So I'm suggesting a more explicit message.

## How To Test This
Let's be wild and crazy and not test this.

## Environment

This should go into all branches, 7.8, 7.9 and 7.10. Thanks