### PR TITLE
Prevent studio labels being overwritten by generic module labels

### DIFF
--- a/modules/ModuleBuilder/tpls/labels.tpl
+++ b/modules/ModuleBuilder/tpls/labels.tpl
@@ -70,7 +70,7 @@
 	{html_options name='selected_lang' options=$available_languages selected=$selected_lang onchange='this.form.action.value="EditLabels";ModuleBuilder.handleSave("editlabels")'}
         </td>
 	</tr>
-    {foreach from=$MOD item='label' key='key'}
+    {foreach from=$MOD_LABELS item='label' key='key'}
     <tr>
         <td align="right" style="padding: 0 1em 0 0">{$key}:</td>
         <td><input type='hidden' name='label_{$key}' id='label_{$key}' value='no_change'><input id='input_{$key}' onchange='document.getElementById("label_{$key}").value = this.value; ModuleBuilder.state.isDirty=true;' value='{$label}' size='60'></td>

--- a/modules/ModuleBuilder/views/view.labels.php
+++ b/modules/ModuleBuilder/views/view.labels.php
@@ -159,7 +159,7 @@ class ViewLabels extends ViewModulefields
         }
         $mod_strings = $mod_bak;
         ksort($formatted_mod_strings);
-		$smarty->assign('MOD', $formatted_mod_strings);
+		$smarty->assign('MOD_LABELS', $formatted_mod_strings);
 		$smarty->assign('view_module', $editModule);
 		$smarty->assign('APP', $GLOBALS['app_strings']);
 		$smarty->assign('selected_lang', $selected_lang);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changes the name of the variable in which studio stores the language strings when editing labels, to avoid them being overwritten by the 'ModuleBuilder' module strings.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #5432 

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Click on Admin.
2. Click on Studio.
3. Click on a module
4. Click on Labels

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->