### PR TITLE
Fix #719 YUI https - Blocked loading mixed active content

### DIFF
--- a/jssource/JSGroupings.php
+++ b/jssource/JSGroupings.php
@@ -1,10 +1,11 @@
 <?php
-/*********************************************************************************
+/**
+ *
  * SugarCRM Community Edition is a customer relationship management program developed by
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
-
- * SuiteCRM is an extension to SugarCRM Community Edition developed by Salesagility Ltd.
- * Copyright (C) 2011 - 2014 Salesagility Ltd.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2018 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the
@@ -15,7 +16,7 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
  * details.
  *
  * You should have received a copy of the GNU Affero General Public License along with
@@ -33,9 +34,9 @@
  * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
  * these Appropriate Legal Notices must retain the display of the "Powered by
  * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
- * reasonably feasible for  technical reasons, the Appropriate Legal Notices must
- * display the words  "Powered by SugarCRM" and "Supercharged by SuiteCRM".
- ********************************************************************************/
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
 
 /*
  * This is the array that is used to determine how to group/concatenate js files together
@@ -97,40 +98,58 @@
                'include/SugarFields/Fields/Collection/SugarFieldCollection.js' => 'include/javascript/sugar_field_grp.js',
                'include/SugarFields/Fields/Datetimecombo/Datetimecombo.js' => 'include/javascript/sugar_field_grp.js',
            ),
-            $sugar_grp1_yui = array(
-			//YUI scripts loaded on first page
-            'include/javascript/yui3/build/yui/yui-min.js'              => 'include/javascript/sugar_grp1_yui.js',
-            'include/javascript/yui3/build/loader/loader-min.js'        => 'include/javascript/sugar_grp1_yui.js',
-            'include/javascript/yui3/build/oop/oop-min.js'              => 'include/javascript/sugar_grp1_yui.js',
-            'include/javascript/yui3/build/event-custom/event-custom-base-min.js' => 'include/javascript/sugar_grp1_yui.js',
-            'include/javascript/yui3/build/io/io-base-min.js'           => 'include/javascript/sugar_grp1_yui.js',
-			'include/javascript/yui/build/yahoo/yahoo-min.js'           => 'include/javascript/sugar_grp1_yui.js',
-            'include/javascript/yui/build/dom/dom-min.js'               => 'include/javascript/sugar_grp1_yui.js',
-			'include/javascript/yui/build/yahoo-dom-event/yahoo-dom-event.js'
-			    => 'include/javascript/sugar_grp1_yui.js',
-			'include/javascript/yui/build/event/event-min.js'           => 'include/javascript/sugar_grp1_yui.js',
-			'include/javascript/yui/build/logger/logger-min.js'         => 'include/javascript/sugar_grp1_yui.js',
-            'include/javascript/yui/build/animation/animation-min.js'   => 'include/javascript/sugar_grp1_yui.js',
-            'include/javascript/yui/build/connection/connection-min.js' => 'include/javascript/sugar_grp1_yui.js',
-            'include/javascript/yui/build/dragdrop/dragdrop-min.js'     => 'include/javascript/sugar_grp1_yui.js',
-            //Ensure we grad the SLIDETOP custom container animation
-            'include/javascript/yui/build/container/container-min.js'   => 'include/javascript/sugar_grp1_yui.js',
-            'include/javascript/yui/build/element/element-min.js'       => 'include/javascript/sugar_grp1_yui.js',
-            'include/javascript/yui/build/tabview/tabview-min.js'       => 'include/javascript/sugar_grp1_yui.js',
-            'include/javascript/yui/build/selector/selector.js'     => 'include/javascript/sugar_grp1_yui.js',
-            //This should probably be removed as it is not often used with the rest of YUI
-            'include/javascript/yui/ygDDList.js'                        => 'include/javascript/sugar_grp1_yui.js',
-            //YUI based quicksearch
-            'include/javascript/yui/build/datasource/datasource-min.js' => 'include/javascript/sugar_grp1_yui.js',
-            'include/javascript/yui/build/json/json-min.js'             => 'include/javascript/sugar_grp1_yui.js',
-            'include/javascript/yui/build/autocomplete/autocomplete-min.js'=> 'include/javascript/sugar_grp1_yui.js',
-            'include/javascript/quicksearch.js'                         => 'include/javascript/sugar_grp1_yui.js',
-            'include/javascript/yui/build/menu/menu-min.js'             => 'include/javascript/sugar_grp1_yui.js',
-			'include/javascript/sugar_connection_event_listener.js'     => 'include/javascript/sugar_grp1_yui.js',
-			'include/javascript/yui/build/calendar/calendar.js'     => 'include/javascript/sugar_grp1_yui.js',
-            'include/javascript/yui/build/history/history.js'     => 'include/javascript/sugar_grp1_yui.js',
-            'include/javascript/yui/build/resize/resize-min.js'     => 'include/javascript/sugar_grp1_yui.js',
-            ),
+
+           $sugar_grp1_yui = array(
+               //YUI scripts loaded on first page
+               'include/javascript/yui3/build/yui/yui-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/loader/loader-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/oop/oop-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/event-custom/event-custom-base-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/io/io-base-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/dom/dom-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/event/event-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/attribute/attribute-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/pluginhost/pluginhost-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/classnamemanager/classnamemanager-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/base/base-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/node/node-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/widget/widget-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/widget/widget-stdmod-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/widget/widget-position-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/widget/widget-position-align-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/widget/widget-stack-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/widget/widget-position-constrain-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/overlay/overlay-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/plugin/plugin-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/anim/anim-base-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/widget-anim/widget-anim-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui3/build/event-custom/event-custom-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui/build/yahoo/yahoo-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui/build/dom/dom-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui/build/yahoo-dom-event/yahoo-dom-event.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui/build/event/event-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui/build/logger/logger-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui/build/animation/animation-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui/build/connection/connection-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui/build/dragdrop/dragdrop-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               //Ensure we grad the SLIDETOP custom container animation
+               'include/javascript/yui/build/container/container-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui/build/element/element-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui/build/tabview/tabview-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui/build/selector/selector.js' => 'include/javascript/sugar_grp1_yui.js',
+               //This should probably be removed as it is not often used with the rest of YUI
+               'include/javascript/yui/ygDDList.js' => 'include/javascript/sugar_grp1_yui.js',
+               //YUI based quicksearch
+               'include/javascript/yui/build/datasource/datasource-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui/build/json/json-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui/build/autocomplete/autocomplete-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/quicksearch.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui/build/menu/menu-min.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/sugar_connection_event_listener.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui/build/calendar/calendar.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui/build/history/history.js' => 'include/javascript/sugar_grp1_yui.js',
+               'include/javascript/yui/build/resize/resize-min.js' => 'include/javascript/sugar_grp1_yui.js',
+           ),
 
             $sugar_grp_yui_widgets = array(
 			//sugar_grp1_yui must be laoded before sugar_grp_yui_widgets


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
SuiteCRM can try to load in external YUI3 JavaScript not included YUI grouping file, when using HTTPS or internal instance this can cause functionality to fail

## How To Test This

- Rebuild cache js, clear browser cache
- Go to the Calendar
- Click any slot to add a meeting
- See that no additional JavaScript files are attempted to be load in externally ,
- It will still try to load external CSS file, but are not necessary!?! 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->