### PR TITLE
Fix #5520 Do not clear existing attachments when loading a template

### DIFF
--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -2524,8 +2524,7 @@ class Email extends Basic
         ////    ATTACHMENTS FROM DRAFTS
         if (($this->type == 'out' || $this->type == 'draft')
             && $this->status == 'draft'
-            && isset($_REQUEST['record'])
-            && empty($_REQUEST['ignoreParentAttachments'])) {
+            && isset($_REQUEST['record'])) {
             $this->getNotes($_REQUEST['record']); // cn: get notes from OLD email for use in new email
         }
         ////    END ATTACHMENTS FROM DRAFTS

--- a/modules/Emails/EmailsController.php
+++ b/modules/Emails/EmailsController.php
@@ -60,7 +60,7 @@ class EmailsController extends SugarController
     const ERR_REPLY_TO_FROMAT_INVALID_NO_NAME = 112;
     const ERR_REPLY_TO_FROMAT_INVALID_NO_ADDR = 113;
     const ERR_REPLY_TO_FROMAT_INVALID_AS_FROM = 114;
-    
+
     /**
      * @var Email $bean ;
      */

--- a/modules/Emails/include/ComposeView/ComposeView.tpl
+++ b/modules/Emails/include/ComposeView/ComposeView.tpl
@@ -191,19 +191,6 @@
         </div>
     </div>
     <div class="attachments">
-        {if $RETURN_MODULE != 'Emails' && $RETURN_ID}
-            <div class="bean-attachments">
-                <div class="bean-attachment-group-container">
-                    <input type="hidden" id="bean_attachment_{$RETURN_ID}" multiple="multiple">
-                    <label for="bean_attachment_{$RETURN_ID}" class="">
-                        <div class="bean-attachment-file-container file-image">
-                            <span class="bean-attachment-type glyphicon glyphicon-file"></span>
-                            <span class="bean-attachment-name">{$ATTACHMENT_NAME}</span>
-                        </div>
-                    </label>
-                </div>
-            </div>
-        {/if}
         <div class="file-attachments"></div>
         <div class="document-attachments"></div>
     </div>

--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -1237,6 +1237,7 @@
     }).done(function (jsonResponse) {
       var response = JSON.parse(jsonResponse);
       if (typeof response.data !== "undefined") {
+        $('.file-attachments').empty();
         $.fn.EmailsComposeView.loadAttachmentDataFromAjaxResponse(response);
       }
       if (typeof response.errors !== "undefined") {
@@ -1269,7 +1270,6 @@
 
   $.fn.EmailsComposeView.loadAttachmentDataFromAjaxResponse = function (response) {
     var isDraft = (typeof response.data.draft !== undefined && response.data.draft ? true : false);
-    $('.file-attachments').empty();
     var inputName = 'template_attachment[]';
     var removeName = 'temp_remove_attachment[]';
     if (isDraft) {

--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -1281,13 +1281,6 @@
         .attr('type', 'hidden')
         .attr('name', 'removeAttachment')
         .appendTo($('.file-attachments'));
-      if (!isDraft) {
-        $('<input>')
-          .attr('type', 'hidden')
-          .attr('name', 'ignoreParentAttachments')
-          .attr('value', '1')
-          .appendTo($('.file-attachments'));
-      }
       for (i = 0; i < response.data.attachments.length; i++) {
         var id = response.data.attachments[i]['id'];
         var fileGroupContainer = $('<div></div>')

--- a/modules/Emails/views/view.compose.php
+++ b/modules/Emails/views/view.compose.php
@@ -57,6 +57,8 @@ class EmailsViewCompose extends ViewEdit
      */
     public function __construct()
     {
+        parent::__construct();
+
         $this->type = 'compose';
         if (empty($_REQUEST['return_module'])) {
             $this->options['show_title'] = false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Change the behavior when selecting a template in Email compose view, so that current attachments are not removed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
#5520 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Compose e-mail
2. Add attachment
3. Select template
4. Attachment still exists, together with any template attachments

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->