### PR TITLE
Fix #4958 Replace related fields

### DIFF
--- a/modules/Accounts/Account.php
+++ b/modules/Accounts/Account.php
@@ -296,6 +296,27 @@ class Account extends Company implements EmailInterface {
 
         function create_export_query($order_by, $where, $relate_link_join='')
         {
+            $relatedJoins = [];
+            $relatedSelects = [];
+            foreach (explode('AND', $where) as $whereClause) {
+                $newWhereClause = str_replace('( ', '(', $whereClause);
+                foreach ($this->field_defs as $field_def) {
+                    $needle = '(' . $field_def['name'] . ' like';
+                    if (strpos($newWhereClause, $needle) !== false) {
+                        $joinAlias = 'rjt' . count($relatedJoins);
+                        $relatedJoins[] = ' LEFT JOIN ' . $field_def['table'] . ' as ' . $joinAlias . ' on ' .
+                            $joinAlias . '.id ' . ' = accounts.' . $field_def['id_name'] . ' ';
+                        $relatedSelects[] = ' ,' . $joinAlias . '.id ,' . $joinAlias . '.' . $field_def['rname'] . ' ';
+                        $newWhereClause = str_replace(
+                            $field_def['name'],
+                            $joinAlias . '.' . $field_def['rname'],
+                            $newWhereClause
+                        );
+                        $where = str_replace($whereClause, $newWhereClause, $where);
+                    }
+                }
+            }
+
             $custom_join = $this->getCustomJoin(true, true, $where);
             $custom_join['join'] .= $relate_link_join;
                          $query = "SELECT
@@ -305,6 +326,9 @@ class Account extends Company implements EmailInterface {
                                 "accounts.name as account_name,
                                 users.user_name as assigned_user_name ";
             $query .= $custom_join['select'];
+
+            $query .= implode('', $relatedSelects);
+
 						 $query .= " FROM accounts ";
                          $query .= "LEFT JOIN users
 	                                ON accounts.assigned_user_id=users.id ";
@@ -312,6 +336,8 @@ class Account extends Company implements EmailInterface {
 						//join email address table too.
 						$query .=  ' LEFT JOIN  email_addr_bean_rel on accounts.id = email_addr_bean_rel.bean_id and email_addr_bean_rel.bean_module=\'Accounts\' and email_addr_bean_rel.deleted=0 and email_addr_bean_rel.primary_address=1 ';
 						$query .=  ' LEFT JOIN email_addresses on email_addresses.id = email_addr_bean_rel.email_address_id ' ;
+
+            $query .= implode('', $relatedJoins);
 
             $query .= $custom_join['join'];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a bug in the Accounts export query generation, when exporting Accounts the generated query does not handle related fields correctly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
#4958 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Add a related field such as 'parent_name' or 'campaign_name' to the available fields on layouts filter and list views using studio
Filter accounts by this field, filter works fine
Select all accounts after filter and export them using export on 'bulk action' menu
The export works

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->