### PR TITLE
Fix for #5544

### DIFF
--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -5324,7 +5324,7 @@ class InboundEmail extends SugarBean
             if(empty($email->date_entered)) {
 
                 $possibleFormats = [
-                    \DateTime::RFC2822,
+                    \DateTime::RFC2822.'+',
                     str_replace(['D, '], '', \DateTime::RFC2822), // day-of-week is optional
                     str_replace([':s'], '', \DateTime::RFC2822), // seconds are optional
                     str_replace(['D, ', ':s'], '', \DateTime::RFC2822), // day-of-week is optional, seconds are optional


### PR DESCRIPTION
Simple fix for #5544 
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding a .'+' to the \DateTime::RFC2822 will make the pattern more tolerant and accept Date: headers with CFWS (comments)
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Headers with or without CFWS will be tolerated:

RFC2822 date without CFWS:	"Date: Tue, 19 Jan 2016 16:51:02 +0300"
RFC2822 date with CFWS:	        "Date: Tue, 19 Jan 2016 16:51:02 +0300 (MSK)"
## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->