### PR TITLE
set password expiry to zero when upgrading

### DIFF
--- a/modules/UpgradeWizard/PasswordExpirationService.php
+++ b/modules/UpgradeWizard/PasswordExpirationService.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ *
+ * SugarCRM Community Edition is a customer relationship management program developed by
+ * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2018 SalesAgility Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License version 3 as published by the
+ * Free Software Foundation with the addition of the following permission added
+ * to Section 15 as permitted in Section 7(a): FOR ANY PART OF THE COVERED WORK
+ * IN WHICH THE COPYRIGHT IS OWNED BY SUGARCRM, SUGARCRM DISCLAIMS THE WARRANTY
+ * OF NON INFRINGEMENT OF THIRD PARTY RIGHTS.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program; if not, see http://www.gnu.org/licenses or write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ *
+ * You can contact SugarCRM, Inc. headquarters at 10050 North Wolfe Road,
+ * SW2-130, Cupertino, CA 95014, USA. or at email address contact@sugarcrm.com.
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "Powered by
+ * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+class PasswordExpirationService
+{
+    const EXPIRATION_MESSAGE = 'Warning! Password expiraton is set to none!';
+
+    /**
+     * @return string
+     */
+    public function getExpirationMessage()
+    {
+        $this->setExpiration();
+        return self::EXPIRATION_MESSAGE;
+    }
+
+    /**
+     *
+     */
+    private function setExpiration()
+    {
+        global $sugar_config;
+
+        $sugar_config['passwordsetting']['systexpiration'] = '';
+        write_array_to_file("sugar_config", $sugar_config, "config.php");
+    }
+}

--- a/modules/UpgradeWizard/PasswordExpirationService.php
+++ b/modules/UpgradeWizard/PasswordExpirationService.php
@@ -44,7 +44,24 @@ if (!defined('sugarEntry') || !sugarEntry) {
 
 class PasswordExpirationService
 {
-    const EXPIRATION_MESSAGE = 'Warning! Password expiraton is set to none!';
+    /**
+     * @var array
+     */
+    private $suiteConfig;
+
+    /**
+     * @var array
+     */
+    private $modStrings;
+
+    public function __construct()
+    {
+        global $sugar_config;
+        global $mod_strings;
+
+        $this->suiteConfig = $sugar_config;
+        $this->modStrings = $mod_strings;
+    }
 
     /**
      * @return string
@@ -52,7 +69,15 @@ class PasswordExpirationService
     public function getExpirationMessage()
     {
         $this->setExpiration();
-        return self::EXPIRATION_MESSAGE;
+
+        $expirationMessage = sprintf(
+            '%s! <a href="%s/index.php?module=Administration&action=PasswordManager">%s</a>',
+            $this->modStrings['LBL_PASSWORD_EXPIRATON_CHANGED'],
+            $this->suiteConfig['site_url'],
+            $this->modStrings['LBL_PASSWORD_EXPIRATON_REDIRECT']
+        );
+
+        return $expirationMessage;
     }
 
     /**
@@ -60,9 +85,7 @@ class PasswordExpirationService
      */
     private function setExpiration()
     {
-        global $sugar_config;
-
-        $sugar_config['passwordsetting']['systexpiration'] = '';
-        write_array_to_file("sugar_config", $sugar_config, "config.php");
+        $this->suiteConfig['passwordsetting']['systexpiration'] = '';
+        write_array_to_file("sugar_config", $this->suiteConfig, "config.php");
     }
 }

--- a/modules/UpgradeWizard/end.php
+++ b/modules/UpgradeWizard/end.php
@@ -275,6 +275,9 @@ $cleanUrl = "{$parsedSiteUrl['scheme']}://{$host}{$port}{$path}/index.php";
 check_now(get_sugarbeat());
 ob_end_clean();*/
 
+include 'PasswordExpirationService.php';
+$expirationMessage = (new PasswordExpirationService())->getExpirationMessage();
+
 $uwMain = <<<eoq
 <table cellpadding="3" cellspacing="0" border="0">
 
@@ -287,6 +290,8 @@ $uwMain = <<<eoq
 			<br>
             <b>{$mod_strings['LBL_UW_END_LOGOUT_PRE']}</b> {$mod_strings['LBL_UW_END_LOGOUT']}
 			</p>
+			<br>
+			<p>{$expirationMessage}</p>
 		</td>
 	</tr>
 </table>

--- a/modules/UpgradeWizard/language/en_us.lang.php
+++ b/modules/UpgradeWizard/language/en_us.lang.php
@@ -249,7 +249,6 @@ $mod_strings = array(
     'ERROR_VERSION_INCOMPATIBLE' => 'The uploaded file is not compatible with this version of SuiteCRM: ',
     'ERROR_PHP_VERSION_INCOMPATIBLE' => 'The uploaded file is not compatible with this version of PHP: ',
     'ERROR_SUITECRM_VERSION_INCOMPATIBLE' => 'The uploaded file is not compatible with this version of SuiteCRM: ',
-    'ERROR_FLAVOR_INCOMPATIBLE' => 'The uploaded file is not compatible with this flavor (Community Edition, Professional, or Enterprise) of SuiteCRM: ',
     'LBL_LANGPACKS' => 'Language Packs' /*for 508 compliance fix*/,
     'LBL_MODULELOADER' => 'Module Loader' /*for 508 compliance fix*/,
     'LBL_PATCHUPGRADES' => 'Patch Upgrades' /*for 508 compliance fix*/,

--- a/modules/UpgradeWizard/language/en_us.lang.php
+++ b/modules/UpgradeWizard/language/en_us.lang.php
@@ -249,6 +249,7 @@ $mod_strings = array(
     'ERROR_VERSION_INCOMPATIBLE' => 'The uploaded file is not compatible with this version of SuiteCRM: ',
     'ERROR_PHP_VERSION_INCOMPATIBLE' => 'The uploaded file is not compatible with this version of PHP: ',
     'ERROR_SUITECRM_VERSION_INCOMPATIBLE' => 'The uploaded file is not compatible with this version of SuiteCRM: ',
+    'ERROR_FLAVOR_INCOMPATIBLE' => 'The uploaded file is not compatible with this flavor (Community Edition, Professional, or Enterprise) of SuiteCRM: ',
     'LBL_LANGPACKS' => 'Language Packs' /*for 508 compliance fix*/,
     'LBL_MODULELOADER' => 'Module Loader' /*for 508 compliance fix*/,
     'LBL_PATCHUPGRADES' => 'Patch Upgrades' /*for 508 compliance fix*/,
@@ -268,4 +269,6 @@ $mod_strings = array(
         7 => 'Failed to write file to disk.',
         8 => 'File upload stopped by extension.',
     ),
+    'LBL_PASSWORD_EXPIRATON_CHANGED' => 'Warning: password expiration is set to none!',
+    'LBL_PASSWORD_EXPIRATON_REDIRECT' => 'Please update your settings here',
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Drung the upgrade of SuiteCRM, password expiry's set to zero and user be informed about that.
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
- upgrade Suite
- check the warning message about password expiry in the end.
- check password expiry changed in password management [or systexpiration => '' in config.php[]
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->