### PR TITLE
Fix #5393 Load AOS_Products_Quotes from DB if it exists

### DIFF
--- a/modules/AOS_Products_Quotes/AOS_Products_Quotes.php
+++ b/modules/AOS_Products_Quotes/AOS_Products_Quotes.php
@@ -73,7 +73,10 @@ class AOS_Products_Quotes extends AOS_Products_Quotes_sugar
             if ($post_data[$key . 'deleted'][$i] == 1) {
                 $this->mark_deleted($post_data[$key . 'id'][$i]);
             } else {
-                $product_quote = new AOS_Products_Quotes();
+                $product_quote = BeanFactory::getBean('AOS_Products_Quotes', $post_data[$key . 'id'][$i]);
+                if (!$product_quote) {
+                    $product_quote = new AOS_Products_Quotes();
+                }
                 foreach ($this->field_defs as $field_def) {
                     $field_name = $field_def['name'];
                     if (isset($post_data[$key . $field_name][$i])) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When saving AOS_Products_Quotes instead of always creating a new bean we fetch the existing bean if there is one.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #5393 

## How To Test This
<!--- Please describe in detail how to test your changes. -->

- Create Quote with some Line Items
- Create WorkFlow for module Line Items with Run On: Modified Records
- Change the quantify in a Quote
- Look at the WorkFlow process audit

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->