### PR TITLE
Fixed #5586 -PHP error: Non-static method SecurityGroup::getGroupWhere() should not be called statically

### DIFF
--- a/modules/SecurityGroups/SecurityGroup.php
+++ b/modules/SecurityGroups/SecurityGroup.php
@@ -39,7 +39,7 @@ class SecurityGroup extends SecurityGroup_sugar
      * @param string $user_id
      * @return string
      */
-    public function getGroupWhere($table_name, $module, $user_id)
+    public static function getGroupWhere($table_name, $module, $user_id)
     {
 
         //need a different query if doing a securitygroups check


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Deprecated: Non-static method SecurityGroup::getGroupWhere() should not be called statically in /home/ccxxxx/public_html/suitecrm/data/SugarBean.php on line 3554

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Check that the PHP error is no longer present on the homepage

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #5586 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->