### PR TITLE
Fix/5585 re enable ajax module

### DIFF
--- a/modules/Administration/controller.php
+++ b/modules/Administration/controller.php
@@ -138,6 +138,7 @@ class AdministrationController extends SugarController
         $cfg = new Configurator();
         $disabled = json_decode(html_entity_decode  ($_REQUEST['disabled_modules'], ENT_QUOTES));
         $cfg->config['addAjaxBannedModules'] = empty($disabled) ? FALSE : $disabled;
+        $cfg->addKeyToIgnoreOverride('addAjaxBannedModules', $disabled);
         $cfg->handleOverride();
         $this->view = "configureajaxui";
     }

--- a/modules/Configurator/Configurator.php
+++ b/modules/Configurator/Configurator.php
@@ -153,7 +153,8 @@ class Configurator {
 	}
 
     /**
-     * @param $key
+     * @param mixed $key
+     * @param mixed $value
      */
     public function addKeyToIgnoreOverride($key, $value)
     {

--- a/modules/Configurator/Configurator.php
+++ b/modules/Configurator/Configurator.php
@@ -50,6 +50,12 @@ class Configurator {
 	var $logger = NULL;
 	var $previous_sugar_override_config_array = array();
 	var $useAuthenticationClass = false;
+
+    /**
+     * @var array
+     */
+    protected $keysToIgnoreLoadedOverrideFile = [];
+
 	protected $error = null;
 
 	function __construct() {
@@ -98,6 +104,10 @@ class Configurator {
 		$diffArray = deepArrayDiff($this->config, $sugar_config);
 		$overrideArray = sugarArrayMergeRecursive($overrideArray, $diffArray);
 
+      foreach ($this->keysToIgnoreLoadedOverrideFile as $key => $val) {
+          $overrideArray[$key] = $val;
+      }
+
 		// To remember checkbox state
 		if (!$this->useAuthenticationClass && !$fromParseLoggerSettings) {
 			if (isset($overrideArray['authenticationClass']) &&
@@ -141,6 +151,14 @@ class Configurator {
 		$this->saveOverride($overideString);
 		if(isset($this->config['logger']['level']) && $this->logger) $this->logger->setLevel($this->config['logger']['level']);
 	}
+
+    /**
+     * @param $key
+     */
+    public function addKeyToIgnoreOverride($key, $value)
+    {
+        $this->keysToIgnoreLoadedOverrideFile[$key] = $value;
+    }
 
 	//bug #27947 , if previous $sugar_config['stack_trace_errors'] is true and now we disable it , we should clear all the cache.
 	function clearCache(){


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a bug where a module cannot be enabled for ajax after being disabled.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #5585 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to the Administration page, then 'System Settings', and click the 'Configure AJAX User Interface' link
2. Drag the Leads module from the enabled side to the disabled side.
3. Save.
4. Go back to the main Administration page, then 'System Settings', and click the 'Configure AJAX User Interface' link
5. Drag the Leads module back to the enabled side.
6. Save.
7. Go back to the main Administration page, then 'System Settings', and click the 'Configure AJAX User Interface' link

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->