### PR TITLE
Fix #5280 Set cookie to remember subpanel collapse status

### DIFF
--- a/include/SubPanel/SubPanelTiles.js
+++ b/include/SubPanel/SubPanelTiles.js
@@ -77,6 +77,7 @@ current_subpanel_url=url;var loadingImg='<img src="themes/'+SUGAR.themes.theme_n
 request_id++;}});}else{var subpanel=document.getElementById('subpanel_'+child_field);subpanel.style.display='';set_div_cookie(subpanel.cookie_name,'');if(current_child_field!=''&&child_field!=current_child_field){hideSubPanel(current_child_field);}
 current_child_field=child_field;}
 if(typeof(url)!='undefined'&&url!=null&&url.indexOf('refresh_page=1')>0){document.location.reload();}}
+function toggleSubpanelCookie(tab){set_div_cookie(get_module_name()+'_'+tab+'_v',!$('#subpanel_'+tab).is(":visible"));}
 function markSubPanelLoaded(child_field){child_field_loaded[child_field]=2;}
 function hideSubPanel(child_field){var subpanel=document.getElementById('subpanel_'+child_field);subpanel.style.display='none';set_div_cookie(subpanel.cookie_name,'none');}
 var sub_cookie_name=get_module_name()+'_divs';var temp=Get_Cookie(sub_cookie_name);var div_cookies=new Array();if(temp&&typeof(temp)!='undefined'){div_cookies=get_sub_cookies(temp);}

--- a/include/SubPanel/SubPanelTiles.php
+++ b/include/SubPanel/SubPanelTiles.php
@@ -298,33 +298,27 @@ class SubPanelTiles
                 }
             }
 
-            $display = 'none';
             $div_display = $default_div_display;
-            $cookie_name =   $tab . '_v';
 
-            if (isset($thisPanel->_instance_properties['collapsed']) && $thisPanel->_instance_properties['collapsed'])
-            {
+            if (isset($thisPanel->_instance_properties['collapsed'])
+                && $thisPanel->_instance_properties['collapsed']) {
                 $div_display = 'none';
             }
 
-            if(isset($div_cookies[$cookie_name])){
-                // If defaultSubPanelExpandCollapse is set, ignore the cookie that remembers whether the panel is expanded or collapsed.
-                // To be used with the above 'collapsed' metadata setting so they will always be set the same when the page is loaded.
-                if(!isset($sugar_config['defaultSubPanelExpandCollapse']) || $sugar_config['defaultSubPanelExpandCollapse'] == false)
-                {
-                    $div_display = 	$div_cookies[$cookie_name];
-                }
-            }
-
-            if(!empty($sugar_config['hide_subpanels']) or $thisPanel->isDefaultHidden()) {
+            if (!empty($sugar_config['hide_subpanels']) || $thisPanel->isDefaultHidden()) {
                 $div_display = 'none';
             }
 
-            if($div_display == 'none'){
-                $opp_display  = 'inline';
+            $cookie_name = $this->module . '_' . $tab . '_v';
+            if (isset($div_cookies[$cookie_name])) {
+                $div_display = $div_cookies[$cookie_name] === 'false' ? 'none' : '';
+            }
+
+            if ($div_display == 'none') {
+                $opp_display = 'inline';
                 $tabs_properties[$t]['expanded_subpanels'] = false;
-            } else{
-                $opp_display  = 'none';
+            } else {
+                $opp_display = 'none';
                 $tabs_properties[$t]['expanded_subpanels'] = true;
             }
 

--- a/jssource/src_files/include/SubPanel/SubPanelTiles.js
+++ b/jssource/src_files/include/SubPanel/SubPanelTiles.js
@@ -326,6 +326,10 @@ function showSubPanel(child_field, url, force_load, layout_def_key) {
 
 }
 
+function toggleSubpanelCookie(tab) {
+  set_div_cookie(get_module_name() + '_' + tab + '_v', !$('#subpanel_' + tab).is(":visible"));
+}
+
 function markSubPanelLoaded(child_field) {
   child_field_loaded[child_field] = 2;
 }

--- a/themes/SuiteP/include/SubPanel/tpls/SubPanelTiles.tpl
+++ b/themes/SuiteP/include/SubPanel/tpls/SubPanelTiles.tpl
@@ -10,10 +10,11 @@
             <div class="panel-heading panel-heading-collapse">
 
             {if $subpanel_tabs_properties.$i.expanded_subpanels == true}
-                <a id="subpanel_title_{$subpanel_tab}" class="in" role="button" data-toggle="collapse" href="#subpanel_{$subpanel_tab}" aria-expanded="false">
+                <a id="subpanel_title_{$subpanel_tab}" class="in" role="button" data-toggle="collapse" href="#subpanel_{$subpanel_tab}" aria-expanded="false"
+                   onclick="toggleSubpanelCookie('{$subpanel_tab}');">
             {else}
-                    <a id="subpanel_title_{$subpanel_tab}" class="collapsed" role="button" data-toggle="collapse"
-                       href="#subpanel_{$subpanel_tab}" aria-expanded="false" onclick="showSubPanel('{$subpanel_tab}')">
+                    <a id="subpanel_title_{$subpanel_tab}" class="collapsed" role="button" data-toggle="collapse" href="#subpanel_{$subpanel_tab}" aria-expanded="false"
+                       onclick="showSubPanel('{$subpanel_tab}'); toggleSubpanelCookie('{$subpanel_tab}');">
             {/if}
                     <div class="col-xs-10 col-sm-11 col-md-11">
                         <div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a bug introduced in earlier versions causing subpanel collapse status was not being saved in cookies.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #5280 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Enter any record with subpanels
2. Expand or collapse a subpanel
3. Enter another record of the same type
4. See the same subpanels are collapsed or expanded

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->