### PR TITLE
WIP Stop hiding checkbox that should be visible

### DIFF
--- a/modules/EmailMan/tpls/config.tpl
+++ b/modules/EmailMan/tpls/config.tpl
@@ -642,10 +642,6 @@ function notify_setrequired(f) {
 	document.getElementById("smtp_auth1").style.visibility = (document.getElementById('mail_smtpauth_req').checked) ? "visible" : "hidden";
 	document.getElementById("smtp_auth2").style.display = (document.getElementById('mail_smtpauth_req').checked) ? "" : "none";
 	document.getElementById("smtp_auth2").style.visibility = (document.getElementById('mail_smtpauth_req').checked) ? "visible" : "hidden";
-	if( document.getElementById('mail_smtpauth_req').checked)
-	   YAHOO.util.Dom.removeClass('mail_allow_user', "yui-hidden");
-	else
-	   YAHOO.util.Dom.addClass("mail_allow_user", "yui-hidden");
 
 	return true;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Prevents a checkbox from being hidden.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
The checkbox 'Allow users to use this account for outgoing email' gets hidden if you uncheck 'Use SMTP Authentication'. Since these are not really related this shouldn't happen. 

Result:

![image](https://user-images.githubusercontent.com/34056696/38019284-1687e866-326f-11e8-82fe-0b353a044481.png)

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Go into Admin
Go into Email Settings
Uncheck 'Use SMTP Authentication'
See the checkbox in question is still visible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->