### PR TITLE
Removes a blank inherited function preventing the parent from running

### DIFF
--- a/modules/Tasks/Task.php
+++ b/modules/Tasks/Task.php
@@ -158,13 +158,6 @@ class Task extends SugarBean {
 
         }
 
-
-
-	function fill_in_additional_list_fields()
-	{
-
-	}
-
 	function fill_in_additional_detail_fields()
 	{
         parent::fill_in_additional_detail_fields();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
An empty override in Task::fill_in_additional_list_fields was preventing the parent_name field from showing correctly in List View.
Found and fixed by @Jason-Dang 

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Create a couple of Tasks with Relate To records
2. See they show correctly in List View

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->