### PR TITLE
Fix #5624 Make all widget method signatures match their parents

### DIFF
--- a/include/generic/SugarWidgets/SugarWidgetField.php
+++ b/include/generic/SugarWidgets/SugarWidgetField.php
@@ -165,7 +165,7 @@ class SugarWidgetField extends SugarWidget {
 
 	}
 
-	function displayList($layout_def) {
+	function displayList(&$layout_def) {
 		return $this->displayListPlain($layout_def);
 	}
 

--- a/include/generic/SugarWidgets/SugarWidgetFieldcurrency.php
+++ b/include/generic/SugarWidgets/SugarWidgetFieldcurrency.php
@@ -90,7 +90,7 @@ class SugarWidgetFieldCurrency extends SugarWidgetFieldInt
 
 
 
-    function & displayList($layout_def)
+    function & displayList(&$layout_def)
         {
             global $locale;
             $symbol = $locale->getPrecedentPreference('default_currency_symbol');

--- a/include/generic/SugarWidgets/SugarWidgetFielddate.php
+++ b/include/generic/SugarWidgets/SugarWidgetFielddate.php
@@ -42,7 +42,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 
 class SugarWidgetFieldDate extends SugarWidgetFieldDateTime
 {
-    function displayList($layout_def)
+    function displayList(&$layout_def)
     {
         global $timedate;
         // i guess qualifier and column_function are the same..
@@ -78,7 +78,7 @@ class SugarWidgetFieldDate extends SugarWidgetFieldDateTime
         return $this->queryDateOp($this->_get_column_select($layout_def), $layout_def['input_name0'], "=", "date");
     }
 
-    function queryFilterBetween_Dates(& $layout_def)
+    function queryFilterBetween_Dates($layout_def)
     {
         $begin = $layout_def['input_name0'];
         $end = $layout_def['input_name1'];

--- a/include/generic/SugarWidgets/SugarWidgetFielddatetime.php
+++ b/include/generic/SugarWidgets/SugarWidgetFielddatetime.php
@@ -553,7 +553,7 @@ class SugarWidgetFieldDateTime extends SugarWidgetReportField
         }
     }
 
-    function displayList($layout_def) {
+    function displayList(&$layout_def) {
         global $timedate;
         // i guess qualifier and column_function are the same..
         if (!empty ($layout_def['column_function'])) {

--- a/include/generic/SugarWidgets/SugarWidgetFieldenum.php
+++ b/include/generic/SugarWidgets/SugarWidgetFieldenum.php
@@ -107,7 +107,7 @@ class SugarWidgetFieldEnum extends SugarWidgetReportField
 		return $this->_get_column_select($layout_def)." NOT IN (".$str.")\n";
 	}
 
-    function & displayList($layout_def) {
+    function & displayList(&$layout_def) {
         if(!empty($layout_def['column_key'])){
             $field_def = $this->reporter->all_fields[$layout_def['column_key']];
         }else if(!empty($layout_def['fields'])){

--- a/include/generic/SugarWidgets/SugarWidgetFieldfloat.php
+++ b/include/generic/SugarWidgets/SugarWidgetFieldfloat.php
@@ -41,7 +41,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 
 class SugarWidgetFieldFloat extends SugarWidgetFieldInt
 {
- function displayList($layout_def)
+ function displayList(&$layout_def)
  {
  	
     $vardef = $this->getVardef($layout_def);

--- a/include/generic/SugarWidgets/SugarWidgetFieldid.php
+++ b/include/generic/SugarWidgets/SugarWidgetFieldid.php
@@ -42,7 +42,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 class SugarWidgetFieldId extends SugarWidgetReportField
 {
 
- function queryFilterIs(&$layout_def)
+ function queryFilterIs($layout_def)
  {
 		return $this->_get_column_select($layout_def)."='".$GLOBALS['db']->quote($layout_def['input_name0'])."'\n";
  }

--- a/include/generic/SugarWidgets/SugarWidgetFieldint.php
+++ b/include/generic/SugarWidgets/SugarWidgetFieldint.php
@@ -42,7 +42,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 
 class SugarWidgetFieldInt extends SugarWidgetReportField
 {
- function displayList($layout_def)
+ function displayList(&$layout_def)
  {
 
  	return $this->displayListPlain($layout_def);

--- a/include/generic/SugarWidgets/SugarWidgetFieldmultienum.php
+++ b/include/generic/SugarWidgets/SugarWidgetFieldmultienum.php
@@ -41,7 +41,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 
 
 class SugarWidgetFieldMultiEnum extends SugarWidgetFieldEnum {
-	public function queryFilternot_one_of(&$layout_def) {
+	public function queryFilternot_one_of($layout_def) {
 		$arr = array ();
 		foreach ($layout_def['input_name0'] as $value) {
 			array_push($arr, "'".$GLOBALS['db']->quote($value)."'");
@@ -62,7 +62,7 @@ class SugarWidgetFieldMultiEnum extends SugarWidgetFieldEnum {
 		return '('.$query.')';        
 	}
         
-    public function queryFilterone_of(&$layout_def) {
+    public function queryFilterone_of($layout_def) {
         //Fix for inaccurate filtering of contacts in Contacts dashlet on multiselects.
         $arr = array();
         foreach ($layout_def['input_name0'] as $value) {

--- a/include/generic/SugarWidgets/SugarWidgetFieldname.php
+++ b/include/generic/SugarWidgets/SugarWidgetFieldname.php
@@ -224,7 +224,7 @@ class SugarWidgetFieldName extends SugarWidgetFieldVarchar
 	}
 
     // $rename_columns, if true then you're coming from reports
-	function queryFilterone_of($layout_def, $rename_columns = true)
+	function queryFilterone_of(&$layout_def, $rename_columns = true)
 	{
 
         if($rename_columns) { // this was a hack to get reports working, sugarwidgets should not be renaming $name!

--- a/include/generic/SugarWidgets/SugarWidgetFieldparent_type.php
+++ b/include/generic/SugarWidgets/SugarWidgetFieldparent_type.php
@@ -62,7 +62,7 @@ class SugarWidgetFieldparent_type extends SugarWidgetFieldEnum
     }
 
 
-    function displayListPlain($layout_def) {
+    function & displayListPlain($layout_def) {
         $value= $this->_get_list_value($layout_def);
         if (isset($layout_def['widget_type']) && $layout_def['widget_type'] =='checkbox') {
             if ($value != '' &&  ($value == 'on' || intval($value) == 1 || $value == 'yes'))

--- a/include/generic/SugarWidgets/SugarWidgetFieldrelate.php
+++ b/include/generic/SugarWidgets/SugarWidgetFieldrelate.php
@@ -194,7 +194,7 @@ class SugarWidgetFieldRelate extends SugarWidgetReportField
 		return $cell;
 	}
 
-    function displayList($layout_def) {
+    function displayList(&$layout_def) {
         $reporter = $this->layout_manager->getAttribute("reporter");
         $field_def = $reporter->all_fields[$layout_def['column_key']];
         $display = strtoupper($field_def['secondary_table'].'_name');

--- a/include/generic/SugarWidgets/SugarWidgetFieldsingleenum.php
+++ b/include/generic/SugarWidgets/SugarWidgetFieldsingleenum.php
@@ -43,7 +43,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  
 class SugarWidgetFieldSingleEnum extends SugarWidgetFieldEnum {
     
-    function displayInput(&$layout_def) {
+    function displayInput($layout_def) {
         global $app_list_strings;
 
         if(!empty($layout_def['remove_blank']) && $layout_def['remove_blank']) {

--- a/include/generic/SugarWidgets/SugarWidgetFieldtext.php
+++ b/include/generic/SugarWidgets/SugarWidgetFieldtext.php
@@ -87,7 +87,7 @@ class SugarWidgetFieldText extends SugarWidgetFieldVarchar
         return "($column IS NULL OR ".$this->reporter->db->convert($column, "length")." = 0)";
     }
 
-    function displayList($layout_def) {
+    function displayList(&$layout_def) {
         return nl2br(parent::displayListPlain($layout_def));
     }
 }

--- a/include/generic/SugarWidgets/SugarWidgetFieldtime.php
+++ b/include/generic/SugarWidgets/SugarWidgetFieldtime.php
@@ -41,7 +41,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 
 class SugarWidgetFieldTime extends SugarWidgetFieldDateTime
 {
-        function displayList($layout_def)
+        function displayList(&$layout_def)
         {
                 global $timedate;
                 // i guess qualifier and column_function are the same..

--- a/include/generic/SugarWidgets/SugarWidgetFieldurl.php
+++ b/include/generic/SugarWidgets/SugarWidgetFieldurl.php
@@ -45,7 +45,7 @@ class SugarWidgetFieldURL extends SugarWidgetFieldVarchar
      * @param array $layout_def definition of field which we want to display as link
      * @return string html code
      */
-    function displayList($layout_def) 
+    function displayList(&$layout_def)
     {
         $urlValue = trim($this->_get_list_value($layout_def));
         return '<a target="_blank" href="' . $urlValue . '">' . $urlValue . "</a>";

--- a/include/generic/SugarWidgets/SugarWidgetFielduser_name.php
+++ b/include/generic/SugarWidgets/SugarWidgetFielduser_name.php
@@ -43,7 +43,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 
 class SugarWidgetFielduser_name extends SugarWidgetFieldname
 {
- function displayInput(&$layout_def) 
+ function displayInput($layout_def)
  {
         $selected_users = empty($layout_def['input_name0']) ? '' : $layout_def['input_name0'];
  		$str = '<select multiple="true" size="3" name="' . $layout_def['name'] . '[]">' . get_select_options_with_id(get_user_array(false), $selected_users) . '</select>';

--- a/include/generic/SugarWidgets/SugarWidgetFieldvarchar.php
+++ b/include/generic/SugarWidgets/SugarWidgetFieldvarchar.php
@@ -61,12 +61,12 @@ class SugarWidgetFieldVarchar extends SugarWidgetReportField
     }
 
 
- function queryFilterEquals(&$layout_def)
+ function queryFilterEquals($layout_def)
  {
 		return $this->_get_column_select($layout_def)."='".$GLOBALS['db']->quote($layout_def['input_name0'])."'\n";
  }
 
- function queryFilterNot_Equals_Str(&$layout_def)
+ function queryFilterNot_Equals_Str($layout_def)
  {
 		return $this->_get_column_select($layout_def)."!='".$GLOBALS['db']->quote($layout_def['input_name0'])."'\n";
  }

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelActivitiesStatusField.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelActivitiesStatusField.php
@@ -46,7 +46,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 
 class SugarWidgetSubPanelActivitiesStatusField extends SugarWidgetField
 {
-	function displayList($layout_def)
+	function displayList(&$layout_def)
 	{
 		global $current_language;
 		$app_list_strings = return_app_list_strings_language($current_language);

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelCloseButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelCloseButton.php
@@ -45,7 +45,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 //TODO Rename this to close button field
 class SugarWidgetSubPanelCloseButton extends SugarWidgetField
 {
-	function displayList($layout_def)
+	function displayList(&$layout_def)
 	{
 		global $app_strings;
         global $subpanel_item_count;

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelDelegatesSelectButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelDelegatesSelectButton.php
@@ -43,7 +43,7 @@ require_once('include/generic/SugarWidgets/SugarWidgetSubPanelTopButton.php');
 class SugarWidgetSubPanelDelegatesSelectButton extends SugarWidgetSubPanelTopButton
 {
     
-    function display($defines, $additionalFormFields = null)
+    function display($defines, $additionalFormFields = null, $nonbutton = false)
     {
         global $mod_strings;
         $button = "<script src='include/javascript/checkbox.js' type='text/javascript'></script>";

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelDeleteButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelDeleteButton.php
@@ -44,7 +44,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 
 class SugarWidgetSubPanelDeleteButton extends SugarWidgetField
 {
-	function displayList($layout_def)
+	function displayList(&$layout_def)
 	{
 		global $app_strings;
         global $subpanel_item_count;

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelDetailViewLink.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelDetailViewLink.php
@@ -45,7 +45,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 
 class SugarWidgetSubPanelDetailViewLink extends SugarWidgetField
 {
-	function displayList($layout_def)
+	function displayList(&$layout_def)
 	{
 		global $focus;
 

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelEditButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelEditButton.php
@@ -53,7 +53,7 @@ class SugarWidgetSubPanelEditButton extends SugarWidgetField
 		return '';
 	}
 
-	function displayList($layout_def)
+	function displayList(&$layout_def)
 	{
 		global $app_strings;
         global $subpanel_item_count;

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelEditRoleButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelEditRoleButton.php
@@ -45,7 +45,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 
 class SugarWidgetSubPanelEditRoleButton extends SugarWidgetField
 {
-	function displayHeaderCell(&$layout_def)
+	function displayHeaderCell($layout_def)
 	{
 		return '&nbsp;';
 	}

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelEditSecurityGroupUserButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelEditSecurityGroupUserButton.php
@@ -43,14 +43,14 @@ require_once('include/generic/SugarWidgets/SugarWidgetField.php');
 
 class SugarWidgetSubPanelEditSecurityGroupUserButton extends SugarWidgetField
 {
-	function displayHeaderCell(&$layout_def)
+	function displayHeaderCell($layout_def)
 	{
 		return '&nbsp;';
 	}
 
-	function displayDetail($layout_def) {
+	function & displayDetail($layout_def) {
 
-		return displayList($layout_def);
+		return $this->displayList($layout_def);
 	}
 
 	function displayList(&$layout_def)

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelEmailLink.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelEmailLink.php
@@ -51,7 +51,7 @@ class SugarWidgetSubPanelEmailLink extends SugarWidgetField
      * @param array $layout_def
      * @return string
      */
-    function displayList($layout_def)
+    function displayList(&$layout_def)
     {
         global $current_user;
         global $sugar_config;

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelGetLatestButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelGetLatestButton.php
@@ -50,7 +50,7 @@ class SugarWidgetSubPanelGetLatestButton extends SugarWidgetField
 		return '&nbsp;';
 	}
 
-	function displayList($layout_def)
+	function displayList(&$layout_def)
 	{
 		//if the contract has been executed or selected_revision is same as latest revision
 		//then hide the latest button. 		

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelIcon.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelIcon.php
@@ -50,7 +50,7 @@ class SugarWidgetSubPanelIcon extends SugarWidgetField
 		return '&nbsp;';
 	}
 
-	function displayList($layout_def)
+	function displayList(&$layout_def)
 	{
 		global $app_strings;
 		global $app_list_strings;

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelLoadSignedButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelLoadSignedButton.php
@@ -50,7 +50,7 @@ class SugarWidgetSubPanelLoadSignedButton extends SugarWidgetField
 		return '&nbsp;';
 	}
 
-	function displayList($layout_def)
+	function displayList(&$layout_def)
 	{
 		global $app_strings;
 		

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelManageAcceptancesButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelManageAcceptancesButton.php
@@ -6,7 +6,7 @@ require_once('include/generic/SugarWidgets/SugarWidgetSubPanelTopButton.php');
 class SugarWidgetSubPanelManageAcceptancesButton extends SugarWidgetSubPanelTopButton
 {
     
-    function display($defines, $additionalFormFields = null)
+    function display($defines, $additionalFormFields = null, $nonbutton = false)
     {
         global $mod_strings;
         

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelManageDelegatesButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelManageDelegatesButton.php
@@ -43,7 +43,7 @@ require_once('include/generic/SugarWidgets/SugarWidgetSubPanelTopButton.php');
 class SugarWidgetSubPanelManageDelegatesButton extends SugarWidgetSubPanelTopButton
 {
     
-    function display($defines, $additionalFormFields = null)
+    function display($defines, $additionalFormFields = null, $nonbutton = false)
     {
         global $mod_strings;
         

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelRelFieldEditButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelRelFieldEditButton.php
@@ -45,7 +45,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 //TODO Rename this to edit link
 class SugarWidgetSubPanelRelFieldEditButton extends SugarWidgetField
 {
-	function displayHeaderCell(&$layout_def)
+	function displayHeaderCell($layout_def)
 	{
 		return '&nbsp;';
 	}

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButton.php
@@ -49,7 +49,7 @@ class SugarWidgetSubPanelRemoveButton extends SugarWidgetField
         return '&nbsp;';
     }
 
-    function displayList($layout_def)
+    function displayList(&$layout_def)
     {
 
         global $app_strings;

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButtonAccount.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButtonAccount.php
@@ -43,10 +43,12 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 
 
 class SugarWidgetSubPanelRemoveButtonAccount extends SugarWidgetSubPanelRemoveButton {
-	/**
-	 * 
-	 * @see SugarWidgetSubPanelRemoveButton::displayList()
-	 */
+    /**
+     *
+     * @see SugarWidgetSubPanelRemoveButton::displayList()
+     * @param $layout_def
+     * @return bool|string
+     */
 	function displayList(&$layout_def) {
 		if (!$layout_def['EditView']) {
 			return false;

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButtonMeetings.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButtonMeetings.php
@@ -50,7 +50,7 @@ class SugarWidgetSubPanelRemoveButtonMeetings extends SugarWidgetField
 		return '&nbsp;';
 	}
 
-	function displayList($layout_def)
+	function displayList(&$layout_def)
 	{
 		global $app_strings;
 		

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButtonProjects.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButtonProjects.php
@@ -45,7 +45,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 
 class SugarWidgetSubPanelRemoveButtonProjects extends SugarWidgetField
 {
-	function displayHeaderCell(&$layout_def)
+	function displayHeaderCell($layout_def)
 	{
 		return '&nbsp;';
 	}

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelSelectAllButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelSelectAllButton.php
@@ -42,7 +42,7 @@ require_once('include/generic/SugarWidgets/SugarWidgetSubPanelTopButton.php');
 
 class SugarWidgetSubPanelSelectAllButton extends SugarWidgetSubPanelTopButton
 {
-    function display($defines, $additionalFormFields = null)
+    function display($defines, $additionalFormFields = null, $nonbutton = false)
     {
         $button  = "<form method='post' action='/index.php?module=MODULE_NAME&action=CUSTOM_ACTION'>";
        // $button .= "<input id='custom_hidden_1' type='hidden' name='custom_hidden_1' value=''/>";

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelSendInvitesButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelSendInvitesButton.php
@@ -42,7 +42,7 @@ require_once('include/generic/SugarWidgets/SugarWidgetSubPanelTopButton.php');
 
 class SugarWidgetSubPanelSendInvitesButton extends SugarWidgetSubPanelTopButton
 {
-    function display($defines, $additionalFormFields = null)
+    function display($defines, $additionalFormFields = null, $nonbutton = false)
     {
         global $mod_strings;
        

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelTopCreateCampaignLogEntryButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelTopCreateCampaignLogEntryButton.php
@@ -49,7 +49,7 @@ class SugarWidgetSubPanelTopCreateCampaignLogEntryButton extends SugarWidgetSubP
         return parent::getWidgetId() . '_select_button';
     }
 
-    function display($widget_data)
+    function display($widget_data, $additionalFormFields = null, $nonbutton = false)
     {
         global $app_strings;
         global $mod_strings;

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelTopMessage.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelTopMessage.php
@@ -46,7 +46,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 
 class SugarWidgetSubPanelTopMessage extends SugarWidgetSubPanelTopButton
 {
-	function display($defines)
+	function display($defines, $additionalFormFields = null, $nonbutton = false)
 	{
         return $defines['message'];
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Makes all SugarWidgets method signatures match their parents.

Removed the & reference parameter whenever possible, and added it to all child class methods when not.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Remove phpnotices.
Issue #5624 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->