### PR TITLE
Fix for #5166

### DIFF
--- a/modules/Users/password_utils.php
+++ b/modules/Users/password_utils.php
@@ -85,7 +85,7 @@ function  hasPasswordExpired($username){
 	$current_user->retrieve($usr_id);
     $type='syst';
 
-    if ($current_user->portal_only=='0'){
+    if ( ($current_user->portal_only=='0') && ($current_user->system_generated_password=='1') ){
 	    global $mod_strings, $timedate;
 	    $res=$GLOBALS['sugar_config']['passwordsetting'];
 	  	if ($type != '') {


### PR DESCRIPTION
Check for password expiration only when password was system generated

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
By default, 7.10 would ask users to change their passwords after 7 days even though the password was not system generated. The only way to disable this is to enable the generation of system generated passwords and disable password expiration.
## How To Test This
<!--- Please describe in detail how to test your changes. -->
Don't change any system settings, ie. make sure not to enable system password generation (and keep the default of 7 days password expiration in that section). Set the value of "pwd_last_changed" to a date more than 7 days old. Without my fix, you will be asked to change your password at login; with my change, you won't.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->