### PR TITLE
Fixed #5656 - ListViewDisplay Incorrectly Checking for $this->email to be 'Set' Instead of True/False

### DIFF
--- a/include/ListView/ListViewDisplay.php
+++ b/include/ListView/ListViewDisplay.php
@@ -327,7 +327,7 @@ class ListViewDisplay {
             }
 
             // Compose email
-            if ($this->email) {
+            if (isset($this->email) && $this->email === true) {
                 $menuItems[] = $this->buildComposeEmailLink($this->data['pageData']['offsets']['total'], $location);
             }
 

--- a/include/ListView/ListViewDisplay.php
+++ b/include/ListView/ListViewDisplay.php
@@ -326,8 +326,8 @@ class ListViewDisplay {
                 }
             }
 
-            // compose email
-            if (isset($this->email)) {
+            // Compose email
+            if ($this->email) {
                 $menuItems[] = $this->buildComposeEmailLink($this->data['pageData']['offsets']['total'], $location);
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixes a bug that prevents $this->lv->email = false; from having an effect on showing the email link in the list-view.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #5656 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to employees module..
2. Check that the email link next to bulk action is gone.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->