### PR TITLE
Fix/5628 emails apostrophe

### DIFF
--- a/modules/Emails/EmailsController.php
+++ b/modules/Emails/EmailsController.php
@@ -802,6 +802,8 @@ class EmailsController extends SugarController
                     $this->bean->description;
             }
         }
+
+        $this->bean->description_html = '';
     }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Unset email description html before showing compose view.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Emails with complex html content can break compose view.
Issue #5628 

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Send this email to your monitored inbox: 
2. [Buggy.message.eml.gz](https://github.com/salesagility/SuiteCRM/files/1883496/Buggy.message.eml.gz)
3. Access the email from within SuiteCRM
4. Import it
5. Hit Reply
6. See compose view is not broken

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->