### PR TITLE
WIP: Implementation of StateChecker and StateSaver

### DIFF
--- a/include/StateChecker.php
+++ b/include/StateChecker.php
@@ -1,0 +1,373 @@
+<?php
+/**
+ *
+ * SugarCRM Community Edition is a customer relationship management program developed by
+ * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2018 SalesAgility Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License version 3 as published by the
+ * Free Software Foundation with the addition of the following permission added
+ * to Section 15 as permitted in Section 7(a): FOR ANY PART OF THE COVERED WORK
+ * IN WHICH THE COPYRIGHT IS OWNED BY SUGARCRM, SUGARCRM DISCLAIMS THE WARRANTY
+ * OF NON INFRINGEMENT OF THIRD PARTY RIGHTS.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program; if not, see http://www.gnu.org/licenses or write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ *
+ * You can contact SugarCRM, Inc. headquarters at 10050 North Wolfe Road,
+ * SW2-130, Cupertino, CA 95014, USA. or at email address contact@sugarcrm.com.
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "Powered by
+ * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
+
+namespace SuiteCRM;
+
+use DBManager;
+use DBManagerFactory;
+use mysqli_result;
+use MysqliManager;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+/**
+ * Description of StateChecker
+ *
+ * @author SalesAgility
+ */
+class StateChecker
+{
+
+    /**
+     *
+     * @var DBManager
+     */
+    protected $db;
+    
+    /**
+     *
+     * @var array
+     */
+    protected $hashes;
+
+    /**
+     *
+     * @var string
+     */
+    protected $lastHash;
+    
+    /**
+     *
+     * @var array
+     */
+    protected $traces;
+    
+    /**
+     *
+     * @var integer
+     */
+    protected $memoryLimit;
+    
+    /**
+     *
+     * @throws StateCheckerException
+     */
+    public function __construct()
+    {
+        if (!$this->db = DBManagerFactory::getInstance()) {
+            throw new StateCheckerException('DBManagerFactory get instace failure');
+        }
+        if (!($this->db instanceof MysqliManager)) {
+            throw new StateCheckerException('Incompatible DB type, only supported: mysqli');
+        }
+        $this->resetHashes();
+        $this->resetTraces();
+        
+        if (StateCheckerConfig::get('redefineMemoryLimit')) {
+            $this->memoryLimit = ini_get('memory_limit');
+            ini_set('memory_limit', -1);
+        }
+                
+        if (StateCheckerConfig::get('autoRun')) {
+            $this->getStateHash();
+        }
+    }
+    
+    /**
+     *
+     * @return array traces
+     * @throws StateCheckerException
+     */
+    public function getTraces()
+    {
+        if (StateCheckerConfig::get('saveTraces')) {
+            throw new StateCheckerException('Trace information is not saved, use StateCheckerConfig::get(\'saveTraces\') as true');
+        }
+        return $this->traces;
+    }
+    
+    /**
+     *
+     */
+    public function __destruct()
+    {
+        if (StateCheckerConfig::get('redefineMemoryLimit')) {
+            ini_set('memory_limit', $this->memoryLimit);
+        }
+    }
+    
+    /**
+     * resetTraces
+     */
+    protected function resetTraces()
+    {
+        $this->traces = [];
+    }
+
+    /**
+     * resetHashes
+     */
+    protected function resetHashes()
+    {
+        $this->hashes = [];
+    }
+    
+    /**
+     *
+     * @param string $key
+     * @return boolean
+     */
+    protected function isDetailedKey($key)
+    {
+        $detailedKey = preg_match('/\w+\:\:/', $key);
+        return $detailedKey;
+    }
+    
+    /**
+     *
+     * @param string $hash
+     * @param string $key
+     * @return boolean
+     */
+    protected function checkHash($hash, $key)
+    {
+        $detailedKey = $this->isDetailedKey($key);
+        $needToStore = !$detailedKey || ($detailedKey && StateCheckerConfig::get('storeDetails'));
+        
+        if (!isset($this->hashes[$key])) {
+            if ($needToStore) {
+                $this->hashes[$key] = $hash;
+            }
+        }
+        if ($needToStore) {
+            $match = $this->hashes[$key] == $hash;
+        } else {
+            $match = true;
+        }
+        return $match;
+    }
+    
+    /**
+     *
+     * @param mixed $data should be serializable
+     * @param string $key
+     * @return string
+     * @throws StateCheckerException
+     */
+    protected function getHash($data, $key)
+    {
+        $serialized = serialize($data);
+        if (!$serialized) {
+            throw new StateCheckerException('Serialize object failure');
+        }
+        $hash = md5($serialized);
+        $this->lastHash = $hash;
+        
+        if (!$this->checkHash($hash, $key)) {
+            throw new StateCheckerException('Hash doesn\'t match at key "' . $key . '".');
+        }
+        
+        if (StateCheckerConfig::get('saveTraces')) {
+            $this->traces[$key][] = debug_backtrace();
+        }
+        
+        return $hash;
+    }
+
+    /**
+     *
+     * @return string
+     */
+    public function getLastHash()
+    {
+        return $this->lastHash;
+    }
+    
+    // ------------ DATABASE ----------------
+    
+    /**
+     *
+     * @param mysqli_result $resource
+     * @return array
+     */
+    protected function getMysqliResults(mysqli_result $resource)
+    {
+        $rows = [];
+        while ($row = $resource->fetch_assoc()) {
+            $rows[] = $row;
+        }
+        return $rows;
+    }
+    
+    /**
+     *
+     * @return array
+     * @throws StateCheckerException
+     */
+    protected function getDatabaseTables()
+    {
+        $tables = $this->db->tablesLike('');
+        if (!$tables) {
+            throw new StateCheckerException('get tables failure');
+        }
+        return $tables;
+    }
+    
+    /**
+     *
+     * @return string
+     */
+    protected function getDatabaseHash()
+    {
+        $tables = $this->getDatabaseTables();
+        $hashes = [];
+        foreach ($tables as $table) {
+            $rows = $this->getMysqliResults($this->db->query('SELECT * FROM ' . $table));
+            $hashes[] = $this->getHash($rows, 'database::' . $table);
+        }
+        $hash = $this->getHash($hashes, 'database');
+        return $hash;
+    }
+    
+    // ------------- FILE SYSTEM ---------------
+    
+    /**
+     *
+     * @param string $name filename
+     * @return boolean
+     */
+    protected function isExcludedFile($name)
+    {
+        foreach (StateCheckerConfig::get('fileExludeRegexes') as $regex) {
+            if (preg_match($regex, $name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    /**
+     *
+     * @param string $path
+     * @return array
+     * @throws StateCheckerException
+     */
+    protected function getFiles($path = '.')
+    {
+        $realpath = realpath($path);
+        if (!$realpath) {
+            throw new StateCheckerException('Real path can not resolved for: ' . $path);
+        }
+
+        $objects = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($realpath), RecursiveIteratorIterator::SELF_FIRST);
+        $files = [];
+        foreach ($objects as $name => $object) {
+            if (!$object->isDir() && !$this->isExcludedFile($name)) {
+                $fileObject = $object;
+                $fileObject->modifyTime = filemtime($name);
+                $fileObject->hash = $this->getHash((array)$fileObject, 'filesys::' . $fileObject);
+                $files[] = $name;
+            }
+        }
+        return $files;
+    }
+    
+    /**
+     *
+     * @return string
+     */
+    protected function getFilesystemHash()
+    {
+        $files = $this->getFiles(__DIR__ . '/../');
+        $hash = $this->getHash($files, 'filesys');
+        return $hash;
+    }
+    
+    // -------------- SUPERGLOBALS -----------------
+    
+    /**
+     *
+     * @return string
+     */
+    protected function getSuperGlobalsHash()
+    {
+        $globals = [];
+        foreach (StateCheckerConfig::get('globalKeys') as $globalKey) {
+            $globals[$globalKey] = $this->getHash(isset($GLOBALS[$globalKey]) ? $GLOBALS[$globalKey] : null, 'globals::' . $globalKey);
+        }
+        
+        $hash = $this->getHash($globals, 'globals');
+        return $hash;
+    }
+    
+    // -------------- ERROR LEVEL -------------
+    
+    /**
+     *
+     * @return string hash
+     */
+    protected function getErrorLevelHash()
+    {
+        $level = error_reporting();
+        $hash = $this->getHash($level, 'errlevel');
+        return $hash;
+    }
+    
+    // -------------- ALL ----------------------
+    
+    /**
+     * Retrieve a hash of all 
+     * 
+     * @return string hash
+     */
+    public function getStateHash()
+    {
+        $hashes['database'] = $this->getDatabaseHash();
+        $hashes['filesys'] = $this->getFilesystemHash();
+        $hashes['globals'] = $this->getSuperGlobalsHash();
+        $hashes['errlevel'] = $this->getErrorLevelHash();
+        $hash = $this->getHash($hashes, 'state');
+        return $hash;
+    }
+}

--- a/include/StateCheckerConfig.php
+++ b/include/StateCheckerConfig.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ *
+ * SugarCRM Community Edition is a customer relationship management program developed by
+ * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2018 SalesAgility Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License version 3 as published by the
+ * Free Software Foundation with the addition of the following permission added
+ * to Section 15 as permitted in Section 7(a): FOR ANY PART OF THE COVERED WORK
+ * IN WHICH THE COPYRIGHT IS OWNED BY SUGARCRM, SUGARCRM DISCLAIMS THE WARRANTY
+ * OF NON INFRINGEMENT OF THIRD PARTY RIGHTS.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program; if not, see http://www.gnu.org/licenses or write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ *
+ * You can contact SugarCRM, Inc. headquarters at 10050 North Wolfe Road,
+ * SW2-130, Cupertino, CA 95014, USA. or at email address contact@sugarcrm.com.
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "Powered by
+ * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
+
+namespace SuiteCRM;
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+/**
+ * Description of StateCheckerConfig
+ *
+ * @author SalesAgility
+ */
+class StateCheckerConfig
+{
+    const RUN_NEVER = 0;
+    const RUN_PER_TESTS = 1;
+    const RUN_PER_CLASSES = 2;
+    
+    /**
+     * SuperGlobals Collection
+     * (DO NOT CHANGE!)
+     *
+     * @var array
+     */
+    protected static $globalKeys = ['_POST', '_GET', '_REQUEST', '_SESSION', '_SERVER', '_ENV', '_FILES', '_COOKIE'];
+    
+    /**
+     *
+     * @var array of excluder regexps
+     */
+    protected static $fileExludeRegexes = [
+        '/\/\.git\//',
+        '/\/cache\//',
+        '/\.log$/',
+        '/\/tests\/_output\//',
+        '/\/blowfish\//',
+        '/\/upload\//',
+        '/\/vendor\//',
+        '/\/sugarfield_jjwg_maps_/',
+        '/\/vardefs.ext.php$/',
+        '/\/modules\/AOD_Index\/Index\/Index\//',
+    ];
+    
+    /**
+     * Automatically run state collection in StateChecker constructor
+     * (DO NOT CHANGE!)
+     *
+     * @var boolean
+     */
+    protected static $autoRun = true;
+    
+    /**
+     * Save trace info on state-hash mismatch
+     * (Slow working but give more information about the error location, use in development only)
+     * @var boolean
+     */
+    protected static $saveTraces = false;
+    
+    /**
+     * Redefine memory limit
+     * (For more memory expensive task, for e.g collection stack trace information when $saveTraces is ON, use in development only)
+     * @var boolean
+     */
+    protected static $redefineMemoryLimit = false;
+    
+    /**
+     * Store more information about hash-mismatch,
+     * which part having state of globals/filesys/database.
+     * (Slow working but give more information about the error location, use in development only)
+     *
+     * @var boolean
+     */
+    protected static $storeDetails = false;
+    
+    /**
+     *
+     * @var integer
+     */
+    protected static $testStateCheckMode = self::RUN_NEVER;
+    
+    /**
+     * Test using StateChecker
+     * (Slow working but give more information about the error location, use in development only)
+     *
+     * @var boolean
+     */
+    protected static $testsUseStateChecker = false;
+    
+    /**
+     * Test shows up an assertion failure when hash-mismatch,
+     * use $testsUseStateChecker also, $testsUseAssertionFailureOnError applied only if $testsUseStateChecker = true;
+     * (use in development only)
+     *
+     * @var boolean
+     */
+    protected static $testsUseAssertionFailureOnError = true;
+    
+    /**
+     *
+     * @param string $key
+     * @return boolean
+     */
+    public static function get($key)
+    {
+        if (inDeveloperMode()) {
+            if (in_array($key, ['storeDetails', 'testsUseStateChecker', 'testsUseAssertionFailureOnError'])) {
+                return true;
+            }
+            if (in_array($key, ['testStateCheckMode'])) {
+                return self::RUN_PER_TESTS;
+            }
+        }
+        return self::$$key;
+    }
+}

--- a/include/StateCheckerException.php
+++ b/include/StateCheckerException.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ *
+ * SugarCRM Community Edition is a customer relationship management program developed by
+ * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2018 SalesAgility Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License version 3 as published by the
+ * Free Software Foundation with the addition of the following permission added
+ * to Section 15 as permitted in Section 7(a): FOR ANY PART OF THE COVERED WORK
+ * IN WHICH THE COPYRIGHT IS OWNED BY SUGARCRM, SUGARCRM DISCLAIMS THE WARRANTY
+ * OF NON INFRINGEMENT OF THIRD PARTY RIGHTS.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program; if not, see http://www.gnu.org/licenses or write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ *
+ * You can contact SugarCRM, Inc. headquarters at 10050 North Wolfe Road,
+ * SW2-130, Cupertino, CA 95014, USA. or at email address contact@sugarcrm.com.
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "Powered by
+ * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
+
+namespace SuiteCRM;
+
+use Exception;
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+/**
+ * Description of StateCheckerException
+ *
+ * @author SalesAgility
+ */
+class StateCheckerException extends Exception
+{
+}

--- a/include/StateChecker_PHPUnit_Framework_TestCase.php
+++ b/include/StateChecker_PHPUnit_Framework_TestCase.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ *
+ * SugarCRM Community Edition is a customer relationship management program developed by
+ * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2018 SalesAgility Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License version 3 as published by the
+ * Free Software Foundation with the addition of the following permission added
+ * to Section 15 as permitted in Section 7(a): FOR ANY PART OF THE COVERED WORK
+ * IN WHICH THE COPYRIGHT IS OWNED BY SUGARCRM, SUGARCRM DISCLAIMS THE WARRANTY
+ * OF NON INFRINGEMENT OF THIRD PARTY RIGHTS.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program; if not, see http://www.gnu.org/licenses or write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ *
+ * You can contact SugarCRM, Inc. headquarters at 10050 North Wolfe Road,
+ * SW2-130, Cupertino, CA 95014, USA. or at email address contact@sugarcrm.com.
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "Powered by
+ * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
+
+
+namespace SuiteCRM;
+
+use PHPUnit_Framework_TestCase;
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+/**
+ * Description of StateChecker_PHPUnit_Framework_TestCase
+ *
+ * @author SalesAgility
+ */
+abstract class StateChecker_PHPUnit_Framework_TestCase extends PHPUnit_Framework_TestCase
+{
+   
+    /**
+     *
+     * @var StateChecker
+     */
+    protected static $stateChecker = null;
+    
+    /**
+     * 
+     */
+    protected function saveStates()
+    {
+        if (StateCheckerConfig::get('testsUseStateChecker')) {
+            if (null === self::$stateChecker) {
+                self::$stateChecker = new StateChecker();
+            }
+        }
+    }
+    
+    /**
+     * 
+     */
+    protected function checkStates()
+    {
+        if (StateCheckerConfig::get('testsUseStateChecker') && self::$stateChecker) {
+            try {
+                self::$stateChecker->getStateHash();
+            } catch (StateCheckerException $e) {
+                $message = 'Incorrect state hash: ' . $e->getMessage() . (StateCheckerConfig::get('saveTraces') ? "\nTrace:\n" . $e->getTraceAsString() . "\n" : '');
+                if (StateCheckerConfig::get('testsUseAssertionFailureOnError')) {
+                    self::assertFalse(true, $message);
+                } else {
+                    echo $message;
+                }
+            }
+        }
+    }
+    
+    /**
+     * 
+     */
+    public static function setUpBeforeClass()
+    {
+        if (StateCheckerConfig::get('testStateCheckMode') == StateCheckerConfig::RUN_PER_CLASSES) {
+            self::saveStates();
+        }
+        
+        parent::setUpBeforeClass();
+    }
+    
+    /**
+     * 
+     */
+    public static function tearDownAfterClass()
+    {
+        parent::tearDownAfterClass();
+           
+        if (StateCheckerConfig::get('testStateCheckMode') == StateCheckerConfig::RUN_PER_CLASSES) {
+            self::checkStates();
+        }
+    }
+    
+    /**
+     * Collect state information and storing a hash
+     */
+    public function setUp()
+    {
+        if (StateCheckerConfig::get('testStateCheckMode') == StateCheckerConfig::RUN_PER_TESTS) {
+            self::saveStates();
+        }
+        
+        parent::setUp();
+    }
+    
+    /**
+     * Collect state information and comparing hash
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+           
+        if (StateCheckerConfig::get('testStateCheckMode') == StateCheckerConfig::RUN_PER_TESTS) {
+            self::checkStates();
+        }
+    }
+}

--- a/include/StateSaverException.php
+++ b/include/StateSaverException.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ *
+ * SugarCRM Community Edition is a customer relationship management program developed by
+ * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2018 SalesAgility Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License version 3 as published by the
+ * Free Software Foundation with the addition of the following permission added
+ * to Section 15 as permitted in Section 7(a): FOR ANY PART OF THE COVERED WORK
+ * IN WHICH THE COPYRIGHT IS OWNED BY SUGARCRM, SUGARCRM DISCLAIMS THE WARRANTY
+ * OF NON INFRINGEMENT OF THIRD PARTY RIGHTS.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program; if not, see http://www.gnu.org/licenses or write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ *
+ * You can contact SugarCRM, Inc. headquarters at 10050 North Wolfe Road,
+ * SW2-130, Cupertino, CA 95014, USA. or at email address contact@sugarcrm.com.
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "Powered by
+ * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
+
+
+namespace SuiteCRM;
+
+/**
+ * Description of StateSaverException
+ *
+ * @author SalesAgility
+ */
+
+class StateSaverException extends Exception
+{
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

Extended version on PR: https://github.com/salesagility/SuiteCRM/pull/5612

- State check library for SuperGlobals, FileSystem and DataBase etc.
Implemented in PHP Unit tests.

- State saver library - helper classes for developers.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Check System State
Unit test should be stateless, developers can change `class StateCheckerConfig` properties in local instance to make sure Unit tests don't change the system-state, PHP Unit test have to `extends SuiteCRM\StateChecker_PHPUnit_Framework_TestCase` instead `PHPUnit_Framework_TestCase`

### Save System State - helper lib
Developers have to save and restore the system state before and after the test scripts.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

- Switch developerMode ON in admin panel or config_override.php OR change the `class StateCheckerConfig` properties itself.
- Create a test, which `extends SuiteCRM\StateChecker_PHPUnit_Framework_TestCase` and left some extra state in SuperGlobals, DataBase or FileSystem.
- Run Tests

- Testing for System State Saving: (for developers only, see in examples below)

## Examples for  Check System State:

Example output, when the test redefine superglobals:

for e.g:

       `$_POST['foo'] = 'bar';`

output:
```
"/usr/bin/php" "/var/www/html/SuiteCRM/vendor/bin/codecept" "run" "unit" "-f" "--steps" "-vvv" "--debug"
Cannot load Xdebug - extension already loaded
Codeception PHP Testing Framework v2.4.0
Powered by PHPUnit 4.8.36 by Sebastian Bergmann and contributors.

Unit Tests (1583) --------------------------------------------------------------
Modules: Asserts, \Helper\Unit
--------------------------------------------------------------------------------
- configTest: Test_config
✖ configTest: Test_config (16.57s)
--------------------------------------------------------------------------------


Time: 29.52 seconds, Memory: 2288.50MB

There was 1 failure:

---------
1) configTest: Test_config
 Test  tests/unit/configTest.php:test_config
Incorrect state hash: Hash doesn't match at key "globals::_POST"
...
```

Example2: file changed:


        `file_put_contents('foo.txt', rand(0, 1234));`

output:
```
"/usr/bin/php" "/var/www/html/SuiteCRM/vendor/bin/codecept" "run" "unit" "-f" "--steps" "-vvv" "--debug"
Cannot load Xdebug - extension already loaded
Codeception PHP Testing Framework v2.4.0
Powered by PHPUnit 4.8.36 by Sebastian Bergmann and contributors.

Unit Tests (1583) --------------------------------------------------------------
Modules: Asserts, \Helper\Unit
--------------------------------------------------------------------------------
- configTest: Test_config
✖ configTest: Test_config (10.79s)
--------------------------------------------------------------------------------


Time: 23.12 seconds, Memory: 1875.00MB

There was 1 failure:

---------
1) configTest: Test_config
 Test  tests/unit/configTest.php:test_config
Incorrect state hash: Hash doesn't match at key "filesys::/var/www/html/SuiteCRM/foo.txt".
...
```

## Example usage for System State Saver in test scripts:

StateSaver class is a helper library, typically for test scripts but usable everywhere:

```
	// -------- Save state -------- 

        // Create an instance of StateChecker
        $state = new \SuiteCRM\StateSaver();
        $state->pushGlobals();    // saving superglobals
        $state->pushTable('your_module_stuffs'); // saving a database table
        $state->pushFile('your_file.txt');

        //  -------- Tests -------- 

	// Do some test changes in superglobals
        $_POST['foo'] = 'bar';

        // Test changes in database tables (example only)
        $stuff = BeanFactory::getBean('YourModuleStuff', '{your-module-stuff-id}');
        $stuff->your_property = 'baz';
        $stuff->save();

        // Some changes in your test file:
        file_put_contents('your-file.txt', 'New contents here: ' . rand(1, 10000));
        

        //  -------- Clean up -------- 
        
        $state->popFile('your_file.txt');
        $state->popTable('your_module_stuffs');  // restore table
        $state->popGlobals();  // restore globals

        // ... here you should get the restored super globals, database tables and files.

```


(documentation and codeception implementation soon...)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->