### PR TITLE
Fix - Correcting From Name/Address in stored options to show in compose from dropdown

### DIFF
--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -2678,11 +2678,23 @@ class InboundEmail extends SugarBean
             $mailerId = (isset($_REQUEST['outbound_email'])) ? $_REQUEST['outbound_email'] : "";
 
             $oe = new OutboundEmail();
-            $oe->getSystemMailerSettings($focusUser, $mailerId);
+            if($mailerId != ""){
+                $oe->retrieve($mailerId);
+            }
+            else{
+                $oe->getSystemMailerSettings();
+            }
 
             $stored_options = array();
-            $stored_options['from_name'] = trim($_REQUEST['from_name']);
-            $stored_options['from_addr'] = trim($_REQUEST['from_addr']);
+
+            if($oe->id != ""){
+                $stored_options['from_name'] = trim($oe->smtp_from_name);
+                $stored_options['from_addr'] = trim($oe->smtp_from_addr);
+            }
+            else{
+                $stored_options['from_name'] = trim($_REQUEST['from_name']);
+                $stored_options['from_addr'] = trim($_REQUEST['from_addr']);
+            }
             $stored_options['reply_to_addr'] = trim($_REQUEST['reply_to_addr']);
 
             if (!$this->isPop3Protocol()) {


### PR DESCRIPTION
When user adds from name & addr in updated email personal settings they don't appear in compose view due to stored options inconsistencies

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Steps to recreate the issue:
1. Install 7.10.3
2. User Profile > Edit Settings (Email)
3. Mail Accounts > Add (Inbound Email)
4. Fill in Inbound Email details
5. Select 'Add' dropdown in Outgoing SMTP Mail Server
6. Fill in details including From Name & From Address
7. Save > Done (completely saving the settings)
8. Navigate to Emails module > Compose
9. The 'from address' dropdown is blank but contains id of correct inbound email

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Since adding the From Name/Address to the other screen (dedicated to the Outbound account) users creating new personal accounts would not know what from address they can choose from.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Install 7.10.3
2. User Profile > Edit Settings (Email)
3. Mail Accounts > Add (Inbound Email)
4. Fill in Inbound Email details
5. Select 'Add' dropdown in Outgoing SMTP Mail Server
6. Fill in details including From Name & From Address
7. Save > Done (completely saving the settings)
8. Navigate to Emails module > Compose
9. The 'from address' dropdown shows the newly added outbound from name/address (which may differ for each inbound email) but contains id of correct inbound email.
10. Confirm it sends email with these accurate from name/address

Considerations: Group Emails, Other areas of compose i.e. list view, Using system outbound accounts. Updating Outbound accounts via personal settings (do they keep in sync?)
Technical Debt: Man that Inbound.php needs to be refactored. Do we need stored options anymore, need to consider making it redundant. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->