### PR TITLE
Fix/4021 template pdf format

### DIFF
--- a/modules/AOS_PDF_Templates/formLetterPdf.php
+++ b/modules/AOS_PDF_Templates/formLetterPdf.php
@@ -77,11 +77,13 @@ if(!$template){
 
 $file_name = str_replace(" ", "_", $template->name) . ".pdf";
 
-$pdf = new mPDF('en', 'A4', '', 'DejaVuSansCondensed', $template->margin_left, $template->margin_right, $template->margin_top, $template->margin_bottom, $template->margin_header, $template->margin_footer);
+$format = $template->page_size . ($template->orientation === 'Landscape' ? '-L' : '');
+
+$pdf = new mPDF('en', $format, '', 'DejaVuSansCondensed', $template->margin_left, $template->margin_right, $template->margin_top, $template->margin_bottom, $template->margin_header, $template->margin_footer);
 
 foreach ($recordIds as $recordId) {
     $bean->retrieve($recordId);
-    $pdf_history = new mPDF('en', 'A4', '', 'DejaVuSansCondensed', $template->margin_left, $template->margin_right, $template->margin_top, $template->margin_bottom, $template->margin_header, $template->margin_footer);
+    $pdf_history = new mPDF('en', $format, '', 'DejaVuSansCondensed', $template->margin_left, $template->margin_right, $template->margin_top, $template->margin_bottom, $template->margin_header, $template->margin_footer);
 
     $object_arr = array();
     $object_arr[$bean->module_dir] = $bean->id;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When creating a pdf template and printing a record, only Invoices module was using the correct code to take into account the page format. Other modules would always default to A4.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
#4021

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Make a entry for e.g. A2 in the Dropdown pdf_page_size_dom
2. Go to PDF-Template and choose this entry (paper size, e.g. A2), save the template.
3. Print out the invoice and see the selected format
4. Now go back to the PDF-Template and change the module to Accounts.
5. Print out a PDF from account and the paper format is A4. The selected value will be ignore

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->