### PR TITLE
Fixed #5639 - compose email link in activities subpanel

### DIFF
--- a/include/generic/SugarWidgets/SugarWidgetSubPanelTopComposeEmailButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelTopComposeEmailButton.php
@@ -71,8 +71,10 @@ class SugarWidgetSubPanelTopComposeEmailButton extends SugarWidgetSubPanelTopBut
         } else {
             $client = $defaultPref;
         }
+        /** @var Person|Company $bean */
+        $bean = $defines['focus'];
+
         if ($client != 'sugar') {
-            $bean = $defines['focus'];
             // awu: Not all beans have emailAddress property, we must account for this
             if (isset($bean->emailAddress)) {
                 $to_addrs = $bean->emailAddress->getPrimaryAddress($bean);
@@ -86,12 +88,13 @@ class SugarWidgetSubPanelTopComposeEmailButton extends SugarWidgetSubPanelTopBut
 
             $emailUI = new EmailUI();
             $emailUI->appendTick = false;
-            $button = $emailUI->populateComposeViewFields(
-                $defines['focus'],
-                'email1',
-                true,
-                $app_strings['LBL_COMPOSE_EMAIL_BUTTON_LABEL']
-            );
+            $button = '<a class="email-link" onclick="$(document).openComposeViewModal(this);" data-module="'
+            . $bean->module_name . '" data-record-id="'
+            . $bean->id . '" data-module-name="'
+            . $bean->name .'" data-email-address="'
+            . $bean->email1 .'">'
+            . $app_strings['LBL_COMPOSE_EMAIL_BUTTON_LABEL']
+            . '</a>';
         }
 
         return $button;


### PR DESCRIPTION
issue: #5639 
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
$emailUI->populateComposeViewFields has been incorrectly used in this
case, as it is meant to be used for the list view or detail view.

So I have recreated the link in
SugarWidgetSubPanelTopComposeEmailButton.php . The menu in the
activities subpanel should show the label "Compose email".

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Fixes bug

## How To Test This
<!--- Please describe in detail how to test your changes. -->
- Create an account or view an existing account
- In the detail view expand the activities sub panel
- Select the drop down menu inside toolbar of the subpanel
- You should see compose email link

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->