### PR TITLE
Fix 2971 - A blank screen is displayed instead of an message

### DIFF
--- a/include/utils.php
+++ b/include/utils.php
@@ -1686,7 +1686,7 @@ function sugar_die($error_message, $exit_code = 1)
 {
     global $focus;
     sugar_cleanup();
-    //echo $error_message;
+    echo $error_message;
     //die($exit_code);
     throw new \Exception($error_message, $exit_code);
 }

--- a/include/utils.php
+++ b/include/utils.php
@@ -1687,7 +1687,6 @@ function sugar_die($error_message, $exit_code = 1)
     global $focus;
     sugar_cleanup();
     echo $error_message;
-    //die($exit_code);
     throw new \Exception($error_message, $exit_code);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
Print the error message on `sugar_die()`.
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
See issue #2971
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If the URL of a deleted CRM Record is entered into the browser a blank screen is displayed instead of an message. In the previous versions a message was displayed, something like
that the user either has no access or the record is deleted.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create an Test-Call
2. Copy URL of Test-Call
3. Delete Test-Call record
4. Insert the copied URL of Test-Call in browser
5. It will display a blank page instead of error message as in earlier versions

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->