### PR TITLE
Fixed #5663 - AOR_Reports Date issues

### DIFF
--- a/include/SugarFields/Fields/Datetimecombo/EditView.tpl
+++ b/include/SugarFields/Fields/Datetimecombo/EditView.tpl
@@ -40,15 +40,22 @@
 *}
 {{capture name=idname assign=idname}}{{sugarvar key='name'}}{{/capture}}
 {{if !empty($displayParams.idName)}}
-    {{assign var=idname value=$displayParams.idName}}
+{{assign var=idname value=$displayParams.idName}}
+{{/if}}
+{{if !empty($displayParams.originalFieldName)}}
+{assign var=idname value=$fields[{{sugarvar key='name' stringFormat=true}}].aliasId}
+{assign var=originalId value=$fields[{{sugarvar key='name' stringFormat=true}}].originalId}
+{{else}}
+{{assign var=idname value={{$idname}}
+{{assign var=originalId value={{$idname}}
 {{/if}}
 
 {{assign var=flag_field value=$vardef.name|cat:_flag}}
 <table border="0" cellpadding="0" cellspacing="0" class="dateTime">
 <tr valign="middle">
 <td nowrap class="dateTimeComboColumn">
-<input autocomplete="off" type="text" id="{{$idname}}_date" class="datetimecombo_date" value="{$fields[{{sugarvar key='name' stringFormat=true}}].value}" size="11" maxlength="10" title='{{$vardef.help}}' tabindex="{{$tabindex}}" onblur="combo_{{$idname}}.update();" onchange="combo_{{$idname}}.update(); {{if isset($displayParams.updateCallback)}}{{$displayParams.updateCallback}}{{/if}}"   {{if !empty($displayParams.accesskey)}} accesskey='{{$displayParams.accesskey}}' {{/if}} >
-{capture assign="other_attributes"}alt="{$APP.LBL_ENTER_DATE}" style="position:relative; top:6px" border="0" id="{{$idname}}_trigger"{/capture}
+<input autocomplete="off" type="text" id="{$idname}_date" class="datetimecombo_date" value="{$fields[{{sugarvar key='name' stringFormat=true}}].value}" size="11" maxlength="10" title='{{$vardef.help}}' tabindex="{{$tabindex}}" onblur="combo_{$idname}.update();" onchange="combo_{$idname}.update(); {{if isset($displayParams.updateCallback)}}{{$displayParams.updateCallback}}{{/if}}"   {{if !empty($displayParams.accesskey)}} accesskey='{{$displayParams.accesskey}}' {{/if}} >
+{capture assign="other_attributes"}alt="{$APP.LBL_ENTER_DATE}" style="position:relative; top:6px" border="0" id="{$idname}_trigger"{/capture}
 {sugar_getimage name="jscalendar" ext=".gif" other_attributes="$other_attributes"}&nbsp;
 {{if empty($displayParams.splitDateTime)}}
 </td>
@@ -56,17 +63,17 @@
 {{else}}
 <br>
 {{/if}}
-<div id="{{$idname}}_time_section" class="datetimecombo_time_section"></div>
+<div id="{$idname}_time_section" class="datetimecombo_time_section"></div>
 {{if $displayParams.showNoneCheckbox}}
 <script type="text/javascript">
-function set_{{$idname}}_values(form) {ldelim}
- if(form.{{$idname}}_flag.checked)  {ldelim}
-	form.{{$idname}}_flag.value=1;
-	form.{{$idname}}.value="";
-	form.{{$idname}}.readOnly=true;
+function set_{$idname}_values(form) {ldelim}
+ if(form.{$idname}_flag.checked)  {ldelim}
+	form.{$idname}_flag.value=1;
+	form.{$idname}.value="";
+	form.{$idname}.readOnly=true;
  {rdelim} else  {ldelim}
-	form.{{$idname}}_flag.value=0;
-	form.{{$idname}}.readOnly=false;
+	form.{$idname}_flag.value=0;
+	form.{$idname}.readOnly=false;
  {rdelim}
 {rdelim}
 </script>
@@ -84,44 +91,40 @@ function set_{{$idname}}_values(form) {ldelim}
 </tr>
 {{/if}}
 </table>
-{{if !empty($displayParams.originalFieldName)}}
-<input type="hidden" class="DateTimeCombo" id="{{$idname}}" name="{{$displayParams.originalFieldName}}" value="{$fields[{{sugarvar key='name' stringFormat=true}}].value}">
-{{else}}
-<input type="hidden" class="DateTimeCombo" id="{{$idname}}" name="{{$idname}}" value="{$fields[{{sugarvar key='name' stringFormat=true}}].value}">
-{{/if}}
+<input type="hidden" class="DateTimeCombo" id="{$idname}" name="{$originalId}" value="{$fields[{{sugarvar key='name' stringFormat=true}}].value}">
 <script type="text/javascript" src="{sugar_getjspath file="include/SugarFields/Fields/Datetimecombo/Datetimecombo.js"}"></script>
 <script type="text/javascript">
-var combo_{{$idname}} = new Datetimecombo("{$fields[{{sugarvar key='name' stringFormat=true}}].value}", "{{$idname}}", "{$TIME_FORMAT}", "{{$tabindex}}", '{{$displayParams.showNoneCheckbox}}', false, true);
+var combo_{$idname} = new Datetimecombo("{$fields[{{sugarvar key='name' stringFormat=true}}].value}", "{$idname}", "{$TIME_FORMAT}", "{{$tabindex}}", '{{$displayParams.showNoneCheckbox}}', false, true);
 //Render the remaining widget fields
-text = combo_{{$idname}}.html('{{$displayParams.updateCallback}}');
-document.getElementById('{{$idname}}_time_section').innerHTML = text;
+text = combo_{$idname}.html('{{$displayParams.updateCallback}}');
+document.getElementById('{$idname}_time_section').innerHTML = text;
 
 //Call eval on the update function to handle updates to calendar picker object
-eval(combo_{{$idname}}.jsscript('{{$displayParams.updateCallback}}'));
+eval(combo_{$idname}.jsscript('{{$displayParams.updateCallback}}'));
 
-addToValidateBinaryDependency('{$form_name}',"{{$idname}}_hours", 'alpha', false, "{$APP.ERR_MISSING_REQUIRED_FIELDS} {$APP.LBL_HOURS}" ,"{{$idname}}_date");
-addToValidateBinaryDependency('{$form_name}', "{{$idname}}_minutes", 'alpha', false, "{$APP.ERR_MISSING_REQUIRED_FIELDS} {$APP.LBL_MINUTES}" ,"{{$idname}}_date");
-addToValidateBinaryDependency('{$form_name}', "{{$idname}}_meridiem", 'alpha', false, "{$APP.ERR_MISSING_REQUIRED_FIELDS} {$APP.LBL_MERIDIEM}","{{$idname}}_date");
+addToValidateBinaryDependency('{$form_name}',"{$idname}_hours", 'alpha', false, "{$APP.ERR_MISSING_REQUIRED_FIELDS} {$APP.LBL_HOURS}" ,"{$idname}_date");
+addToValidateBinaryDependency('{$form_name}', "{$idname}_minutes", 'alpha', false, "{$APP.ERR_MISSING_REQUIRED_FIELDS} {$APP.LBL_MINUTES}" ,"{$idname}_date");
+addToValidateBinaryDependency('{$form_name}', "{$idname}_meridiem", 'alpha', false, "{$APP.ERR_MISSING_REQUIRED_FIELDS} {$APP.LBL_MERIDIEM}","{$idname}_date");
 
 YAHOO.util.Event.onDOMReady(function()
 {ldelim}
 
 	Calendar.setup ({ldelim}
-	onClose : update_{{$idname}},
-	inputField : "{{$idname}}_date",
+	onClose : update_{$idname},
+	inputField : "{$idname}_date",
     form : "{{$displayParams.formName}}",
 	ifFormat : "{$CALENDAR_FORMAT}",
 	daFormat : "{$CALENDAR_FORMAT}",
-	button : "{{$idname}}_trigger",
+	button : "{$idname}_trigger",
 	singleClick : true,
 	step : 1,
 	weekNumbers: false,
         startWeekday: {$CALENDAR_FDOW|default:'0'},
-	comboObject: combo_{{$idname}}
+	comboObject: combo_{$idname}
 	{rdelim});
 
 	//Call update for first time to round hours and minute values
-	combo_{{$idname}}.update(false);
+	combo_{$idname}.update(false);
 
 {rdelim}); 
 </script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixes an issue preventing the datetimecombo field from correctly displaying when two date parameters are used as a condition in reports.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #5663 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to report module
2. Create condition
3. Add a date field and choose a date
4. Add another date field

Also check the dashlets, workflow and calendar for the datetimecombo field.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->