### PR TITLE
Fixed #5748 - v7.10.4 API v8 filtering using [[in]] operator is broken.

### DIFF
--- a/lib/API/JsonApi/v1/Filters/Parsers/FilterParser.php
+++ b/lib/API/JsonApi/v1/Filters/Parsers/FilterParser.php
@@ -341,9 +341,11 @@ class FilterParser
      * @return string
      */
     private function stringDifference($a, $b) {
-        if (substr($a, 0, strlen($b)) == $b) {
+        if (substr($a, 0, strlen($b)) === $b) {
             return substr($a, strlen($b));
         }
+        
+        return "";
     }
 
     /**

--- a/lib/API/JsonApi/v1/Filters/Parsers/FilterParser.php
+++ b/lib/API/JsonApi/v1/Filters/Parsers/FilterParser.php
@@ -341,10 +341,9 @@ class FilterParser
      * @return string
      */
     private function stringDifference($a, $b) {
-        $aArray = str_split($a);
-        $bArray = str_split($b);
-        $arrayDiff = array_diff($aArray, $bArray);
-        return implode('', $arrayDiff);
+        if (substr($a, 0, strlen($b)) == $b) {
+            return substr($a, strlen($b));
+        }
     }
 
     /**

--- a/tests/unit/lib/SuiteCRM/API/JsonApi/v1/Filters/Parsers/FilterParserTest.php
+++ b/tests/unit/lib/SuiteCRM/API/JsonApi/v1/Filters/Parsers/FilterParserTest.php
@@ -293,6 +293,17 @@ class FilterParserTest extends \Codeception\Test\Unit
         );
     }
 
+    public function testParseFieldFilterWithDuplicateCharactersInTheValue()
+    {
+        $expect = array(
+            '[[eq]]',
+            'denver'
+        );
+
+        $actual = self::$filterParser->parseFieldFilterAdapter('[[eq]]denver');
+        $this->assertSame($expect, $actual);
+    }
+
     public function testParseFilter()
     {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When removing the operator from the filter value to get the comparator, characters was faulty removed from the comparator. Both the operator and the value was converted to arrays. array_diff was used to remove the operator from the value. array_diff removes multiple occurrences. 
operator = [[eq]] 
value = [[eq]]Denver
result = Dnvr


## Motivation and Context
Filter in API v8 do not work properly.


## How To Test This
1.  Navigate to Admin,  System Settings, Logger Settings set  Log Level to Debug
2. Use the JSON API to filter. https://myhost/api/v8/modules/Accounts?filter[Accounts.name]=[[eq]]Denver
3. Check the SQL WHERE clause in the log "where (accounts.name IN ("Dnvr"))"


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->