### PR TITLE
Fix cases description not showing wysiwyg editor in certain cases

### DIFF
--- a/modules/Cases/views/view.edit.php
+++ b/modules/Cases/views/view.edit.php
@@ -60,23 +60,25 @@ class CasesViewEdit extends ViewEdit {
     }
 
     function display(){
+
         parent::display();
-        global $sugar_config;
-        $new = empty($this->bean->id);
-        if($new){
-            ?>
-            <script>
-                $(document).ready(function(){
+
+        $newScript = '';
+
+        if(empty($this->bean->id)){
+            $newScript = "
                     $('#update_text').closest('.edit-view-row-item').hide();
                     $('#update_text_label').closest('.edit-view-row-item').hide();
                     $('#internal').closest('.edit-view-row-item').hide();
                     $('#internal_label').closest('.edit-view-row-item').hide();
                     $('#addFileButton').closest('.edit-view-row-item').hide();
-                    $('#case_update_form_label').closest('.edit-view-row-item').hide();
-                    tinyMCE.execCommand('mceAddControl', false, document.getElementById('description'));
-                });
-            </script>
-        <?php
+                    $('#case_update_form_label').closest('.edit-view-row-item').hide();";
         }
+
+        echo  "<script>$(document).ready(function(){"
+                  . $newScript
+                  . "tinyMCE.execCommand('mceAddControl', false, document.getElementById('description'));
+                });
+            </script>";
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes the case description field not showing correctly when using the save and continue or next/previous actions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #5815 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. You must have more than 1 Case in the Module
2. Edit a Case
3. Press the Save and Continue button (or Next/Previous) buttons

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->