### PR TITLE
Fix/5794 listview column filter

### DIFF
--- a/modules/MySettings/StoreQuery.php
+++ b/modules/MySettings/StoreQuery.php
@@ -192,7 +192,12 @@ class StoreQuery
     {
         if (isset($_REQUEST['query'])) {
             if (!empty($_REQUEST['clear_query']) && $_REQUEST['clear_query'] == 'true') {
+
+                $this->loadQuery($name);
+                $_REQUEST['displayColumns'] = $this->query['displayColumns'];
                 $this->clearQuery($name);
+                $this->query['displayColumns'] = $_REQUEST['displayColumns'];
+                $this->saveQuery($name);
 
                 return;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Prevent the display columns from resetting when clearing a filter applied to listview.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes #5794 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. open e.g. accounts listview (or an other listview of another module)
2. hide a column by "Column Chooser"
3. filter for an account
4. remove the filter

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->