### PR TITLE
Fix/oauth2 clients custom views

### DIFF
--- a/modules/OAuth2Clients/views/view.detail.php
+++ b/modules/OAuth2Clients/views/view.detail.php
@@ -50,6 +50,11 @@ class OAuth2ClientsViewDetail extends ViewDetail
     public $bean;
 
     /**
+     * @var string $formName
+     */
+    public $formName;
+
+    /**
      * @see SugarView::preDisplay()
      */
     public function getMetaDataFile()

--- a/modules/OAuth2Clients/views/view.detail.php
+++ b/modules/OAuth2Clients/views/view.detail.php
@@ -61,14 +61,23 @@ class OAuth2ClientsViewDetail extends ViewDetail
     private function setViewType()
     {
         switch ($this->bean->allowed_grant_type) {
-            case 'password': $this->type = 'detailpassword'; break;
-            case 'client_credentials': $this->type = 'detailcredentials'; break;
+            case 'password':
+                $this->type = 'detailpassword';
+                $this->formName = 'DetailPassword';
+                break;
+            case 'client_credentials':
+                $this->type = 'detailcredentials';
+                $this->formName = 'DetailCredentials';
+                break;
         }
-        if (!empty($_REQUEST['action'])) {
-            switch ($_REQUEST['action']) {
-                case 'EditViewPassword': $this->type = 'detailpassword'; break;
-                case 'EditViewCredentials': $this->type = 'detailcredentials'; break;
-            }
-        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function display()
+    {
+        $this->dv->formName = $this->formName;
+        parent::display();
     }
 }

--- a/modules/OAuth2Clients/views/view.edit.php
+++ b/modules/OAuth2Clients/views/view.edit.php
@@ -50,6 +50,11 @@ class OAuth2ClientsViewEdit extends ViewEdit
     public $bean;
 
     /**
+     * @var string $formName
+     */
+    public $formName;
+
+    /**
      * @see SugarView::preDisplay()
      */
     public function getMetaDataFile()
@@ -64,14 +69,40 @@ class OAuth2ClientsViewEdit extends ViewEdit
     private function setViewType()
     {
         switch ($this->bean->allowed_grant_type) {
-            case 'password': $this->type = 'editpassword'; break;
-            case 'client_credentials': $this->type = 'editcredentials'; break;
+            case 'password':
+                $this->type = 'editpassword';
+                $this->formName = 'EditPassword';
+                break;
+            case 'client_credentials':
+                $this->type = 'editcredentials';
+                $this->formName = 'EditCredentials';
+                break;
         }
         if (!empty($_REQUEST['action'])) {
             switch ($_REQUEST['action']) {
-                case 'EditViewPassword': $this->type = 'editpassword'; break;
-                case 'EditViewCredentials': $this->type = 'editcredentials'; break;
+                case 'EditViewPassword':
+                    $this->type = 'editpassword';
+                    $this->formName = 'EditPassword';
+                    break;
+                case 'EditViewCredentials':
+                    $this->type = 'editcredentials';
+                    $this->formName = 'EditCredentials';
+                    break;
             }
         }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getEditView()
+    {
+        if(empty($this->ev)) {
+            $this->ev = new EditView();
+        }
+
+        $this->ev->formName = $this->formName;
+
+        return $this->ev;
     }
 }

--- a/modules/OAuth2Clients/views/view.edit.php
+++ b/modules/OAuth2Clients/views/view.edit.php
@@ -95,14 +95,9 @@ class OAuth2ClientsViewEdit extends ViewEdit
     /**
      * @inheritdoc
      */
-    public function getEditView()
+    public function display()
     {
-        if(empty($this->ev)) {
-            $this->ev = new EditView();
-        }
-
         $this->ev->formName = $this->formName;
-
-        return $this->ev;
+        parent::display();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes an issue where the different views for OAuth Clients would not show depending on the client type. 

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Loads a different edit and detail view depending on the type of client.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Create a Client Credentials type of client.
Create a Password type of client.
See each one displays a different form in edit and detail view.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->