### PR TITLE
Stop formatting already formatted number

### DIFF
--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -106,8 +106,6 @@ class templateParser
                     if ($repl_arr['aos_products_quotes_discount'] == 'Percentage') {
                         $sep = get_number_seperators();
                         $value = rtrim(rtrim(format_number($value), '0'), $sep[1]);//.$app_strings['LBL_PERCENTAGE_SYMBOL'];
-                    } else {
-                        $value = currency_format_number($value, $params = array('currency_symbol' => false));
                     }
                 } else {
                     $value = '';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Prevent aos pdf template parser from formatting an already formatted number.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes #5829

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Create a quote
Create a line with discount > $1000
Generate a PDF of the quote

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->