### PR TITLE
Do not get the cached version for newly created beans from Factory

### DIFF
--- a/data/BeanFactory.php
+++ b/data/BeanFactory.php
@@ -231,4 +231,24 @@ class BeanFactory
 
         return true;
     }
+
+    /*
+     * Clears a bean from cache so that it will be retrieved from DB next time
+     *
+     * @param $beanId
+     */
+    public static function unregisterBean($module, $id)
+    {
+        if (empty($id)) {
+            return false;
+        }
+        if (!isset(self::$loadedBeans[$module][$id])) {
+            return false;
+        }
+
+        unset(self::$loadedBeans[$module][$id]);
+        unset(self::$touched[$module][$id]);
+
+        return true;
+    }
 }

--- a/modules/AOW_Actions/actions/templateParser.php
+++ b/modules/AOW_Actions/actions/templateParser.php
@@ -36,6 +36,15 @@ class aowTemplateParser extends templateParser {
 			foreach($bean_arr as $bean_name => $bean_id) {
 
 				$focus = BeanFactory::getBean($bean_name, $bean_id);
+
+        if (!$focus->fetched_row) {
+
+            // We do not want the cached version for a newly created bean, as some data such as date fields and
+            // auto increment fields will only be correct after a retrieve operation
+            BeanFactory::unregisterBean($bean_name, $bean_id);
+            $focus = BeanFactory::getBean($bean_name, $bean_id);
+        }
+
 				$string = aowTemplateParser::parse_template_bean($string, strtolower($beanList[$bean_name]), $focus);
 
                 if($focus instanceof Person){

--- a/modules/AOW_Actions/actions/templateParser.php
+++ b/modules/AOW_Actions/actions/templateParser.php
@@ -5,7 +5,7 @@
  * @package Advanced OpenSales for SugarCRM
  * @subpackage Products
  * @copyright SalesAgility Ltd http://www.salesagility.com
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE as published by
  * the Free Software Foundation; either version 3 of the License, or
@@ -25,17 +25,19 @@
  */
 
 require_once 'modules/AOS_PDF_Templates/templateParser.php';
- 
-class aowTemplateParser extends templateParser {
 
-		static function parse_template($string, $bean_arr) {
-			global $beanList;
+class aowTemplateParser extends templateParser
+{
 
-            $person = array();
-	
-			foreach($bean_arr as $bean_name => $bean_id) {
+    static function parse_template($string, $bean_arr)
+    {
+        global $beanList;
 
-				$focus = BeanFactory::getBean($bean_name, $bean_id);
+        $person = [];
+
+        foreach ($bean_arr as $bean_name => $bean_id) {
+
+            $focus = BeanFactory::getBean($bean_name, $bean_id);
 
             if (!$focus->fetched_row) {
 
@@ -45,22 +47,21 @@ class aowTemplateParser extends templateParser {
                 $focus = BeanFactory::getBean($bean_name, $bean_id);
             }
 
-				$string = aowTemplateParser::parse_template_bean($string, strtolower($beanList[$bean_name]), $focus);
+            $string = aowTemplateParser::parse_template_bean($string, strtolower($beanList[$bean_name]), $focus);
 
-                if($focus instanceof Person){
-                    $person[] = $focus;
-                }
-				
-			}
-
-            if(!empty($person)){
-                $focus = $person[0];
-            } else {
-                $focus = new Contact();
+            if ($focus instanceof Person) {
+                $person[] = $focus;
             }
-            $string = aowTemplateParser::parse_template_bean($string, 'contact', $focus);
 
-			return $string;
-		}
-	}
-?>
+        }
+
+        if (!empty($person)) {
+            $focus = $person[0];
+        } else {
+            $focus = new Contact();
+        }
+        $string = aowTemplateParser::parse_template_bean($string, 'contact', $focus);
+
+        return $string;
+    }
+}

--- a/modules/AOW_Actions/actions/templateParser.php
+++ b/modules/AOW_Actions/actions/templateParser.php
@@ -37,13 +37,13 @@ class aowTemplateParser extends templateParser {
 
 				$focus = BeanFactory::getBean($bean_name, $bean_id);
 
-        if (!$focus->fetched_row) {
+            if (!$focus->fetched_row) {
 
-            // We do not want the cached version for a newly created bean, as some data such as date fields and
-            // auto increment fields will only be correct after a retrieve operation
-            BeanFactory::unregisterBean($bean_name, $bean_id);
-            $focus = BeanFactory::getBean($bean_name, $bean_id);
-        }
+                // We do not want the cached version for a newly created bean, as some data such as date fields and
+                // auto increment fields will only be correct after a retrieve operation
+                BeanFactory::unregisterBean($bean_name, $bean_id);
+                $focus = BeanFactory::getBean($bean_name, $bean_id);
+            }
 
 				$string = aowTemplateParser::parse_template_bean($string, strtolower($beanList[$bean_name]), $focus);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Sometimes when creating a new bean, the data stored in the cached version of the BeanFactory will not be correct. For example auto increment fields will only have correct data once they've been inserted and then retrieved.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Adds an unregister function to the BeanFactory. Calling it will remove a given Bean from cache, so that next time it will be fetched from the DB.

In the workflow template parser we check for a bean being new, and then make sure it is retrieved at least once from the db.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes #5814
Fixes #3468
Fixes #5719

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Create a new workflow
2. Related to cases
3. Run on saving new records
4. Action: send email, case creation template
5. Create a new case

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->