### PR TITLE
Fixed #5902: Not audited if the user was not update for the value of …

### DIFF
--- a/include/database/DBManager.php
+++ b/include/database/DBManager.php
@@ -3005,10 +3005,19 @@ abstract class DBManager
                 ) {
                     $change = false;
                     if (trim($before_value) !== trim($after_value)) {
+			 // decode value for field type of 'text' or 'varchar' to check before audit if the value contain trip tags or special character
+                        if($field_type == 'varchar' || $field_type == 'name' || $field_type == 'text') {
+                            $decode_before_value = strip_tags(html_entity_decode($before_value));
+                            $decode_after_value = strip_tags(html_entity_decode($after_value));
+                            if($decode_before_value == $decode_after_value) {
+                                continue;
+                            }
+                            $change = true;
+                        }
                         // Bug #42475: Don't directly compare numeric values, instead do the subtract and see if the comparison comes out to be "close enough", it is necessary for floating point numbers.
                         // Manual merge of fix 95727f2eed44852f1b6bce9a9eccbe065fe6249f from DBHelper
                         // This fix also fixes Bug #44624 in a more generic way and therefore eliminates the need for fix 0a55125b281c4bee87eb347709af462715f33d2d in DBHelper
-                        if ($this->isNumericType($field_type)) {
+                        else if ($this->isNumericType($field_type)) {
                             $numerator = abs(2 * ((trim($before_value) + 0) - (trim($after_value) + 0)));
                             $denominator = abs(((trim($before_value) + 0) + (trim($after_value) + 0)));
                             // detect whether to use absolute or relative error. use absolute if denominator is zero to avoid division by zero


### PR DESCRIPTION
…the field type 'text', 'varchar'

<!--- Provide a general summary of your changes in the Title above -->

## Description
See detail in #5902 
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The system has audited the value incorrect for some fields

## How To Test This
<!--- Please describe in detail how to test your changes. -->
We are 2 case need verify:
Case 1:
1. Go to any module > Create new record > In Name field type value contain character double quotes (").
2. From detail record > Click on 'Action button' > Edit > Do not change any thing > Save
3. View change Log

Expected:
- Name field should not audited because The user has not any change

Case 2: (Technical test, need a developer test to make sure)
1. Go to studio and add field type of 'text', MUST integrate TinyMCE editor plugin for this field.
2. Create new record on module just added field at step 1 (Must type value for text field created in step 1) > Save
3. From record detail > Click on Action button > Edit > Do not change any thing > Save.
4. View change log

Expected:
- Text field created in step 1 should not audited because The user has not any change

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->

