### PR TITLE
Clear an additional field to make sure filenames are forgotten on delete

### DIFF
--- a/modules/Notes/Note.php
+++ b/modules/Notes/Note.php
@@ -179,6 +179,7 @@ class Note extends File
             if (!unlink($removeFile)) {
                 $GLOBALS['log']->error("*** Could not unlink() file: [ {$removeFile} ]");
             } else {
+                $this->uploadfile = '';
                 $this->filename = '';
                 $this->file_mime_type = '';
                 $this->file = '';
@@ -187,6 +188,7 @@ class Note extends File
                 return true;
             }
         } else {
+            $this->uploadfile = '';
             $this->filename = '';
             $this->file_mime_type = '';
             $this->file = '';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When deleting an attachment from a Note a bug was preventing the file name field from clearing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes #5872 
Fixes #5873

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Create a note and attach a file
2. Edit that note
3. click on remove attachment
4a. attach a new file and save
or
4b. save

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->