### PR TITLE
fix a bug for product image overwritten by the other product image

### DIFF
--- a/modules/AOS_Products/AOS_Products.php
+++ b/modules/AOS_Products/AOS_Products.php
@@ -48,6 +48,22 @@ class AOS_Products extends AOS_Products_sugar {
         self::__construct();
     }
 
+    function getGUID(){
+        if (function_exists('com_create_guid')){
+            return com_create_guid();
+        }
+        else {
+            mt_srand((double)microtime()*10000);//optional for php 4.2.0 and up.
+            $charid = strtoupper(md5(uniqid(rand(), true)));
+            $hyphen = chr(45);// "-"
+            $uuid = substr($charid, 0, 8).$hyphen
+                .substr($charid, 8, 4).$hyphen
+                .substr($charid,12, 4).$hyphen
+                .substr($charid,16, 4).$hyphen
+                .substr($charid,20,12);
+            return $uuid;
+        }
+    }
 
 	function save($check_notify=false){
 		global $sugar_config,$mod_strings;
@@ -67,8 +83,9 @@ class AOS_Products extends AOS_Products_sugar {
 
             }
             else {
-                $this->product_image=$sugar_config['site_url'].'/'.$sugar_config['upload_dir'].$_FILES['uploadimage']['name'];
-                move_uploaded_file($_FILES['uploadimage']['tmp_name'], $sugar_config['upload_dir'].$_FILES['uploadimage']['name']);
+                $prefix_image = $this->getGUID().'_';
+                $this->product_image=$sugar_config['site_url'].'/'.$sugar_config['upload_dir'].$prefix_image.$_FILES['uploadimage']['name'];
+                move_uploaded_file($_FILES['uploadimage']['tmp_name'], $sugar_config['upload_dir'].$prefix_image.$_FILES['uploadimage']['name']);
 
             }
 	    }


### PR DESCRIPTION
When the image have the same filename, it would overwriteen the previous
image of another product. So added guid as a prefix to the filename to
differentiate the images with the same filename.
