### PR TITLE
Fix bugged opt-in flag change

### DIFF
--- a/include/SugarEmailAddress/SugarEmailAddress.php
+++ b/include/SugarEmailAddress/SugarEmailAddress.php
@@ -1249,7 +1249,7 @@ class SugarEmailAddress extends SugarBean
 
         // confirmed opt in check
         if (!is_null($optInFlag)) {
-            $optInFlag = 0;
+            $optInFlag = (int)$optInFlag;
         }
 
         $isValidEmailAddress = ($opt_out !== 1 && $invalid !== 1);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a bug where $optInFlag was being set to 0 in every case.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixes #5901 

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Have Lead with Confirmed Email
2. Select Action/Convert
3. Converted Contact's Email is still confirmed opt in
4. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->