### PR TITLE
Fix subpanels producing wrong email link

### DIFF
--- a/include/ListView/ListViewSubPanel.php
+++ b/include/ListView/ListViewSubPanel.php
@@ -489,7 +489,13 @@ if (!defined('sugarEntry') || !sugarEntry) {
                                 }
                                 else {
                                     if (isset($list_field['widget_class']) && $list_field['widget_class'] == 'SubPanelEmailLink') {
-                                        $widget_contents[$aVal][$field_name] = $layout_manager->widgetDisplay($list_field);
+
+                                        if (isset($list_field['fields']['EMAIL1_LINK'])) {
+                                            $widget_contents[$aVal][$field_name] = $list_field['fields']['EMAIL1_LINK'];
+                                        }
+                                        else {
+                                            $widget_contents[$aVal][$field_name] = $layout_manager->widgetDisplay($list_field);
+                                        }
                                     }
                                 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a bug where every contact in a subpanel was showing the parent record's email address.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixes #5934 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to account record
2. Look on subpanel Contacts
3. relate some contacts to account
4. refresh page and see the emails displays correctly for each record

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->