### PR TITLE
Fix typo so view icon appears in custom modules

### DIFF
--- a/themes/SuiteP/css/sidebar.scss
+++ b/themes/SuiteP/css/sidebar.scss
@@ -123,7 +123,7 @@
     background-image: url("../../../../themes/SuiteP/images/sidebar/View_Create_Email_Templates.svg");
   }
 
-  .actionMenuSidebar li a.side-bar-View, .actionMenuSidebar li a .side-bar-List {
+  .actionMenuSidebar li a .side-bar-View, .actionMenuSidebar li a .side-bar-List {
     background-image: url("../../../../themes/SuiteP/images/sidebar/View.png");
     background-image: url("../../../../themes/SuiteP/images/sidebar/View.svg");
   }


### PR DESCRIPTION
Appears to be a missing space between "a" and the class "side-bar-View" that keeps the eyeball from appearing on custom module menus.  I am using 7.8.19 but it appears to be in the 7.9.x branch as well.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Create a custom module.  No eyeball in the list view of custom modules next to the action View.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Create a custom module.  Go to the list view.  The side bar menu will show an eyeball icon next to the View <module> link.   
 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->