### PR TITLE
Check for existance of the global variable, do not use it in isset()

### DIFF
--- a/modules/SugarFeed/SugarFeed.php
+++ b/modules/SugarFeed/SugarFeed.php
@@ -494,68 +494,61 @@ class SugarFeed extends Basic {
 
     static function getTimeLapse($startDate)
     {
-        if (!isset($GLOBALS['timedate'])) {
-            LoggerManager::getLogger()->warn('SugarFeed getTimeLapse: Trying to get property of non-object ($GLOBALS[timedate]->getNow()->ts)');
-            $globalsTimedateNowTs = null;
-        } else {
-            $globalsTimedateNowTs = $GLOBALS['timedate']->getNow()->ts;
-        }
+        global $timedate;
 
-        if (!isset($GLOBALS['timedate'])) {
-            LoggerManager::getLogger()->warn('SugarFeed getTimeLapse: Trying to get property of non-object ($GLOBALS[timedate]->fromUser($startDate)->ts)');
-            $globalsTimedateFromUserStartDateTs = null;
-        } else {
-            $globalsTimedateFromUserStartDateTs = $GLOBALS['timedate']->fromUser($startDate)->ts;
-        }
-            
-        $seconds = $globalsTimedateNowTs - $globalsTimedateFromUserStartDateTs;
-        $minutes =   $seconds/60;
+        $timedate->getInstance()->userTimezone();
+        $currentTime = $timedate->now();
+
+        $first = strtotime($currentTime);
+        $second = strtotime($startDate);
+
+        $seconds = $first - $second;
+        $minutes = $seconds / 60;
         $seconds = $seconds % 60;
-        $hours = floor( $minutes / 60);
+        $hours = floor($minutes / 60);
         $minutes = $minutes % 60;
-        $days = floor( $hours / 24);
+        $days = floor($hours / 24);
         $hours = $hours % 24;
-        $weeks = floor( $days / 7);
+        $weeks = floor($days / 7);
         $days = $days % 7;
         $result = '';
-        if($weeks == 1){
-            $result = translate('LBL_TIME_LAST_WEEK','SugarFeed').' ';
-            return $result;
-        }else if($weeks > 1){
-            $result .= $weeks . ' '.translate('LBL_TIME_WEEKS','SugarFeed').' ';
-            if($days > 0) {
-                $result .= ' ' .translate('LBL_TIME_AND','SugarFeed').' ';
-                $result .= $days . ' '.translate('LBL_TIME_DAYS','SugarFeed').' ';
+        if ($weeks == 1) {
+            return translate('LBL_TIME_LAST_WEEK', 'SugarFeed') . ' ';
+        } elseif ($weeks > 1) {
+            $result .= $weeks . ' ' . translate('LBL_TIME_WEEKS', 'SugarFeed') . ' ';
+            if ($days > 0) {
+                $result .= ' ' . translate('LBL_TIME_AND', 'SugarFeed') . ' ';
+                $result .= $days . ' ' . translate('LBL_TIME_DAYS', 'SugarFeed') . ' ';
             }
-        }else{
-            if($days == 1){
-                $result = translate('LBL_TIME_YESTERDAY','SugarFeed').' ';
-                return $result;
-            }else if($days > 1){
-                $result .= $days . ' '. translate('LBL_TIME_DAYS','SugarFeed').' ';
-            }else{
-                if($hours == 1) {
-                    $result .= $hours . ' '.translate('LBL_TIME_HOUR','SugarFeed').' ';
+        } else {
+            if ($days == 1) {
+                return translate('LBL_TIME_YESTERDAY', 'SugarFeed') . ' ';
+            } elseif ($days > 1) {
+                $result .= $days . ' ' . translate('LBL_TIME_DAYS', 'SugarFeed') . ' ';
+            } else {
+                if ($hours == 1) {
+                    $result .= $hours . ' ' . translate('LBL_TIME_HOUR', 'SugarFeed') . ' ';
                 } else {
-                    $result .= $hours . ' '.translate('LBL_TIME_HOURS','SugarFeed').' ';
+                    $result .= $hours . ' ' . translate('LBL_TIME_HOURS', 'SugarFeed') . ' ';
                 }
-                if($hours < 6){
-                    if($minutes == 1) {
-                        $result .= $minutes . ' ' . translate('LBL_TIME_MINUTE','SugarFeed'). ' ';
+                if ($hours < 6) {
+                    if ($minutes == 1) {
+                        $result .= $minutes . ' ' . translate('LBL_TIME_MINUTE', 'SugarFeed') . ' ';
                     } else {
-                        $result .= $minutes . ' ' . translate('LBL_TIME_MINUTES','SugarFeed'). ' ';
+                        $result .= $minutes . ' ' . translate('LBL_TIME_MINUTES', 'SugarFeed') . ' ';
                     }
                 }
-                if($hours == 0 && $minutes == 0) {
-                    if($seconds == 1 ) {
-                        $result = $seconds . ' ' . translate('LBL_TIME_SECOND','SugarFeed');
+                if ($hours == 0 && $minutes == 0) {
+                    if ($seconds == 1) {
+                        $result = $seconds . ' ' . translate('LBL_TIME_SECOND', 'SugarFeed');
                     } else {
-                        $result = $seconds . ' ' . translate('LBL_TIME_SECONDS','SugarFeed');
+                        $result = $seconds . ' ' . translate('LBL_TIME_SECONDS', 'SugarFeed');
                     }
                 }
             }
         }
-        return $result . ' ' . translate('LBL_TIME_AGO','SugarFeed');
+
+        return $result . ' ' . translate('LBL_TIME_AGO', 'SugarFeed');
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Bug #5918 documents that the Activity feed now shows all items being from 0 seconds ago. This fixes that.



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Want to know when the activity occurred. 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Open up 7.10.5's home page with activity feed on 7.10.5 and this PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->