### PR TITLE
Make massupdate choose the value of dynamic enum fields better

### DIFF
--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -159,7 +159,7 @@ eoq;
 	function handleMassUpdate(){
 
 		require_once('include/formbase.php');
-		global $current_user, $db, $disable_date_format, $timedate;
+		global $current_user, $db, $disable_date_format, $timedate, $app_list_strings;
 
 		foreach($_POST as $post=>$value){
 			if(is_array($value)){
@@ -341,8 +341,16 @@ eoq;
 									list($dynamic_field_value) = explode('_', $newbean->$dynamic_field_name);
 
 									if($parentenum_value != $dynamic_field_value) {
+
 										// Change to the default value of the correct value set.
-										$newbean->$dynamic_field_name = $parentenum_value . '_' . $parentenum_value;
+                      $defaultValue = $parentenum_value . '_' . $parentenum_value;
+                      foreach ($app_list_strings[$field_name['options']] as $key => $value) {
+                          if (strpos($key, $parentenum_value) === 0) {
+                              $defaultValue = $key;
+                              break;
+                          }
+                      }
+                      $newbean->$dynamic_field_name = $defaultValue;
 									}
 								}
 							}

--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -343,7 +343,7 @@ eoq;
 									if($parentenum_value != $dynamic_field_value) {
 
 										// Change to the default value of the correct value set.
-                      $defaultValue = $parentenum_value . '_' . $parentenum_value;
+                      $defaultValue = '';
                       foreach ($app_list_strings[$field_name['options']] as $key => $value) {
                           if (strpos($key, $parentenum_value) === 0) {
                               $defaultValue = $key;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changes the way massupdate will set the value of dynamic enum fields.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Previously a child field would always be set to `Open_Open` if the parent value was `Open`, regardless of this being a valid status for the child field or not, causing some bugs.
Now it is consistent with the way it works in the edit view: upon changing the value of the parent field, the child field will take the first available valid value.

Fixes #5949 

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Create account (or use existing)
2. Create a case from account
3. Change this case state to 'closed' with mass update in list mode
4. Change this case state to 'open' with mass update

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->