### PR TITLE
Fixing styles in form to remove double spacing of multiline text fields

### DIFF
--- a/themes/SuiteP/css/suitep-base/editview.scss
+++ b/themes/SuiteP/css/suitep-base/editview.scss
@@ -626,14 +626,19 @@ slot {
   font-weight: 400;
   background-color: $detail-view-field-bg;
   color: $main-font-color;
-  padding: 0px 10px;
+  padding: 10px 10px;
   border: 1px solid transparent;
   border-radius: $border-radius-base;
-  line-height: 38px;
   text-align: left;
   min-height: 38px;
   vertical-align: baseline;
   white-space: inherit;
+}
+
+.detail-view-field span {
+  line-height: normal;
+  display: inline-block;
+  vertical-align: middle;
 }
 
 .detail-view-field a {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Currently if you have more than one row of text in a text field it makes all of the text double spaced within it. It appears this is a side-effect of attempting to use line-height to center the text in form fields.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Multi-line text such as long notes look terrible because it's all double-spaced.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* Create a note object which has more than one line within the body of the note.
* Look at how it looks (double spaced)
* Build scss files, clear cache
* Look at how the note looks now

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
**Note** Some people may like this look :-/ but it seems to go against the new theme to try and remove excess spacing.

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

**Note** I have not committed the compiled scss file as I'm not sure if the project would prefer that or not.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->