### PR TITLE
fix #5944 parse email variables

### DIFF
--- a/modules/EmailTemplates/EmailTemplateParser.php
+++ b/modules/EmailTemplates/EmailTemplateParser.php
@@ -160,7 +160,7 @@ class EmailTemplateParser
         $charVariable = chr(36);
         $charUnderscore = chr(95);
 
-        if (strpos($variable, $charVariable) || strpos($variable, $charUnderscore) === false) {
+        if (strpos($variable, $charVariable) === false || strpos($variable, $charUnderscore) === false) {
             $GLOBALS['log']->warn(sprintf(
                 'Variable %s parsed to an empty string, because attribute has no %s or %s character',
                 $variable,

--- a/modules/EmailTemplates/EmailTemplateParser.php
+++ b/modules/EmailTemplates/EmailTemplateParser.php
@@ -183,7 +183,7 @@ class EmailTemplateParser
         }
 
         $GLOBALS['log']->warn(sprintf(
-            'Variable %s parsed to an empty string, because attribute %s does not set in %s bean',
+            'Variable %s parsed to an empty string, because attribute %s is not set in %s bean',
             $variable,
             $attribute,
             get_class($this->module)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix parsing variables in email templates when it's sent as a campaign.
#5944 

<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
- make an email campaign
- add some beans to the target list, like accounts, contacts or leads
- send test emails and check how the variables are parsed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->