### PR TITLE
Fixed #5968 - AOR Reports - incorrect start date calculated for LastQuarter period when in the 4th quarter

### DIFF
--- a/modules/AOR_Reports/aor_utils.php
+++ b/modules/AOR_Reports/aor_utils.php
@@ -305,7 +305,7 @@ function getPeriodDate($date_time_period_list_selected)
             $datetime_period = $q[3]['start']->sub(new DateInterval('P3M'));
         } elseif ($thisMonth >= $q[4]['start'] && $thisMonth <= $q[4]['end']) {
             // quarter 4 - 3 months
-            $datetime_period = $q[3]['start']->sub(new DateInterval('P3M'));
+            $datetime_period = $q[4]['start']->sub(new DateInterval('P3M'));
         }
     } elseif ($date_time_period_list_selected == 'this_year') {
         $datetime_period = $datetime_period = $datetime_period->setDate(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixes a typo in report utils when fetching the getPeriodDate.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #5968 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Create a report using a Last Quarter date period condition and check that the results are returned correctly when the current date is in the 4th quarter.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->