### PR TITLE
Set Message-ID for outgoing email - SuiteCRM issue #5977

### DIFF
--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -2822,6 +2822,9 @@ class Email extends Basic
         //$mail->Subject = html_entity_decode($this->name, ENT_QUOTES, 'UTF-8');
         $mail->Subject = $this->name;
 
+        //Set MessageID for outgoing mail array
+        $mail->MessageID = '<' . $this->message_id . '@' . $sugar_config['host_name'] . '>';
+
         ///////////////////////////////////////////////////////////////////////
         ////	ATTACHMENTS
         if (isset($this->saved_attachments)) {

--- a/modules/Emails/EmailsController.php
+++ b/modules/Emails/EmailsController.php
@@ -166,6 +166,9 @@ class EmailsController extends SugarController
 
         $request = $_REQUEST;
 
+        // Set message_id for email record in DB
+        $request['message_id'] = 'SUITECRM_' . md5('HELLO'.(idate("U")-1000000000).uniqid());
+
         $this->bean = $this->bean->populateBeanFromRequest($this->bean, $request);
         $inboundEmailAccount = new InboundEmail();
         $inboundEmailAccount->retrieve($_REQUEST['inbound_email_id']);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This patch sets the Message-ID for outgoing emails so that they are also stored in the database for future reference.
This is for issue #5977

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I'm working on a project that includes matching incoming email to the email/thread that they are replying to. Currently the Message-ID header for outgoing mail is set in such a way that it cannot be stored in the database.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
After applying this patch, outgoing email will have a Message-ID header that starts with 'SUITECRM_', so you know it's working. It will also record the same ID in the message_id field of the 'emails' table in the DB.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->