### PR TITLE
Fix #5998 - Can't select document on email compose using search

### DIFF
--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -728,6 +728,37 @@
         fileInputID = document_attachment_id;
       }
 
+      $.fn.EmailsComposeView.selectDocumentFromPopup = function(resultData) {
+        set_return(resultData);
+        if (fileInputID.val().length === 0) {
+          // id is empty
+          fileGroupContainer.remove();
+          self.updateDocumentIDs();
+        } else {
+          // id is full
+          if (fileGroupContainer.find('.attachment-remove').length === 0) {
+            var removeAttachment = $('<a class="attachment-remove"><span class="glyphicon glyphicon-remove"></span></a>');
+            fileGroupContainer.append(removeAttachment);
+            // handle when user removes attachment
+            removeAttachment.click(function () {
+              fileGroupContainer.remove();
+              self.updateDocumentIDs();
+            });
+          }
+
+          fileInput.val(fileInputID.val());
+          fileLabel.empty();
+
+          var fileContainer = $('<div class="attachment-file-container"></div>');
+          fileContainer.appendTo(fileLabel);
+          fileContainer.append('<span class="attachment-name"> ' + fileInputName.val() + ' </span>');
+
+          fileLabel.removeClass('attachment-blank');
+
+          self.updateDocumentIDs();
+        }
+      };
+
       //language=JQuery-CSS
       var document_attachment_name = $('[name=document_attachment_name]');
       var fileInputName = undefined;
@@ -758,7 +789,7 @@
           true,
           false,
           {
-            "call_back_function": 'set_return',
+            "call_back_function": '$.fn.EmailsComposeView.selectDocumentFromPopup',
             "form_name": "ComposeView",
             "field_to_name_array": {
               "id": "document_attachment_id",
@@ -769,37 +800,6 @@
           false
         );
 
-        popupWindow.onbeforeunload = function () {
-          setTimeout(function () {
-            if (fileInputID.val().length === 0) {
-              // id is empty
-              fileGroupContainer.remove();
-              self.updateDocumentIDs();
-            } else {
-              // id is full
-              if (fileGroupContainer.find('.attachment-remove').length === 0) {
-                var removeAttachment = $('<a class="attachment-remove"><span class="glyphicon glyphicon-remove"></span></a>');
-                fileGroupContainer.append(removeAttachment);
-                // handle when user removes attachment
-                removeAttachment.click(function () {
-                  fileGroupContainer.remove();
-                  self.updateDocumentIDs();
-                });
-              }
-
-              fileInput.val(fileInputID.val());
-              fileLabel.empty();
-
-              var fileContainer = $('<div class="attachment-file-container"></div>');
-              fileContainer.appendTo(fileLabel);
-              fileContainer.append('<span class="attachment-name"> ' + fileInputName.val() + ' </span>');
-
-              fileLabel.removeClass('attachment-blank');
-
-              self.updateDocumentIDs();
-            }
-          }, 300);
-        }
       };
 
       // Mimic the file attachment behaviour


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
See issue #5998
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We are trying to attach a document when sending an email, applying a filter. The document is not attached.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to Emails, click Compose.
2. Click the attach document button.
3. Apply a search on the oppened popup.
4. Select one document.
5. See that the document is not attached.
6. Apply PR and repeat 1-4.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->