### PR TITLE
Fix round up for cases where there is an increase in integral part. 

### DIFF
--- a/modules/AOS_Products_Quotes/line_items.js
+++ b/modules/AOS_Products_Quotes/line_items.js
@@ -942,7 +942,13 @@ function formatNumber(n, num_grp_sep, dec_sep, round, precision) {
     if (round > 0 && n.length > 1) {
       n[1] = parseFloat("0." + n[1]);
       n[1] = Math.round(n[1] * Math.pow(10, round)) / Math.pow(10, round);
+      if(n[1].toString().includes('.')) {
       n[1] = n[1].toString().split(".")[1];
+    }
+      else {
+	  n[0] = (parseInt(n[0]) + n[1]).toString();
+	  n[1] = "";
+      }
     }
     if (round <= 0) {
       n[0] = Math.round(parseInt(n[0], 10) * Math.pow(10, round)) / Math.pow(10, round);

--- a/tests/acceptance/modules/Invoices/InvoicesCest.php
+++ b/tests/acceptance/modules/Invoices/InvoicesCest.php
@@ -92,4 +92,65 @@ class InvoicesCest
         $detailView->acceptPopup();
         $listView->waitForListViewVisible();
     }
+
+    /**
+     * @param \AcceptanceTester $I
+     * @param \Step\Acceptance\DetailView $detailView
+     * @param \Step\Acceptance\ListView $listView
+     * @param \\Step\Acceptance\EditView $editView
+     * @param \Step\Acceptance\Invoices $invoice
+     * @param \Helper\WebDriverHelper $webDriverHelper
+     *
+     * As administrative user I want to create an invoice and check the number rounding
+     */
+    public function testScenarioInvoiceRounding(
+        \AcceptanceTester $I,
+        \Step\Acceptance\DetailView $detailView,
+        \Step\Acceptance\ListView $listView,
+        \Step\Acceptance\EditView $editView,
+        \Step\Acceptance\Invoices $invoice,
+        \Helper\WebDriverHelper $webDriverHelper
+    ) {
+        $I->wantTo('Create an Invoice');
+
+        $I->amOnUrl(
+            $webDriverHelper->getInstanceURL()
+        );
+
+        // Navigate to invoices list-view
+        $I->loginAsAdmin();
+        $invoice->gotoInvoices();
+        $listView->waitForListViewVisible();
+
+        // Create invoice
+        $this->fakeData->seed($this->fakeDataSeed);
+        $invoice->createInvoice('Test_'. $this->fakeData->company());
+
+        // Set total
+        $detailView->clickActionMenuItem('Edit');
+        $editView->waitForEditViewVisible();
+        $I->fillField('#total_amt', 0);
+        $I->fillField('#discount_amount', 0);
+        $I->fillField('#subtotal_amount', 0);
+        $I->fillField('#shipping_amount', 475.99999999999994);
+        $I->fillField('#shipping_tax_amt', 0);
+        $I->fillField('#tax_amount', 0);
+        $I->selectOption('#status', 'Unpaid');
+        $I->selectOption('#currency_id_select', 'US Dollars : $');
+        $I->selectOption('#shipping_tax', '0%');
+
+        $editView->clickSaveButton();
+        $detailView->waitForDetailViewVisible();
+
+        $detailView->clickActionMenuItem('Edit');
+        $editView->waitForEditViewVisible();
+        $I->scrollTo('#shipping_amount');
+        $I->seeInSource('476.00');
+        $editView->clickSaveButton();
+
+        // Delete invoice
+        $detailView->clickActionMenuItem('Delete');
+        $detailView->acceptPopup();
+        $listView->waitForListViewVisible();
+    }
 }


### PR DESCRIPTION
The `function formatNumber`  does not correctly handle the round of numbers that causes an increase in the integral part. 

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
The function formatNumber does not correctly handle the round of numbers that causes an increase in the integral part. Reported as issue #6003. 

## Motivation and Context
The function should round up values correctly. 

## How To Test This
Apply changes and test in browser console giving number 475.99999999999994, round=2 and precision=2.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->