### PR TITLE
Fix quicksearch for member org in accounts

### DIFF
--- a/modules/Home/controller.php
+++ b/modules/Home/controller.php
@@ -144,7 +144,7 @@ class HomeController extends SugarController{
         $quicksearch_js = $template_handler->createQuickSearchCode($vardefFields, $vardefFields, $view);
         $quicksearch_js = str_replace($_REQUEST['field'], $_REQUEST['field'] . '_display', $quicksearch_js);
 
-        if($_REQUEST['field'] != "parent_name" || ($_REQUEST['field'] == "parent_name" && $_REQUEST['current_module'] == "Accounts")) {
+        if($_REQUEST['field'] != "parent_name" || $_REQUEST['current_module'] == "Accounts") {
             $quicksearch_js = str_replace($vardefFields[$_REQUEST['field']]['id_name'], $_REQUEST['field'], $quicksearch_js);
         }
 

--- a/modules/Home/controller.php
+++ b/modules/Home/controller.php
@@ -144,7 +144,7 @@ class HomeController extends SugarController{
         $quicksearch_js = $template_handler->createQuickSearchCode($vardefFields, $vardefFields, $view);
         $quicksearch_js = str_replace($_REQUEST['field'], $_REQUEST['field'] . '_display', $quicksearch_js);
 
-        if($_REQUEST['field'] != "parent_name") {
+        if($_REQUEST['field'] != "parent_name" || ($_REQUEST['field'] == "parent_name" && $_REQUEST['current_module'] == "Accounts")) {
             $quicksearch_js = str_replace($vardefFields[$_REQUEST['field']]['id_name'], $_REQUEST['field'], $quicksearch_js);
         }
 


### PR DESCRIPTION
Quicksearch for the member organization (parent_name) field in Accounts does not work.  The quicksearch dropdown list works but does not attempt to populate the related _display field.  The conditional code for parent_name does not work correctly for this field.  It works correctly without it.  (This might mean the better fix would be to change how the field is built so it works like the other parent_name fields...)

Found in 7.8.19 - verfied exists in demo 7.10.6.

#### Expected Behavior
<!--- Tell us what should happen -->
Quicksearch should correctly populate the member organization field in Account Detail View.

#### Actual Behavior
When selected the field will goes blank.

#### Possible Fix
See code change.

#### Context
Grumpy Sales Exec showed me the bug while attempting to enter something.

#### Your Environment
<!--- Include as many relevant details about the environment you experienced the bug in -->
* SuiteCRM Version used: 7.8.19
* Browser name and version (e.g. Chrome Version 51.0.2704.63 (64-bit)): Firefox 52.3
* Environment name and version (e.g. MySQL, PHP 7): PHP 7.1
* Operating System and version (e.g Ubuntu 16.04): CentOS

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Use quicksearch on member org field, should poulate correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->