### PR TITLE
Fix missing Call's Due date in Activities subpanel

### DIFF
--- a/modules/Calls/metadata/subpanels/ForActivities.php
+++ b/modules/Calls/metadata/subpanels/ForActivities.php
@@ -88,6 +88,8 @@ $subpanel_layout = array(
 		'date_start'=>array(
 			 'vname' => 'LBL_LIST_DUE_DATE',
 			 'width' => '10%',
+  		         'alias' => 'date_due',
+                         'sort_by' => 'date_due'
 		),
 		'assigned_user_name' => array (
 			'name' => 'assigned_user_name',


### PR DESCRIPTION
## Description
This is a tip from @nejck-ikservis [here](https://github.com/salesagility/SuiteCRM/pull/5535#issuecomment-375371290), confirmed by this [forum thread](https://suitecrm.com/suitecrm/forum/suitecrm-7-0-discussion/19465-still-some-fields-missing) 

## How To Test This
In any Activities subpanel (I tried from Contacts module), any Calls with Due date set would show an empty due date.

1. Create call, set due date, associate with a Contact
2. Go into the Contact's detail view and scroll to the Activities subpanel
3. Check the Due date appears on the list.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

I tried this on 7.10.6, but from the code I believe it should go into every branch, 7.8, 7.9 and 7.10.