### PR TITLE
Fix #5918 Activity Stream elapsed time calculation

### DIFF
--- a/modules/SugarFeed/SugarFeed.php
+++ b/modules/SugarFeed/SugarFeed.php
@@ -501,7 +501,7 @@ class SugarFeed extends Basic {
         if (null !== ($userStartDate = $timedate->fromUser($startDate))) {
             $userStartDateTs = $userStartDate->ts;
         } else {
-            LoggerManager::getLogger()->warn('Invalid $startDate)');
+            LoggerManager::getLogger()->warn('Invalid $startDate');
 
             return '';
         }

--- a/modules/SugarFeed/SugarFeed.php
+++ b/modules/SugarFeed/SugarFeed.php
@@ -496,13 +496,17 @@ class SugarFeed extends Basic {
     {
         global $timedate;
 
-        $timedate->getInstance()->userTimezone();
-        $currentTime = $timedate->now();
+        $nowTs = $timedate->getNow()->ts;
 
-        $first = strtotime($currentTime);
-        $second = strtotime($startDate);
+        if (null !== ($userStartDate = $timedate->fromUser($startDate))) {
+            $userStartDateTs = $userStartDate->ts;
+        } else {
+            LoggerManager::getLogger()->warn('Invalid $startDate)');
 
-        $seconds = $first - $second;
+            return '';
+        }
+
+        $seconds = $nowTs - $userStartDateTs;
         $minutes = $seconds / 60;
         $seconds = $seconds % 60;
         $hours = floor($minutes / 60);

--- a/tests/unit/modules/SugarFeed/SugarFeedTest.php
+++ b/tests/unit/modules/SugarFeed/SugarFeedTest.php
@@ -249,7 +249,9 @@ class SugarFeedTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
     public function testgetTimeLapse()
     {
-        $result = SugarFeed::getTimeLapse('2016-01-15 11:16:02');
+        global $timedate;
+
+        $result = SugarFeed::getTimeLapse($timedate->asUser($timedate->fromDb('2016-01-15 11:16:02')));
         $this->assertTrue(isset($result));
         $this->assertGreaterThan(0, strlen($result));
     }


### PR DESCRIPTION
The fix in 7.10.5 doesn't fully fix this issue

## Description
This fix correctly calculated the time elapsed and handles invalid start dates

## How To Test This
Check the Activity Stream time elapsed calculates correctly regardless of date/time settings 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->