### PR TITLE
Improve where clause when removing securitygroups relationships.

### DIFF
--- a/data/Relationships/M2MRelationship.php
+++ b/data/Relationships/M2MRelationship.php
@@ -276,6 +276,10 @@ class M2MRelationship extends SugarRelationship
 				$this->def['join_key_rhs'] => $rhs->id
 			);
 
+            if(!empty($this->def['relationship_role_column']) && !empty($this->def['relationship_role_column_value'])) {
+                $dataToRemove[$this->def['relationship_role_column']] = $this->def['relationship_role_column_value'];
+            }
+            $dataToRemove['deleted'] = 0;
 
               if (empty($_SESSION['disable_workflow']) || $_SESSION['disable_workflow'] != "Yes")
               {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added conditions (module = 'Module' AND deleted = '0') to where clause for query that deletes from securitygroups_records and securitygroups_users.
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
securitygroups_records identifies record by `record_id` and `module` columns.
Also when querying just by securitygroup_id and record_id, indices not used. It is slow in big databases.
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Remove group from some record. Watch query log.
Current example:
```sql
UPDATE securitygroups_records set deleted=1 , date_modified = 'x' WHERE securitygroup_id = 'x' AND record_id = 'x'
```
Fixed example:
```sql
UPDATE securitygroups_records set deleted=1 , date_modified = 'x' WHERE securitygroup_id = 'x' AND record_id = 'x' AND module = 'Opportunities' AND deleted = '0'
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->