### PR TITLE
Fix #6052 - AOR_Reports are showing date+hour on date fields

### DIFF
--- a/modules/AOW_WorkFlow/aow_utils.php
+++ b/modules/AOW_WorkFlow/aow_utils.php
@@ -585,7 +585,11 @@ function getModuleField(
             if($fieldlist[$fieldname]['type'] == 'date') $convert_format = "Y-m-d";
             $fieldlist[$fieldname]['value'] = $timedate->to_display($value, $convert_format, $params['date_format']);
         }else{
-            $fieldlist[$fieldname]['value'] = $timedate->to_display_date_time($value, true, true);
+            if($fieldlist[$fieldname]['type'] == 'date') {
+                $fieldlist[$fieldname]['value'] = $timedate->to_display_date($value, true, true);
+            } else {
+                $fieldlist[$fieldname]['value'] = $timedate->to_display_date_time($value, true, true);
+            }
         }
         $fieldlist[$fieldname]['name'] = $aow_field;
     } else if(isset( $fieldlist[$fieldname]['type'] ) && ($fieldlist[$fieldname]['type'] == 'datetimecombo' || $fieldlist[$fieldname]['type'] == 'datetime' || $fieldlist[$fieldname]['type'] == 'date')){


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If field type is 'date' display the field as 'date' not as 'datetime'.
See #6052
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We have some reports that have date fields, and the result when you consult the report or export it as PDF is that date fields are displayed lke datetime fields.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create a new report on Invoice module.
2. Add at least 'Invoice Date' field.
3. See that the values of this column displays the date + hour while only the date should be shown.
4. Apply PR.
5. Repeat step 3 and see that now 'Invoice Date' field is displayed in date format.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->