### PR TITLE
Prevent securitygroups mass assign damage

### DIFF
--- a/modules/SecurityGroups/AssignGroups.php
+++ b/modules/SecurityGroups/AssignGroups.php
@@ -151,6 +151,9 @@ function mass_assign($event, $arguments)
 				}
 				$group_options =  get_select_options_with_id($options, "");
 
+				$export_where = !empty($_SESSION['export_where']) ? $_SESSION['export_where'] : '';
+				$export_where_md5 = md5($export_where);
+
 				$mass_assign = <<<EOQ
 
 <script type="text/javascript" language="javascript">
@@ -241,6 +244,7 @@ function send_massassign(mode, no_record_txt, start_string, end_string, del) {
 			<input type='hidden' name='module' value='SecurityGroups' />
 			<input type='hidden' name='return_action' value='${action}' />
 			<input type='hidden' name='return_module' value='${module}' />
+			<input type="hidden" name="export_where_md5" value="{$export_where_md5}">
 			<textarea style='display: none' name='uid'></textarea>
 
 

--- a/modules/SecurityGroups/MassAssign.php
+++ b/modules/SecurityGroups/MassAssign.php
@@ -41,6 +41,13 @@ elseif(isset($_REQUEST['entire'])) {
 	} else {
 		$where = '';
 	}
+	$export_where = !empty($_SESSION['export_where']) ? $_SESSION['export_where'] : '';
+	if (empty($_REQUEST['export_where_md5']) || $_REQUEST['export_where_md5'] != md5($export_where)) {
+		$err = translate('LBL_ERROR_EXPORT_WHERE_CHANGED', 'SecurityGroups');
+		SugarApplication::appendErrorMessage($err);
+		header("Location: index.php?action={$_POST['return_action']}&module={$_POST['return_module']}");
+		sugar_die('');
+	}
 	if(empty($order_by))$order_by = '';
 	$query = $sugarbean->create_export_query($order_by,$where);
 	$result = $db->query($query,true);

--- a/modules/SecurityGroups/language/en_us.lang.php
+++ b/modules/SecurityGroups/language/en_us.lang.php
@@ -85,6 +85,7 @@ $mod_strings = array (
   
   'LBL_GROUP_SELECT' => 'Select which groups should have access to this record',
   'LBL_ERROR_DUPLICATE' => 'Due to a possible duplicate detected by SuiteCRM you will have to manually add Security Groups to your newly created record.',
+  'LBL_ERROR_EXPORT_WHERE_CHANGED' => 'Update failed because search filter was modified. Please try again.',
 
   'LBL_INBOUND_EMAIL' => 'Inbound email account',
   'LBL_INBOUND_EMAIL_DESC' => 'Only allow access to an email account if user belongs to a group that is assigned to the mail account.',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make `$_SESSION['export_where']` digest to be sending in request from "Security Groups: Mass Assign" panel.
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
Create two records: account "test1" and "test2", for example. Create any group.
Go to "View Accounts". Apply filter: Name = test1
Open another browser tab, go to "View Accounts". Apply filter: Name = test
Return to first browser tab. Click "Select All (1)" in list view.
In "Security Groups: Mass Assign" panel choose group and click assign.
Alert asks "Are you sure you want to update the 1 selected record(s)?". Confirm.
Look at test2 account. It is updated with new group too.
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
When fixed, error message will be shown, group relationships will not be modified.
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->