### PR TITLE
Set default field tabindex to 0 instead of -1

### DIFF
--- a/include/SugarFields/Fields/Base/SugarFieldBase.php
+++ b/include/SugarFields/Fields/Base/SugarFieldBase.php
@@ -187,10 +187,8 @@ class SugarFieldBase
      */
     public function getSmartyView($parentFieldArray, $vardef, $displayParams, $tabindex, $view)
     {
-
-        // set $tabindex = -1 by default
         if (!is_numeric($tabindex)) {
-            $tabindex = -1;
+            $tabindex = 0;
         }
 
         $this->setup($parentFieldArray, $vardef, $displayParams, $tabindex);
@@ -202,7 +200,7 @@ class SugarFieldBase
     /**
      * @param array $parentFieldArray
      * @param array $vardef
-     * @param array $displayParams
+     * @param array $displayparams
      * @param string $col (unused)
      * @return string
      */

--- a/include/SugarFields/Fields/Base/SugarFieldBase.php
+++ b/include/SugarFields/Fields/Base/SugarFieldBase.php
@@ -200,7 +200,7 @@ class SugarFieldBase
     /**
      * @param array $parentFieldArray
      * @param array $vardef
-     * @param array $displayparams
+     * @param array $displayParams
      * @param string $col (unused)
      * @return string
      */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Default tabindex for form fields should be 0. Previously it was being set to -1, preventing users from tabbing through a form's fields.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
#5995 
#6069

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. In listview, open the search popup
2. From a subpanel, open the select record popup
3. See that you can tab through fields in their logical order.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->