### PR TITLE
Set a distinct emails import view name to avoid cache conflicts

### DIFF
--- a/modules/Emails/views/view.import.php
+++ b/modules/Emails/views/view.import.php
@@ -76,6 +76,9 @@ class EmailsViewImport extends ViewEdit {
         $this->ev = $this->getEditView();
         $this->ev->ss =& $this->ss;
 
+        // Set a distinct view name to avoid cache conflicts with regular edit view
+        $this->ev->formName = 'EditNonImported';
+
         if(!isset($this->bean->mailbox_id) || empty($this->bean->mailbox_id)) {
             $inboundEmailID = $current_user->getPreference('defaultIEAccount', 'Emails');
             $this->ev->ss->assign('INBOUND_ID', $inboundEmailID);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Provides a distinct name for the Import View cache file to avoid using the same cache file as regular edit view.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fix #6050 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Repair and Rebuild
2. Go to Emails
3. Import an Email
4. Edit the imported Email
5. See buttons appear

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->