### PR TITLE
Show Audit log even if user does not exist (anymore)

### DIFF
--- a/modules/Audit/Audit.php
+++ b/modules/Audit/Audit.php
@@ -124,7 +124,7 @@ class Audit extends SugarBean {
 
         if($focus->is_AuditEnabled()){
             $order= ' order by '.$focus->get_audit_table_name().'.date_created desc' ;//order by contacts_audit.date_created desc
-            $query = "SELECT ".$focus->get_audit_table_name().".*, users.user_name FROM ".$focus->get_audit_table_name().", users WHERE ".$focus->get_audit_table_name().".created_by = users.id AND ".$focus->get_audit_table_name().".parent_id = '$focus->id'".$order;
+            $query = "SELECT ".$focus->get_audit_table_name().".*, users.user_name FROM ".$focus->get_audit_table_name()." LEFT JOIN users ON ".$focus->get_audit_table_name().".created_by = users.id WHERE ".$focus->get_audit_table_name().".parent_id = '$focus->id'".$order;
 
 		    $result = $focus->db->query($query);
                 // We have some data.


### PR DESCRIPTION
If a user is missing in the user table the audit log entries are not shown. But even if you do not know the user it is good to know there was a change.
