### PR TITLE
#6126 fix(Change-log) - decode prev value before compare

### DIFF
--- a/include/database/DBManager.php
+++ b/include/database/DBManager.php
@@ -2978,7 +2978,7 @@ abstract class DBManager
             $field_defs = array_intersect_key($field_defs, (array)$bean);
 
             foreach ($field_defs as $field => $properties) {
-                $before_value = $fetched_row[$field];
+                $before_value = from_html($fetched_row[$field]);
                 $after_value = $bean->$field;
                 if (isset($properties['type'])) {
                     $field_type = $properties['type'];


### PR DESCRIPTION
If field value contains single quote, on each save CRM will treat this field as a changed and add new line to bean change-log with same value before and after

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
fix issue https://github.com/salesagility/SuiteCRM/issues/6126

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This

1. Create Account with single quote in name
3. Open and save Account without changes
4. New line will not added to change-log

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->