### PR TITLE
#6126 fix(Workflow AnyChange condition) - decode prev value before compare

### DIFF
--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -618,6 +618,8 @@ class AOW_WorkFlow extends Basic
                             $value = $condition_bean->rel_fields_before_value[$condition->field];
                         } else {
                             $value = from_html($condition_bean->fetched_row[$condition->field]);
+							// Bug - on delete bean action CRM load bean in a different way and bean can contain html characters
+                            $field = from_html($field);
                         }
                         if(in_array($data['type'],$dateFields)) {
                             $value = strtotime($value);

--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -617,7 +617,7 @@ class AOW_WorkFlow extends Basic
                             && isset($condition_bean->rel_fields_before_value[$condition->field])) {
                             $value = $condition_bean->rel_fields_before_value[$condition->field];
                         } else {
-                            $value = $condition_bean->fetched_row[$condition->field];
+                            $value = from_html($condition_bean->fetched_row[$condition->field]);
                         }
                         if(in_array($data['type'],$dateFields)) {
                             $value = strtotime($value);


### PR DESCRIPTION
If field value contains single quote, on each save CRM will treat this field as a changed and trigger all Worflows with condition AnyChange on this field

## Description
fix issue #6126

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create Account with single quote in name
1. Create Workflow with condition AnyChange on Account name field
3. Open and save Account without changes
4. Workflow should not be triggerd

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->