### PR TITLE
Do not call tiny mceAddControl on edit view

### DIFF
--- a/modules/Cases/views/view.edit.php
+++ b/modules/Cases/views/view.edit.php
@@ -59,26 +59,21 @@ class CasesViewEdit extends ViewEdit {
         self::__construct();
     }
 
-    function display(){
-
+    public function display()
+    {
         parent::display();
 
-        $newScript = '';
-
-        if(empty($this->bean->id)){
-            $newScript = "
+        if (empty($this->bean->id)) {
+            $script = "
                     $('#update_text').closest('.edit-view-row-item').hide();
                     $('#update_text_label').closest('.edit-view-row-item').hide();
                     $('#internal').closest('.edit-view-row-item').hide();
                     $('#internal_label').closest('.edit-view-row-item').hide();
                     $('#addFileButton').closest('.edit-view-row-item').hide();
                     $('#case_update_form_label').closest('.edit-view-row-item').hide();";
-        }
+            $script .= "tinyMCE.execCommand('mceAddControl', false, document.getElementById('description'));";
 
-        echo  "<script>$(document).ready(function(){"
-                  . $newScript
-                  . "tinyMCE.execCommand('mceAddControl', false, document.getElementById('description'));
-                });
-            </script>";
+            echo '<script>$(document).ready(function(){' . $script . '})</script>';
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Another fix for the cases description field. This time to fix a bug introduced in the last fix, which prevents tiny from correctly sending the description field content when editing an existing case.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixes #6081 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to Cases module
2. Create a new case, fill out description
3. See it saves correctly
4. Edit the same case, change the description
5. See it saves correctly

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->