### PR TITLE
Adjust the emails module width taking into account the sidebar

### DIFF
--- a/modules/Campaigns/wizard.js
+++ b/modules/Campaigns/wizard.js
@@ -4,7 +4,7 @@
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
  *
  * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
- * Copyright (C) 2011 - 2017 SalesAgility Ltd.
+ * Copyright (C) 2011 - 2018 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the

--- a/modules/Emails/javascript/EmailUIShared.js
+++ b/modules/Emails/javascript/EmailUIShared.js
@@ -65,7 +65,7 @@ SUGAR.email2 = {
         tHeight = Math.max(tHeight, 550);
         c.style.height = tHeight + "px";
         SUGAR.email2.complexLayout.set('height', tHeight);
-        SUGAR.email2.complexLayout.set('width', YAHOO.util.Dom.getViewportWidth() - 40);
+        SUGAR.email2.complexLayout.set('width', YAHOO.util.Dom.getViewportWidth() - 40 - getSideBarCurrentWidth());
         SUGAR.email2.complexLayout.render();
         SUGAR.email2.listViewLayout.resizePreview();        
     }

--- a/modules/Emails/javascript/complexLayout.js
+++ b/modules/Emails/javascript/complexLayout.js
@@ -287,12 +287,12 @@ myBufferedListenerObject.refit = function() {
 }
 
 function getSideBarCurrentWidth() {
-	var $sideBarContainer = $('#sidebar_container');
-	if (!$sideBarContainer.length) {
-		return 0;
-	}
+  var $sideBarContainer = $('#sidebar_container');
+  if (!$sideBarContainer.length) {
+    return 0;
+  }
 
-	var $firstDivChild = $sideBarContainer.children('div:first');
+  var $firstDivChild = $sideBarContainer.children('div:first');
   if (!$firstDivChild.length || !$firstDivChild.is(':visible')) {
     return 0;
   }

--- a/modules/Emails/javascript/complexLayout.js
+++ b/modules/Emails/javascript/complexLayout.js
@@ -113,11 +113,12 @@ function complexLayoutInit() {
             // initialize state manager, we will use cookies
         	var viewHeight = document.documentElement ? document.documentElement.clientHeight : self.innerHeight;
             var heightOffset = $('#dcmenu').length > 0 ? $('#dcmenu').height() : $('#header').height();
+            var availableWidth = Dom.getViewportWidth() - 40 - getSideBarCurrentWidth();
         	se.complexLayout = new YAHOO.widget.Layout("container", {
         		border:true,
                 hideOnLayout: true,
                 height: Dom.getViewportHeight() - heightOffset - 65,
-                width: Dom.getViewportWidth() - 40,
+                width: availableWidth,
                 units: [{
                 	position: "center",
                     scroll:false,
@@ -283,4 +284,18 @@ myBufferedListenerObject.refit = function() {
     if(SUGAR.email2.grid) {
         SUGAR.email2.grid.autoSize();
     }
+}
+
+function getSideBarCurrentWidth() {
+	var $sideBarContainer = $('#sidebar_container');
+	if (!$sideBarContainer.length) {
+		return 0;
+	}
+
+	var $firstDivChild = $sideBarContainer.children('div:first');
+  if (!$firstDivChild.length || !$firstDivChild.is(':visible')) {
+    return 0;
+  }
+
+  return $firstDivChild.width();
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Previously the emails module would be too wide if the left sidebar was opened, forcing the user to use the bottom scrollbar.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Checks if the left sidebar is opened, then substracts the width from the available space for the emails module.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Go to the Emails module
2. Click Compose
3. See you can access the sidebar on the right (to upload documents) without scrolling

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->