### PR TITLE
Make Email Template field in Events not be inline editable

### DIFF
--- a/modules/FP_events/vardefs.php
+++ b/modules/FP_events/vardefs.php
@@ -188,6 +188,7 @@ $dictionary['FP_events'] = array(
                 'options' => 'email_templet_list',
                 'studio' => 'visible',
                 'dependency' => false,
+                'inline_edit' => false,
             ),
         'accept_redirect' =>
             array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Disabled inline edit for this field.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixes #6179 
The function which builds the template list for Events edit view is not called during the setup of the inline edit field.
Disabling inline editing for this field seems to be cleanest option in my opinion.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Not much to test since inline editing is disabled now

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->