### PR TITLE
Prevent massive slowdown if someone accidently added many favorites

### DIFF
--- a/modules/Favorites/Favorites.php
+++ b/modules/Favorites/Favorites.php
@@ -110,7 +110,7 @@ class Favorites extends Basic
         if ($id) {
             $query = "SELECT parent_id, parent_type FROM favorites WHERE assigned_user_id = '" . $current_user->id . "' AND parent_id = '" . $id . "' AND deleted = 0 ORDER BY date_entered DESC";
         } else {
-            $query = "SELECT parent_id, parent_type FROM favorites WHERE assigned_user_id = '" . $current_user->id . "' AND deleted = 0 ORDER BY date_entered DESC";
+            $query = "SELECT parent_id, parent_type FROM favorites WHERE assigned_user_id = '" . $current_user->id . "' AND deleted = 0 ORDER BY date_entered DESC LIMIT 30";
         }
 
         $result = $db->query($query);


### PR DESCRIPTION
Steps to reproduce:
- Add 200 to 400 Favorites for a user
- SuiteCRM becomes unusable slow ( For me <1sec will become 6-10 sec on each page load)

Solution: There are never more than 30 favorites displayed, so we do not need to get all of them.

Refers to https://github.com/salesagility/SuiteCRM/issues/6142