### PR TITLE
Fix: Email body is the same on the detail view

### DIFF
--- a/include/Smarty/plugins/function.sugar_literal.php
+++ b/include/Smarty/plugins/function.sugar_literal.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * by passes the smarty parsing for the detail view.
+ * Smarty {sugar_literal} function plugin
+ *
+ * example
+ * {sugar_literal content=$vardef.value}
+ *
+ *
+ * @param array $params
+ * @param Smarty $smarty
+ * @return string with content wrapped around with literals
+ */
+function smarty_function_sugar_literal($params, &$smarty)
+{
+    $content = '';
+
+   if (!isset($params['content'])) {
+       return $content;
+   }
+    return $params['content'];
+}

--- a/include/Smarty/plugins/function.sugar_literal.php
+++ b/include/Smarty/plugins/function.sugar_literal.php
@@ -9,10 +9,9 @@
  *
  *
  * @param array $params
- * @param Smarty $smarty
  * @return string with content wrapped around with literals
  */
-function smarty_function_sugar_literal($params, &$smarty)
+function smarty_function_sugar_literal($params)
 {
     $content = '';
 

--- a/include/Smarty/plugins/function.sugar_varname.php
+++ b/include/Smarty/plugins/function.sugar_varname.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ *
+ * Smarty {sugar_varname key='value'} function plugin
+ *
+ * example
+ * {sugar_literal key='value'}
+ *
+ *
+ * @param array $params
+ * @param Smarty $smarty
+ * @return string smarty varname
+ */
+function smarty_function_sugar_varname($params, &$smarty)
+{
+
+    if(empty($params['key']))  {
+        $smarty->trigger_error("sugarvar: missing 'key' parameter");
+        return;
+    }
+
+    $object = (empty($params['objectName']))?$smarty->get_template_vars('parentFieldArray'): $params['objectName'];
+
+    $vardefs = $smarty->get_template_vars('vardef');
+    $member = $vardefs['name'];
+
+    $_contents =  '$'. $object . '.' . $member . '.' . $params['key'];
+    return $_contents;
+}

--- a/include/SugarFields/Fields/EmailBody/DetailView.tpl
+++ b/include/SugarFields/Fields/EmailBody/DetailView.tpl
@@ -38,7 +38,7 @@
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 *}
-<span class="sugar_field" id="{{if empty($displayParams.idName)}}{{sugarvar key='name'}}{{else}}{{$displayParams.idName}}{{/if}}">{{sugarvar key='value'}}</span>
+<span class="sugar_field" id="{{if empty($displayParams.idName)}}{{sugarvar key='name'}}{{else}}{{$displayParams.idName}}{{/if}}">{sugar_literal content={{sugar_varname key='value'}}}</span>
 {{if !empty($displayParams.enableConnectors)}}
 {{sugarvar_connector view='DetailView'}}
 {{/if}}

--- a/include/SugarFields/Fields/Html/DetailView.tpl
+++ b/include/SugarFields/Fields/Html/DetailView.tpl
@@ -38,7 +38,7 @@
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 *}
-<span class="sugar_field" id="{{if empty($displayParams.idName)}}{{sugarvar key='name'}}{{else}}{{$displayParams.idName}}{{/if}}">{{$vardef.value}}</span>
+<span class="sugar_field" id="{{if empty($displayParams.idName)}}{{sugarvar key='name'}}{{else}}{{$displayParams.idName}}{{/if}}">{sugar_literal content={{sugar_varname key='value'}}}</span>
 {{if !empty($displayParams.enableConnectors)}}
 {{sugarvar_connector view='DetailView'}}
 {{/if}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When users access the detail view of multiple emails, the body of the email appears to be the same.

This fix utilises the fact that the template is parsed twice. I have added two new methods. sugar_varname to get the smarty variable name. sugar_literal to by pass the second parsing, so that elements such as "style" or "script" do not break the smarty parser.

## Motivation and Context
- Fixes bug

<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->
- Ensure development mode is turned off
- Set up inbound email
- Access multiple emails
- Check that the body is not the same as the previously accessed email

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->