### PR TITLE
Fix #5885 - SAML2, Resolve failure to login

### DIFF
--- a/modules/Users/authentication/SAML2Authenticate/SAML2Authenticate.php
+++ b/modules/Users/authentication/SAML2Authenticate/SAML2Authenticate.php
@@ -42,7 +42,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-
+require_once dirname(dirname(__FILE__)).'/SAML2Authenticate/lib/onelogin/php-saml/_toolkit_loader.php';
 require_once('modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php');
 
 /**
@@ -99,7 +99,7 @@ class SAML2Authenticate extends SugarAuthenticate
             $_SESSION['samlSessionIndex'] = $auth->getSessionIndex();
             unset($_SESSION['AuthNRequestID']);
 
-            if (isset($_POST['RelayState'])) {
+            if (isset($_POST['RelayState']) && OneLogin_Saml2_Utils::getSelfURL() != $_POST['RelayState']) {
                 $relayStateUrl = $_POST['RelayState'] . '?action=Login&module=Users';
                 $selfurl = OneLogin_Saml2_Utils::getSelfURL();
                 if ($selfurl === $relayStateUrl) {

--- a/modules/Users/authentication/SAML2Authenticate/SAML2AuthenticateUser.php
+++ b/modules/Users/authentication/SAML2Authenticate/SAML2AuthenticateUser.php
@@ -66,7 +66,7 @@ class SAML2AuthenticateUser extends SugarAuthenticateUser
 
         // set the ID in the seed user.  This can be used for retrieving the full user record later
         //if it's falling back on Sugar Authentication after the login failed on an external authentication return empty if the user has external_auth_disabled for them
-        if (empty($row) || !empty($row['external_auth_only'])) {
+        if (empty($row) || empty($row['external_auth_only'])) {
             return '';
         }
         return $row['id'];


### PR DESCRIPTION
## Description
SAML2 authentication currently results in either a fatal error occurring (white screen, 500) or fails to login.

## Motivation and Context
Currently the external_auth_only check in place is a boolean, meaning, only upon it not being a SAML user should the return be empty, not when an auth is. The current logic would return no results. No OneLogin instance was working prior to these changes.

Issues raised that could relate to this:
https://github.com/salesagility/SuiteCRM/issues/5921
https://github.com/salesagility/SuiteCRM/issues/5885

...And possibly others, though, non descriptive error codes.

## How To Test This

- Create a trial one login account.
- Link it to a SugarCRM SAML2
- Add the user to one login
- Set the user up in the CRM
- Login to the CRM with the urls set and x509 cert set.

- Confirm non SAML users are working with ?no_saml=1 set after index.php e.g: 
- `yourinstance/index.php?no_saml=1`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.