### PR TITLE
Fixed #6244 - 7.8.20LTS AOR_Report fails using a date parameter

### DIFF
--- a/modules/AOR_Reports/AOR_Report.js
+++ b/modules/AOR_Reports/AOR_Report.js
@@ -68,11 +68,11 @@ function updateTimeDateFields(fieldInput, ln) {
 
 function updateHiddenReportFields(ln, _form) {
 // Fix for issue #1272 - AOR_Report module cannot update Date type parameter.
-  if ($('#aor_conditions_value\\['+ln+'\\]\\[0\\]').length) {
-      var fieldValue = $('#aor_conditions_value\\['+ln+'\\]\\[0\\]').val();
-      var fieldSign = $('#aor_conditions_value\\['+ln+'\\]\\[1\\]').val();
-      var fieldNumber = $('#aor_conditions_value\\['+ln+'\\]\\[2\\]').val();
-      var fieldTime = $('#aor_conditions_value\\['+ln+'\\]\\[3\\]').val();
+  if ($("#aor_conditions_value\\["+ln+"\\]\\[0\\]").length) {
+      var fieldValue = $("#aor_conditions_value\\["+ln+"\\]\\[0\\]").val();
+      var fieldSign = $("#aor_conditions_value\\["+ln+"\\]\\[1\\]").val();
+      var fieldNumber = $("#aor_conditions_value\\["+ln+"\\]\\[2\\]").val();
+      var fieldTime = $("#aor_conditions_value\\["+ln+"\\]\\[3\\]").val();
 
       _form.append('<input type="hidden" name="parameter_date_value['+ ln + ']" value="' + fieldValue + '">');
       _form.append('<input type="hidden" name="parameter_date_sign['+ ln + ']" value="' + fieldSign + '">');
@@ -95,16 +95,16 @@ function appendHiddenFields(_form, ln, id) {
     _form.append('<input type="hidden" name="parameter_id\[' + ln + '\]" value="' + id + '">');
     var operator = $("#aor_conditions_operator\\[" + ln + "\\]").val();
     _form.append('<input type="hidden" name="parameter_operator\[' + ln + '\]" value="' + operator + '">');
-    var fieldType = $('#aor_conditions_value_type\\[' + ln + '\\]').val();
+    var fieldType = $("#aor_conditions_value_type\\[" + ln + "\\]").val();
     _form.append('<input type="hidden" name="parameter_type[' + ln + ']" value="' + fieldType + '">');
 
     // values can be #aor_conditions_value3 or #aor_conditions_value[3]
     var fieldInput = '';
-    if ($('#aor_conditions_value\\['+ln+'\\]\\[0\\]').length > 0) {
-        fieldInput = $('#aor_conditions_value\\['+ln+'\\]\\[0\\]').val();
+    if ($("#aor_conditions_value\\["+ln+"\\]\\[0\\]").length > 0) {
+        fieldInput = $("#aor_conditions_value\\["+ln+"\\]\\[0\\]").val();
         fieldInput = updateTimeDateFields(fieldInput, ln);
     } else {
-        fieldInput = $('#aor_conditions_value\\[' + ln + '\\]').val();
+        fieldInput = $("#aor_conditions_value\\[" + ln + "\\]").val();
     }
 
     _form.append('<input type="hidden" name="parameter_value[' + ln + ']" value="' + fieldInput + '">');
@@ -171,16 +171,16 @@ function changeReportPage(record, offset, group_value, table_id) {
     var fieldType = $('#aor_conditions_value_type\\[' + ln + '\\]').val();
     query += "&parameter_type[]=" + fieldType;
     var fieldInput = '';
-    if ($('#aor_conditions_value' + ln).length > 0) {
-		var fieldValue = $('#aor_conditions_value\\['+ln+'\\]\\[0\\]').val();
+    if ($("#aor_conditions_value\\["+ln+"\\]\\[0\\]").length > 0) {
+		var fieldValue = $("#aor_conditions_value\\["+ln+"\\]\\[0\\]").val();
         query += "&parameter_date_value[]=" + fieldValue;
-        var fieldSign = $('#aor_conditions_value\\['+ln+'\\]\\[1\\]').val();
+        var fieldSign = $("#aor_conditions_value\\["+ln+"\\]\\[1\\]").val();
         query += "&parameter_date_sign[]=" + fieldSign;
-        var fieldNumber = $('#aor_conditions_value\\['+ln+'\\]\\[2\\]').val();
+        var fieldNumber = $("#aor_conditions_value\\["+ln+"\\]\\[2\\]").val();
         query += "&parameter_date_number[]=" + fieldNumber;
-        var fieldTime = $('#aor_conditions_value\\['+ln+'\\]\\[3\\]').val();
+        var fieldTime = $("#aor_conditions_value\\["+ln+"\\]\\[3\\]").val();
         query += "&parameter_date_time[]=" + fieldTime;
-        fieldInput = $('#aor_conditions_value' + ln).val();
+        fieldInput = $("#aor_conditions_value\\["+ln+"\\]\\[0\\]").val();
         fieldInput = updateTimeDateFields(fieldInput, ln);
     } else {
         fieldInput = $('#aor_conditions_value\\[' + ln + '\\]').val();

--- a/modules/AOR_Reports/AOR_Report.js
+++ b/modules/AOR_Reports/AOR_Report.js
@@ -68,14 +68,13 @@ function updateTimeDateFields(fieldInput, ln) {
 
 function updateHiddenReportFields(ln, _form) {
 // Fix for issue #1272 - AOR_Report module cannot update Date type parameter.
-  if ($('#aor_conditions_value' + ln).length) {
-      var conditionsValue = $('#aor_conditions_value' + ln).val();
-      var fieldValue = conditionsValue;
-      var fieldSign = conditionsValue;
-      var fieldNumber = conditionsValue;
-      var fieldTime = conditionsValue;
+  if ($('#aor_conditions_value\\['+ln+'\\]\\[0\\]').length) {
+      var fieldValue = $('#aor_conditions_value\\['+ln+'\\]\\[0\\]').val();
+      var fieldSign = $('#aor_conditions_value\\['+ln+'\\]\\[1\\]').val();
+      var fieldNumber = $('#aor_conditions_value\\['+ln+'\\]\\[2\\]').val();
+      var fieldTime = $('#aor_conditions_value\\['+ln+'\\]\\[3\\]').val();
 
-      _form.append('<input type="hidden" name="parameter_date_value['+ ln + '] value="' + fieldValue + '">');
+      _form.append('<input type="hidden" name="parameter_date_value['+ ln + ']" value="' + fieldValue + '">');
       _form.append('<input type="hidden" name="parameter_date_sign['+ ln + ']" value="' + fieldSign + '">');
       _form.append('<input type="hidden" name="parameter_date_number['+ ln + ']" value="' + fieldNumber + '">');
       _form.append('<input type="hidden" name="parameter_date_time['+ ln + ']" value="' + fieldTime + '">');
@@ -101,8 +100,8 @@ function appendHiddenFields(_form, ln, id) {
 
     // values can be #aor_conditions_value3 or #aor_conditions_value[3]
     var fieldInput = '';
-    if ($('#aor_conditions_value' + ln).length > 0) {
-        fieldInput = $('#aor_conditions_value' + ln).val();
+    if ($('#aor_conditions_value\\['+ln+'\\]\\[0\\]').length > 0) {
+        fieldInput = $('#aor_conditions_value\\['+ln+'\\]\\[0\\]').val();
         fieldInput = updateTimeDateFields(fieldInput, ln);
     } else {
         fieldInput = $('#aor_conditions_value\\[' + ln + '\\]').val();
@@ -173,6 +172,14 @@ function changeReportPage(record, offset, group_value, table_id) {
     query += "&parameter_type[]=" + fieldType;
     var fieldInput = '';
     if ($('#aor_conditions_value' + ln).length > 0) {
+		var fieldValue = $('#aor_conditions_value\\['+ln+'\\]\\[0\\]').val();
+        query += "&parameter_date_value[]=" + fieldValue;
+        var fieldSign = $('#aor_conditions_value\\['+ln+'\\]\\[1\\]').val();
+        query += "&parameter_date_sign[]=" + fieldSign;
+        var fieldNumber = $('#aor_conditions_value\\['+ln+'\\]\\[2\\]').val();
+        query += "&parameter_date_number[]=" + fieldNumber;
+        var fieldTime = $('#aor_conditions_value\\['+ln+'\\]\\[3\\]').val();
+        query += "&parameter_date_time[]=" + fieldTime;
         fieldInput = $('#aor_conditions_value' + ln).val();
         fieldInput = updateTimeDateFields(fieldInput, ln);
     } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixed issue #6244 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The report fails with a MySql syntax error when using a non-simple Date value and hitting the Update button. The report also fails when paginating, exporting CSV and exporting PDF.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create a report with a date condition such as today-36 months as a parameter.
2. Click on Update or Paginate the report.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->