### PR TITLE
Fixed #6148 - API v8: "[Unable to convert datetime field using SugarBean]" on update

### DIFF
--- a/lib/API/JsonApi/v1/Resource/SuiteBeanResource.php
+++ b/lib/API/JsonApi/v1/Resource/SuiteBeanResource.php
@@ -115,7 +115,7 @@ class SuiteBeanResource extends Resource
                 throw $exception;
             }
 
-            if ($definition['type'] === 'datetime' && isset($sugarBean->$fieldName)) {
+            if ($definition['type'] === 'datetime' && isset($sugarBean->$fieldName) && $sugarBean->$fieldName !== '') {
                 // Convert to DB date
                 $datetime = $dateTimeConverter->fromUser($sugarBean->$fieldName);
                 if (empty($datetime)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixes an issue when email address "confirm_opt_in_date" is empty, if you PATCH the address, you receive [Unable to convert datetime field using SugarBean] "confirm_opt_in_date".

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #6148 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Generate an API token
2. Create an EmailAddress
3. Update the EmailAddress: 
```
PATCH v8/modules/EmailAddresses/496d18ba-e2b5-2b7a-313c-5b4851c15a2f
{'data': {'attributes': {'email_address': 'test2@test.com',
                         'email_address_caps': 'TEST2@TEST.COM'},
                         'type': 'EmailAddresses'}}
```
4. Check suitecrm.log

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->