### PR TITLE
Allow module to be in custom directory

### DIFF
--- a/include/MVC/View/SugarView.php
+++ b/include/MVC/View/SugarView.php
@@ -1185,7 +1185,7 @@ EOHTML;
      */
     protected function _checkModule()
     {
-        if (!empty($this->module) && !file_exists('modules/' . $this->module)) {
+        if (!empty($this->module) && !file_exists('modules/' . $this->module) && !file_exists('custom/modules/' . $this->module)) {
             $error = str_replace("[module]", "$this->module", $GLOBALS['app_strings']['ERR_CANNOT_FIND_MODULE']);
             $GLOBALS['log']->fatal($error);
             echo $error;


### PR DESCRIPTION
Change to Allow module to be only in custom directory

## Description

Changed code to allow module to be in custom directory

## Motivation and Context

It's seem all added module should go in custom and /module should be for SuiteCRM only stuff.

## How To Test This

Put a module only in the custom directory

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.