### PR TITLE
Do not show img tag with same src attribute if an image field is empty

### DIFF
--- a/include/SugarFields/Fields/Image/DetailView.tpl
+++ b/include/SugarFields/Fields/Image/DetailView.tpl
@@ -38,6 +38,9 @@
  ********************************************************************************/
 *}
 <span class="sugar_field" id="{{if empty($displayParams.idName)}}{{sugarvar key='name'}}{{else}}{{$displayParams.idName}}{{/if}}">
-
-<img src="index.php?entryPoint=download&id={$fields.{{$vardef.fileId}}.value}_{{if empty($displayParams.idName)}}{{sugarvar key='name'}}{{else}}{{$displayParams.idName}}{{/if}}{$fields.width.value}&type={{$vardef.linkModule}}" style="max-width: {if !$vardef.width}{{$vardef.width}}{else}200{/if}px;" height="{if !$vardef.height}{{$vardef.height}}{else}50{/if}">
+{if strlen({{sugarvar key='value' string=true}}) <= 0}
+    <img src="" style="max-width: {if !$vardef.width}{{$vardef.width}}{else}200{/if}px;" height="{if !$vardef.height}{{$vardef.height}}{else}50{/if}">
+{else}
+    <img src="index.php?entryPoint=download&id={$fields.{{$vardef.fileId}}.value}_{{if empty($displayParams.idName)}}{{sugarvar key='name'}}{{else}}{{$displayParams.idName}}{{/if}}{$fields.width.value}&type={{$vardef.linkModule}}" style="max-width: {if !$vardef.width}{{$vardef.width}}{else}200{/if}px;" height="{if !$vardef.height}{{$vardef.height}}{else}50{/if}">
+{/if}
 </span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes a small bug with the image type field from Studio / Module Builder.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Image fields have in their src attribute the url of an entrypoint composed of the id of the record we're viewing and the name of the field. However, once we clear an image field, since this url doesn't change the browser might display a cached version where we would expect not to see any image.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Add an image field to any module
2. Add it to detail and edit view
3. Edit a record, upload an image to this field
4. See it displays in detail view
5. Edit the record, remove the image
6. See it doesn't display in detail view. The img tag should have an empty src attribute.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->