### PR TITLE
Fixed #6312 - Charts in Dashlets cause php errors in 7.8.21

### DIFF
--- a/include/Dashlets/DashletGenericChart.php
+++ b/include/Dashlets/DashletGenericChart.php
@@ -1,11 +1,11 @@
 <?php
-if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
-/*********************************************************************************
+/**
+ *
  * SugarCRM Community Edition is a customer relationship management program developed by
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
-
- * SuiteCRM is an extension to SugarCRM Community Edition developed by Salesagility Ltd.
- * Copyright (C) 2011 - 2014 Salesagility Ltd.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2018 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the
@@ -16,7 +16,7 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
  * details.
  *
  * You should have received a copy of the GNU Affero General Public License along with
@@ -34,9 +34,13 @@ if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
  * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
  * these Appropriate Legal Notices must retain the display of the "Powered by
  * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
- * reasonably feasible for  technical reasons, the Appropriate Legal Notices must
- * display the words  "Powered by SugarCRM" and "Supercharged by SuiteCRM".
- ********************************************************************************/
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
 
 require_once('include/Dashlets/Dashlet.php');
 require_once('include/generic/LayoutManager.php');
@@ -95,25 +99,24 @@ abstract class DashletGenericChart extends Dashlet
     /**
      * Constructor
      *
-     * @param int   $id
+     * @param int $id
      * @param array $options
      */
     public function __construct(
         $id,
         array $options = null
-        )
-    {
+    ) {
         parent::__construct($id);
 
-        if ( isset($options) ) {
-            foreach ( $options as $key => $value ) {
+        if (isset($options)) {
+            foreach ($options as $key => $value) {
                 $this->$key = $value;
             }
         }
 
         // load searchfields
         $classname = get_class($this);
-        if ( is_file("modules/Charts/Dashlets/$classname/$classname.data.php") ) {
+        if (is_file("modules/Charts/Dashlets/$classname/$classname.data.php")) {
             require("modules/Charts/Dashlets/$classname/$classname.data.php");
             $this->_searchFields = $dashletData[$classname]['searchFields'];
         }
@@ -121,16 +124,20 @@ abstract class DashletGenericChart extends Dashlet
         // load language files
         $this->loadLanguage($classname, 'modules/Charts/Dashlets/');
 
-        if ( empty($options['title']) )
+        if (empty($options['title'])) {
             $this->title = $this->dashletStrings['LBL_TITLE'];
-        if ( isset($options['autoRefresh']) )
+        }
+        if (isset($options['autoRefresh'])) {
             $this->autoRefresh = $options['autoRefresh'];
+        }
 
         $this->layoutManager = new LayoutManager();
         $this->layoutManager->setAttribute('context', 'Report');
         // fake a reporter object here just to pass along the db type used in many widgets.
         // this should be taken out when sugarwidgets change
-        $temp = (object) array('db' => &DBManagerFactory::getInstance(), 'report_def_str' => '');
+        $db = DBManagerFactory::getInstance();
+
+        $temp = (object)array('db' => &$db, 'report_def_str' => '');
         $this->layoutManager->setAttributePtr('reporter', $temp);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
If you have charts in a dashlet in 7.8.21 php throws an error and does not show the home dashboard at all.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #6312 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Navigate to dashboard.
2. Add chart dashlet.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->