### PR TITLE
Fixed #6312 - Charts in Dashlets cause php errors in 7.10.8

### DIFF
--- a/include/Dashlets/DashletGenericChart.php
+++ b/include/Dashlets/DashletGenericChart.php
@@ -1,7 +1,4 @@
 <?php
-if (!defined('sugarEntry') || !sugarEntry) {
-    die('Not A Valid Entry Point');
-}
 /**
  *
  * SugarCRM Community Edition is a customer relationship management program developed by
@@ -40,6 +37,10 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * reasonably feasible for technical reasons, the Appropriate Legal Notices must
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
 
 require_once('include/Dashlets/Dashlet.php');
 require_once('include/generic/LayoutManager.php');
@@ -134,7 +135,8 @@ abstract class DashletGenericChart extends Dashlet
         $this->layoutManager->setAttribute('context', 'Report');
         // fake a reporter object here just to pass along the db type used in many widgets.
         // this should be taken out when sugarwidgets change
-        $temp = (object) array('db' => &DBManagerFactory::getInstance(), 'report_def_str' => '');
+        $db = DBManagerFactory::getInstance();
+        $temp = (object) array('db' => &$db, 'report_def_str' => '');
         $this->layoutManager->setAttributePtr('reporter', $temp);
     }
 

--- a/tests/_support/Step/Acceptance/Dashboard.php
+++ b/tests/_support/Step/Acceptance/Dashboard.php
@@ -14,5 +14,6 @@ class Dashboard extends Tester
     {
         $I = $this;
         $I->waitForElementVisible('.dashboard', 120);
+        $I->waitForElementVisible('.dashletcontainer', 5);
     }
 }

--- a/tests/acceptance/modules/Home/HomeCest.php
+++ b/tests/acceptance/modules/Home/HomeCest.php
@@ -1,0 +1,60 @@
+<?php
+
+use Faker\Generator;
+
+class HomeCest
+{
+    /**
+     * @var Generator $fakeData
+     */
+    protected $fakeData;
+
+    /**
+     * @var integer $fakeDataSeed
+     */
+    protected $fakeDataSeed;
+
+    /**
+     * @param AcceptanceTester $I
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        if (!$this->fakeData) {
+            $this->fakeData = Faker\Factory::create();
+        }
+
+        $this->fakeDataSeed = rand(0, 2048);
+        $this->fakeData->seed($this->fakeDataSeed);
+    }
+
+
+    /**
+     * @param \AcceptanceTester $I
+     * @param \Step\Acceptance\Dashboard $dashboard
+     * @param \Helper\WebDriverHelper $webDriverHelper
+     *
+     * As a user I want to see the due date on the activities module
+     */
+    public function testCreateChartsDashlet(
+        \AcceptanceTester $I,
+        \Step\Acceptance\Dashboard $dashboard,
+        \Step\Acceptance\DetailView $detailView,
+        \Helper\WebDriverHelper $webDriverHelper
+    ) {
+        $I->wantTo('Create a chart dashlet on the dashboard');
+
+        $I->amOnUrl(
+            $webDriverHelper->getInstanceURL()
+        );
+
+        // Navigate to dashboard
+        $I->loginAsAdmin();
+        $dashboard->waitForDashboardVisible();
+        $detailView->clickActionMenuItem('Add Dashlets');
+        $I->click('Charts');
+        $I->click('All Opportunities By Lead Source By Outcome');
+        $I->click('Close');
+        $dashboard->waitForDashboardVisible();
+        $I->see('All Opportunities By Lead Source By Outcome');
+    }
+}

--- a/tests/acceptance/modules/Home/HomeCest.php
+++ b/tests/acceptance/modules/Home/HomeCest.php
@@ -51,6 +51,7 @@ class HomeCest
         $I->loginAsAdmin();
         $dashboard->waitForDashboardVisible();
         $detailView->clickActionMenuItem('Add Dashlets');
+        $I->waitForText('Charts');
         $I->click('Charts');
         $I->click('All Opportunities By Lead Source By Outcome');
         $I->click('Close');

--- a/tests/acceptance/modules/Home/HomeCest.php
+++ b/tests/acceptance/modules/Home/HomeCest.php
@@ -33,7 +33,7 @@ class HomeCest
      * @param \Step\Acceptance\Dashboard $dashboard
      * @param \Helper\WebDriverHelper $webDriverHelper
      *
-     * As a user I want to see the due date on the activities module
+     * As a user I want to see a chart added to my dashboard
      */
     public function testCreateChartsDashlet(
         \AcceptanceTester $I,
@@ -51,11 +51,22 @@ class HomeCest
         $I->loginAsAdmin();
         $dashboard->waitForDashboardVisible();
         $detailView->clickActionMenuItem('Add Dashlets');
-        $I->waitForText('Charts');
-        $I->click('Charts');
+        $I->wait(1);
+        $I->click('#chartCategory');
         $I->click('All Opportunities By Lead Source By Outcome');
         $I->click('Close');
         $dashboard->waitForDashboardVisible();
+        $I->wait(1);
         $I->see('All Opportunities By Lead Source By Outcome');
+        $dashboardID = $I->grabAttributeFrom('descendant-or-self::div[@class="dashletPanel"]', 'id');
+        if ($dashboardID != "") {
+            $dashboardID = str_replace("dashlet_entire_", "", $dashboardID);
+        }
+        $I->comment("The All Opportunities By Lead Source By Outcome dashboard ID is: ".$dashboardID);
+        $I->click('//*[@id="dashlet_header_'.$dashboardID.'"]/div[2]/table/tbody/tr/td[2]/div/a[3]/span');
+        $I->wait(1);
+        $detailView->acceptPopup();
+        $I->wait(1);
+        $I->dontSee('All Opportunities By Lead Source By Outcome');
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
If you have charts in a dashlet in 7.10.8 php throws an error and does not show the home dashboard at all.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #6312 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Navigate to dashboard.
2. Add chart dashlet.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->