### PR TITLE
Fixed #6321 - using same form name as back-end does

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## SuiteCRM 7.10.7
+## SuiteCRM 7.10.8
 
 [![Build Status](https://travis-ci.org/salesagility/SuiteCRM.svg?branch=hotfix)](https://travis-ci.org/salesagility/SuiteCRM)
 [![codecov](https://codecov.io/gh/salesagility/SuiteCRM/branch/hotfix/graph/badge.svg)](https://codecov.io/gh/salesagility/SuiteCRM/branch/hotfix)

--- a/modules/Emails/include/ImportView/ImportView.tpl
+++ b/modules/Emails/include/ImportView/ImportView.tpl
@@ -41,7 +41,7 @@
 
 {{sugar_include type="smarty" file=$headerTpl}}
 {sugar_include include=$includes}
-<form class="email-import-view" id="EditView" name="EditView" method="POST" action="index.php?module=Emails&action=send">
+<form class="email-import-view" id="EditView" name="EditNonImported" method="POST" action="index.php?module=Emails&action=send">
     <input type="hidden" name="module" value="Emails">
     <input type="hidden" name="action" value="Import">
     <input type="hidden" name="record" value="">

--- a/modules/Emails/include/ListView/ImportEmailAction.js
+++ b/modules/Emails/include/ListView/ImportEmailAction.js
@@ -73,7 +73,7 @@
 
 
       var action = 'index.php?module=Emails&action=ImportFromListView';
-      var view = caller[0].messageBox.controls.modal.content.find('[name="EditView"]');
+      var view = caller[0].messageBox.controls.modal.content.find('[name="EditNonImported"]');
       caller[0].messageBox.hideFooter();
       $('<div class="in-progress"><img src="themes/'+SUGAR.themes.theme_name+'/images/loading.gif"></div>')
         .prependTo(view.parent());

--- a/suitecrm_version.php
+++ b/suitecrm_version.php
@@ -3,5 +3,5 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-$suitecrm_version      = '7.10.7';
-$suitecrm_timestamp    = '2018-06-18 17:00';
+$suitecrm_version      = '7.10.8';
+$suitecrm_timestamp    = '2018-09-13 17:00';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixed #6321 - using same form name as back-end does
 the popup didn't fill out the form because didn't find it. caused by the wrong form-name
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
see at issue #6321
## How To Test This
<!--- Please describe in detail how to test your changes. -->
see at issue #6321
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->