### PR TITLE
Fixed #6322 - creating parent-child relationship in clean install of 7.10.9 causes parent display to break

### DIFF
--- a/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButtonAccount.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButtonAccount.php
@@ -55,7 +55,7 @@ class SugarWidgetSubPanelRemoveButtonAccount extends SugarWidgetSubPanelRemoveBu
      */
     public function displayList(&$layout_def)
     {
-        if (!$layout_def['EditView'])
+        if (!$layout_def['EditView']) {
             return false;
         }
         return parent::displayList($layout_def);

--- a/tests/acceptance/modules/Accounts/AccountsCest.php
+++ b/tests/acceptance/modules/Accounts/AccountsCest.php
@@ -135,6 +135,7 @@ class AccountsCest
     public function testScenarioCreateAccountChild(
         \AcceptanceTester $I,
         \Step\Acceptance\DetailView $detailView,
+        \Step\Acceptance\EditView $editView,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\Accounts $accounts,
         \Helper\WebDriverHelper $webDriverHelper
@@ -152,14 +153,6 @@ class AccountsCest
 
         // Create account
         $this->fakeData->seed($this->fakeDataSeed);
-        $accountName = 'Test_' . $this->fakeData->company();
-        $accounts->createAccount($accountName);
-
-        // Navigate to accounts list-view
-        $accounts->gotoAccounts();
-        $listView->waitForListViewVisible();
-
-        // Create Second account
         $parentAccountName = 'Test_' . $this->fakeData->company();
         $accounts->createAccount($parentAccountName);
 
@@ -168,10 +161,12 @@ class AccountsCest
         $I->waitForElementVisible('#member_accounts_create_button', 60);
 
         // Add child account
+        $accountName = 'Test_' . $this->fakeData->company();
         $I->click('#member_accounts_create_button');
-        $I->wait(1);
+        $I->click('#Accounts_subpanel_full_form_button');
+        $editView->waitForEditViewVisible();
         $I->fillfield('#name', $accountName);
-        $I->click('#Accounts_subpanel_save_button');
+        $editView->clickSaveButton();
         $detailView->waitForDetailViewVisible();
         $I->see($accountName);
 

--- a/tests/acceptance/modules/Accounts/AccountsCest.php
+++ b/tests/acceptance/modules/Accounts/AccountsCest.php
@@ -131,4 +131,69 @@ class AccountsCest
         $I->clickWithLeftButton('.suitepicon-action-confirm');
         $I->see('InlineAccountNameEdit');
     }
+
+    public function testScenarioCreateAccountChild(
+        \AcceptanceTester $I,
+        \Step\Acceptance\DetailView $detailView,
+        \Step\Acceptance\ListView $listView,
+        \Step\Acceptance\Accounts $accounts,
+        \Helper\WebDriverHelper $webDriverHelper
+    ) {
+        $I->wantTo('Create an Account');
+
+        $I->amOnUrl(
+            $webDriverHelper->getInstanceURL()
+        );
+
+        // Navigate to accounts list-view
+        $I->loginAsAdmin();
+        $accounts->gotoAccounts();
+        $listView->waitForListViewVisible();
+
+        // Create account
+        $this->fakeData->seed($this->fakeDataSeed);
+        $accountName = 'Test_' . $this->fakeData->company();
+        $accounts->createAccount($accountName);
+
+        // Navigate to accounts list-view
+        $accounts->gotoAccounts();
+        $listView->waitForListViewVisible();
+
+        // Create Second account
+        $this->fakeData->seed($this->fakeDataSeed);
+        $parentAccountName = 'Test_' . $this->fakeData->company();
+        $accounts->createAccount($parentAccountName);
+
+        // Click on Member Organizations subpanel
+        $I->click(['id' => 'subpanel_title_accounts']);
+        $I->waitForElementVisible('#member_accounts_create_button', 60);
+
+        // Add child account
+        $I->click('#member_accounts_create_button');
+        $I->waitForElementVisible('#name', 60);
+        $I->click('#name');
+        $I->fillfield('#name', $accountName);
+        $I->click('#Accounts_subpanel_save_button');
+        $detailView->waitForDetailViewVisible();
+        $I->see($accountName);
+
+        // Delete account
+        $detailView->clickActionMenuItem('Delete');
+        $detailView->acceptPopup();
+        $listView->waitForListViewVisible();
+
+        // Select record from list view
+        $listView->clickFilterButton();
+        $listView->click('Quick Filter');
+        $listView->fillField('#name_basic', $accountName);
+        $listView->click('Search', '.submitButtons');
+        $listView->waitForListViewVisible();
+        $listView->clickNameLink($accountName);
+        $detailView->waitForDetailViewVisible();
+
+        // Delete account
+        $detailView->clickActionMenuItem('Delete');
+        $detailView->acceptPopup();
+        $listView->waitForListViewVisible();
+    }
 }

--- a/tests/acceptance/modules/Accounts/AccountsCest.php
+++ b/tests/acceptance/modules/Accounts/AccountsCest.php
@@ -167,8 +167,10 @@ class AccountsCest
         $editView->waitForEditViewVisible();
         $I->fillfield('#name', $accountName);
         $editView->clickSaveButton();
+
+        // View child account in parent account subpanel
         $detailView->waitForDetailViewVisible();
-        $I->see($accountName);
+        $I->see($accountName, '//*[@id="list_subpanel_accounts"]/table/tbody/tr/td[2]/a');
 
         // Delete account
         $detailView->clickActionMenuItem('Delete');

--- a/tests/acceptance/modules/Accounts/AccountsCest.php
+++ b/tests/acceptance/modules/Accounts/AccountsCest.php
@@ -160,7 +160,6 @@ class AccountsCest
         $listView->waitForListViewVisible();
 
         // Create Second account
-        $this->fakeData->seed($this->fakeDataSeed);
         $parentAccountName = 'Test_' . $this->fakeData->company();
         $accounts->createAccount($parentAccountName);
 
@@ -170,8 +169,7 @@ class AccountsCest
 
         // Add child account
         $I->click('#member_accounts_create_button');
-        $I->waitForElementVisible('#name', 60);
-        $I->click('#name');
+        $I->wait(1);
         $I->fillfield('#name', $accountName);
         $I->click('#Accounts_subpanel_save_button');
         $detailView->waitForDetailViewVisible();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
"PHP Parse error: syntax error, unexpected 'return' (T_RETURN), expecting function (T_FUNCTION) in (root directory)/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButtonAccount.php on line 61"

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #6322 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create an account.
2. Add a parent account.
3. View parent account/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->