### PR TITLE
Checkbox fields when exported to csv from report are blank

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -1117,15 +1117,12 @@ class AOR_Report extends Basic
                     if ($att['function'] != '' || $att['params'] != '') {
                         $csv .= $this->encloseForCSV($row[$name]);
                     } else {
-                        $csv .= $this->encloseForCSV(trim(strip_tags(getModuleField(
-                            $att['module'],
-                            $att['field'],
-                            $att['field'],
-                            'DetailView',
-                            $row[$name],
-                            '',
-                            $currency_id
-                        ))));
+                        $tempField = getModuleField($att['module'], $att['field'], $att['field'], 'DetailView', $row[$name], '', $currency_id);
+                        if (preg_match('/checkbox/', $tempField)) {
+                            $csv .= $this->encloseForCSV($row[$name]);
+                        } else {
+                            $csv .= $this->encloseForCSV(trim(strip_tags($tempField)));
+                        }
                     }
                     $csv .= $delimiter;
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Applied previous fix from github and modified it to handle report date field parameters.

## Motivation and Context
Resolves issue with exports reports with checkboxes.

## How To Test This
Create a report with a checkbox field.
Save report and export is as CSV.
Checkboxes should have values of 1 and 0 in exported CSV.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->