### PR TITLE
Fixed #6364 - "Create Scheduler" broken - no Jobs to select

### DIFF
--- a/modules/Schedulers/Scheduler.php
+++ b/modules/Schedulers/Scheduler.php
@@ -1048,7 +1048,7 @@ class Scheduler extends SugarBean {
 
 			// job functions
 			self::$job_strings = array('url::' => 'URL');
-			foreach(self::$job_strings as $k=>$v){
+			foreach($job_strings as $k=>$v){
 				self::$job_strings['function::' . $v] = $mod_strings['LBL_'.strtoupper($v)];
 			}
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixes an issue with schedulers job drop-down only showing a single value "URL".

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #6364 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to Administrator -> Admin -> Scheduler -> Create Scheduler -> click on Job field
2. Check that the drop-down has all the expected values not just URL.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->