### PR TITLE
Fixed #6046 - SQL "rank" is a reserved word, can't be used as a field…

### DIFF
--- a/metadata/user_feedsMetaData.php
+++ b/metadata/user_feedsMetaData.php
@@ -43,7 +43,7 @@ $dictionary['users_feeds'] = array ( 'table' => 'users_feeds'
     
        array('name' =>'user_id', 'type' =>'varchar', 'len'=>'36', )
       , array('name' =>'feed_id', 'type' =>'varchar', 'len'=>'36', )
-      , array('name' =>'rank', 'type' =>'int', 'required' => false)
+      , array('name' =>'suite_rank', 'type' =>'int', 'required' => false)
       , array ('name' => 'date_modified','type' => 'datetime')
       , array('name' =>'deleted', 'type' =>'bool', 'len'=>'', 'default'=>'0', 'required' => false)
                                                       ) 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
It seems that rank is an SQL reserved word since MySQL 8.0.2:
https://dev.mysql.com/doc/refman/8.0/en/keywords.html

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #6046 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Install SuiteCRM with MYSQL 8.0.2

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->