### PR TITLE
Fixed #5948 - 7.8.18 Content Field on Campaign module can't be edited…

### DIFF
--- a/modules/Campaigns/vardefs.php
+++ b/modules/Campaigns/vardefs.php
@@ -195,7 +195,8 @@ $dictionary['Campaign'] = array('audited' => true,
             'name' => 'content',
             'vname' => 'LBL_CAMPAIGN_CONTENT',
             'type' => 'text',
-            'comment' => 'The campaign description'
+            'comment' => 'The campaign description',
+            'inline_edit' => false
         ),
         'prospectlists' => array(
             'name' => 'prospectlists',


### PR DESCRIPTION
… on inline editing.

<!--- Provide a general summary of your changes in the Title above -->

## Description
temporary fix, to stop users from inline editing in campaigns due to fundamental field name clash.  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
1. repair and rebuild
2. open campaign and description cannot be edited.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->