### PR TITLE
Time issue fixed in email template for datetime fields

### DIFF
--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -133,7 +133,7 @@ class templateParser
                 if ($value != '') {
                     $dt = explode(' ', $value);
                     $value = $dt[0];
-                    if(isset($dt[1]) && isset($dt[1]!=''){
+                    if(isset($dt[1]) && $dt[1]!=''){
                         if (strpos($dt[1], 'am') > 0 || strpos($dt[1], 'pm') > 0) {
                             $value = $dt[0].' '.$dt[1];
                         }

--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -133,6 +133,11 @@ class templateParser
                 if ($value != '') {
                     $dt = explode(' ', $value);
                     $value = $dt[0];
+                    if(isset($dt[1]) && isset($dt[1]!=''){
+                        if (strpos($dt[1], 'am') > 0 || strpos($dt[1], 'pm') > 0) {
+                            $value = $dt[0].' '.$dt[1];
+                        }
+                    }
                 }
             }
             if ($value != '' && is_string($value)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Datetime fix in the email template, previously for datetime field it was only taking the date in email templates.

## Description
It was taking the only date in the email for DateTime fields as well because in the logic it was splitting the value with space. In the value first part is date and the second part is time but it was assigning only first part that's why only date value was assigned in a variable and displayed in emails.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Lot of people were facing this issue because they were not able to see time in email.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1- Create a field as DateTime in any module
2- Create an email template and use this variable in email
3- Send this email template and check if it date and time both

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)

