### PR TITLE
Bug fix create language cache in multilanguage system

### DIFF
--- a/include/SugarObjects/LanguageManager.php
+++ b/include/SugarObjects/LanguageManager.php
@@ -63,10 +63,13 @@ class LanguageManager
         if(empty($lang))
             $lang = $GLOBALS['sugar_config']['default_language'];
 		static $createdModules = array();
-		if(empty($createdModules[$module]) && ($refresh || !file_exists(sugar_cached('modules/').$module.'/language/'.$lang.'.lang.php'))){
+        if (!isset($createdModules[$module])) {
+            $createdModules[$module] = array();
+        }
+        if(empty($createdModules[$module][$lang]) && ($refresh || !file_exists(sugar_cached('modules/').$module.'/language/'.$lang.'.lang.php'))){
 			$loaded_mod_strings = array();
 			$loaded_mod_strings = LanguageManager::loadTemplateLanguage($module , $templates, $lang , $loaded_mod_strings);
-			$createdModules[$module] = true;
+            $createdModules[$module][$lang] = true;
 			LanguageManager::refreshLanguage($module,$lang, $loaded_mod_strings);
 		}
 	}
@@ -189,8 +192,11 @@ class LanguageManager
 				 );
 
 		#27023, if this module template language file was not attached , get the template from this module vardef cache file if exsits and load the template language files.
-		static $createdModules;
-		if(empty($createdModules[$module]) && isset($GLOBALS['beanList'][$module])){
+        static $createdModules = array();
+        if (!isset($createdModules[$module])) {
+            $createdModules[$module] = array();
+        }
+        if(empty($createdModules[$module][$lang]) && isset($GLOBALS['beanList'][$module])){
 				$object = $GLOBALS['beanList'][$module];
 
 				if ($object == 'aCase')
@@ -199,7 +205,7 @@ class LanguageManager
 		        if(!empty($GLOBALS["dictionary"]["$object"]["templates"])){
 		        	$templates = $GLOBALS["dictionary"]["$object"]["templates"];
 					$loaded_mod_strings = LanguageManager::loadTemplateLanguage($module , $templates, $lang , $loaded_mod_strings);
-					$createdModules[$module] = true;
+                    $createdModules[$module][$lang] = true;
 		        }
 		}
 		//end of fix #27023


### PR DESCRIPTION
## Description
Let the system has multiple languages installed, the system default language is different from the language of the current user and a language cache files has not yet been created. Let there is a custom module created on the Basic template using language files from the template. Then, during the initial creation of the cache for the user's language, the language files from the template will not be used.

## Motivation and Context
This change solves the problem described above by taking check the creation of a cache for each system language separately.

## How To Test This
To check it is necessary to repeat the sequence described above.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
