### PR TITLE
Fixed #5286 - Empty help message when creating user

### DIFF
--- a/modules/Users/language/en_us.lang.php
+++ b/modules/Users/language/en_us.lang.php
@@ -214,6 +214,7 @@ $mod_strings = array(
     'LBL_MODULE_TITLE' => 'Users: Home',
     'LBL_NAME' => 'Full Name',
     'LBL_SIGNATURE_NAME' => 'Name',
+    'LBL_NAVIGATION_PARADIGM_DESCRIPTION' => 'Select to be able to view modules in the navigation bar based on pre-defined groups. When selected, the "Filter Menu By" feature will appear in the "More" menu.',
     'LBL_USE_GROUP_TABS' => 'Module Menu Filters',
     'LBL_NEW_FORM_TITLE' => 'New User',
     'LBL_NEW_PASSWORD' => 'New Password',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixed #5286  - Empty help message when creating user

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When creating a user and clicking the exclamation mark next to "Module Menu Filters" an empty help message was displayed.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Click create user
2. Click Layout Options
3. Click the exclamation mark next to the text "Module Menu Filters"


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->