### PR TITLE
Fixed #6336 - DateTime fields inside templates rendered as Dates

### DIFF
--- a/include/SugarFields/Fields/Datetime/SugarFieldDatetime.php
+++ b/include/SugarFields/Fields/Datetime/SugarFieldDatetime.php
@@ -200,7 +200,7 @@ class SugarFieldDatetime extends SugarFieldBase
         global $timedate,$current_user;
 
         //check to see if the date is in the proper format
-        $user_dateFormat = $timedate->get_date_format();
+        $user_dateFormat = $timedate->get_date_time_format();
         if (!empty($vardef['value']) && !$timedate->check_matching_format($vardef['value'], $user_dateFormat)) {
 
             //date is not in proper user format, so get the SugarDateTiemObject and inject the vardef with a new element


### PR DESCRIPTION
The class responsible for rendering datetimes inside templates, `include/SugarFields/Datetime/SugarFieldDatetime.php`, looks for the format to use with

`$user_dateFormat = $timedate->get_date_format();`

instead of

`$user_dateFormat = $timedate->get_date_time_format();`

so if you use a datetime inside a *viewdefs.php, it gets rendered as a date instead of a datetime.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.