### PR TITLE
Fixed #5771 - Salutation variable in campaigns displays item name instead of value 7.10.4

### DIFF
--- a/modules/EmailTemplates/EmailTemplateParser.php
+++ b/modules/EmailTemplates/EmailTemplateParser.php
@@ -157,42 +157,44 @@ class EmailTemplateParser
      */
     private function getValueFromBean($variable)
     {
-        $reference = null;
-        $parts = explode('_', ltrim($variable, '$'));
-        list($moduleName, $attribute) = [array_shift($parts), join('_', $parts)];
+        global $app_list_strings;
 
-        switch ($moduleName) {
-            case 'surveys':
-                if ($this->campaign->survey_id === '') {
-                    $GLOBALS['log']->fatal(sprintf(
-                        'Variable %s could not be parsed, because Campaign has no Survey',
-                        $variable
-                    ));
-                    return $variable;
-                }
-                $reference = $this->getSurvey();
-                break;
-            case 'contact':
-                $reference = $this->module;
-                break;
+        $charVariable = chr(36);
+        $charUnderscore = chr(95);
+
+        if (strpos($variable, $charVariable) === false || strpos($variable, $charUnderscore) === false) {
+            $GLOBALS['log']->warn(sprintf(
+                'Variable %s parsed to an empty string, because attribute has no %s or %s character',
+                $variable,
+                $charVariable,
+                $charUnderscore
+            ));
+            return '';
         }
 
+        $parts = explode($charUnderscore, ltrim($variable, $charVariable));
+        list($moduleName, $attribute) = [array_shift($parts), join($charUnderscore, $parts)];
         if (in_array($attribute, static::$allowedVariables, true)) {
             return $this->getNonDBVariableValue($attribute);
         }
 
-        if (isset($reference->$attribute)) {
-            return $reference->$attribute;
+        if ($this->module instanceof $moduleName && property_exists($this->module, $attribute)) {
+            if (isset($this->module->field_name_map[$attribute]['type']) && ($this->module->field_name_map[$attribute]['type']) === 'enum') {
+                $enum = $this->module->field_name_map[$attribute]['options'];
+                if (isset($app_list_strings[$enum][$this->module->$attribute])) {
+                    $this->module->$attribute = $app_list_strings[$enum][$this->module->$attribute];
+                }
+            }
+            return $this->module->$attribute;
         }
 
-        $GLOBALS['log']->fatal(sprintf(
-            'Variable %s could not be parsed, because attribute %s does not set in %s bean',
+        $GLOBALS['log']->warn(sprintf(
+            'Variable %s parsed to an empty string, because attribute %s is not set in %s bean',
             $variable,
             $attribute,
-            $moduleName
+            get_class($this->module)
         ));
-
-        return $variable;
+        return '';
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When sending an email template through the campaigns module, the variables do not parse correctly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #5944
Issue reference: #5771
Issue reference: #3321

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Admin panel -> studio -> contacts -> contact_salutation drop-down menu -> edit.
2. Create a template with the $contact_salutation variable and an accounts module variable.
3. Use the template within a campaign.
4. The variables will be correctly replaced with the language string for both contacts and accounts.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->