### PR TITLE
Fixed #4123 - reports: fix adding parameterized reports to target lists

### DIFF
--- a/modules/AOR_Reports/AOR_Report.js
+++ b/modules/AOR_Reports/AOR_Report.js
@@ -153,9 +153,9 @@ function setProspectReturn(popup_reply_data) {
   var prospect_id = popup_reply_data.name_to_value_array.prospect_id;
   var record = document.getElementsByName('record')[0].value;
 
-  YAHOO.util.Connect.asyncRequest("GET", "index.php?module=AOR_Reports&action=addToProspectList&record=" + record + "&prospect_id=" + prospect_id, callback);
-
-
+  var form = addParametersToForm("addToProspectList");
+  var query = form.serialize();
+  YAHOO.util.Connect.asyncRequest("GET", "index.php?" + query + "&prospect_id=" + prospect_id, callback);
 }
 
 function changeReportPage(record, offset, group_value, table_id) {

--- a/modules/AOR_Reports/controller.php
+++ b/modules/AOR_Reports/controller.php
@@ -139,6 +139,7 @@ class AOR_ReportsController extends SugarController
 
         $key = Relationship::retrieve_by_modules($this->bean->report_module, 'ProspectLists', $GLOBALS['db']);
         if (!empty($key)) {
+            $this->bean->user_parameters = requestToUserParameters();
             $sql = $this->bean->build_report_query();
             $result = $this->bean->db->query($sql);
             $beans = array();


### PR DESCRIPTION
## Description

Given a report with parameters, the action "Add To Target List" did not
take into account the report parameters, resulting in all records getting
added to the target list as if there were no parameters.

Fix this by updating the form with the current parameters and also send
it to the "addToProspectList" controller action. In the controller extract
the parameters before creating the query like with other actions.

This makes the list of records added to the target list match the one the user
sees on the report page.

Fixes #4123

## How To Test This

1. Create a report which has a parameter and results in a record being shown
2. Adjust the parameter so that no record is shown
3. Use the Add To Target List" action and select a target list
4. With this fix applied no record should get added to the target list

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
