### PR TITLE
Fixed #6351 - Triple email sending when i use activities subpanel in Contact Module

### DIFF
--- a/include/generic/SugarWidgets/SugarWidgetSubPanelTopComposeEmailButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelTopComposeEmailButton.php
@@ -119,6 +119,11 @@ class SugarWidgetSubPanelTopComposeEmailButton extends SugarWidgetSubPanelTopBut
             return '';
         }
 
-        return parent::display($defines, $additionalFormFields);
+        $inputID = $this->getWidgetId();
+
+        $button = $this->_get_form($defines, $additionalFormFields);
+        $button .= "<a id='$inputID'>$this->form_value</a>";
+
+        return $button;
     }
 }

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelTopComposeEmailButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelTopComposeEmailButton.php
@@ -114,11 +114,6 @@ class SugarWidgetSubPanelTopComposeEmailButton extends SugarWidgetSubPanelTopBut
 
     public function display($defines, $additionalFormFields = null, $nonbutton = false)
     {
-        $focus = new Meeting;
-        if (!$focus->ACLAccess('EditView')) {
-            return '';
-        }
-
         $inputID = $this->getWidgetId();
 
         $button = $this->_get_form($defines, $additionalFormFields);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixes an issue where the compose email button in the activities subpanel would have its popup duplicated 3 times. Also fixes an issue where a user's role that does not include "Meeting" will prevent this button from being visible.

Credit for this fix goes to @mattlorimer 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #6351 
Issue reference: #6467 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
```
1. Open any contact in Contact module
2. Try to send email from Activities subpanel
3. See result
```
```
1. Create role R with permission to Email and Contact modules, and user U with role R.
2. Create some contact C with email address
3. Disable AJAX for Contact module.
4. As user U, go to contact C, see Activities sub-panel, there is no "Compose Email" button.
5. Modify role R and add permissions for Meeting module.
6. As user U, go back to contact C, see Activities sub-panel "Compose Email" and "Meeting" buttons are now displayed.
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->