### PR TITLE
#6457 : Manage SuiteCRM version in manifest files (Module Loader)

### DIFF
--- a/ModuleInstall/PackageManager/PackageManager.php
+++ b/ModuleInstall/PackageManager/PackageManager.php
@@ -148,7 +148,7 @@ class PackageManager
                 //array_push($nodes[$mypack['category_id']]['packages'], $package_arr);
             }
         }
-        $GLOBALS['log']->debug("NODES". var_export($nodes, true));
+        LoggerManager::getLogger()->debug("NODES". var_export($nodes, true));
         return $nodes;
     }
 
@@ -213,11 +213,11 @@ class PackageManager
      */
     public function download($category_id, $package_id, $release_id)
     {
-        $GLOBALS['log']->debug('RELEASE _ID: '.$release_id);
+        LoggerManager::getLogger()->debug('RELEASE _ID: '.$release_id);
         if (!empty($release_id)) {
             $filename = PackageManagerComm::addDownload($category_id, $package_id, $release_id);
             if ($filename) {
-                $GLOBALS['log']->debug('RESULT: '.$filename);
+                LoggerManager::getLogger()->debug('RESULT: '.$filename);
                 PackageManagerComm::errorCheck();
                 $filepath = PackageManagerComm::performDownload($filename);
                 return $filepath;
@@ -432,14 +432,14 @@ class PackageManager
             die($mod_strings['ERROR_MANIFEST_TYPE']);
         }
         $type = $manifest['type'];
-        $GLOBALS['log']->debug("Getting InstallType");
+        LoggerManager::getLogger->debug("Getting InstallType");
         if ($this->getInstallType("/$type/") == "") {
-            $GLOBALS['log']->debug("Error with InstallType".$type);
+            LoggerManager::getLogger->debug("Error with InstallType".$type);
             die($mod_strings['ERROR_PACKAGE_TYPE']. ": '" . $type . "'.");
         }
-        $GLOBALS['log']->debug("Passed with InstallType");
+        LoggerManager::getLogger()->debug("Passed with InstallType");
         if (isset($manifest['acceptable_sugar_versions'])) {
-            $GLOBALS['log']->debug("Getting AcceptableSugarVersions");
+            LoggerManager::getLogger->debug("Getting AcceptableSugarVersions");
             $version_sugar_ok = false;
             $matches_empty = true;
             if (isset($manifest['acceptable_sugar_versions']['exact_matches'])) {
@@ -447,7 +447,7 @@ class PackageManager
                 foreach ($manifest['acceptable_sugar_versions']['exact_matches'] as $match) {
                     if ($match == $sugar_version) {
                         $version_sugar_ok = true;
-                        $GLOBALS['log']->debug("Passed AcceptableSugarVersions");
+                        LoggerManager::getLogger->debug("Passed AcceptableSugarVersions");
                         break;
                     }
                 }
@@ -457,19 +457,19 @@ class PackageManager
                 foreach ($manifest['acceptable_sugar_versions']['regex_matches'] as $match) {
                     if (preg_match("/$match/", $sugar_version)) {
                         $version_sugar_ok = true;
-                        $GLOBALS['log']->debug("Passed AcceptableSugarVersions");
+                        LoggerManager::getLogger->debug("Passed AcceptableSugarVersions");
                         break;
                     }
                 }
             }
 
             if (!$matches_empty && !$version_sugar_ok) {
-                $GLOBALS['log']->debug("Error with AcceptableSugarVersions");
+                LoggerManager::getLogger->debug("Error with AcceptableSugarVersions");
                 die($mod_strings['ERROR_VERSION_INCOMPATIBLE'] . $sugar_version);
             }
         }
         if (isset($manifest['acceptable_suitecrm_versions'])) {
-            $GLOBALS['log']->debug("Getting AcceptableSuiteCRMVersions");
+            LoggerManager::getLogger->debug("Getting AcceptableSuiteCRMVersions");
             $version_suitecrm_ok = false;
             $matches_empty = true;
             if (isset($manifest['acceptable_suitecrm_versions']['exact_matches'])) {
@@ -477,7 +477,7 @@ class PackageManager
                 foreach ($manifest['acceptable_suitecrm_versions']['exact_matches'] as $match) {
                     if ($match == $suitecrm_version) {
                         $version_suitecrm_ok = true;
-                        $GLOBALS['log']->debug("Passed AcceptableSuitecrmVersions");
+                        LoggerManager::getLogger->debug("Passed AcceptableSuitecrmVersions");
                         break;
                     }
                 }
@@ -487,14 +487,14 @@ class PackageManager
                 foreach ($manifest['acceptable_suitecrm_versions']['regex_matches'] as $match) {
                     if (preg_match("/$match/", $suitecrm_version)) {
                         $version_suitecrm_ok = true;
-                        $GLOBALS['log']->debug("Passed AcceptableSuitecrmVersions");
+                        LoggerManager::getLogger->debug("Passed AcceptableSuitecrmVersions");
                         break;
                     }
                 }
             }
 
             if (!$matches_empty && !$version_suitecrm_ok) {
-                $GLOBALS['log']->debug("Error with AcceptableSuiteCRMVersions");
+                LoggerManager::getLogger->debug("Error with AcceptableSuiteCRMVersions");
                 die($mod_strings['ERROR_SUITECRM_VERSION_INCOMPATIBLE'] . $suitecrm_version);
             }
         }
@@ -520,20 +520,20 @@ class PackageManager
     {
         global $sugar_config,$mod_strings;
         $base_filename = urldecode($tempFile);
-        $GLOBALS['log']->debug("BaseFileName: ".$base_filename);
+        LoggerManager::getLogger()->debug("BaseFileName: ".$base_filename);
         $base_upgrade_dir       = $this->upload_dir.'/upgrades';
         $base_tmp_upgrade_dir   = "$base_upgrade_dir/temp";
         $manifest_file = $this->extractManifest($base_filename, $base_tmp_upgrade_dir);
-        $GLOBALS['log']->debug("Manifest: ".$manifest_file);
+        LoggerManager::getLogger()->debug("Manifest: ".$manifest_file);
         if ($view == 'module') {
             $license_file = $this->extractFile($base_filename, 'LICENSE.txt', $base_tmp_upgrade_dir);
         }
         if (is_file($manifest_file)) {
-            $GLOBALS['log']->debug("VALIDATING MANIFEST". $manifest_file);
+            LoggerManager::getLogger()->debug("VALIDATING MANIFEST". $manifest_file);
             require_once($manifest_file);
             $this->validate_manifest($manifest);
             $upgrade_zip_type = $manifest['type'];
-            $GLOBALS['log']->debug("VALIDATED MANIFEST");
+            LoggerManager::getLogger()->debug("VALIDATED MANIFEST");
             // exclude the bad permutations
             if ($view == "module") {
                 if ($upgrade_zip_type != "module" && $upgrade_zip_type != "theme" && $upgrade_zip_type != "langpack") {
@@ -603,21 +603,21 @@ class PackageManager
             mkdir_recursive($base_tmp_upgrade_dir, true);
         }
 
-        $GLOBALS['log']->debug("INSTALLING: ".$file);
+        LoggerManager::getLogger()->debug("INSTALLING: ".$file);
         $mi = new ModuleInstaller();
         $mi->silent = $silent;
         $mod_strings = return_module_language($current_language, "Administration");
-        $GLOBALS['log']->debug("ABOUT TO INSTALL: ".$file);
+        LoggerManager::getLogger()->debug("ABOUT TO INSTALL: ".$file);
         if (preg_match("#.*\.zip\$#", $file)) {
-            $GLOBALS['log']->debug("1: ".$file);
+            LoggerManager::getLogger()->debug("1: ".$file);
             // handle manifest.php
             $target_manifest = remove_file_extension($file) . '-manifest.php';
             include($target_manifest);
-            $GLOBALS['log']->debug("2: ".$file);
+            LoggerManager::getLogger()->debug("2: ".$file);
             $unzip_dir = mk_temp_dir($base_tmp_upgrade_dir);
             $this->addToCleanup($unzip_dir);
             unzip($file, $unzip_dir);
-            $GLOBALS['log']->debug("3: ".$unzip_dir);
+            LoggerManager::getLogger()->debug("3: ".$unzip_dir);
             $id_name = $installdefs['id'];
             $version = $manifest['version'];
             $uh = new UpgradeHistory();
@@ -633,7 +633,7 @@ class PackageManager
             } else {
                 $mi->install($unzip_dir);
             }
-            $GLOBALS['log']->debug("INSTALLED: ".$file);
+            LoggerManager::getLogger()->debug("INSTALLED: ".$file);
             $new_upgrade = new UpgradeHistory();
             $new_upgrade->filename      = $file;
             $new_upgrade->md5sum        = md5_file($file);
@@ -887,7 +887,7 @@ class PackageManager
                     if ($populate) {
                         $manifest_file = $this->extractManifest($filename, $base_tmp_upgrade_dir);
                         require_once($manifest_file);
-                        $GLOBALS['log']->info("Filling in upgrade_history table");
+                        LoggerManager::getLogger()->info("Filling in upgrade_history table");
                         $populate = false;
                         if (isset($manifest['name'])) {
                             $name = $manifest['name'];

--- a/ModuleInstall/PackageManager/PackageManager.php
+++ b/ModuleInstall/PackageManager/PackageManager.php
@@ -444,10 +444,14 @@ class PackageManager
         global $suitecrm_version;
 
         if ($key == "acceptable_sugar_versions")
+        {
             $checkedVersion = $sugar_version;
-        else
+            $errorStringKey = "ERROR_SUGARCRM_VERSION_INCOMPATIBLE";
+        }else{
             $checkedVersion = $suitecrm_version;
-
+            $errorStringKey = "ERROR_SUITECRM_VERSION_INCOMPATIBLE";
+        }
+        
         if (isset($acceptable_versions)) {
             LoggerManager::getLogger()->debug("Getting $key");
             $version_crm_ok = false;
@@ -475,7 +479,7 @@ class PackageManager
 
             if (!$matches_empty && !$version_crm_ok) {
                 LoggerManager::getLogger()->debug("Error with $key");
-                echo($mod_strings['ERROR_SUITECRM_VERSION_INCOMPATIBLE'] . $checkedVersion);
+                echo($mod_strings[$errorStringKey] . $checkedVersion);
                 return false;
             }
             else

--- a/ModuleInstall/PackageManager/PackageManager.php
+++ b/ModuleInstall/PackageManager/PackageManager.php
@@ -424,6 +424,7 @@ class PackageManager
         // takes a manifest.php manifest array and validates contents
         global $subdirs;
         global $sugar_version;
+        global $suitecrm_version;
         global $sugar_flavor;
         global $mod_strings;
 
@@ -438,27 +439,63 @@ class PackageManager
         }
         $GLOBALS['log']->debug("Passed with InstallType");
         if (isset($manifest['acceptable_sugar_versions'])) {
-            $version_ok = false;
+            $GLOBALS['log']->debug("Getting AcceptableSugarVersions");
+            $version_sugar_ok = false;
             $matches_empty = true;
             if (isset($manifest['acceptable_sugar_versions']['exact_matches'])) {
                 $matches_empty = false;
                 foreach ($manifest['acceptable_sugar_versions']['exact_matches'] as $match) {
                     if ($match == $sugar_version) {
-                        $version_ok = true;
+                        $version_sugar_ok = true;
+                        $GLOBALS['log']->debug("Passed AcceptableSugarVersions");
+                        break;
                     }
                 }
             }
-            if (!$version_ok && isset($manifest['acceptable_sugar_versions']['regex_matches'])) {
+            if (!$version_sugar_ok && isset($manifest['acceptable_sugar_versions']['regex_matches'])) {
                 $matches_empty = false;
                 foreach ($manifest['acceptable_sugar_versions']['regex_matches'] as $match) {
                     if (preg_match("/$match/", $sugar_version)) {
-                        $version_ok = true;
+                        $version_sugar_ok = true;
+                        $GLOBALS['log']->debug("Passed AcceptableSugarVersions");
+                        break;
                     }
                 }
             }
 
-            if (!$matches_empty && !$version_ok) {
+            if (!$matches_empty && !$version_sugar_ok) {
+                $GLOBALS['log']->debug("Error with AcceptableSugarVersions");
                 die($mod_strings['ERROR_VERSION_INCOMPATIBLE'] . $sugar_version);
+            }
+        }
+        if (isset($manifest['acceptable_suitecrm_versions'])) {
+            $GLOBALS['log']->debug("Getting AcceptableSuiteCRMVersions");
+            $version_suitecrm_ok = false;
+            $matches_empty = true;
+            if (isset($manifest['acceptable_suitecrm_versions']['exact_matches'])) {
+                $matches_empty = false;
+                foreach ($manifest['acceptable_suitecrm_versions']['exact_matches'] as $match) {
+                    if ($match == $suitecrm_version) {
+                        $version_suitecrm_ok = true;
+                        $GLOBALS['log']->debug("Passed AcceptableSuitecrmVersions");
+                        break;
+                    }
+                }
+            }
+            if (!$version_suitecrm_ok && isset($manifest['acceptable_suitecrm_versions']['regex_matches'])) {
+                $matches_empty = false;
+                foreach ($manifest['acceptable_suitecrm_versions']['regex_matches'] as $match) {
+                    if (preg_match("/$match/", $suitecrm_version)) {
+                        $version_suitecrm_ok = true;
+                        $GLOBALS['log']->debug("Passed AcceptableSuitecrmVersions");
+                        break;
+                    }
+                }
+            }
+
+            if (!$matches_empty && !$version_suitecrm_ok) {
+                $GLOBALS['log']->debug("Error with AcceptableSuiteCRMVersions");
+                die($mod_strings['ERROR_SUITECRM_VERSION_INCOMPATIBLE'] . $suitecrm_version);
             }
         }
     }

--- a/ModuleInstall/PackageManager/PackageManager.php
+++ b/ModuleInstall/PackageManager/PackageManager.php
@@ -493,17 +493,15 @@ class PackageManager
     {
         // takes a manifest.php manifest array and validates contents
         global $subdirs;
-        global $sugar_version;
-        global $suitecrm_version;
         global $sugar_flavor;
         global $mod_strings;
 
-        if (!validate_manifest_type($manifest['type']))
+        if (!PackageManager::validate_manifest_type($manifest['type']))
             exit();
 
 
-        $versionSugarOk = validate_manifest_crm_version($manifest['acceptable_sugar_versions'], 'acceptable_sugar_versions');
-        $versionSuiteOk = validate_manifest_crm_version($manifest['acceptable_suitecrm_versions'], 'acceptable_suitecrm_versions');
+        $versionSugarOk = PackageManager::validate_manifest_crm_version($manifest['acceptable_sugar_versions'], 'acceptable_sugar_versions');
+        $versionSuiteOk = PackageManager::validate_manifest_crm_version($manifest['acceptable_suitecrm_versions'], 'acceptable_suitecrm_versions');
 
         if (!$versionSugarOk || !$versionSuiteOk)
             exit();

--- a/ModuleInstall/PackageManager/PackageManager.php
+++ b/ModuleInstall/PackageManager/PackageManager.php
@@ -432,14 +432,14 @@ class PackageManager
             die($mod_strings['ERROR_MANIFEST_TYPE']);
         }
         $type = $manifest['type'];
-        LoggerManager::getLogger->debug("Getting InstallType");
+        LoggerManager::getLogger()->debug("Getting InstallType");
         if ($this->getInstallType("/$type/") == "") {
             LoggerManager::getLogger->debug("Error with InstallType".$type);
             die($mod_strings['ERROR_PACKAGE_TYPE']. ": '" . $type . "'.");
         }
         LoggerManager::getLogger()->debug("Passed with InstallType");
         if (isset($manifest['acceptable_sugar_versions'])) {
-            LoggerManager::getLogger->debug("Getting AcceptableSugarVersions");
+            LoggerManager::getLogger()->debug("Getting AcceptableSugarVersions");
             $version_sugar_ok = false;
             $matches_empty = true;
             if (isset($manifest['acceptable_sugar_versions']['exact_matches'])) {
@@ -447,7 +447,7 @@ class PackageManager
                 foreach ($manifest['acceptable_sugar_versions']['exact_matches'] as $match) {
                     if ($match == $sugar_version) {
                         $version_sugar_ok = true;
-                        LoggerManager::getLogger->debug("Passed AcceptableSugarVersions");
+                        LoggerManager::getLogger()->debug("Passed AcceptableSugarVersions");
                         break;
                     }
                 }
@@ -457,19 +457,19 @@ class PackageManager
                 foreach ($manifest['acceptable_sugar_versions']['regex_matches'] as $match) {
                     if (preg_match("/$match/", $sugar_version)) {
                         $version_sugar_ok = true;
-                        LoggerManager::getLogger->debug("Passed AcceptableSugarVersions");
+                        LoggerManager::getLogger()->debug("Passed AcceptableSugarVersions");
                         break;
                     }
                 }
             }
 
             if (!$matches_empty && !$version_sugar_ok) {
-                LoggerManager::getLogger->debug("Error with AcceptableSugarVersions");
+                LoggerManager::getLogger()->debug("Error with AcceptableSugarVersions");
                 die($mod_strings['ERROR_VERSION_INCOMPATIBLE'] . $sugar_version);
             }
         }
         if (isset($manifest['acceptable_suitecrm_versions'])) {
-            LoggerManager::getLogger->debug("Getting AcceptableSuiteCRMVersions");
+            LoggerManager::getLogger()->debug("Getting AcceptableSuiteCRMVersions");
             $version_suitecrm_ok = false;
             $matches_empty = true;
             if (isset($manifest['acceptable_suitecrm_versions']['exact_matches'])) {
@@ -477,7 +477,7 @@ class PackageManager
                 foreach ($manifest['acceptable_suitecrm_versions']['exact_matches'] as $match) {
                     if ($match == $suitecrm_version) {
                         $version_suitecrm_ok = true;
-                        LoggerManager::getLogger->debug("Passed AcceptableSuitecrmVersions");
+                        LoggerManager::getLogger()->debug("Passed AcceptableSuitecrmVersions");
                         break;
                     }
                 }
@@ -487,14 +487,14 @@ class PackageManager
                 foreach ($manifest['acceptable_suitecrm_versions']['regex_matches'] as $match) {
                     if (preg_match("/$match/", $suitecrm_version)) {
                         $version_suitecrm_ok = true;
-                        LoggerManager::getLogger->debug("Passed AcceptableSuitecrmVersions");
+                        LoggerManager::getLogger()->debug("Passed AcceptableSuitecrmVersions");
                         break;
                     }
                 }
             }
 
             if (!$matches_empty && !$version_suitecrm_ok) {
-                LoggerManager::getLogger->debug("Error with AcceptableSuiteCRMVersions");
+                LoggerManager::getLogger()->debug("Error with AcceptableSuiteCRMVersions");
                 die($mod_strings['ERROR_SUITECRM_VERSION_INCOMPATIBLE'] . $suitecrm_version);
             }
         }


### PR DESCRIPTION
PR for managing the suggestion submitted on #6457 
Module Loader currently does not check Suitecrm version (no manifest defs are coded to check suitecrm version)

Just added a new portion of code (duplicate the sugar version check) as **acceptable_suitecrm_versions**

Unlike UpgradeWizard code (where the **acceptable_suitecrm_versions** as coded !), I think this is better to perform both checks : sugar_version first, and then suitecrm in second as modules can only have sugar_versions defined (all previous modules)

I also updated few logs lines and added break instruction in foreach as soon as the version is OK.
(performance point of view)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
