### PR TITLE
Workflow Date - Remove incorrect branch when unserialize fails - Fix #6328

### DIFF
--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -439,7 +439,6 @@ class AOW_WorkFlow extends Basic
                     $params = @unserialize(base64_decode($condition->value));
                     if ($params === false) {
                         LoggerManager::getLogger()->error('Unserializable data given');
-                    } else {
                         $params = [null];
                     }
 


### PR DESCRIPTION
Any 'Date' conditions fails to build correct SQL query.  
## Description
There is an incorrect error condition where when there is **no error** the condition sets the `$params`  to a empty array. This should the the opposite of what is needed.  set `$params = [null]` when it _fails_ .  

This fixes #6328. 

## Motivation and Context
None of Workflow with Date conditions work. 

## How To Test This

1. Create Workflow with date condtion
2. See logs that mysql error .
   1. Error is due to incorrect query
1.  Apply patch
   1. See no errors in log entries
   2. Verify that workflow ran successfully

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
