### PR TITLE
Fixed #6485 - Users: Display opt-in ticks also for external email clients

### DIFF
--- a/modules/Emails/EmailUI.php
+++ b/modules/Emails/EmailUI.php
@@ -423,6 +423,24 @@ eoq;
     }
 
     /**
+     * @param string $module_name
+     * @param string $record_id
+     * @param string $name
+     * @param string $addr
+     * @param string $text
+     * @return string
+     */
+    private function createEmailLink($module_name, $record_id, $name, $addr, $text) {
+        return '<a class="email-link"'
+            . ' onclick="$(document).openComposeViewModal(this);"'
+            . ' data-module="' . $module_name
+            . '" data-record-id="' . $record_id
+            . '" data-module-name="' . $name
+            . '" data-email-address="' . $addr  . '">'
+            . $text . '</a>';
+    }
+
+    /**
      *
      * @global SugarBean $focus
      * @param SugarBean|null $bean
@@ -458,13 +476,8 @@ eoq;
             $GLOBALS['log']->warn('EmailUI::populateComposeViewFields - $bean is empty');
         }
 
-        $emailLink = '<a class="email-link"'
-            . ' onclick="$(document).openComposeViewModal(this);"'
-            . ' data-module="' . $myBean->module_name
-            . '" data-record-id="' . $myBean->id
-            . '" data-module-name="' . $myBean->name
-            . '" data-email-address="">'
-            . $innerText;
+        $emailLink = $this->createEmailLink(
+            $myBean->module_name, $myBean->id, $myBean->name, '', $innerText);
 
         // focus is set?
         if (!is_object($myBean)) {
@@ -490,25 +503,20 @@ eoq;
 
             foreach ($emailFields as $emailField) {
                 if (!empty($composeData)) {
-                    $emailLink = '<a onclick=" $(document).openComposeViewModal(this);" ' .
-                        'data-module="' . $composeData['parent_type'] . '" ' . 'data-record-id="' .
-                        $composeData['parent_id'] . '" data-module-name="' . $composeData['parent_name'] .
-                        '"  data-email-address="' . $composeData['to_addrs'] . '">';
+                    $emailLink = $this->createEmailLink(
+                        $composeData['parent_type'], $composeData['parent_id'],
+                        $composeData['parent_name'], $composeData['to_addrs'],
+                        '');
                 } elseif (is_object($myBean) && (property_exists($myBean, $emailField))) {
                     $email_tick = $this->getEmailAddressConfirmOptInTick($myBean, $emailField);
                     $optOut = false;
                     $invalid = false;
 
                     if ($enableConfirmedOptIn === SugarEmailAddress::COI_STAT_DISABLED) {
-                        $emailLink = '<a class="email-link"'
-                            . ' onclick="$(document).openComposeViewModal(this);"'
-                            . ' data-module="'
-                            . $myBean->module_name . '" ' . 'data-record-id="'
-                            . $myBean->id . '" data-module-name="'
-                            . $myBean->name . '" data-email-address="'
-                            . $myBean->{$emailField} . '">';
 
-                        $emailLink .= $myBean->{$emailField} . '</a>';
+                        $emailLink = $this->createEmailLink(
+                            $myBean->module_name, $myBean->id, $myBean->name,
+                            $myBean->{$emailField}, $myBean->{$emailField});
                         return $emailLink;
                     }
 
@@ -537,35 +545,30 @@ eoq;
                                         $optOut === true
                                         || $invalid === true
                                     ) {
-                                        $emailLink =
-                                            '<a class="email-link"'
-                                            . ' onclick="$(document).openComposeViewModal(this);"'
-                                            . ' data-module="' . $myBean->module_name . '" ' . 'data-record-id="'
-                                            . $myBean->id . '" data-module-name="'
-                                            . $myBean->name . '" data-email-address="'
-                                            . $myBean->{$emailField} . '">';
+                                        $emailText = '';
                                         if ($this->appendTick) {
-                                            $emailLink .= $email_tick;
+                                            $emailText .= $email_tick;
                                         }
-                                        $emailLink .= '<span class="email-line-through">';
-                                        $emailLink .= $myBean->{$emailField};
+                                        $emailText .= '<span class="email-line-through">';
+                                        $emailText .= $myBean->{$emailField};
                                         $emailLink .= '</span>';
-                                    } else {
-                                        $emailLink =
-                                            '<a class="email-link"'
-                                            . ' onclick="$(document).openComposeViewModal(this);"'
-                                            . ' data-module="'
-                                            . $myBean->module_name . '" ' . 'data-record-id="'
-                                            . $myBean->id . '" data-module-name="'
-                                            . $myBean->name . '" data-email-address="'
-                                            . $myBean->{$emailField} . '">';
-                                        if ($this->appendTick) {
-                                            $emailLink .= $email_tick;
-                                        }
-                                        $emailLink .= $myBean->{$emailField};
-                                    }
-                                    $emailLink .= '</a>';
 
+                                        $emailLink = $this->createEmailLink(
+                                            $myBean->module_name, $myBean->id, $myBean->name,
+                                            $myBean->{$emailField}, $emailText);
+                                    } else {
+
+                                        $emailText = '';
+                                        if ($this->appendTick) {
+                                            $emailText .= $email_tick;
+                                        }
+
+                                        $emailText .= $myBean->{$emailField};
+
+                                        $emailLink = $this->createEmailLink(
+                                            $myBean->module_name, $myBean->id, $myBean->name,
+                                            $myBean->{$emailField}, $emailText);
+                                    }
                                     return $emailLink;
                                 }
                             }
@@ -575,8 +578,6 @@ eoq;
                     }
                 }
             }
-
-            $emailLink .= '</a>';
 
             return $emailLink;
         }

--- a/modules/Emails/EmailUI.php
+++ b/modules/Emails/EmailUI.php
@@ -431,12 +431,20 @@ eoq;
      * @return string
      */
     private function createEmailLink($module_name, $record_id, $name, $addr, $text) {
+        global $current_user;
+
+        if ($current_user->getEmailClient() == 'sugar') {
+            return '<a class="email-link"'
+                . ' onclick="$(document).openComposeViewModal(this);"'
+                . ' data-module="' . $module_name
+                . '" data-record-id="' . $record_id
+                . '" data-module-name="' . $name
+                . '" data-email-address="' . $addr  . '">'
+                . $text . '</a>';
+        }
+
         return '<a class="email-link"'
-            . ' onclick="$(document).openComposeViewModal(this);"'
-            . ' data-module="' . $module_name
-            . '" data-record-id="' . $record_id
-            . '" data-module-name="' . $name
-            . '" data-email-address="' . $addr  . '">'
+            . ' href="mailto:' .  $addr . '">'
             . $text . '</a>';
     }
 

--- a/modules/Users/User.php
+++ b/modules/Users/User.php
@@ -1736,19 +1736,7 @@ EOQ;
         $class = ''
     ) {
         $emailLink = '';
-        global $sugar_config;
-
-        if (!isset($sugar_config['email_default_client'])) {
-            $this->setDefaultsInConfig();
-        }
-
-        $userPref = $this->getPreference('email_link_type');
-        $defaultPref = $sugar_config['email_default_client'];
-        if ($userPref != '') {
-            $client = $userPref;
-        } else {
-            $client = $defaultPref;
-        }
+        $client = $this->getEmailClient();
 
         if ($client == 'sugar') {
             require_once('modules/Emails/EmailUI.php');
@@ -1768,6 +1756,31 @@ EOQ;
         }
 
         return $emailLink;
+    }
+
+    /**
+     * Returns the email client type that should be used for this user.
+     * Either "sugar" for the "SuiteCRM E-mail Client" or "mailto" for the
+     * "External Email Client".
+     *
+     * @return string
+     */
+    public function getEmailClient() {
+        global $sugar_config;
+
+        if (!isset($sugar_config['email_default_client'])) {
+            $this->setDefaultsInConfig();
+        }
+
+        $userPref = $this->getPreference('email_link_type');
+        $defaultPref = $sugar_config['email_default_client'];
+        if ($userPref != '') {
+            $client = $userPref;
+        } else {
+            $client = $defaultPref;
+        }
+
+        return $client;
     }
 
     /**
@@ -1793,20 +1806,7 @@ EOQ;
     ) {
         require_once('modules/Emails/EmailUI.php');
         $emailLink = '';
-        global $sugar_config;
-
-
-        if (!isset($sugar_config['email_default_client'])) {
-            $this->setDefaultsInConfig();
-        }
-
-        $userPref = $this->getPreference('email_link_type');
-        $defaultPref = $sugar_config['email_default_client'];
-        if ($userPref != '') {
-            $client = $userPref;
-        } else {
-            $client = $defaultPref;
-        }
+        $client = $this->getEmailClient();
 
         if ($client == 'sugar') {
             $emailUI = new EmailUI();

--- a/modules/Users/User.php
+++ b/modules/Users/User.php
@@ -44,6 +44,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
 
 require_once('include/SugarObjects/templates/person/Person.php');
 require_once __DIR__ . '/../../include/EmailInterface.php';
+require_once __DIR__ . '/../Emails/EmailUI.php';
 
 // User is used to store customer information.
 class User extends Person implements EmailInterface
@@ -1736,23 +1737,16 @@ EOQ;
         $class = ''
     ) {
         $emailLink = '';
-        $client = $this->getEmailClient();
 
-        if ($client == 'sugar') {
-            require_once('modules/Emails/EmailUI.php');
-            $emailUI = new EmailUI();
-            for ($i = 0; $i < count($focus->emailAddress->addresses); $i++) {
-                $emailField = 'email' . (string) ($i + 1);
-                $optOut = (bool)$focus->emailAddress->addresses[$i]['opt_out'];
-                if (!$optOut && $focus->emailAddress->addresses[$i]['email_address'] === $emailAddress) {
-                    $focus->$emailField = $emailAddress;
-                    $emailLink = $emailUI->populateComposeViewFields($focus, $emailField);
-                    break;
-                }
+        $emailUI = new EmailUI();
+        for ($i = 0; $i < count($focus->emailAddress->addresses); $i++) {
+            $emailField = 'email' . (string) ($i + 1);
+            $optOut = (bool)$focus->emailAddress->addresses[$i]['opt_out'];
+            if (!$optOut && $focus->emailAddress->addresses[$i]['email_address'] === $emailAddress) {
+                $focus->$emailField = $emailAddress;
+                $emailLink = $emailUI->populateComposeViewFields($focus, $emailField);
+                break;
             }
-        } else {
-            // straight mailto:
-            $emailLink = sprintf('<a href="mailto:%1$s">%1$s</a>', $emailAddress);
         }
 
         return $emailLink;
@@ -1804,17 +1798,8 @@ EOQ;
         $ret_id = '',
         $class = ''
     ) {
-        require_once('modules/Emails/EmailUI.php');
-        $emailLink = '';
-        $client = $this->getEmailClient();
-
-        if ($client == 'sugar') {
-            $emailUI = new EmailUI();
-            $emailLink = $emailUI->populateComposeViewFields($focus);
-        } else {
-            // straight mailto:
-            $emailLink = sprintf('<a href="mailto:%1$s">%1$s</a>', $focus->$attribute);
-        }
+        $emailUI = new EmailUI();
+        $emailLink = $emailUI->populateComposeViewFields($focus);
 
         return $emailLink;
     }


### PR DESCRIPTION
## Description
This PR contains 3 commits, the first two are refactorings, the last one fixes
the issue.

----

In case the user had selected the external email client all email links would
not display any opt-in information (ticks). This is due to the ticks logic
being implemented in EmailUI which is only used in the sugar client case. The
external client path falls back to a simple mailto link.

This makes things always use EmailUI for rendering email links (including
ticks) and makes EmailUI use simple mailto links in case the user settings are
set to an external client.

## Motivation and Context

Fixes #6485

## How To Test This

Change the email client setting for the active user. The email links should always contain opt-in ticks.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.