### PR TITLE
Fixed #6487 - opt-in: use the DB time for writing confirm_opt_in_*date

### DIFF
--- a/include/SugarEmailAddress/SugarEmailAddress.php
+++ b/include/SugarEmailAddress/SugarEmailAddress.php
@@ -1925,9 +1925,7 @@ class SugarEmailAddress extends SugarBean
      */
     public function confirmOptIn()
     {
-        global $timedate;
-        $date = new DateTime();
-        $this->confirm_opt_in_date = $date->format($timedate::DB_DATETIME_FORMAT);
+        $this->confirm_opt_in_date = TimeDate::getInstance()->nowDb();
         $this->confirm_opt_in = self::COI_STAT_CONFIRMED_OPT_IN;
     }
 

--- a/modules/Campaigns/WebToPersonCapture.php
+++ b/modules/Campaigns/WebToPersonCapture.php
@@ -240,8 +240,7 @@ if (isset($_POST['campaign_id']) && !empty($_POST['campaign_id'])) {
                         $configurator = new Configurator();
                         if ($configurator->isConfirmOptInEnabled()) {
                             $emailman = new EmailMan();
-                            $date = new DateTime();
-                            $now = $date->format($timedate::DB_DATETIME_FORMAT);
+                            $now = TimeDate::getInstance()->nowDb();
                             
                             if (!$emailman->sendOptInEmail($sea, $person->module_name, $person->id)) {
                                 $errors[] = 'Confirm Opt In email sending failed, please check email address is correct: ' . $sea->email_address;

--- a/modules/EmailMan/EmailManDelivery.php
+++ b/modules/EmailMan/EmailManDelivery.php
@@ -263,8 +263,7 @@ do {
                 $emailAddress = new EmailAddress();
                 $emailAddress->email_address = $emailAddress->getAddressesByGUID($row['related_id'], $row['related_type']);
                 
-                $date = new DateTime();
-                $now = $date->format($timedate::DB_DATETIME_FORMAT);
+                $now = TimeDate::getInstance()->nowDb();
                     
                 if (!$emailman->sendOptInEmail($emailAddress, $row['related_type'], $row['related_id'])) {
                     $GLOBALS['log']->fatal("Confirm Opt In Email delivery FAILURE:" . print_r($row, true));

--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -4555,8 +4555,7 @@ eoq;
             $bean = BeanFactory::getBean($row['bean_module'], $row['bean_id']);
 
             $actionSendEmail = new actionSendEmail();
-            $date = new DateTime();
-            $now = $date->format($timedate::DB_DATETIME_FORMAT);
+            $now = TimeDate::getInstance()->nowDb();
             if (!$actionSendEmail->run_action($bean, $params)) {
                 $emailAddress->confirm_opt_in_fail_date = $now;
             } else {


### PR DESCRIPTION
## Description

confirm_opt_in_sent_date, confirm_opt_in_date and confirm_opt_in_fail_date get
set to the local time and then saved to the database. Other modules like
reports and workflows expect dates in the DB to be in the DB timezone and
convert them to the local time. Since the dates are saved in the local time
this result in the wrong time being used/shown.

Fix this by always using the DB time when setting those fields like everywhere
else.

See #6487

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
