### PR TITLE
Fixed 6472 - Fix wrong image sizes for email templates in the campaign wizard

### DIFF
--- a/modules/Campaigns/WizardMarketing.html
+++ b/modules/Campaigns/WizardMarketing.html
@@ -758,21 +758,6 @@
 							</div>
 						</div>
 						{/if}
-
-						<div class="panel-toolbar">
-
-							<div class="template-container-full">
-								{if !$hide_width_set}
-								<label>{$MOD.LBL_CLICK_TO_ADD}</label>
-								<br>
-								{/if}
-								{$BODY_EDITOR}
-							</div>
-							<!--
-                            <iframe id="html_frame" src="" style="width:100%; height:500px"></iframe>
-                            <pre id="email_template_view"></pre>
-                            -->
-						</div>
 					</div>
 				</div>
 			</div>
@@ -1392,6 +1377,16 @@
 </td>
 </tr>
 </table>
+
+<div class="template-panel-container panel">
+	<div class="template-container-full">
+		{if !$hide_width_set}
+		<label>{$MOD.LBL_CLICK_TO_ADD}</label>
+		<br>
+		{/if}
+		{$BODY_EDITOR}
+	</div>
+</div>
 
 {literal}
 <script language="javascript">


### PR DESCRIPTION
## Description

In the campaign wizard the editor (mozaik in this case) is embedded in the
main table. The table has the CSS classes "other view" and the theme contains
various rules that just force the size of all img tags there etc. This affects
various elements of the editor making the preview not match the actual email.

To avoid the theme CSS affecting the editor move the editor out of the table.

#### Before:
![before](https://user-images.githubusercontent.com/991986/48554982-1eb07800-e8e0-11e8-8b95-ed709fa227f3.png)
#### After:
![after](https://user-images.githubusercontent.com/991986/48554986-24a65900-e8e0-11e8-9ede-858d20951d5c.png)

## Motivation and Context

Fixes #6472

## How To Test This

* Create an email template with an image and resize the image to be smaller
* Start the campaign wizard and select the email template
* Look at the template preview at the bottom, it should look the same as in the editor

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
