### PR TITLE
Add a SAML2 metadata endpoint

### DIFF
--- a/include/MVC/Controller/entry_point_registry.php
+++ b/include/MVC/Controller/entry_point_registry.php
@@ -73,6 +73,7 @@ $entry_point_registry = array(
     'getYUIComboFile' => array('file' => 'include/javascript/getYUIComboFile.php', 'auth' => false),
     'UploadFileCheck' => array('file' => 'modules/Configurator/UploadFileCheck.php', 'auth' => true),
     'SAML'=>  array('file' => 'modules/Users/authentication/SAMLAuthenticate/index.php', 'auth' => false),
+    'SAML2Metadata'=>  array('file' => 'modules/Users/authentication/SAML2Authenticate/SAML2Metadata.php', 'auth' => false),
     'jslang'=> array('file' => 'include/language/getJSLanguage.php', 'auth' => true),
     'deleteAttachment' => array('file' => 'include/SugarFields/Fields/Image/deleteAttachment.php', 'auth' => false),
     'responseEntryPoint' => array('file' => 'modules/FP_events/responseEntryPoint.php', 'auth' => false),

--- a/modules/Users/authentication/SAML2Authenticate/SAML2Authenticate.php
+++ b/modules/Users/authentication/SAML2Authenticate/SAML2Authenticate.php
@@ -45,6 +45,27 @@ if (!defined('sugarEntry') || !sugarEntry) {
 require_once('modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php');
 
 /**
+ * Returns the XML metadata which can be used to register the SP with the IDP
+ *
+ * @param array $settingsInfo a SAML2 settings array structure
+ * @return string the xml metadata
+ * @throws OneLogin_Saml2_Error In case the settings/metadata are invalid
+ */
+function getSAML2Metadata($settingsInfo) {
+    $auth = new OneLogin_Saml2_Auth($settingsInfo);
+    $settings = $auth->getSettings();
+    $metadata = $settings->getSPMetadata();
+    $errors = $settings->validateMetadata($metadata);
+    if (!empty($errors)) {
+        throw new OneLogin_Saml2_Error(
+            'Invalid SP metadata: '.implode(', ', $errors),
+            OneLogin_Saml2_Error::METADATA_SP_INVALID
+        );
+    }
+    return $metadata;
+}
+
+/**
  * Class SAML2Authenticate for SAML2 auth
  */
 class SAML2Authenticate extends SugarAuthenticate

--- a/modules/Users/authentication/SAML2Authenticate/SAML2Metadata.php
+++ b/modules/Users/authentication/SAML2Authenticate/SAML2Metadata.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ *
+ * SugarCRM Community Edition is a customer relationship management program developed by
+ * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2018 SalesAgility Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License version 3 as published by the
+ * Free Software Foundation with the addition of the following permission added
+ * to Section 15 as permitted in Section 7(a): FOR ANY PART OF THE COVERED WORK
+ * IN WHICH THE COPYRIGHT IS OWNED BY SUGARCRM, SUGARCRM DISCLAIMS THE WARRANTY
+ * OF NON INFRINGEMENT OF THIRD PARTY RIGHTS.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program; if not, see http://www.gnu.org/licenses or write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ *
+ * You can contact SugarCRM, Inc. headquarters at 10050 North Wolfe Road,
+ * SW2-130, Cupertino, CA 95014, USA. or at email address contact@sugarcrm.com.
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "Powered by
+ * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
+ * reasonably feasible for  technical reasons, the Appropriate Legal Notices must
+ * display the words  "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+require_once __DIR__ . '/SAML2Authenticate.php';
+require_once __DIR__ . '/lib/onelogin/settings.php';
+
+try {
+    $xml = getSAML2Metadata($settingsInfo);
+    header('Content-Type: text/xml');
+    echo $xml;
+} catch (Exception $e) {
+    echo $e->getMessage();
+}

--- a/tests/unit/phpunit/modules/Users/SAML2AuthenticateTest.php
+++ b/tests/unit/phpunit/modules/Users/SAML2AuthenticateTest.php
@@ -1,0 +1,67 @@
+<?php
+use SuiteCRM\StateSaver;
+
+require_once __DIR__ . '/../../../../../modules/Users/authentication/SAML2Authenticate/SAML2Authenticate.php';
+
+class SAML2MetadataTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract {
+
+    public function testEntryPointNoAuth() {
+        $controller = new SugarController();
+        $result = $controller->checkEntryPointRequiresAuth('SAML2Metadata');
+        $this->assertFalse($result);
+    }
+
+    public function testIncompleteSettings() {
+        $state = new StateSaver();
+        $state->pushErrorLevel();
+        // php-saml triggers deprecation warnings, so disable temporarily
+        error_reporting(E_ALL & ~E_DEPRECATED);
+
+        $failed = false;
+        try {
+            $settings = array('sp' => array(), 'idp' => array());
+            try {
+                getSAML2Metadata($settings);
+            } catch (Exception $e) {
+                $failed = true;
+            }
+        } finally {
+            $state->popErrorLevel();
+        }
+
+        $this->assertTrue($failed);
+    }
+
+    public function testMinimalValidExample() {
+        $settings = array(
+            'sp' => array(
+                'entityId' => 'someid',
+                'assertionConsumerService' => array(
+                    'url' => 'https://someurl',
+                ),
+            ),
+            'idp' => array(
+                'entityId' => 'someotherid',
+                'singleSignOnService' => array(
+                    'url' => 'https://localhost/foo',
+                ),
+            ),
+        );
+
+        $state = new StateSaver();
+        $state->pushErrorLevel();
+        // php-saml triggers deprecation warnings, so disable temporarily
+        error_reporting(E_ALL & ~E_DEPRECATED);
+        try {
+            $xml = getSAML2Metadata($settings);
+        } finally {
+            $state->popErrorLevel();
+        }
+        $this->assertNotEmpty($xml);
+        $this->assertRegexp('/someid/', $xml);
+        $this->assertRegexp('/someurl/', $xml);
+        $this->assertNotFalse(simplexml_load_string($xml));
+    }
+}
+
+?>


### PR DESCRIPTION
## Description

This adds a new endpoint which returns the XML metadata for the SAML2
integration. The output can be used to register the service with the identity
provider.

The endpoint can be reached through "index.php?entryPoint=SAML2Metadata"

Based on the php-saml example: https://github.com/onelogin/php-saml/blob/master/demo1/metadata.php

## Motivation and Context

This makes it easy to to register SuiteCRM with the IDP as you don't have to
build the XML/configuration manually.

It also makes it easier to configure the SuiteCRM SAML2 config as one can
compare the metadata to the metadata of an already existing/registered
service.

## How To Test This

Given a working SAML2 configuration visit "index.php?entryPoint=SAML2Metadata".
It should return XMl similar to: https://en.wikipedia.org/wiki/SAML_2.0#Service_Provider_Metadata

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
