### PR TITLE
Fixed #6504 - Fix and implement proper bounce email handling

### DIFF
--- a/modules/Campaigns/ProcessBouncedEmails.php
+++ b/modules/Campaigns/ProcessBouncedEmails.php
@@ -53,13 +53,25 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * @param Email $email
  * @return string
  */
-function retrieveErrorReportAttachment($email)
+function retrieveErrorReportAttachment(Email $email)
 {
     $contents = "";
-    $query = "SELECT description FROM notes WHERE file_mime_type = 'messsage/rfc822' AND parent_type='Emails' AND parent_id = '".$email->id."' AND deleted=0";
-    $rs = DBManagerFactory::getInstance()->query($query);
-    while ($row = DBManagerFactory::getInstance()->fetchByAssoc($rs)) {
-        $contents .= $row['description'];
+
+    $email->getNotes($email->id);
+    foreach ($email->attachments as $note) {
+        if ($note->file_mime_type == 'message/rfc822') {
+            $note_content = $note->getAttachmentContent();
+            if ($note_content !== false) {
+                // XXX: we don't know the encoding of the attached email, but
+                // assume it's quoted-printable.
+                $contents .= quoted_printable_decode($note_content);
+            }
+        } else if ($note->file_mime_type == 'message/delivery-status') {
+            $note_content = $note->getAttachmentContent();
+            if ($note_content !== false) {
+                $contents .= $note_content;
+            }
+        }
     }
 
     return $contents;
@@ -88,16 +100,70 @@ function createBouncedCampaignLogEntry($row, $email, $email_description)
     $bounce->related_type='Emails';
     $bounce->related_id= $email->id;
 
-    //do we have the phrase permanent error in the email body.
-    if (preg_match('/permanent[ ]*error/', $email_description)) {
+    if (checkBouncedEmailInvalid($email_description)) {
         $bounce->activity_type='invalid email';
-        markEmailAddressInvalid($email);
+        markBounceEmailAddressInvalid($bounce);
     } else {
         $bounce->activity_type='send error';
     }
 
     $return_id=$bounce->save();
     return $return_id;
+}
+
+/**
+ * Given an bounce entry, mark the related email address as invalid.
+ *
+ * @param CampaignLog $bounce
+ */
+function markBounceEmailAddressInvalid(CampaignLog $bounce)
+{
+    $sea = new SugarEmailAddress();
+    $email_address = $sea->getPrimaryAddress(false, $bounce->target_id, $bounce->target_type);
+    if (empty($email_address)) {
+        return;
+    }
+
+    LoggerManager::getLogger()->info("Marking email address as invalid: ". $email_address);
+    markEmailAddressInvalid($email_address);
+}
+
+/**
+ * Given the email description returns whether the email should be marked invalid.
+ *
+ * @param string $email_description
+ * @return bool
+ */
+function checkBouncedEmailInvalid($email_description)
+{
+    /* Consider as invalid if we get a permanent error status (5.X.X)
+     * and in addition we get an smtp error 550.
+     * https://tools.ietf.org/html/rfc3464#section-2.3.4
+     * https://tools.ietf.org/html/rfc3464#section-2.3.6
+     * https://www.usps.org/info/smtp_codes.html
+     * Example:
+     *  Status: 5.0.0
+     *  Diagnostic-Code: smtp; 550 #5.1.0 Address rejected.
+     * Example:
+     *  Status: 5.5.0
+     *  Diagnostic-Code: smtp; 550 5.5.0 Requested action not taken: mailbox unavailable
+     * Example:
+     *  Status: 5.1.1
+     *  Diagnostic-Code: smtp; 554 5.1.1
+     */
+    if (preg_match('/^Status:\s*([0-9]+)\.([0-9]+)\.([0-9]+)/m', $email_description, $match)) {
+        // 5.1.1 (permanent) Bad destination mailbox address
+        if ($match[1] == '5' && $match[2] == '1' && $match[3] == '1') {
+            return true;
+        }
+
+        // Permanent error with smtp error code for non-existent email address
+        if ($match[1] == '5' && preg_match('/^Diagnostic-Code:\s*smtp\s*;.*550/m', $email_description)) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 /**
@@ -166,15 +232,9 @@ function campaign_process_bounced_emails(&$email, &$email_header)
     $emailFromAddress = $email_header->fromaddress;
     $email_description = $email->raw_source;
 
-    //if raw_source is empty, try using the description instead
-    if (empty($email_description)) {
-        $email_description = $email->description;
-    }
-
     $email_description .= retrieveErrorReportAttachment($email);
 
     if (preg_match('/MAILER-DAEMON|POSTMASTER/i', $emailFromAddress)) {
-        $email_description=quoted_printable_decode($email_description);
         $matches=array();
 
         //do we have the identifier tag in the email?

--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -1957,7 +1957,7 @@ class Email extends Basic
         }
 
         $noteArray = array();
-        $q = "SELECT id FROM notes WHERE deleted = 0 AND parent_id = '" . $id . "'";
+        $q = "SELECT id FROM notes WHERE deleted = 0 AND parent_id = " . $this->db->quoted($id);
         $r = $this->db->query($q);
 
         while ($a = $this->db->fetchByAssoc($r)) {

--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -4456,12 +4456,10 @@ class InboundEmail extends SugarBean
                 } // end if disposition type 'attachment'
             }// end ifdisposition
             //Retrieve contents of subtype rfc8822
-            elseif ($part->type == 2 && isset($part->subtype) && strtolower($part->subtype) == 'rfc822') {
-                $tmp_eml = $this->getImap()->fetchBody($msgNo, $thisBc);
+            elseif ($part->type == 2 && isset($part->subtype) && (strtolower($part->subtype) == 'rfc822' || strtolower($part->subtype) == 'delivery-status')) {
                 $attach = $this->getNoteBeanForAttachment($emailId);
-                $attach->file_mime_type = 'messsage/rfc822';
-                $attach->description = $tmp_eml;
-                $attach->filename = 'bounce.eml';
+                $attach->file_mime_type = 'message/' . strtolower($part->subtype);
+                $attach->filename = 'bounce-' . strtolower($part->subtype) . '.txt';
                 $attach->safeAttachmentName();
                 if ($forDisplay) {
                     $attach->id = $this->getTempFilename();

--- a/modules/Notes/Note.php
+++ b/modules/Notes/Note.php
@@ -205,6 +205,22 @@ class Note extends File
         return "$this->name";
     }
 
+    /**
+     * Returns the content as string or false if there is no attachment or it
+     * couldn't be located.
+     *
+     * @return bool|string
+     */
+    public function getAttachmentContent()
+    {
+        $path = "upload://{$this->id}";
+        if (!file_exists($path)) {
+            return false;
+        }
+
+        return file_get_contents($path);
+    }
+
     public function create_export_query($order_by, $where, $relate_link_join = '')
     {
         $custom_join = $this->getCustomJoin(true, true, $where);

--- a/tests/unit/phpunit/modules/Emails/EmailTest.php
+++ b/tests/unit/phpunit/modules/Emails/EmailTest.php
@@ -712,6 +712,13 @@ class EmailTest extends StateCheckerPHPUnitTestCaseAbstract
         $email->delete($email->id);
     }
 
+    public function testgetNotesSqlEscape()
+    {
+        $email = new Email();
+        $email->getNotes("'=");
+        $this->assertFalse(DBManagerFactory::getInstance()->lastError());
+    }
+
     public function testcleanEmails()
     {
         $email = new Email();


### PR DESCRIPTION
## Description

Bounce handling is currently broken for multiple reasons:

(1) The imported bounce email is saved in the notes description field which is
marked as text and strips away all HTML on save(). This removes/mangles the
link containing the tracking ID so the attachment can't be linked to the
campaign log later on.

(2) SMTP servers usually return the original email as an attachment on a
bounce and include an addition attachment containing the delivery status (RFC
3464). Since this attachment wasn't saved, hard bounces weren't detected.

(3) In case the tracking ID makes it through and the email is considered a
hard bounce then marking the email as invalid failed because
markEmailAddressInvalid() was called with an email object but expected a
string.

To fix all these:

For (1) we don't save the attachment in the description and read it from the
saved attachment file instead. This makes sure we get the original content and
can extract the tracking ID.

For (2) we also save the delivery-status attachments in addition to the email
copy and also evaluate it in the bounce handling code. This allows us to
confidently classify hard bounces by parsing the status and diagnostic fields
in the delivery status attachment.

For (3) fix markEmailAddressInvalid() to take a bounce entry and figure out
the email address from there and mark it as invalid.

## Motivation and Context

To fix #6504

This likely also fixes #5980, #5898 and #1578

## How To Test This

See #6504

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribut