### PR TITLE
Fixed #6516 - (filler) elements in layouts are removed by gridlayout parser

### DIFF
--- a/modules/ModuleBuilder/parsers/views/GridLayoutMetaDataParser.php
+++ b/modules/ModuleBuilder/parsers/views/GridLayoutMetaDataParser.php
@@ -627,7 +627,7 @@ class GridLayoutMetaDataParser extends AbstractMetaDataParser implements MetaDat
 
                     	$newRow [ $colID - $offset ] = $fieldname;
                     	continue;
-                    }else if(!isset($fielddefs[$fieldname])){
+                    }else if(!isset($fielddefs[$fieldname]) && $fieldname != $this->FILLER['name']){
                        continue;
                      }
 


### PR DESCRIPTION
The parser rewrites editviews, detailviews and quickcreateviews. It however deletes all (filler) elements (see bug description for images).

The method _convertToCanonicalForm does include code to convert the (filler) elements to empty placeholders, however this code is never reached, because before it checks if the field name corresponds to an existing field definition.

## Description
This change make sure that (filler) elements are not removed when rewriting a view layout, see issue #6516 

## Motivation and Context
It solves deletion of (filler) elements in view layouts:
 * when new modules are installed or uninstalled that are related by many-to-one with a parent module
 * when layouts are manipulated directly using the GridLayoutMetaDataparser

## How To Test This
See reproduction in #6516

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.