### PR TITLE
Manage subscriptions: Fix unsubscribed users showing up as subscribed sometimes

### DIFF
--- a/modules/Campaigns/utils.php
+++ b/modules/Campaigns/utils.php
@@ -489,8 +489,7 @@ function get_subscription_lists($focus, $descriptions = false)
                 } else {
                     //this list is not exempt, and user is subscribed, so add to subscribed array, and unset from the unsubs_arr
                     //as long as this list is not in exempt array
-                    $temp = "prospect_list@".$news_list['prospect_list_id']."@campaign@".$news_list['campaign_id'];
-                    if (!array_search($temp, $unsubs_arr)) {
+                    if (!array_key_exists($news_list['name'], $unsubs_arr)) {
                         $subs_arr[$news_list['name']] = "prospect_list@".$news_list['prospect_list_id']."@campaign@".$news_list['campaign_id'];
                         $match = 'true';
                         unset($unsubs_arr[$news_list['name']]);


### PR DESCRIPTION
## Description

In the subscription manager sometimes a newsletter ends up in the subscribed
list even though the contact/lead is in the exempt list of that newsletter.

The code was checking if the user was unsubscribed with the list ID of the
subscription list. This will never work and depending on the iteration order
(if the unsubscribed list gets checked first) this results in the user being
displayed as subscribed even in case he/she is on an exempt list.

This fixes the code to check if the campaign name is in the unsubscribed list
instead, like happens in the case where the non-exempt list comes first.

get_subscription_lists_keyed(), which does the same thing as
get_subscription_lists() but returns the result in a more structured way,
also uses the campaign name and the same logic for this case.

## Motivation and Context

The subscription manager should reflect the real state of newsletter
subscriptions.

## How To Test This

* Add an except list first, then an subscription list
* Use them in a campaign
* Add a contact to the subscription list
* Try to adjust the subscription status of the contact through the
  subscription manager

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.