### PR TITLE
Fixed: ElasticSearch Save Redirect

### DIFF
--- a/modules/Administration/Search/ajaxSubmit.js
+++ b/modules/Administration/Search/ajaxSubmit.js
@@ -50,13 +50,33 @@ $("form").submit(function (e) {
         return SUGAR.language.get("Administration", label);
     }
 
+    function alertMsg(message) {
+        var alertMsg = document.createElement("p");
+        var classAttr = document.createAttribute("class");
+        classAttr.value = "error";
+
+        alertMsg.setAttributeNode(classAttr);
+
+        var alertContent = document.createTextNode(message);
+        alertMsg.appendChild(alertContent);
+
+        var pageContent = document.getElementById("pagecontent");
+        pageContent.insertBefore(alertMsg, pageContent.firstChild);
+    }
+
     $.ajax({
         url: action,
         type: method.toLowerCase(),
         data: data
-    }).success(function () {
-        alert(translate("LBL_AJAX_SUBMIT_SUCCESS"));
+    }).success(function (result) {
+        if (result.status == 'success') {
+            window.location.href="index.php?module=Administration&action=index";
+        } else {
+            alertMsg("Error: " + translate("LBL_AJAX_SUBMIT_FAIL"));
+        }
+        return false;
     }).fail(function () {
-        alert("LBL_AJAX_SUBMIT_FAIL");
+        alertMsg("Error: " + translate("LBL_AJAX_SUBMIT_FAIL"));
+        return false;
     });
 });

--- a/modules/Administration/language/en_us.lang.php
+++ b/modules/Administration/language/en_us.lang.php
@@ -977,7 +977,5 @@ $mod_strings = array(
     'LBL_SIMPLE_SQL_SEARCH_ENGINE' => 'Simple SQL Search Engine',
 
     // Ajax Submit
-    'LBL_AJAX_SUBMIT_SUCCESS' => 'The settings have been saved successfully.',
     'LBL_AJAX_SUBMIT_FAIL' => 'An error has occurred while saving the settings.',
 );
-


### PR DESCRIPTION
Fix: Redirect the user back to the Administration section when saving the Elastic Search.

## Description
Within the current version the save button on the "ElasticSearch" page alerts the user that the section has save successfully; however, the other sections redirect the user back to the Administration section. This fix will take away the alert message and redirect the user back to the Administration page as expected.

## Motivation and Context
To keep the flow of the application consistent.  

## How To Test This

1. Go to Scheduler and locate the Elastic Search Schedule, if there is no schedule for Elastic Search created. Click on "Create Scheduler" (On Left). Create a new Elastic Search Scheduler in the normal way.

2. Go to: Admin > click "ElasticSearch" > Input the correct Host, Username and Password and Click the "Test connection" button. Click Enable Elasticsearch.

3. Click the save button

4. This should redirect you to the Administration section.

5. Click on the "ElasticSearch" > Check the correct details are still entered.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->