### PR TITLE
Fix: Notification count styling

### DIFF
--- a/themes/SuiteP/css/suitep-base/navbar.scss
+++ b/themes/SuiteP/css/suitep-base/navbar.scss
@@ -979,7 +979,7 @@
 	line-height:37px;
 	padding-top:0;
 	padding-bottom:0;
-	
+
 }
 
 .quickcreatetop .dropdown-toggle:hover {
@@ -1089,6 +1089,7 @@
   line-height: 20px;
   width: 20px;
   height: 20px;
+  z-index: 200;
 }
 
 .desktop_notifications .alert {
@@ -1311,7 +1312,7 @@
     background-color: $navbar-quick-create-mobile-btn-bg;
     padding: 5px 5px 5px 12px;
     text-decoration: none;
- 
+
   }
 
   .quickcreatetop .suitepicon-action-caret {
@@ -1324,7 +1325,7 @@
 	height:auto;
 	line-height:100%;
 	padding: 5px 32px 5px 12px;
-	
+
 }
 
   .quickcreatetop .dropdown-toggle:hover {
@@ -1750,13 +1751,13 @@
     width: 40px;
     height: 40px;
   }
-  
+
   .navbar-search .btn-default.searchbutton {
     width: 40px;
     height: 40px;
     color: $navbar-link-color;
   }
-    
+
 
   .navbar-search .btn-default.searchbutton:active {
     padding: 0;
@@ -1773,8 +1774,8 @@
     height: 40px;
     color: $navbar-link-color-hover;
   }
-  
-  
+
+
 
   .desktop-bar .navbar-search.open .dropdown-menu {
     top: -(($navbar-toolbar-height / 4) - 12px);
@@ -2058,7 +2059,7 @@
   .desktop-toolbar .navbar-brand-container {
     margin-left: 10px;
   }
-  
+
   .navbar-brand {
 	  height:30px;
 	  top:4px;


### PR DESCRIPTION
Fix: Notification Count Styling 

## Description
This fix will correct the styling on the notification count, at the moment one of the sides of the count is hidden, this will fix this issue and display the count background properly. 

## Motivation and Context
To fix the display of the application.

## How To Test This

From:
![screenshot-localhost-9002-2018 11 26-17-31-50](https://user-images.githubusercontent.com/542894/49031237-530a1b00-f1a1-11e8-804c-73aa2ab6f63a.png)

To:
![screenshot-localhost-9002-2018 11 26-17-34-27](https://user-images.githubusercontent.com/542894/49031349-982e4d00-f1a1-11e8-97ca-491ec9c0b573.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.