### PR TITLE
Fix/Individual Flat Subpanels

### DIFF
--- a/include/SubPanel/SubPanelTiles.php
+++ b/include/SubPanel/SubPanelTiles.php
@@ -440,10 +440,14 @@ class SubPanelTiles
             }
         }
         require_once('include/Smarty/plugins/function.sugar_action_menu.php');
-        $widget_contents = smarty_function_sugar_action_menu(array(
-            'buttons' => $buttons,
-            'class' => 'clickMenu fancymenu',
-        ), $this->xTemplate);
+        $widget_contents = smarty_function_sugar_action_menu(
+            [
+                'buttons' => $buttons,
+                'flat' => !empty($thisPanel->_instance_properties['flat']),
+                'class' => 'clickMenu fancymenu',
+            ],
+            $this->xTemplate
+        );
         return $widget_contents;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Passes the expected `flat` variable into the function that creates subpanel buttons.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
The function that builds the array of subpanel buttons checks for a variable named `flat` to decide on an individual subpanel basis whether to display the buttons ins drop down menu.
This variable was never being passed into the function from the SubPanel class despite being available.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Now we can define individual subpanels as flat in the defs.

Result: Flat and Dropdown subpanels in the same instance and the same module.
![image](https://user-images.githubusercontent.com/34056696/49077768-6d450700-f23c-11e8-837c-4b140a864ee0.png)

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Override a subpanel definition (example `custom/Extension/modules/Leads/Ext/LayoutDefs/myCustomization.php`)
2. Add this line: `$layout_defs['Leads']['subpanel_setup']['history']['flat] = 1`
3. Repair and Rebuild
4. Go to Leads module
5. See only the History module now has its buttons displayed not in a dropdown

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->