### PR TITLE
Fixed #6452 - Api/V8 create record does not support unicode and space in attributes

### DIFF
--- a/Api/V8/Param/Options/Fields.php
+++ b/Api/V8/Param/Options/Fields.php
@@ -7,7 +7,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class Fields extends BaseOption
 {
-    const REGEX_FIELD_PATTERN = '/[^\w-,]/';
+    const REGEX_FIELD_PATTERN = '/[^\w-,\s\]/';
 
     /**
      * @inheritdoc


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Change `REGEX_FIELD_PATTERN = '/[^\w-,]/' to REGEX_FIELD_PATTERN = '/[^\w-,\s\]/'`
See issue [#6452](https://github.com/salesagility/SuiteCRM/issues/6452)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When create record with Api/V8 it validate attributes with regex pattern const REGEX_FIELD_PATTERN = '/[^\w-,]/', so if you use unicode or space on value will occur error "The option attributes with value array is invalid." in the response.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
```
POST SuiteCRM/Api/V8/module
BODY {
  "data": {
    "type": "Accounts",
    "attributes": {
      "name": "Cocacola company",
      "description": "very friendly account"
    }
  }
}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->