### PR TITLE
Fixed redirection to new record while useing Close and new Button

### DIFF
--- a/include/formbase.php
+++ b/include/formbase.php
@@ -247,19 +247,18 @@ function buildRedirectURL($return_id='', $return_module='')
 	}
 	if(isset($_REQUEST['return_action']) && $_REQUEST['return_action'] != "")
 	{
-	    
-	   //if we are doing a "Close and Create New"
-        if(isCloseAndCreateNewPressed())
-        {
-            $return_action = "EditView";    
-            $isDuplicate = "true";        
+
+        //if we are doing a "Close and Create New"
+        if (isCloseAndCreateNewPressed()) {
+            $return_action = "EditView";
+            $isDuplicate = "true";
             $status = "";
-            
+
             // Meeting Integration
-            if(isset($_REQUEST['meetingIntegrationFlag']) && $_REQUEST['meetingIntegrationFlag'] == 1) {
-            	$additionalFlags = array('meetingIntegrationShowForm' => '1');
-				//Set redirection to the new record created
-				$_REQUEST['return_id'] = $return_id?$return_id:$_REQUEST['return_id'];
+            if (isset($_REQUEST['meetingIntegrationFlag']) && $_REQUEST['meetingIntegrationFlag'] == 1) {
+                $additionalFlags = array('meetingIntegrationShowForm' => '1');
+                //Set redirection to the new record created
+                $_REQUEST['return_id'] = $return_id ? $return_id : $_REQUEST['return_id'];
             }
             // END Meeting Integration
         } 

--- a/include/formbase.php
+++ b/include/formbase.php
@@ -258,6 +258,8 @@ function buildRedirectURL($return_id='', $return_module='')
             // Meeting Integration
             if(isset($_REQUEST['meetingIntegrationFlag']) && $_REQUEST['meetingIntegrationFlag'] == 1) {
             	$additionalFlags = array('meetingIntegrationShowForm' => '1');
+				//Set redirection to the new record created
+				$_REQUEST['return_id'] = $return_id?$return_id:$_REQUEST['return_id'];
             }
             // END Meeting Integration
         } 


### PR DESCRIPTION
When the user press the "Close And Create" button in the calls module is redirected to the Edit View of the parent (the record id is not updated). This modification allows the user to be redirected to the new record created.

## Description
When the user press the "Close And Create" button in the calls module is redirected to the Edit View of the parent (the record id is not updated). This modification allows the user to be redirected to the new record created.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
-Create a call log
-Click on Close and Create
-Modify the details
-Click again in Close and Create


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->