### PR TITLE
Fixed #6036 AOR Reports entering a date parameter with Period operato…

### DIFF
--- a/modules/AOR_Reports/aor_utils.php
+++ b/modules/AOR_Reports/aor_utils.php
@@ -95,6 +95,7 @@ function getDisplayForField($modulePath, $field, $reportModule)
 
 function requestToUserParameters($reportBean = null)
 {
+    global $app_list_strings;
     $params = array();
     if (!empty($_REQUEST['parameter_id'])) {
         $dateCount = 0;
@@ -108,7 +109,9 @@ function requestToUserParameters($reportBean = null)
 
             $condition = BeanFactory::getBean('AOR_Conditions', $_REQUEST['parameter_id'][$key]);
             $value = $_REQUEST['parameter_value'][$key];
-            if ($reportBean && $condition) {
+
+            // Fix for issue #9846 fixUpFormatting doesn't expect a period value
+            if ($reportBean && $condition && !array_key_exists($value,$app_list_strings['date_time_period_list'])){
                 $value = fixUpFormatting($reportBean->report_module, $condition->field, $value);
             }
 


### PR DESCRIPTION
…r type results in empty page and php fatal error

Issue
While viewing any AOR Reports, an empty page will result when entering Date as parameter and updating.
Other parameter types such as Field and Date may not work correctly.
After checking logs and some debugging, what happens is that a PHP fatal error occurs because the period value is being removed by code introduced in the latest changes to aor_utils.php file.

Expected Behavior
When choosing a date period parameter, results should appear filtered by the selected criteria.

Actual Behavior
After pressing update an empty content page will result.
PHP Error logs will show there was a fatal error:
`PHP Fatal error: Uncaught Error: Call to a member function format() on null in /bitnami/suitecrm/modules/AOR_Reports/AOR_Report.php:1803

Possible Fix
The issue actually begins in modules/AOR_Reports/aor_utils.php: 106
The parameter value is sent to a function called fixUpFormatting which does not seem to expect values such as 'today','yesterday', etc... for date/datetime fields.
Using the value directly from the $_REQUEST object as it was before "fixes" the issue for this type of parameter, but I guess the use of the fixUpFormatting function is there for some other reasons.

Steps to Reproduce
Create a new report with any module (e.g. Cases), with any fields (e.g. Account Name) and with at least one condition checked as a parameter using a date field (e.g. Date created). Save the report.
In the report view, choose any operator, Period type and any value for the date field parameter.
Press update.
Observe empty page instead of results.
Context
Reports using date periods as parameters will initially load, but won't work anytime the Update button is pressed. I also believe this affects other types of date parameters such as Date and Field. If the type is chosen as Value it seems to work correctly.

<!--- Provide a general summary of your changes in the Title above -->
Inserted a condition to prevent to call fixUpFormatting() to a date_time_period value
## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->