### PR TITLE
campaing wizard: fix template editor being shown in all steps

### DIFF
--- a/modules/Campaigns/WizardMarketing.html
+++ b/modules/Campaigns/WizardMarketing.html
@@ -1378,7 +1378,7 @@
 </tr>
 </table>
 
-<div class="template-panel-container panel">
+<div class="template-panel-container panel" id="step1_editor">
 	<div class="template-container-full">
 		{if !$hide_width_set}
 		<label>{$MOD.LBL_CLICK_TO_ADD}</label>
@@ -1469,6 +1469,9 @@ function determine_back(){
 				// show uploader form below template form only
 
 				$('#step1_uploader').css('display', $('#step1').css('display'));
+
+				// only show the template editor below step 1
+				$('#step1_editor').css('display', $('#step1').css('display'));
 
 				// hide cancel and save button on summary page
 


### PR DESCRIPTION
## Description

In 442af7f8539d99c2 the template editor was moved out of the main table to prevent
the table css affect the template editor content.

I missed that the content in the table is replaced in the wizard steps and by moving
the template editor out the editor is now being shown in all steps instead of only the
first one.

Fix this by tying the visiblity state of the editor to the first step panel.

## Motivation and Context

Fixes the template editor being shown in all final steps of the campaign wizard

## How To Test This

Create an email campaign, the template editor should only be shown in the template step.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
