### PR TITLE
Fixed #2400 - Language manifest is duplicated and overwritten on each

### DIFF
--- a/modules/Administration/UpgradeWizard_prepare.php
+++ b/modules/Administration/UpgradeWizard_prepare.php
@@ -1,7 +1,4 @@
 <?php
-if (!defined('sugarEntry') || !sugarEntry) {
-    die('Not A Valid Entry Point');
-}
 /**
  *
  * SugarCRM Community Edition is a customer relationship management program developed by
@@ -41,12 +38,11 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
-
-
-
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
 
 require_once('modules/Administration/UpgradeWizardCommon.php');
-
 
 unset($_SESSION['rebuild_relationships']);
 unset($_SESSION['rebuild_extensions']);
@@ -413,6 +409,12 @@ if ($show_files == true) {
 
         if ($mode == "Install") {
             $checked = "checked";
+
+            if ($install_type === 'langpack' && $the_file == "./manifest.php") {
+                $checked = '';
+                $disabled = "disabled=\"true\"";
+            }
+
             foreach ($zip_force_copy as $pattern) {
                 if (preg_match("#" . $pattern . "#", $unzip_file)) {
                     $disabled = "disabled=\"true\"";
@@ -431,20 +433,22 @@ if ($show_files == true) {
                 print(" (no changes)");
             }
             print("<br>\n");
-        } elseif ($mode == "Uninstall" && file_exists($new_file)) {
-            if (md5_file($unzip_file) == md5_file($new_file)) {
-                $checked = "checked=\"true\"";
-            } else {
-                $highlight_start    = "<font color=red>";
-                $highlight_end      = "</font>";
+        } else {
+            if ($mode == "Uninstall" && file_exists($new_file)) {
+                if (md5_file($unzip_file) == md5_file($new_file)) {
+                    $checked = "checked=\"true\"";
+                } else {
+                    $highlight_start = "<font color=red>";
+                    $highlight_end = "</font>";
+                }
+                print("<li><input name=\"copy_$count\" type=\"checkbox\" value=\"" . $the_file . "\" $checked $disabled > " . $highlight_start . $new_file . $highlight_end . "<br>\n");
             }
-            print("<li><input name=\"copy_$count\" type=\"checkbox\" value=\"" . $the_file . "\" $checked $disabled > " . $highlight_start . $new_file . $highlight_end . "<br>\n");
         }
         $count++;
     }
     print("</ul>\n");
 }
-//    echo '</div>';
+
 if ($mode == "Disable" || $mode == "Enable") {
     //check to see if any files have been modified
     $modified_files = getDiffFiles($unzip_dir, $install_file, ($mode == 'Enable'), $previous_version);


### PR DESCRIPTION
## Description
Prevents manifest.php from being copied to the root directory when installing a language pack. See original issue for details.

This merge is for hotfix

hotfix-7.8.x version is at #5454 

Motivation and Context
Issue reference: #2400

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.