### PR TITLE
FIX #6651 - Added LBL_CHECKMARK to SecurityGruop language

### DIFF
--- a/modules/SecurityGroups/language/en_us.lang.php
+++ b/modules/SecurityGroups/language/en_us.lang.php
@@ -122,5 +122,6 @@ $mod_strings = array(
     'LBL_INBOUND_EMAIL' => 'Inbound email account',
     'LBL_INBOUND_EMAIL_DESC' => 'Only allow access to an email account if user belongs to a group that is assigned to the mail account.',
     'LBL_PRIMARY_GROUP' => 'Primary Group',
+    'LBL_CHECKMARK' => 'Checkmark',
 
 );


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Solved #6651 where a php notice appear in the SecurityGroups modules, in the User subpanel.
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
 The problem was that the SubPanelDef is looking for the LBL_CHECKMARK in the SecurityGroup language file, and not in the User language file, that's where it is.
To avoid this, we added the LBL_CHECKMARK to SecurityGroup language file
## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->