### PR TITLE
Fixed #4872 - Fix some async subpanel actions failing if refresh_page=1

### DIFF
--- a/include/SubPanel/SubPanelTiles.js
+++ b/include/SubPanel/SubPanelTiles.js
@@ -70,13 +70,13 @@ function got_data(args,inline){var list_subpanel=document.getElementById('list_s
 SUGAR.util.evalScript(args.responseText);subpanel.style.display='';set_div_cookie(subpanel.cookie_name,'');if(current_child_field!=''&&child_field!=current_child_field){}
 current_child_field=child_field;$("ul.clickMenu").each(function(index,node){$(node).sugarActionMenu();});}}
 function showSubPanel(child_field,url,force_load,layout_def_key){var inline=1;if(typeof(force_load)=='undefined'||force_load==null){force_load=false;}
+function checkRefreshPage(url){if(typeof(url)!='undefined'&&url!=null&&url.indexOf('refresh_page=1')>0){document.location.reload();}}
 if(force_load||typeof(child_field_loaded[child_field])=='undefined'){request_map[request_id]=child_field;if(typeof(url)=='undefined'||url==null){var module=get_module_name();var id=get_record_id();if(typeof(layout_def_key)=='undefined'||layout_def_key==null){layout_def_key=get_layout_def_key();}
 url='index.php?sugar_body_only=1&module='+module+'&subpanel='+child_field+'&action=SubPanelViewer&inline='+inline+'&record='+id+'&layout_def_key='+layout_def_key;}
 if(url.indexOf('http://')!=0&&url.indexOf('https://')!=0){url=''+url;}
 current_subpanel_url=url;var loadingImg='<img src="themes/'+SUGAR.themes.theme_name+'/images/loading.gif">';$("#list_subpanel_"+child_field.toLowerCase()).html(loadingImg);$.ajax({type:"GET",async:true,cache:false,url:url+'&inline='+inline+'&ajaxSubpanel=true',success:function(data){request_map[request_id]=child_field;var returnstuff={"responseText":data,"responseXML":'',"request_id":request_id};got_data(returnstuff,inline);if($('#whole_subpanel_'+child_field).hasClass('useFooTable')){$('#whole_subpanel_'+child_field+' .table-responsive').footable();}
-request_id++;}});}else{var subpanel=document.getElementById('subpanel_'+child_field);subpanel.style.display='';set_div_cookie(subpanel.cookie_name,'');if(current_child_field!=''&&child_field!=current_child_field){hideSubPanel(current_child_field);}
-current_child_field=child_field;}
-if(typeof(url)!='undefined'&&url!=null&&url.indexOf('refresh_page=1')>0){document.location.reload();}}
+request_id++;checkRefreshPage(url);}});}else{var subpanel=document.getElementById('subpanel_'+child_field);subpanel.style.display='';set_div_cookie(subpanel.cookie_name,'');if(current_child_field!=''&&child_field!=current_child_field){hideSubPanel(current_child_field);}
+current_child_field=child_field;checkRefreshPage(url);}}
 function toggleSubpanelCookie(tab){set_div_cookie(get_module_name()+'_'+tab+'_v',!$('#subpanel_'+tab).is(":visible"));}
 function markSubPanelLoaded(child_field){child_field_loaded[child_field]=2;}
 function hideSubPanel(child_field){var subpanel=document.getElementById('subpanel_'+child_field);subpanel.style.display='none';set_div_cookie(subpanel.cookie_name,'none');}

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelEditSecurityGroupUserButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelEditSecurityGroupUserButton.php
@@ -55,7 +55,7 @@ class SugarWidgetSubPanelEditSecurityGroupUserButton extends SugarWidgetField
         return $this->displayList($layout_def);
     }
 
-    public function displayList($layout_def)
+    public function displayList(&$layout_def)
     {
         global $app_strings;
         global $image_path;

--- a/jssource/src_files/include/SubPanel/SubPanelTiles.js
+++ b/jssource/src_files/include/SubPanel/SubPanelTiles.js
@@ -266,6 +266,12 @@ function showSubPanel(child_field, url, force_load, layout_def_key) {
     force_load = false;
   }
 
+  function checkRefreshPage(url) {
+    if (typeof(url) != 'undefined' && url != null && url.indexOf('refresh_page=1') > 0) {
+      document.location.reload();
+    }
+  }
+
   if (force_load || typeof( child_field_loaded[child_field] ) == 'undefined') {
     request_map[request_id] = child_field;
     if (typeof (url) == 'undefined' || url == null) {
@@ -304,6 +310,8 @@ function showSubPanel(child_field, url, force_load, layout_def_key) {
           $('#whole_subpanel_' + child_field + ' .table-responsive').footable();
         }
         request_id++;
+
+        checkRefreshPage(url);
       }
     });
 
@@ -319,11 +327,9 @@ function showSubPanel(child_field, url, force_load, layout_def_key) {
     }
 
     current_child_field = child_field;
-  }
-  if (typeof(url) != 'undefined' && url != null && url.indexOf('refresh_page=1') > 0) {
-    document.location.reload();
-  }
 
+    checkRefreshPage(url);
+  }
 }
 
 function toggleSubpanelCookie(tab) {


### PR DESCRIPTION
## Description

In case the subpanel layout uses refresh_page=1 then showSubPanel() will start an
async request and after that reload the page. In many cases this will lead to the
just started request being aborted and the page gets reloaded without anything changing.

This was introduced in 829a06f5b8af where the previously sync call was replaced with an
async one.

This is most visible for me in the "Users" module were I can't remove security groups
through the subpanel and it just refreshes the page without removing the group.

Fix this my moving the page refresh check in the ajax callback so the page gets only reloaded
once the request is finished.

## Motivation and Context

Make adding and removing security groups and roles in the Users module work
for example.

## How To Test This

(Using Firefox, in case that makes a difference)

1) Admin -> User Management
2) Select a user
3) Scroll down to the security groups subpanel
4) Add a security group
5) Click "Edit" on the newly added group and then "Remove"

Without this patch the page reloads and the security group is still there.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
