### PR TITLE
Change default view on template to avoid date created/modified issues

### DIFF
--- a/include/SugarObjects/templates/basic/metadata/detailviewdefs.php
+++ b/include/SugarObjects/templates/basic/metadata/detailviewdefs.php
@@ -56,28 +56,30 @@ $viewdefs[$module_name]['DetailView'] = array(
         ),
     ),
 
-    'panels' => array(
-
+    'panels' =>
         array(
-            'name',
-            'assigned_user_name',
-        ),
+            'default' =>
+                array(
+                    array(
+                        'name',
+                        'assigned_user_name',
+                    ),
+                    array(
+                            array(
+                                'name' => 'date_entered',
+                                'customCode' => '{$fields.date_entered.value} {$APP.LBL_BY} {$fields.created_by_name.value}',
+                                'label' => 'LBL_DATE_ENTERED',
+                            ),
+                            array(
+                                'name' => 'date_modified',
+                                'customCode' => '{$fields.date_modified.value} {$APP.LBL_BY} {$fields.modified_by_name.value}',
+                                'label' => 'LBL_DATE_MODIFIED',
+                            ),
+                    ),
 
-        array(
-            array(
-                'name' => 'date_entered',
-                'customCode' => '{$fields.date_entered.value} {$APP.LBL_BY} {$fields.created_by_name.value}',
-                'label' => 'LBL_DATE_ENTERED',
-            ),
-            array(
-                'name' => 'date_modified',
-                'customCode' => '{$fields.date_modified.value} {$APP.LBL_BY} {$fields.modified_by_name.value}',
-                'label' => 'LBL_DATE_MODIFIED',
-            ),
-        ),
-
-        array(
-            'description',
-        ),
-    )
+                    array(
+                        'description',
+                    ),
+                )
+        )
 );

--- a/include/SugarObjects/templates/company/metadata/detailviewdefs.php
+++ b/include/SugarObjects/templates/company/metadata/detailviewdefs.php
@@ -50,44 +50,46 @@ $viewdefs[$module_name]['DetailView'] = array(
         ),
     ),
     'panels' => array(
-        array('name', 'phone_office'),
-        array(array('name' => 'website', 'type' => 'link'), 'phone_fax'),
-        array('ticker_symbol', array('name' => 'phone_alternate', 'label' => 'LBL_OTHER_PHONE')),
-        array('', 'employees'),
-        array('ownership', 'rating'),
-        array('industry'),
-        array($_object_name . '_type', 'annual_revenue'),
-        array(
+        'default' => array(
+            array('name', 'phone_office'),
+            array(array('name' => 'website', 'type' => 'link'), 'phone_fax'),
+            array('ticker_symbol', array('name' => 'phone_alternate', 'label' => 'LBL_OTHER_PHONE')),
+            array('', 'employees'),
+            array('ownership', 'rating'),
+            array('industry'),
+            array($_object_name . '_type', 'annual_revenue'),
             array(
-                'name' => 'date_modified',
-                'label' => 'LBL_DATE_MODIFIED',
-                'customCode' => '{$fields.date_modified.value} {$APP.LBL_BY} {$fields.modified_by_name.value}'
-            ),
-        ),
-        array(
-            array('name' => 'assigned_user_name', 'label' => 'LBL_ASSIGNED_TO_NAME'),
-            array(
-                'name' => 'date_entered',
-                'customCode' => '{$fields.date_entered.value} {$APP.LBL_BY} {$fields.created_by_name.value}'
-            )
-        ),
-        array(
-            array(
-                'name' => 'billing_address_street',
-                'label' => 'LBL_BILLING_ADDRESS',
-                'type' => 'address',
-                'displayParams' => array('key' => 'billing'),
+                array(
+                    'name' => 'date_modified',
+                    'label' => 'LBL_DATE_MODIFIED',
+                    'customCode' => '{$fields.date_modified.value} {$APP.LBL_BY} {$fields.modified_by_name.value}'
+                ),
             ),
             array(
-                'name' => 'shipping_address_street',
-                'label' => 'LBL_SHIPPING_ADDRESS',
-                'type' => 'address',
-                'displayParams' => array('key' => 'shipping'),
+                array('name' => 'assigned_user_name', 'label' => 'LBL_ASSIGNED_TO_NAME'),
+                array(
+                    'name' => 'date_entered',
+                    'customCode' => '{$fields.date_entered.value} {$APP.LBL_BY} {$fields.created_by_name.value}'
+                )
             ),
-        ),
+            array(
+                array(
+                    'name' => 'billing_address_street',
+                    'label' => 'LBL_BILLING_ADDRESS',
+                    'type' => 'address',
+                    'displayParams' => array('key' => 'billing'),
+                ),
+                array(
+                    'name' => 'shipping_address_street',
+                    'label' => 'LBL_SHIPPING_ADDRESS',
+                    'type' => 'address',
+                    'displayParams' => array('key' => 'shipping'),
+                ),
+            ),
 
-        array('description'),
-        array('email1'),
+            array('description'),
+            array('email1'),
+        ),
     ),
 
 );

--- a/include/SugarObjects/templates/file/metadata/detailviewdefs.php
+++ b/include/SugarObjects/templates/file/metadata/detailviewdefs.php
@@ -54,45 +54,46 @@ $viewdefs[$module_name]['DetailView'] = array(
         ),
     ),
     'panels' => array(
-
-        array(
-
-            array(
-                'name' => 'document_name',
-                'label' => 'LBL_DOC_NAME',
-            ),
-            array(
-                'name' => 'uploadfile',
-                'displayParams' => array('link' => 'uploadfile', 'id' => 'id'),
-            ),
-
-        ),
-        array(
-            'category_id',
-            'subcategory_id',
-        ),
-
-        array(
-
-            'status',
-
-        ),
-        array(
-            'active_date',
-            'exp_date',
-        ),
-
-        array(
-            array('name' => 'assigned_user_name', 'label' => 'LBL_ASSIGNED_TO'),
-        ),
-
-        array(
+        'default' => array(
 
             array(
-                'name' => 'description',
-                'label' => 'LBL_DOC_DESCRIPTION',
+
+                array(
+                    'name' => 'document_name',
+                    'label' => 'LBL_DOC_NAME',
+                ),
+                array(
+                    'name' => 'uploadfile',
+                    'displayParams' => array('link' => 'uploadfile', 'id' => 'id'),
+                ),
+
+            ),
+            array(
+                'category_id',
+                'subcategory_id',
+            ),
+
+            array(
+
+                'status',
+
+            ),
+            array(
+                'active_date',
+                'exp_date',
+            ),
+
+            array(
+                array('name' => 'assigned_user_name', 'label' => 'LBL_ASSIGNED_TO'),
+            ),
+
+            array(
+
+                array(
+                    'name' => 'description',
+                    'label' => 'LBL_DOC_DESCRIPTION',
+                ),
             ),
         ),
-
     )
 );

--- a/include/SugarObjects/templates/issue/metadata/detailviewdefs.php
+++ b/include/SugarObjects/templates/issue/metadata/detailviewdefs.php
@@ -51,48 +51,50 @@ $viewdefs[$module_name]['DetailView'] = array(
     ),
 
     'panels' => array(
-
-        array(
-            $_object_name . '_number',
-            'assigned_user_name',
-        ),
-
-        array(
-            'priority',
-        ),
-
-        array(
-            'resolution',
-            'status',
-        ),
-
-        array(
-            array(
-                'name' => 'date_entered',
-                'customCode' => '{$fields.date_entered.value} {$APP.LBL_BY} {$fields.created_by_name.value}',
-                'label' => 'LBL_DATE_ENTERED',
-            ),
-            array(
-                'name' => 'date_modified',
-                'customCode' => '{$fields.date_modified.value} {$APP.LBL_BY} {$fields.modified_by_name.value}',
-                'label' => 'LBL_DATE_MODIFIED',
-            ),
-        ),
-
-        array(
+        'default' => array(
 
             array(
-                'name' => 'name',
-                'label' => 'LBL_SUBJECT',
+                $_object_name . '_number',
+                'assigned_user_name',
             ),
-        ),
 
-        array(
-            'description',
-        ),
+            array(
+                'priority',
+            ),
 
-        array(
-            'work_log',
-        ),
+            array(
+                'resolution',
+                'status',
+            ),
+
+            array(
+                array(
+                    'name' => 'date_entered',
+                    'customCode' => '{$fields.date_entered.value} {$APP.LBL_BY} {$fields.created_by_name.value}',
+                    'label' => 'LBL_DATE_ENTERED',
+                ),
+                array(
+                    'name' => 'date_modified',
+                    'customCode' => '{$fields.date_modified.value} {$APP.LBL_BY} {$fields.modified_by_name.value}',
+                    'label' => 'LBL_DATE_MODIFIED',
+                ),
+            ),
+
+            array(
+
+                array(
+                    'name' => 'name',
+                    'label' => 'LBL_SUBJECT',
+                ),
+            ),
+
+            array(
+                'description',
+            ),
+
+            array(
+                'work_log',
+            ),
+        )
     )
 );

--- a/include/SugarObjects/templates/sale/metadata/detailviewdefs.php
+++ b/include/SugarObjects/templates/sale/metadata/detailviewdefs.php
@@ -54,28 +54,29 @@ $viewdefs[$module_name]['DetailView'] = array(
         ),
     ),
     'panels' => array(
-        array('name', array('name' => 'amount', 'label' => '{$MOD.LBL_AMOUNT} ({$CURRENCY})'),),
-        //'{$MOD.LBL_AMOUNT} ({$CURRENCY})'),),
-        array('date_closed', 'sales_stage'),
-        array($_object_name . '_type', 'next_step'),
-        array(
-            'lead_source',
+        'default' => array(
+            array('name', array('name' => 'amount', 'label' => '{$MOD.LBL_AMOUNT} ({$CURRENCY})'),),
+            array('date_closed', 'sales_stage'),
+            array($_object_name . '_type', 'next_step'),
             array(
-                'name' => 'date_entered',
-                'customCode' => '{$fields.date_entered.value} {$APP.LBL_BY} {$fields.created_by_name.value}'
+                'lead_source',
+                array(
+                    'name' => 'date_entered',
+                    'customCode' => '{$fields.date_entered.value} {$APP.LBL_BY} {$fields.created_by_name.value}'
+                ),
             ),
-        ),
-        array(
-            'probability'
-        ),
-        array(
-            'assigned_user_name',
             array(
-                'name' => 'date_modified',
-                'label' => 'LBL_DATE_MODIFIED',
-                'customCode' => '{$fields.date_modified.value} {$APP.LBL_BY} {$fields.modified_by_name.value}'
-            )
-        ),
-        array(array('name' => 'description', 'nl2br' => true)),
+                'probability'
+            ),
+            array(
+                'assigned_user_name',
+                array(
+                    'name' => 'date_modified',
+                    'label' => 'LBL_DATE_MODIFIED',
+                    'customCode' => '{$fields.date_modified.value} {$APP.LBL_BY} {$fields.modified_by_name.value}'
+                )
+            ),
+            array(array('name' => 'description', 'nl2br' => true)),
+        )
     )
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
add 'default' => to the panel name, so that changes to the view retain the "date by name" format. To reproduce bug, create any custom module, then edit the detail view and see that the "date by name" format is lost and it will instead just be the date field.

## Motivation and Context
It solves the issue of custom modules not having the "date by name" format if you change the view at any point. There is caching issues with just having the date fields.

## How To Test This
Create any module, use one of the templates which have been changed in the MR. Modify the detail view - see the bug as specified. Apply fix and retest and see that date by name format is there. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->