### PR TITLE
fixed #6440 - Emails imported automatically won't allow to change the user assigned to

### DIFF
--- a/include/Imap/ImapHandler.php
+++ b/include/Imap/ImapHandler.php
@@ -77,17 +77,24 @@ class ImapHandler implements ImapHandlerInterface
      * @var bool
      */
     protected $logCalls;
+
+    /**
+     *
+     * @var string
+     */
+    protected $charset;
     
     /**
      *
      * @param bool $log
      */
-    public function __construct($logErrors = true, $logCalls = true)
+    public function __construct($logErrors = true, $logCalls = true, $charset = null)
     {
         $this->logCall(__FUNCTION__, func_get_args());
         $this->logErrors = $logErrors;
         $this->logCalls = $logCalls;
         $this->logger = LoggerManager::getLogger();
+        $this->charset = $charset;
     }
     
     /**
@@ -330,8 +337,10 @@ class ImapHandler implements ImapHandlerInterface
      */
     public function sort($criteria, $reverse, $options = 0, $search_criteria = null, $charset = null)
     {
+        // Default to class charset if none is specified
+        $emailCharset = (!empty($charset)) ? $charset : $this->charset;
         $this->logCall(__FUNCTION__, func_get_args());
-        $ret = imap_sort($this->getStream(), $criteria, $reverse, $options, $search_criteria, $charset);
+        $ret = imap_sort($this->getStream(), $criteria, $reverse, $options, $search_criteria, $emailCharset);
         $this->logReturn(__FUNCTION__, $ret);
         return $ret;
     }
@@ -692,8 +701,13 @@ class ImapHandler implements ImapHandlerInterface
      */
     public function search($criteria, $options = SE_FREE, $charset = null)
     {
+        // Default to class charset if none is specified
+        $emailCharset = (!empty($charset)) ? $charset : $this->charset;
+
         $this->logCall(__FUNCTION__, func_get_args());
-        $ret = imap_search($this->getStream(), $criteria, $options, $charset);
+
+        $ret = imap_search($this->getStream(), $criteria, $options, $emailCharset);
+
         if (!$ret) {
             $this->log('IMAP search error');
         }

--- a/include/Imap/ImapHandlerFactory.php
+++ b/include/Imap/ImapHandlerFactory.php
@@ -182,8 +182,10 @@ class ImapHandlerFactory
     {
         if (null === $this->interfaceObject) {
             global $sugar_config;
+
             $test = (isset($sugar_config['imap_test']) && $sugar_config['imap_test']) || $testSettings;
-            
+            $charset = (isset($sugar_config['default_email_charset'])) ? $sugar_config['default_email_charset'] : null;
+
             if (inDeveloperMode()) {
                 $logErrors = true;
                 $logCalls = true;
@@ -191,12 +193,12 @@ class ImapHandlerFactory
                 $logErrors = true;
                 $logCalls = false;
             }
-            
+
             $interfaceClass = ImapHandler::class;
             if ($test) {
                 $this->loadTestSettings($testSettings);
             } else {
-                $this->setInterfaceObject(new $interfaceClass($logErrors, $logCalls));
+                $this->setInterfaceObject(new $interfaceClass($logErrors, $logCalls, $charset));
             }
         }
         return $this->interfaceObject;

--- a/include/SugarFolders/SugarFolders.php
+++ b/include/SugarFolders/SugarFolders.php
@@ -649,11 +649,11 @@ class SugarFolder
     /**
      * Convenience method, pass a SugarBean
      *
-     * @param $bean
+     * @param SugarBean $bean
      *
      * @return boolean
      */
-    public function addBean($bean)
+    public function addBean(SugarBean $bean)
     {
         if (empty($bean->id) || empty($bean->module_dir)) {
             $GLOBALS['log']->fatal("*** FOLDERS: addBean() got empty bean - not saving");

--- a/include/SugarFolders/SugarFolders.php
+++ b/include/SugarFolders/SugarFolders.php
@@ -649,11 +649,11 @@ class SugarFolder
     /**
      * Convenience method, pass a SugarBean
      *
-     * @param SugarBean $bean
+     * @param $bean
      *
      * @return boolean
      */
-    public function addBean(SugarBean $bean)
+    public function addBean($bean)
     {
         if (empty($bean->id) || empty($bean->module_dir)) {
             $GLOBALS['log']->fatal("*** FOLDERS: addBean() got empty bean - not saving");

--- a/modules/Emails/include/ListView/ListViewSmartyEmails.php
+++ b/modules/Emails/include/ListView/ListViewSmartyEmails.php
@@ -102,7 +102,6 @@ class ListViewSmartyEmails extends ListViewSmarty
             }
         }
 
-
         $this->seed = $seed;
 
         $filter_fields = $this->setupFilterFields($filter_fields);

--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -5662,7 +5662,6 @@ class InboundEmail extends SugarBean
             SE_UID
         );
 
-
         foreach ($emailSortedHeaders as $uid) {
             $response[] = $this->returnImportedEmail(null, $uid);
         }

--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -6808,7 +6808,7 @@ class InboundEmail extends SugarBean
                         $importStatus = $this->returnImportedEmail($msgNo, $uid);
                         // add to folder
                         if ($importStatus) {
-                            $sugarFolder->addBean($this->email);
+                            $sugarFolder->addBean($this);
                             if (!$copy && isset($_REQUEST['delete']) && ($_REQUEST['delete'] == "true") && $importStatus) {
                                 $GLOBALS['log']->error("********* delete from mailserver [ {explode(", ", $uids)} ]");
                                 // delete from mailserver

--- a/modules/Schedulers/_AddJobsHere.php
+++ b/modules/Schedulers/_AddJobsHere.php
@@ -170,7 +170,7 @@ function pollMonitoredInboxes()
                         if ($isGroupFolderExists) {
                             if ($ieX->returnImportedEmail($msgNo, $uid)) {
                                 // add to folder
-                                $sugarFolder->addBean($ieX->email);
+                                $sugarFolder->addBean($ieX);
                                 if ($ieX->isPop3Protocol()) {
                                     $messagesToDelete[] = $msgNo;
                                 } else {
@@ -623,7 +623,7 @@ function pollMonitoredInboxesAOP()
                             if (!empty($emailId)) {
                                 // add to folder
 
-                                $sugarFolder->addBean($aopInboundEmailX->email);
+                                $sugarFolder->addBean($aopInboundEmailX);
                                 if ($aopInboundEmailX->isPop3Protocol()) {
                                     $messagesToDelete[] = $msgNo;
                                 } else {

--- a/modules/Schedulers/_AddJobsHere.php
+++ b/modules/Schedulers/_AddJobsHere.php
@@ -549,29 +549,38 @@ function pollMonitoredInboxesAOP()
 
     require_once('modules/Configurator/Configurator.php');
     $aopInboundEmail = new AOPInboundEmail();
+
     $sqlQueryResult = $aopInboundEmail->db->query(
-        'SELECT id, name FROM inbound_email WHERE is_personal = 0 AND deleted=0 AND status=\'Active\''.
+        'SELECT id, name FROM inbound_email WHERE is_personal = 0 AND deleted=0 AND status=\'Active\'' .
         ' AND mailbox_type != \'bounce\''
     );
+
     $GLOBALS['log']->debug('Just got Result from get all Inbounds of Inbound Emails');
 
     while ($inboundEmailRow = $aopInboundEmail->db->fetchByAssoc($sqlQueryResult)) {
+
         $GLOBALS['log']->debug('In while loop of Inbound Emails');
+
         $aopInboundEmailX = new AOPInboundEmail();
+
         if (!$aopInboundEmailX->retrieve($inboundEmailRow['id']) || !$aopInboundEmailX->id) {
             throw new Exception('Error retrieving AOP Inbound Email: ' . $inboundEmailRow['id']);
         }
+
         $mailboxes = $aopInboundEmailX->mailboxarray;
+
         foreach ($mailboxes as $mbox) {
             $aopInboundEmailX->mailbox = $mbox;
             $newMsgs = array();
             $msgNoToUIDL = array();
             $connectToMailServer = false;
+
             if ($aopInboundEmailX->isPop3Protocol()) {
                 $msgNoToUIDL = $aopInboundEmailX->getPop3NewMessagesToDownloadForCron();
                 // get all the keys which are msgnos;
                 $newMsgs = array_keys($msgNoToUIDL);
             }
+
             if ($aopInboundEmailX->connectMailserver() == 'true') {
                 $connectToMailServer = true;
             } // if
@@ -579,9 +588,11 @@ function pollMonitoredInboxesAOP()
             $GLOBALS['log']->debug('Trying to connect to mailserver for [ ' . $inboundEmailRow['name'] . ' ]');
             if ($connectToMailServer) {
                 $GLOBALS['log']->debug('Connected to mailserver');
+
                 if (!$aopInboundEmailX->isPop3Protocol()) {
                     $newMsgs = $aopInboundEmailX->getNewMessageIds();
                 }
+
                 if (is_array($newMsgs)) {
                     $current = 1;
                     $total = count($newMsgs);
@@ -608,8 +619,10 @@ function pollMonitoredInboxesAOP()
                         } // else
                         if ($isGroupFolderExists) {
                             $emailId = $aopInboundEmailX->returnImportedEmail($msgNo, $uid, false, true, $isGroupFolderExists);
-                            if ($emailId) {
+
+                            if (!empty($emailId)) {
                                 // add to folder
+
                                 $sugarFolder->addBean($aopInboundEmailX->email);
                                 if ($aopInboundEmailX->isPop3Protocol()) {
                                     $messagesToDelete[] = $msgNo;
@@ -662,7 +675,8 @@ function pollMonitoredInboxesAOP()
                     } // foreach
                     // update Inbound Account with last robin
                 } // if
-                if ($isGroupFolderExists) {
+
+                if (!empty($isGroupFolderExists)) {
                     $leaveMessagesOnMailServer = $aopInboundEmailX->get_stored_options("leaveMessagesOnMailServer", 0);
                     if (!$leaveMessagesOnMailServer) {
                         if ($aopInboundEmailX->isPop3Protocol()) {


### PR DESCRIPTION
This PR will fix the importing of email issue.

## Description
This PR was created to fix the importing issue - #6440 Emails imported automatically won't allow to change the user assigned to.

## Motivation and Context
To fix the issue (see Description)

## How To Test This
1. Set up inbound email account with import emails automatically set
2. Email the inbound email account
3. Check the email address has imported correctly
4. Check that you can assign the email to a user


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.