### PR TITLE
Fix #4361 Use Parameter $imageJSONEncode if returning sprites, too

### DIFF
--- a/include/SugarTheme/SugarTheme.php
+++ b/include/SugarTheme/SugarTheme.php
@@ -751,7 +751,7 @@ EOHTML;
 
                      if($sprite = $this->getSprite($sp['class'], $other_attributes, $alt))
                      {
-                         return $sprite;
+                         return $imageJSONEncode ? json_encode($sprite) : $sprite;
                      }
 				}
 			}


### PR DESCRIPTION
Fix https://github.com/salesagility/SuiteCRM/issues/4361
Parameter $imageJSONEncode should also be used if returning sprites.