### PR TITLE
Fix #4361 Use Parameter $imageJSONEncode if returning sprites

### DIFF
--- a/include/SugarTheme/SugarTheme.php
+++ b/include/SugarTheme/SugarTheme.php
@@ -767,7 +767,7 @@ EOHTML;
                     $other_attributes .= ' data-orig="'.$imageName.'"';
 
                     if ($sprite = $this->getSprite($sp['class'], $other_attributes, $alt)) {
-                        return $sprite;
+                        return $imageJSONEncode ? json_encode($sprite) : $sprite;
                     }
                 }
             }


### PR DESCRIPTION
Fix https://github.com/salesagility/SuiteCRM/issues/4361
Parameter $imageJSONEncode should also be used if returning sprites.