### PR TITLE
unit tests: force enable E_ALL in bootstrap

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -42,6 +42,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 /* bootstrap sugarcrm */
 //echo "CWD:" . getcwd() . "\n";
+error_reporting(E_ALL);
 chdir('../');
 define('sugarEntry', true);
 global $sugar_config, $db;


### PR DESCRIPTION
## Description

This makes sure that users running the test suite locally have the same error
reporting level that is used on travis-ci. For example the default error
level on Debian is "E_ALL & ~E_DEPRECATED & ~E_STRICT" and not E_ALL.

## Motivation and Context

I was confused why travis-ci failed for #6503 while it worked locally.

## How To Test This

Run the unit tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.