### PR TITLE
Fixed #3598 - WebToPersonCapture: Fix assignment of multi select values

### DIFF
--- a/modules/Campaigns/WebToPersonCapture.php
+++ b/modules/Campaigns/WebToPersonCapture.php
@@ -140,6 +140,9 @@ if (isset($_POST['campaign_id']) && !empty($_POST['campaign_id'])) {
                 } else {
                     if (array_key_exists($k, $person) || array_key_exists($k, $person->field_defs)) {
                         if (in_array($k, $possiblePersonCaptureFields)) {
+                            if (is_array($v)) {
+                                $v = encodeMultienumValue($v);
+                            }
                             $person->$k = $v;
                         } else {
                             LoggerManager::getLogger()->warn('Trying to set a non-valid field via WebToPerson Form: ' . $k);

--- a/tests/unit/phpunit/include/UtilsTest.php
+++ b/tests/unit/phpunit/include/UtilsTest.php
@@ -80,4 +80,17 @@ class UtilsTest extends StateCheckerPHPUnitTestCaseAbstract
         // clean up
         unset($app_strings['TEST_NONEXISTS_LABEL']);
     }
+
+    public function testencodeMultienumValue()
+    {
+        $this->assertEquals('', encodeMultienumValue(array()));
+        $this->assertEquals('^foo^', encodeMultienumValue(array('foo')));
+        $this->assertEquals('^foo^,^bar^', encodeMultienumValue(array('foo', 'bar')));
+    }
+
+    public function testunencodeMultienumValue()
+    {
+        $this->assertEquals(array('foo'), unencodeMultienum('^foo^'));
+        $this->assertEquals(array('foo', 'bar'), unencodeMultienum('^foo^,^bar^'));
+    }
 }


### PR DESCRIPTION
## Description

In case the the web form contains a multi select field the resulting value is
passed as an array. This was assigned as is to the newly created record and
probably thrown out at some later point because it wasn't a string.

To fix this use encodeMultienumValue() to convert the value list to the
expected internal format and assign that instead.

I've also noticed that encodeMultienumValue() doesn't have any tests, so I've
added some in a separate commit.

## Motivation and Context

I have a form which uses multi select fields and want them to end up in the
created lead record.

I suspect that this fixes #3598

## How To Test This

* Add a new multi select field to Leads
* Create a "Web to Person" form including the multi select
* Fill out the form and submit
* The selected values should show up in the CRM

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.