### PR TITLE
AOR Reports: Add a security groups subpanel

### DIFF
--- a/modules/AOR_Reports/metadata/subpaneldefs.php
+++ b/modules/AOR_Reports/metadata/subpaneldefs.php
@@ -26,5 +26,17 @@ $layout_defs['AOR_Reports'] = array(
                         ),
                 ),
         ),
+        'securitygroups' => array(
+            'top_buttons' => array(array('widget_class' => 'SubPanelTopSelectButton', 'popup_module' => 'SecurityGroups', 'mode' => 'MultiSelect'),),
+            'order' => 900,
+            'sort_by' => 'name',
+            'sort_order' => 'asc',
+            'module' => 'SecurityGroups',
+            'refresh_page' => 1,
+            'subpanel_name' => 'default',
+            'get_subpanel_data' => 'SecurityGroups',
+            'add_subpanel_data' => 'securitygroup_id',
+            'title_key' => 'LBL_SECURITYGROUPS_SUBPANEL_TITLE',
+        ),
     ),
 );


### PR DESCRIPTION
## Description

Adds a security groups subpanel at the bottom of a reports detail view.
Otherwise there is no way to change security groups for reports.

## Motivation and Context

When I create new records I'd like to assign them to the security groups that
are going to use them.

## How To Test This

* View a report
* See the security groups subpanel at the bottom of the page

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.