### PR TITLE
Add email account name to inbox button

### DIFF
--- a/modules/Emails/include/ListView/ListViewHeader.js
+++ b/modules/Emails/include/ListView/ListViewHeader.js
@@ -126,22 +126,25 @@ $(document).ready(function () {
     cache: false,
     url: 'index.php?module=Emails&action=GetFolders'
   }).done(function (data) {
+    var query = JSON.parse($('[name=current_query_by_page]').val());
+    var jQueryBtnEmailsCurrentFolder = $('.btn-emails-current-folder');
     var response = JSON.parse(data);
 
-    response = response.response;
+    responses = response.response;
 
-    jQueryBtnEmailsCurrentFolder.text(response[0].text);
+
+    if(typeof query.folder === 'undefined' ||  query.folder === '') {
+      jQueryBtnEmailsCurrentFolder.remove();
+    } else if(query.folder === null) {
+      jQueryBtnEmailsCurrentFolder.html('<span class="glyphicon glyphicon-alert"></span>');
+    }
+
+    for (let i = 0; i < (responses.length); i++) {
+
+      if (responses[i].id === query.folders_id) {
+        jQueryBtnEmailsCurrentFolder.text(responses[(i)].text);
+      }
+    }
   });
-
-  var query = JSON.parse($('[name=current_query_by_page]').val());
-  var jQueryBtnEmailsCurrentFolder = $('.btn-emails-current-folder');
-
-  if(typeof query.folder === 'undefined' ||  query.folder === '') {
-    jQueryBtnEmailsCurrentFolder.remove();
-  } else if(query.folder === null) {
-    jQueryBtnEmailsCurrentFolder.html('<span class="glyphicon glyphicon-alert"></span>');
-  } else {
-    jQueryBtnEmailsCurrentFolder.text(query.folder);
-  }
 
 });

--- a/modules/Emails/include/ListView/ListViewHeader.js
+++ b/modules/Emails/include/ListView/ListViewHeader.js
@@ -121,6 +121,18 @@ SUGAR.Emails.handleSelectedListViewItems =  function(
 
 $(document).ready(function () {
 
+  $.ajax({
+    type: "GET",
+    cache: false,
+    url: 'index.php?module=Emails&action=GetFolders'
+  }).done(function (data) {
+    var response = JSON.parse(data);
+
+    response = response.response;
+
+    jQueryBtnEmailsCurrentFolder.text(response[0].text);
+  });
+
   var query = JSON.parse($('[name=current_query_by_page]').val());
   var jQueryBtnEmailsCurrentFolder = $('.btn-emails-current-folder');
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Small UI change to display the email account name on the folder button in order to make it easier to tell which account you are using.

![gmail](https://user-images.githubusercontent.com/26431166/50781724-ff114c80-129d-11e9-9cb8-0374d72c53f8.png)


## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Setup personal email in user profile.
2. View the email module list-view and check the button accurately displays the account name.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->