### PR TITLE
Fix the style of the navigation bar's search field

### DIFF
--- a/themes/SuiteP/css/Dawn/variables.scss
+++ b/themes/SuiteP/css/Dawn/variables.scss
@@ -22,6 +22,8 @@ $warning: $color-47;
 $selection-color: $color-80;
 $selection-bg: $color-50;
 
+$nav-selection-color: $color-7;
+$nav-selection-bg: $color-80;
 
 //
 $page-content-spacing: 20px;

--- a/themes/SuiteP/css/suitep-base/navbar.scss
+++ b/themes/SuiteP/css/suitep-base/navbar.scss
@@ -19,6 +19,15 @@
 
 //Style
 
+.searchform .query_string::selection { /* Safari */
+  background-color: $nav-selection-bg !important;
+  color: $nav-selection-color !important;
+}
+
+.searchform .query_string::-moz-selection { /* Firefox */
+  background-color: $nav-selection-bg !important;
+  color: $nav-selection-color !important;
+}
 
 .navbar-left {
   float: left!important;


### PR DESCRIPTION
Fix: navbar search field's ::selection color and background-color.

## Description

This PR will change the navigation bar's search field ::selection colour and background colour.

## Motivation and Context

To make the theme consistent.

## How To Test This

From:
![screenshot-localhost-9002-2019 01 08-15-45-04](https://user-images.githubusercontent.com/542894/50841376-80c7af80-135c-11e9-93c8-f40d9283176b.png)

To:
![screenshot-localhost-9002-2019 01 08-15-38-27](https://user-images.githubusercontent.com/542894/50841396-8a511780-135c-11e9-8626-82f0bee6cad7.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.