### PR TITLE
Also set opt-in send/fail dates when sending emails through the action menu

### DIFF
--- a/modules/Campaigns/WebToPersonCapture.php
+++ b/modules/Campaigns/WebToPersonCapture.php
@@ -240,13 +240,9 @@ if (isset($_POST['campaign_id']) && !empty($_POST['campaign_id'])) {
                         $configurator = new Configurator();
                         if ($configurator->isConfirmOptInEnabled()) {
                             $emailman = new EmailMan();
-                            $now = TimeDate::getInstance()->nowDb();
-                            
+
                             if (!$emailman->sendOptInEmail($sea, $person->module_name, $person->id)) {
                                 $errors[] = 'Confirm Opt In email sending failed, please check email address is correct: ' . $sea->email_address;
-                                $sea->confirm_opt_in_fail_date = $now;
-                            } else {
-                                $sea->confirm_opt_in_sent_date = $now;
                             }
                         }
                         if ($configurator->isOptInEnabled()) {

--- a/modules/EmailMan/EmailMan.php
+++ b/modules/EmailMan/EmailMan.php
@@ -1477,18 +1477,22 @@ class EmailMan extends SugarBean
 
         $mailer->replace('sugarurl', $sugar_config['site_url']);
 
+        $timedate = TimeDate::getInstance();
         if (!$mailer->send()) {
+            $emailAddress->confirm_opt_in_fail_date = $timedate->nowDb();
             $ret = false;
             $log->fatal(
                 'Confirm Opt In Email sending failed. Mailer Error Info: '
                 . $mailer->ErrorInfo
             );
         } else {
+            $emailAddress->confirm_opt_in_sent_date = $timedate->nowDb();
             $log->debug(
                 'Confirm Opt In Email sent: '
                 . $emailAddress->email_address
             );
         }
+        $emailAddress->save();
 
         return $ret;
     }


### PR DESCRIPTION
## Description

In case one uses "Send Confirm Opt In Email" in the "Actions" menu of a contact/lead etc
then action_sendConfirmOptInEmail() gets called which in turn calls EmailMan::sendOptInEmail().
This leads to the email being sent without any send/fail dates being recorded.

To fix this set the dates in EmailMan::sendOptInEmail() instead of leaving it to the caller.

Also remove the date set code from WebToPersonCapture because that's no longer needed now that
sendOptInEmail() handles it.

## Motivation and Context

I have some logic which depends on the opt-in dates and while it works when adding a record through the web form it doesn't work when I manually add a contact and send an opt-in email through the actions menu.

## How To Test This

* Create a record
* In the Actions menu send an opt-in email
* Look in the "email_addresses" table of the database and check that the opt-in dates are set

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.