### PR TITLE
Fix emails losing confirmed opt-in when converting a lead to a contact

### DIFF
--- a/include/SugarEmailAddress/SugarEmailAddress.php
+++ b/include/SugarEmailAddress/SugarEmailAddress.php
@@ -1268,7 +1268,15 @@ class SugarEmailAddress extends SugarBean
             $isValidEmailAddress
             && (int)$optInFlag === 1
         ) {
-            $new_confirmed_opt_in = self::COI_STAT_OPT_IN;
+            // In case optInFlag is set and there is a duplicate,
+            // copy the opt-in state from it if it has some kind of opt-in set.
+            // This prevents losing the confirmed opt-in state in case we
+            // update an existing record with "confirmed-opt-in"
+            if (!empty($duplicate_email['id']) && $duplicate_email['confirm_opt_in'] != self::COI_STAT_DISABLED) {
+                $new_confirmed_opt_in = $duplicate_email['confirm_opt_in'];
+            } else {
+                $new_confirmed_opt_in = self::COI_STAT_OPT_IN;
+            }
         } else {
             // Reset the opt in status
             $new_confirmed_opt_in = self::COI_STAT_DISABLED;


### PR DESCRIPTION
## Description

When confirmed opt-in is enabled then converting a lead with a confirmed email
address to a contact makes the address lose its confirmation.

AddUpdateEmailAddress only gets a flag if opt-in is set or not, and when trying to update
the existing email record it replaces the COI_STAT_CONFIRMED_OPT_IN state with just
COI_STAT_OPT_IN because of that.

To fix this, in case the passed opt-in flag is 1 and the existing record has some kind
of opt-in state (!COI_STAT_DISABLED) we use that existing state to update the record instead
of forcing COI_STAT_OPT_IN.

In case of a lead conversion where nothing is changed this result in no DB update being
performed on the address.

## Motivation and Context

I'd prefer if converting a lead wouldn't change the opt-in status of the
linked email address.

## How To Test This

* Create a lead, set email and opt-in flag
* Send a confirmation email and wait until confirmed
* Convert the lead to a contact

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
