### PR TITLE
Fixed #6037 - Reports: Fix adding relations from the first tree node

### DIFF
--- a/modules/AOR_Reports/AOR_Report_Before.js
+++ b/modules/AOR_Reports/AOR_Report_Before.js
@@ -172,7 +172,9 @@ $(document).ready(function(){
           if(relData[field]['type'] == 'relationship') {
             modulePath = field;
             if (node) {
-              modulePath = node.module_path + ":" + field;
+              if (node.module_path) {
+                modulePath = node.module_path + ":" + field;
+              }
               modulePathDisplay = node.module_path_display + " : "+relData[field]['module_label'];
             }else{
               modulePathDisplay = $('#report_module option:selected').text() + ' : ' + relData[field]['module_label'];


### PR DESCRIPTION
## Description

The main report module is added to the module tree as well, but with an empty
module_path. When selecting related modules the module paths get concatenated
with the root module which is empty in this case and results in a wrong module
path being stored in the report.

This patch works around the issue by checking for an empty module_path before adding
the next module to the path.

Note that this wont fix existing reports that are broken because of this because
the wrong path is saved in the database and persists.

There is really no difference in the children of the first module and the other
toplevel nodes, so ideally the main module wouldn't have any child nodes in the first
place, but this would require more work and can be changed another time.

## Motivation and Context

It's currently easy to create reports which just show empty results without any
feedback because of wrong module paths which result in broken SQL.

Should fix #6037

## How To Test This

* Create a report
* Select Leads
* Select the first tree module node ("Leads")
* Add first name, last name to the report
* Select the "Email Address" sub-node of the "Leads" node
* Add "Email Address" to the report
* Save

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.