### PR TITLE
#6615 - Fixed issue with parent_field query generation

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -1595,6 +1595,10 @@ class SugarBean
                                 " FROM " . $templates[$child_info['parent_type']]->table_name .
                                 " WHERE id IN ('$childInfoParentId'";
                         }
+                    } else {
+                        if (empty($parent_child_map[$child_info['parent_id']])) {
+                            $queries[$child_info['parent_type']] .= " ,'{$child_info['parent_id']}'";
+                        }
                     }
 
                     if (isset($child_info['parent_id'])) {


### PR DESCRIPTION
## Description
At some point, this `else` statement was removed from the retrieve_parent_fields loop for query generation,  meaning that only the first result was ever returned.

Adding it back in fixed the issue with the workflow audit log only showing 1 link and name for audit records in the workflow subpanel.