### PR TITLE
Fixed #6484 - Fix image insertion with mozaik

### DIFF
--- a/modules/Emails/javascript/Email.js
+++ b/modules/Emails/javascript/Email.js
@@ -213,22 +213,18 @@ function multiFiles( list_target){
             element.onchange = function() {
                 var url = 'index.php?to_pdf=1&module=EmailTemplates&action=AttachFiles',
                     new_element;
-
-                // allow attachments with TinyMCE or Direct HTML;
-                if (typeof mozaik == 'undefined') {
-                    var mozaik={};
-                }
+                var isMozaik = typeof mozaik !== 'undefined';
 
                 //AJAX call begins
                 YAHOO.util.Connect.setForm(document.getElementById("upload_form"), true, true);
                 YAHOO.util.Connect.asyncRequest('POST', url, {upload: function(e) {
-					if(mozaik.uploadPathField) {
+					if(isMozaik && mozaik.uploadPathField) {
 						var resp = JSON.parse(e.responseText);
 						document.getElementById(mozaik.uploadPathField).value = resp[0];
 					}
 				}}, null);
                 //AJAX call ends
-				if(!mozaik.uploadPathField) {
+				if(!isMozaik || !mozaik.uploadPathField) {
 					// New file input
 					new_element = document.createElement('input');
 					new_element.type = 'file';


### PR DESCRIPTION
## Description

In #6329 mozaik was set to a dummy object to make it work when not using
the mozaik editor. But the added variable declaration shadows the global
variable breaking the case where mozaik is actually used, setting it to
undefined.

This breaks inserting images into emails, the file gets uploaded but the
URL field stays empty.

Fix this by explicitly checking if we are using mozaik instead of using
a dummy object.

## Motivation and Context

Fixes #6484 which is a regression introduced by #6329

## How To Test This

* Use mozaik
* Insert > Insert/edit image
* Select a file and upload
* The "Source" field should contain a path to the added image file

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
