### PR TITLE
Fixed #321 Hitting enter in the password input saves the user but not the password

### DIFF
--- a/modules/Users/views/view.edit.php
+++ b/modules/Users/views/view.edit.php
@@ -227,6 +227,22 @@ class UsersViewEdit extends ViewEdit
 EOD
         ;
         $action_button_header[] = <<<EOD
+                    <script>
+                       $('#EditView').submit(function(){
+                                            var theForm =$('#EditView');
+                                           if (!set_password(theForm[0],newrules('{$minpwdlength}','{$maxpwdlength}','{$REGEX}'))){
+                                             return false;
+                                           }
+                                           if (!Admin_check()){
+                                                return false;
+                                            }
+                                             $('#EditView input[name=action]').val('save');
+                                            return true;
+                        });
+                     </script>
+EOD
+        ;
+        $action_button_header[] = <<<EOD
                     <input	title="{$APP['LBL_CANCEL_BUTTON_TITLE']}" id="CANCEL_HEADER" accessKey="{$APP['LBL_CANCEL_BUTTON_KEY']}"
                               class="button" onclick="var _form = $('#EditView')[0]; _form.action.value='{$RETURN_ACTION}'; _form.module.value='{$RETURN_MODULE}'; _form.record.value='{$RETURN_ID}'; _form.submit()"
                               type="button" name="button" value="{$APP['LBL_CANCEL_BUTTON_LABEL']}">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixes an issue where hitting the enter button wouldn't save a user and instead re-directs you to the users list-view.

Issue reference: #321 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Admin -> user management -> new user.
2. Fill out the username, last name, email and password fields.
3. Hit enter.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->