### PR TITLE
Don't delete the composer.lock when running tests on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,6 @@ before_script:
   - phpenv config-add travis.php.ini
   - sudo service apache2 restart
   # Install composer
-  - rm composer.lock
   - composer install
   - ./vendor/bin/codecept build
 


### PR DESCRIPTION
## Description
Fixes #6759, removing the `composer.lock` has the side-effect of making tests less consistent. This PR changes the `.travis.yml` to make sure the lockfile isn't deleted.

## Motivation and Context
We should always be testing on the same base of dependencies. As long as the commit is the same, we should always have the same dependencies whether it's 2019 or 2029. Deleting the lockfile lets composer essentially install whatever it wants.

## How To Test This
Make sure Travis continues to pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines