### PR TITLE
EmailTemplates: Use html2text library for generating the text only body

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "symfony/options-resolver": "^3.4",
     "symfony/validator": "^3.4",
     "ezyang/htmlpurifier": "^4.10",
-    "leafo/scssphp": "^0.7.7"
+    "leafo/scssphp": "^0.7.7",
+    "soundasleep/html2text": "~0.5"
   },
   "require-dev": {
     "mikey179/vfsStream": "1.6.*",

--- a/composer.lock
+++ b/composer.lock
@@ -1049,6 +1049,56 @@
             "time": "2018-09-16T10:54:21+00:00"
         },
         {
+            "name": "soundasleep/html2text",
+            "version": "0.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/soundasleep/html2text.git",
+                "reference": "cdb89f6ffa2c4cc78f8ed9ea6ee0594a9133ccad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/soundasleep/html2text/zipball/cdb89f6ffa2c4cc78f8ed9ea6ee0594a9133ccad",
+                "reference": "cdb89f6ffa2c4cc78f8ed9ea6ee0594a9133ccad",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4.0",
+                "soundasleep/component-tests": "dev-master"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Html2Text\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "EPL-1.0"
+            ],
+            "authors": [
+                {
+                    "name": "Jevon Wright",
+                    "homepage": "https://jevon.org",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A PHP script to convert HTML into a plain text format",
+            "homepage": "https://github.com/soundasleep/html2text",
+            "keywords": [
+                "email",
+                "html",
+                "php",
+                "text"
+            ],
+            "time": "2017-04-19T22:01:50+00:00"
+        },
+        {
             "name": "symfony/options-resolver",
             "version": "v3.4.20",
             "source": {

--- a/modules/EmailTemplates/EmailTemplate.php
+++ b/modules/EmailTemplates/EmailTemplate.php
@@ -307,15 +307,16 @@ class EmailTemplate extends SugarBean
         if (empty($this->body) && !empty($this->body_html)) {
             global $sugar_config;
 
-            $bodyCleanup = html_entity_decode($this->body_html, ENT_COMPAT, $sugar_config['default_charset']);
+            $bodyCleanup = $this->body_html;
+
+            $bodyCleanup = html_entity_decode($bodyCleanup, ENT_COMPAT, $sugar_config['default_charset']);
 
             // Template contents should contains at least one
             // white space character at after the variable names
             // to recognise it when parsing and replacing variables
+            $bodyCleanup = preg_replace('/(\$\w+\b)([^\s\/&"\'])/', '$1 $2', $bodyCleanup);
 
-            $bodyCleanup = preg_replace('/(\$\w+\b)([^\s])/', '$1 $2', $bodyCleanup);
-
-            $bodyCleanup = strip_tags($bodyCleanup);
+            $bodyCleanup = Html2Text\Html2Text::convert($bodyCleanup, true);
 
             $this->body = $bodyCleanup;
         }

--- a/tests/unit/phpunit/modules/EmailTemplates/EmailTemplateTest.php
+++ b/tests/unit/phpunit/modules/EmailTemplates/EmailTemplateTest.php
@@ -128,6 +128,45 @@ class EmailTemplateTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $this->assertEquals('some html text', $emailTemplate->body);
     }
 
+    public function testfill_in_additional_detail_fields_body_to_text()
+    {
+        // simple examples
+        $emailTemplate = new EmailTemplate();
+        $emailTemplate->body_html = htmlentities('<h1>Hello</h1><br><a href="https://suitecrm.com">text</b>');
+        $emailTemplate->fill_in_additional_detail_fields();
+        $this->assertEquals("Hello\n\n[text](https://suitecrm.com)", $emailTemplate->body);
+
+        // entities and tags
+        $emailTemplate = new EmailTemplate();
+        $emailTemplate->body_html = htmlentities('&#60;a&#62;<b>');
+        $emailTemplate->fill_in_additional_detail_fields();
+        $this->assertEquals("<a>", $emailTemplate->body);
+
+        // invalid html
+        $emailTemplate = new EmailTemplate();
+        $emailTemplate->body_html = htmlentities('foo<bar');
+        $emailTemplate->fill_in_additional_detail_fields();
+        $this->assertEquals("foo", $emailTemplate->body);
+
+        // variables
+        $emailTemplate = new EmailTemplate();
+        $emailTemplate->body_html = htmlentities('Hello <b>$foo</b>bar');
+        $emailTemplate->fill_in_additional_detail_fields();
+        $this->assertEquals('Hello $foo bar', $emailTemplate->body);
+
+        // variables in URLs (opt-in confirmation emails etc)
+        $emailTemplate = new EmailTemplate();
+        $emailTemplate->body_html = htmlentities('<a href="$url/index.php?foo=$bar&quux=$baz">text</a>');
+        $emailTemplate->fill_in_additional_detail_fields();
+        $this->assertEquals('[text]($url/index.php?foo=$bar&quux=$baz)', $emailTemplate->body);
+
+        // decoding latin-1 html
+        $emailTemplate = new EmailTemplate();
+        $emailTemplate->body_html = htmlentities('<meta charset="ISO-8859-1">' . "\xe4", ENT_QUOTES, "ISO-8859-1");
+        $emailTemplate->fill_in_additional_detail_fields();
+        $this->assertEquals("\xc3\xa4", $emailTemplate->body);
+    }
+
     public function testfill_in_additional_parent_fields()
     {
         $state = new SuiteCRM\StateSaver();


### PR DESCRIPTION
## Description

When creating an email template with the editor and saving then SuiteCRM
will generate a text version automatically by stripping away tags and decoding
html entities (it also gets regenerated if the text field is cleared before saving)

This currently has the downside that many features of the email are lost,
like basic structure through headings/lists and, more importantly, links.

This patch adds the soundasleep/html2text library and uses it instead to generate the
initial text version. It also adjusts the regex for separating variables from surrounding
text to be less strict to allow using variables in HTML links (see the tests)

This for example makes the generated text from the included opt-in confirmation email usable
without having to manually fix it.

Also adds a few tests for common edge cases.

## Motivation and Context

I'd like the auto converted email body to be good enough so that you normally
can just use it as is.

## How To Test This

* Create an email template with HTML
* Save
* Look the the template preview and click "Show Plain Text"
* The text version should somewhat resemble the HTML version

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.