### PR TITLE
Reports: fix "Illegal string offset 'record_id'" errors

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -233,7 +233,7 @@ class AOR_Report extends Basic
             $fields[$label]['total'] = $field->total;
 
 
-            $fields[$label]['params'] = $field->format;
+            $fields[$label]['format'] = $field->format;
 
             // get the main group
 
@@ -258,7 +258,7 @@ class AOR_Report extends Basic
             foreach ($fields as $name => $att) {
                 $currency_id = isset($row[$att['alias'] . '_currency_id']) ? $row[$att['alias'] . '_currency_id'] : '';
 
-                if ($att['function'] != 'COUNT' && empty($att['params']) && !is_numeric($row[$name])) {
+                if ($att['function'] != 'COUNT' && empty($att['format']) && !is_numeric($row[$name])) {
                     $row[$name] = trim(strip_tags(getModuleField(
                         $att['module'],
                         $att['field'],
@@ -706,7 +706,7 @@ class AOR_Report extends Basic
             $fields[$label]['link'] = $field->link;
             $fields[$label]['total'] = $field->total;
 
-            $fields[$label]['params'] = $field->format;
+            $fields[$label]['format'] = $field->format;
 
 
             if ($fields[$label]['display']) {
@@ -816,10 +816,10 @@ class AOR_Report extends Basic
 
                     $currency_id = isset($row[$att['alias'] . '_currency_id']) ? $row[$att['alias'] . '_currency_id'] : '';
 
-                    if ($att['function'] == 'COUNT' || !empty($att['params'])) {
+                    if ($att['function'] == 'COUNT' || !empty($att['format'])) {
                         $html .= $row[$name];
                     } else {
-                        $att['params']['record_id'] = $row[$att['alias'] . '_id'];
+                        $params = array('record_id' => $row[$att['alias'] . '_id']);
                         $html .= getModuleField(
                             $att['module'],
                             $att['field'],
@@ -828,7 +828,7 @@ class AOR_Report extends Basic
                             $row[$name],
                             '',
                             $currency_id,
-                            $att['params']
+                            $params
                         );
                     }
 
@@ -1094,7 +1094,7 @@ class AOR_Report extends Basic
             $fields[$label]['function'] = $field->field_function;
             $fields[$label]['module'] = $field_module;
             $fields[$label]['alias'] = $field_alias;
-            $fields[$label]['params'] = $field->format;
+            $fields[$label]['format'] = $field->format;
 
             if ($field->display) {
                 $csv .= $this->encloseForCSV($field->label);
@@ -1116,7 +1116,7 @@ class AOR_Report extends Basic
             foreach ($fields as $name => $att) {
                 $currency_id = isset($row[$att['alias'] . '_currency_id']) ? $row[$att['alias'] . '_currency_id'] : '';
                 if ($att['display']) {
-                    if ($att['function'] != '' || $att['params'] != '') {
+                    if ($att['function'] != '' || $att['format'] != '') {
                         $csv .= $this->encloseForCSV($row[$name]);
                     } else {
                         $csv .= $this->encloseForCSV(trim(strip_tags(getModuleField(


### PR DESCRIPTION
## Description

The 'params' value was changed from an array to a string in 6bdf937e9a07cd55e8
but not all usages fixed. This results in the "$att['params']['record_id']" assignment failing
and in lots of "Illegal string offset 'record_id'" errors when viewing a simple report.

This patch renames the 'params' key to 'format', because it's used only for the field format string
at this point, and creates a new $params array for passing the record_id to getModuleField().
From what I see the field format is checked everywhere because the reports module implements
its own date formatting and avoids calling into getModuleField() when a field has its own
a date format set.

This gets rid of the "Illegal string offset" errors and results in the correct record_id getting
passed to getModuleField().

## Motivation and Context

Viewing a simple report resulted in lots of PHP errors in the logs (one per report line)

Some reports about the errors in the forum:
* https://suitecrm.com/suitecrm/forum/suitecrm-7-0-discussion/20869-how-to-solve-warning-illegal-string-offset
* https://suitecrm.com/suitecrm/forum/installation-upgrade-hilfe/21022-creating-a-report-error-message-illegal-string-offset-record-id-in-aor-report-php-on-line-822

## How To Test This

* Create a report for "Leads"
* Add a field for "First Name", change nothing
* Save and view the record
* Check the PHP logs

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.