### PR TITLE
Fixed #6786 -  Edit item list replace spaces with html entity "%20"

### DIFF
--- a/modules/ModuleBuilder/javascript/SimpleList.js
+++ b/modules/ModuleBuilder/javascript/SimpleList.js
@@ -287,13 +287,15 @@ if(typeof(SimpleList) == 'undefined'){
         if(record){
             SimpleList.jstransaction.record('changeDropDownValue', {'id':id, 'new':val, 'old':document.getElementById('value_'+ id).value});
         }
-        var dispSpan = document.getElementById('span_'+id);
-        var editSpan = document.getElementById('span_edit_'+id);
-        var textbox = document.getElementById('input_'+id);
+        let dispSpan = document.getElementById('span_'+id);
+        let editSpan = document.getElementById('span_edit_'+id);
+        // let textbox = document.getElementById('input_'+id);
 
-        var value = escape(val);
+        let value = encodeURI(val);
+
         dispSpan.style.display = 'inline';
         editSpan.style.display = 'none';
+        value = decodeURI(value);
         dispSpan.innerHTML = "["+value+"]";
         document.getElementById('value_'+ id).value = value;
         SimpleList.lastEdit = null; // Bug 14662 - clear the last edit point behind us

--- a/modules/ModuleBuilder/javascript/SimpleList.js
+++ b/modules/ModuleBuilder/javascript/SimpleList.js
@@ -290,9 +290,7 @@ if(typeof(SimpleList) == 'undefined'){
         let dispSpan = document.getElementById('span_'+id);
         let editSpan = document.getElementById('span_edit_'+id);
         
-
         let value = encodeURI(val);
-
         dispSpan.style.display = 'inline';
         editSpan.style.display = 'none';
         value = decodeURI(value);

--- a/modules/ModuleBuilder/javascript/SimpleList.js
+++ b/modules/ModuleBuilder/javascript/SimpleList.js
@@ -289,7 +289,7 @@ if(typeof(SimpleList) == 'undefined'){
         }
         let dispSpan = document.getElementById('span_'+id);
         let editSpan = document.getElementById('span_edit_'+id);
-        // let textbox = document.getElementById('input_'+id);
+        
 
         let value = encodeURI(val);
 


### PR DESCRIPTION
Fixed #6786 

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This fixes the issue of when adding a space in the drop-down editor it changes to "&20"
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to Admin
2. Go to Dropdown Editor
3. Select a drop down and edit it
4. Put a space in the name
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->