### PR TITLE
Fixed #6810 - Campaign page failure/imapfactory

### DIFF
--- a/modules/Campaigns/WizardEmailSetup.php
+++ b/modules/Campaigns/WizardEmailSetup.php
@@ -1,14 +1,11 @@
 <?php
-if (!defined('sugarEntry') || !sugarEntry) {
-    die('Not A Valid Entry Point');
-}
 /**
  *
  * SugarCRM Community Edition is a customer relationship management program developed by
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
  *
  * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
- * Copyright (C) 2011 - 2018 SalesAgility Ltd.
+ * Copyright (C) 2011 - 2019 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the
@@ -41,22 +38,13 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
-/*********************************************************************************
-
- * Description:  TODO: To be written.
- * Portions created by SugarCRM are Copyright (C) SugarCRM, Inc.
- * All Rights Reserved.
- * Contributor(s): ______________________________________..
- ********************************************************************************/
-
-/*************** general UI Stuff ****************/
-
-
-
-
+if (!defined('sugarEntry') || !sugarEntry) {
+       die('Not A Valid Entry Point');
+}
 
 global $mod_strings,$app_list_strings,$app_strings,$current_user;
 
+require_once __DIR__ . "/../../include/Imap/ImapHandlerFactory.php";
 
 if (!is_admin($current_user)&& !is_admin_for_module($GLOBALS['current_user'], 'Campaigns')) {
     sugar_die("Unauthorized access to administration.");
@@ -178,6 +166,8 @@ $mboxTable .= "</table>";
 $ss->assign("MAILBOXES_DETECTED_MESSAGE", $mboxTable);
 $ss->assign("MBOX_NEEDED", $need_mbox);
 $ss->assign('ROLLOVER', $email->rolloverStyle);
+
+
 
 $imapFactory = new ImapHandlerFactory();
 $imap = $imapFactory->getImapHandler();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed the issue where a user could not set up emails in the campaign module.

## Description
<!--- Describe your changes in detail -->
Added in a requier_once function to pull in ImapHanderFactory.php file.

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference - #6810

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to the Campaigns module.
2. Click 'set up emails'.
3. The page should appear as normal.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->