### PR TITLE
unittests: Fixes for PHP 7.3

### DIFF
--- a/ModuleInstall/ModuleScanner.php
+++ b/ModuleInstall/ModuleScanner.php
@@ -622,7 +622,7 @@ class ModuleScanner
             } else {
                 $token['_msi'] = token_name($token[0]);
                 switch ($token[0]) {
-                    case T_WHITESPACE: continue;
+                    case T_WHITESPACE: break;
                     case T_EVAL:
                         if (in_array('eval', $this->blackList) && !in_array('eval', $this->blackListExempt)) {
                             $issues[]= translate('ML_INVALID_FUNCTION') . ' eval()';

--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -2532,7 +2532,7 @@ class SugarBean
                     case 'currency':
                     case 'float':
                         if ($this->$field === '' || $this->$field == null || $this->$field == 'NULL') {
-                            continue;
+                            break;
                         }
                         if (is_string($this->$field)) {
                             $this->$field = (float)unformat_number($this->$field);
@@ -2546,7 +2546,7 @@ class SugarBean
                     case 'tinyint':
                     case 'int':
                         if ($this->$field === '' || $this->$field == null || $this->$field == 'NULL') {
-                            continue;
+                            break;
                         }
                         if (is_string($this->$field)) {
                             $this->$field = (int)unformat_number($this->$field);

--- a/include/utils/file_utils.php
+++ b/include/utils/file_utils.php
@@ -471,7 +471,7 @@ CIA;
 */
 function cleanFileName($name)
 {
-    return preg_replace('/[^\w-._]+/i', '', $name);
+    return preg_replace('/[^\w\-._]+/i', '', $name);
 }
 
 /**

--- a/modules/AOW_WorkFlow/aow_utils.php
+++ b/modules/AOW_WorkFlow/aow_utils.php
@@ -975,7 +975,7 @@ function fixUpFormatting($module, $field, $value)
         case 'currency':
         case 'float':
             if ($value === '' || $value == null || $value == 'NULL') {
-                continue;
+                break;
             }
             if (is_string($value)) {
                 $value = (float)unformat_number($value);
@@ -988,7 +988,7 @@ function fixUpFormatting($module, $field, $value)
         case 'tinyint':
         case 'int':
             if ($value === '' || $value == null || $value == 'NULL') {
-                continue;
+                break;
             }
             if (is_string($value)) {
                 $value = (int)unformat_number($value);


### PR DESCRIPTION
## Description

This fixes two types or new errors/warnings in PHP 7.3:

(1) PHP Warning:  "continue" targeting switch is equivalent to "break".
    Did you mean to use "continue 2"?

In all cases the continue was used as a break anyway, so just replace it
with the less confusing break statement.

(2) preg_replace(): Compilation failed: invalid range in character class at offset 4

Fix by properly escaping the "-" in the regex range.

This makes the unit tests pass with PHP 7.3 (the codeception tests still fail)

## Motivation and Context

Debian has php 7.3 now and this allows me to run the tests there.

## How To Test This

Run the unit tests with php 7.3

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.