### PR TITLE
Fixed #6468 - Wrong WHERE composition upon NULL precondition in Company

### DIFF
--- a/include/SugarObjects/templates/company/Company.php
+++ b/include/SugarObjects/templates/company/Company.php
@@ -192,7 +192,7 @@ class Company extends Basic
 
         $where_auto = " $table.deleted=0 ";
 
-        if ($where !== '') {
+        if (!empty($where)) {
             $query .= "WHERE ($where) AND " . $where_auto;
         } else {
             $query .= 'WHERE ' . $where_auto;

--- a/include/SugarObjects/templates/person/Person.php
+++ b/include/SugarObjects/templates/person/Person.php
@@ -335,7 +335,7 @@ class Person extends Basic
 
         $where_auto = " $table.deleted=0 ";
 
-        if ($where != '') {
+        if (!empty($where)) {
             $query .= "WHERE ($where) AND " . $where_auto;
         } else {
             $query .= 'WHERE ' . $where_auto;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
In some cases a NULL precondition is passed the WHERE results in WHERE (), which is invalid SQL and crashes the export.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #6468 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create a new module using the company and person template.
2. Create some records.
3. Export these records from the list-view.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->