### PR TITLE
WIP: Fix regression breaking Accounts detail view

### DIFF
--- a/include/DetailView/DetailView.tpl
+++ b/include/DetailView/DetailView.tpl
@@ -120,17 +120,20 @@ class="yui-navset detailview_tabs"
 		{{assign var='columnsInRow' value=$rowData|@count}}
 		{{assign var='columnsUsed' value=0}}
 		{{foreach name=colIteration from=$rowData key=col item=colData}}
-		{{assign var='totalColumnos' value=$smarty.foreach.colIteration.total}}
+		{{assign var='totalColumns' value=$smarty.foreach.colIteration.total}}
 	    {{if !empty($colData.field.hideIf)}}
 	    	{if !({{$colData.field.hideIf}}) }
 	    {{/if}}
 			{counter name="fieldsUsed"}
 			{{if empty($colData.field.hideLabel)}}
-            {{if $totalColumnos == 1}}
-			    <td width='3.75%' totalCol="{{$totalColumnos}}" scope="col">
+            {{if $totalColumns == 1}}
+			    <td width='3.75%' totalCol="{{$totalColumns}}" scope="col">
             {{else}}
-			    <td width='12.5%' totalCol="{{$totalColumnos}}" scope="col">
+			    <td width='12.5%' totalCol="{{$totalColumns}}" scope="col">
             {{/if}}
+	    	        {{if !empty($colData.field.name)}}
+			    {if !$fields.{{$colData.field.name}}.hidden}
+			{{/if}}
 				{{if isset($colData.field.customLabel)}}
 			       {{$colData.field.customLabel}}
 				{{elseif isset($colData.field.label) && strpos($colData.field.label, '$')}}


### PR DESCRIPTION
From commit 
https://github.com/salesagility/SuiteCRM/commit/223c407d9ce6622c11693a450b40493d47004ee2

This commit removes three lines from the `.tpl`. These lines set up a `{if}` that matches a similar block a few lines below. So when it's missing there will be a mismatch of opening and closing `ifs`.

This comes from a [thread in the Forums](https://suitecrm.com/suitecrm/forum/suitecrm-7-0-discussion/21596-smarty-error-after-upgrade-7-8-20-7-8-25) and the user has confirmed the fix works.

The bug affects versions 7.8.25, theme SuiteR. It was introduced somewhere after 7.8.20, not sure exactly which.

Produced template files:
```
******************************************************
DetailView.tpl - Suitecrm 7.8.25 - NOT WORKING!
******************************************************
<td width='12.5%' totalCol="2" scope="col">
{capture name="label" assign="label"}{sugar_translate label='LBL_NAME' module='Accounts'}{/capture}
{$label|strip_semicolon}:
{/if}
</td>


++++++++++++++++++++++++++++++++++++
DetailView.tpl - Suitecrm 7.8.20 - WORKING !
++++++++++++++++++++++++++++++++++++
<td width='12.5%' scope="col">
{if !$fields.name.hidden}
{capture name="label" assign="label"}{sugar_translate label='LBL_NAME' module='Accounts'}{/capture}
{$label|strip_semicolon}:
{/if}
</td>
```

## How To Test This
Go to the Account Detail view, you get a blank screen, and messages in the logs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
