### PR TITLE
Reports: Hide inaccessible modules in the reports editor

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -71,7 +71,6 @@ class AOR_Report extends Basic
     public function __construct()
     {
         parent::__construct();
-        $this->load_report_beans();
         require_once('modules/AOW_WorkFlow/aow_utils.php');
         require_once('modules/AOR_Reports/aor_utils.php');
     }
@@ -145,6 +144,11 @@ class AOR_Report extends Basic
         return $result;
     }
 
+    public function fill_in_additional_detail_fields()
+    {
+        parent::fill_in_additional_detail_fields();
+        $this->load_report_beans();
+    }
 
     public function load_report_beans()
     {
@@ -154,6 +158,9 @@ class AOR_Report extends Basic
 
         foreach ($app_list_strings['aor_moduleList'] as $mkey => $mvalue) {
             if (!isset($beanList[$mkey]) || str_begin($mkey, 'AOR_') || str_begin($mkey, 'AOW_')) {
+                unset($app_list_strings['aor_moduleList'][$mkey]);
+            }
+            if (!ACLController::checkAccess($mkey, 'list', true)) {
                 unset($app_list_strings['aor_moduleList'][$mkey]);
             }
         }

--- a/modules/AOW_WorkFlow/aow_utils.php
+++ b/modules/AOW_WorkFlow/aow_utils.php
@@ -182,7 +182,7 @@ function getModuleTreeData($module)
                         'module_label'=> $module_label)
     );
 
-    if ($module != '') {
+    if ($module != '' && ACLController::checkAccess($module, 'list', true)) {
         if (isset($beanList[$module]) && $beanList[$module]) {
             $mod = new $beanList[$module]();
 
@@ -191,6 +191,10 @@ function getModuleTreeData($module)
                     $rel_module = $arr['module'];
                 } elseif ($mod->load_relationship($name)) {
                     $rel_module = $mod->$name->getRelatedModuleName();
+                }
+
+                if (!ACLController::checkAccess($rel_module, 'list', true)) {
+                    continue;
                 }
 
                 $rel_module_label = isset($app_list_strings['moduleList'][$rel_module]) ? $app_list_strings['moduleList'][$rel_module] : $rel_module;


### PR DESCRIPTION
## Description

The reports module already hides all fields (in the field list in the bottom left corner)
for modules not accessible to the user but still shows them in the "Module tree" and the
"Report Module" dropdown.

This leads to the users seeing lots of modules and potential relations which are not
usable in the end. To make this clearer also hide inaccessible modules in the module tree
and the module dropdown.

The call to load_report_beans() is moved to fill_in_additional_detail_fields() because
calling into ACLController in the constructor results in an infinite recursion as it
instantiates a AOR_Report itself.

### Before/After

![report-filter](https://user-images.githubusercontent.com/991986/51988141-460cef00-24a4-11e9-94e4-72398d91810e.png)

## Motivation and Context

* Users should not see modules they don't have access to.
* Might be a good enough solution for #5497

## How To Test This

* Log in as a user that only has access to some modules
* Create a report
* Only the modules available for the user should be visible

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.