### PR TITLE
WIP: Fixed #6869 - Users: fix saving user records resetting user preferences

### DIFF
--- a/modules/Users/User.php
+++ b/modules/Users/User.php
@@ -675,7 +675,9 @@ class User extends Person implements EmailInterface
             }
         }
 
-        $this->saveFormPreferences();
+        if (isset($_POST['module']) && $_POST['module'] == 'Users' && isset($_POST['action']) && $_POST['action'] == 'Save') {
+            $this->saveFormPreferences();
+        }
 
         $this->savePreferencesToDB();
 


### PR DESCRIPTION
## Description

In #6404 the code to apply the user edit view form to the preferences
was moved into User::save() unconditionally. This results in the preferences
being reset in case save() is called in a different context than the form.

For example when inline editing a user in the user list view the preferences
for that user get set as if there was an empty edit form.

Fix this by only applying the form updates in case we are in the context of
saving in the edit view page.

## Motivation and Context

#6869

## How To Test This

* Go to "Admin" -> "User Management"
* Edit a user and set "Show Full Names:" to true.
* Go back to the list view and inline edit any of the user fields in the list
* The "Show Full Names" value should still be true after that

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.