### PR TITLE
Fixed #6452 - Api/V8 create record does not support unicode and space in attributes

### DIFF
--- a/Api/V8/Param/Options/Attributes.php
+++ b/Api/V8/Param/Options/Attributes.php
@@ -21,10 +21,6 @@ class Attributes extends BaseOption
             ->setAllowedTypes('attributes', 'array')
             ->setAllowedValues('attributes', $this->validatorFactory->createClosureForIterator([
                 new Assert\NotBlank(),
-                new Assert\Regex([
-                    'pattern' => Fields::REGEX_FIELD_PATTERN,
-                    'match' => false,
-                ]),
             ]))
             ->setNormalizer('attributes', function (Options $options, $values) {
                 $bean = $this->beanManager->newBeanSafe($options->offsetGet('type'));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Duplicate of #6861 for hotfix-7.10.x to fix issue #6452. This also fixes #6893.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. 
```
POST SuiteCRM/Api/V8/module
BODY {
  "data": {
    "type": "Accounts",
    "attributes": {
      "name": "Cocacola company",
      "description": "very friendly account"
    }
  }
}
```

2. Try to pass in non-valid attributes like decimals and integers to ensure that this validation is not necessary due to database sanitization.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->