### PR TITLE
*WIP Fixed #2310 - recaptcha not working with https

### DIFF
--- a/modules/Administration/PasswordManager.php
+++ b/modules/Administration/PasswordManager.php
@@ -78,7 +78,8 @@ $configurator->parseLoggerSettings();
 $valid_public_key = true;
 if (!empty($_POST['saveConfig'])) {
     if ($_POST['captcha_on'] == '1') {
-        $handle = @fopen("http://www.google.com/recaptcha/api/challenge?k=" . $_POST['captcha_public_key'] . "&cachestop=35235354", "r");
+        if ((isset($_SERVER['HTTPS']) && 'on' === $_SERVER['HTTPS']) || (isset($_SERVER['SERVER_PORT']) && 443 === $_SERVER['SERVER_PORT']) ) { $protocol = 'https'; } else { $protocol = 'http'; }
+        $handle = @fopen("$protocol://www.google.com/recaptcha/api/challenge?k=".$_POST['captcha_public_key']."&cachestop=35235354", "r");
         $buffer = '';
         if ($handle) {
             while (!feof($handle)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Recaptcha links are hard coded to http causing firefox to block mixed display of recaptcha when having suitecrm under https.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #2310

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Admin -> password manager -> recaptcha
2. Public key: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
3. Private key: 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
4. Logout and test the recaptcha functionality when resetting password.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->