### PR TITLE
avoid error for a member function access on null values after upload packages

### DIFF
--- a/modules/Administration/UpgradeHistory.php
+++ b/modules/Administration/UpgradeHistory.php
@@ -202,10 +202,10 @@ class UpgradeHistory extends SugarBean
 
             //we will only resort to checking the files if we cannot find the unique_keys
             //or the unique_keys do not match
-            $patch_to_check_backup_path    = clean_path(remove_file_extension(from_html($patch_to_check->filename))).'-restore';
-            $more_recent_patch_backup_path = clean_path(remove_file_extension(from_html($more_recent_patch->filename))).'-restore';
-            $patch_to_check_timestamp = TimeDate::getInstance()->fromUser($patch_to_check->date_entered)->getTimestamp();
-            $more_resent_patch_timestamp = TimeDate::getInstance()->fromUser($more_recent_patch->date_entered)->getTimestamp();
+            $patch_to_check_backup_path = clean_path(remove_file_extension(from_html($patch_to_check->filename))) . '-restore';
+            $more_recent_patch_backup_path = clean_path(remove_file_extension(from_html($more_recent_patch->filename))) . '-restore';
+            $patch_to_check_timestamp = !empty($patch_to_check->date_entered) ? TimeDate::getInstance()->fromUser($patch_to_check->date_entered)->getTimestamp() : null;
+            $more_resent_patch_timestamp = !empty($more_recent_patch->date_entered) ? TimeDate::getInstance()->fromUser($more_recent_patch->date_entered)->getTimestamp() : null;
             if (
                 $this->foundConflict($patch_to_check_backup_path, $more_recent_patch_backup_path) &&
                 ($more_resent_patch_timestamp >= $patch_to_check_timestamp)


### PR DESCRIPTION
## Description

These code changes fix problem for #6930 

When they try to upload some packages, an access error to a member function on null objects can happen,  $patch_to_check and $more_recent_patch.

We need to check first if date values are not empty.

## Motivation and Context

These change can avoid error on access to a member function on null values after upload packages

## How To Test This

On upload and install packages from Administration page.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->