### PR TITLE
Fixed #5918 - Activity Stream elapsed time calculation

### DIFF
--- a/modules/SugarFeed/SugarFeed.php
+++ b/modules/SugarFeed/SugarFeed.php
@@ -495,41 +495,29 @@ class SugarFeed extends Basic {
 
     }
 
-	static function getTimeLapse($startDate)
+    /**
+     * @param $startDate
+     * @return string
+     */
+	public static function getTimeLapse($startDate)
 	{
-            
-            $timedate = null;
-            if (isset($GLOBALS['timedate'])) {
-                $timedate = $GLOBALS['timedate'];
-            } else {
-                LoggerManager::getLogger()->warn('Timedate is not set for SugarFeed time lapse');
-            }
-            
-            $now = null;
-            if ($timedate instanceof TimeDate) {
-                $now = $timedate->getNow();
-                $fromUser = $timedate->fromUser($startDate);
-            } else {
-                LoggerManager::getLogger()->warn('Timedate is not a Timedate. Imposible to get "now" for SugarFeed time laps');
-            }
-            
-            $tsLeft = null;
-            if (isset($now->ts)) {
-                $tsLeft = $now->ts;
-            } else {
-                LoggerManager::getLogger()->warn('No current timestamp info');
-            }
-            
-            $tsRight = null;
-            if (isset($fromUser->ts)) {
-                $tsRight = $fromUser->ts;
-            } else {
-                LoggerManager::getLogger()->warn('No fromUser timestamp info');
-            }
-            
-            
-		$seconds = $tsLeft - $tsRight;
-		$minutes =   $seconds/60;
+        global $timedate;
+
+        if ($timedate instanceof TimeDate) {
+            $nowTs = $timedate->getNow()->ts;
+        } else {
+            LoggerManager::getLogger()->warn('Timedate is not a Timedate. Impossible to get "now" for SugarFeed time laps');
+        }
+
+        if (null !== ($userStartDate = $timedate->fromUser($startDate))) {
+            $userStartDateTs = $userStartDate->ts;
+        } else {
+            LoggerManager::getLogger()->warn('Invalid $startDate');
+            return '';
+        }
+
+        $seconds = $nowTs - $userStartDateTs;
+        $minutes =   $seconds/60;
 		$seconds = $seconds % 60;
 		$hours = floor( $minutes / 60);
 		$minutes = $minutes % 60;

--- a/tests/tests/modules/SugarFeed/SugarFeedTest.php
+++ b/tests/tests/modules/SugarFeed/SugarFeedTest.php
@@ -214,7 +214,8 @@ class SugarFeedTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
     public function testgetTimeLapse()
     {
-        $result = SugarFeed::getTimeLapse('2016-01-15 11:16:02');
+        global $timedate;
+        $result = SugarFeed::getTimeLapse($timedate->asUser($timedate->fromDb('2016-01-15 11:16:02')));
         $this->assertTrue(isset($result));
         $this->assertGreaterThan(0, strlen($result));
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixes an issue with sugarfeed showing 0 seconds for all items.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #5918 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. View "My sugarfeed Dashlet" on homepage.
2. See that the date does not display "0 seconds"

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->