### PR TITLE
Fixed #6778 - Role Management - Header change doesn't update entire column

### DIFF
--- a/modules/ACLRoles/EditAllBody.tpl
+++ b/modules/ACLRoles/EditAllBody.tpl
@@ -92,7 +92,7 @@ Not ideal but it'll work since it's the only way to get that info without editin
 
 			<td align='center'>
 				<div align='center' id="{$ACTION_NAME}link" onclick="aclviewer.toggleDisplay('{$ACTION_NAME}')"><b>{$ACTION_LABEL}</b></div>
-				<div  style="display: none; text-align: center;" id="{$ACTION_NAME}">
+				<div  style="all: initial; display: none; text-align: center;" id="{$ACTION_NAME}">
 					<select name='act_guid{$ACTION_NAME}' id='act_guid{$ACTION_NAME}' onblur="cascadeAccessOption('{$ACTION_NAME}',this); aclviewer.toggleDisplay('{$ACTION_NAME}');" >
 					{html_options options=$ACTION.accessOptions selected=$ACTION.aclaccess }
 					</select>
@@ -147,7 +147,7 @@ Not ideal but it'll work since it's the only way to get that info without editin
 {*
 					<select name='act_guid{$ACTION.id}' id = 'act_guid{$ACTION.id}' onblur="document.getElementById('{$ACTION.id}link').innerHTML=this.options[this.selectedIndex].text; aclviewer.toggleDisplay('{$ACTION.id}');" >
 *}
-						<select name='act_guid{$ACTION.id}' id = 'act_guid{$ACTION.id}' onblur="document.getElementById('{$ACTION.id}link').innerHTML=this.options[this.selectedIndex].text; aclviewer.toggleDisplay('{$ACTION.id}');" >
+						<select class='{$ACTION_NAME}' style="all: initial" name='act_guid{$ACTION.id}' id = 'act_guid{$ACTION.id}' onblur="document.getElementById('{$ACTION.id}link').innerHTML=this.options[this.selectedIndex].text; aclviewer.toggleDisplay('{$ACTION.id}');" >
  					{* END - SECURITY GROUPS *}
 					{html_options options=$ACTION.accessOptions selected=$ACTION.aclaccess }
 					</select>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixed an issue where when changing the header of a column in Role Management, the entire column is not updated. This also fixes two other issues, one where the "Delete" column would have the css of a button and one where the css for the individual roles would vary depending on the column (E.g. "edit" doesn't fit in the box, "view" appears to be invisible.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #6778 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to roles -> Select value in header
2. Check that the style of each header is correct and updates all the items in the row.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->