### PR TITLE
Fixed issue with tab panel and quick create form

### DIFF
--- a/themes/SuiteP/include/DetailView/DetailView.tpl
+++ b/themes/SuiteP/include/DetailView/DetailView.tpl
@@ -329,7 +329,7 @@
                     var selectTabDetailView = function(tab) {
                         $('#content div.tab-content div.tab-pane-NOBOOTSTRAPTOGGLER').hide();
                         $('#content div.tab-content div.tab-pane-NOBOOTSTRAPTOGGLER').eq(tab).show().addClass('active').addClass('in');
-                        $('#content div.panel-content div.panel').hide();
+                        $('#content div.detail-view div.panel-content div.panel.panel').hide();
                         $('#content div.panel-content div.panel.tab-panel-' + tab).show();
                     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
If you change tabs on a module (say from OVERVIEW to MORE INFORMATION or OTHER) while you have a QuickCreate form open on the Activities subpanel, the form disappears but leaves behind 2 sets of SAVE/CANCEL/FULL FORM buttons.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Open Studio, module Account, Detail View
2. Under first tab, add panel. Add more tabs (if there are none).
3. Save and Deploy
4. Panel is shown under each tab.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->