### PR TITLE
Fix priorities when loading language files

### DIFF
--- a/include/SugarObjects/LanguageManager.php
+++ b/include/SugarObjects/LanguageManager.php
@@ -198,8 +198,8 @@ class LanguageManager
         $lang_paths = array(
                     'modules/'.$module.'/language/'.$lang.'.lang.php',
                     'modules/'.$module.'/language/'.$lang.'.lang.override.php',
-                    'custom/modules/'.$module.'/language/'.$lang.'.lang.php',
                     'custom/modules/'.$module.'/Ext/Language/'.$lang.'.lang.ext.php',
+                    'custom/modules/'.$module.'/language/'.$lang.'.lang.php',
                  );
 
         #27023, if this module template language file was not attached , get the template from this module vardef cache file if exsits and load the template language files.


### PR DESCRIPTION
Labels defined in the Extension framework (for example after exporting customizations from Studio and loading the module with Module Loader on another instance) can not be changed with Studio.

The change is properly saved in custom/modules/Calls/language/en_us.php
But it is overriden when LanguageManager loads custom/modules/Calls/Ext/Language/en_us.lang.ext.php which includes the original field label

Context : Any version of SuiteCRM.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change order of loaded language files
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
- Add a field to Calls with Studio
- Export customizations
- Load the generated module in another instance
- Go to Studio and change the label of that field.
- The change is not taken into account.
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Labels customization with Studio

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->