### PR TITLE
Fixed #2117 - Redundant More Button in SuiteP

### DIFF
--- a/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -408,19 +408,21 @@
                             </li>
                         {/if}
                     {/foreach}
-                    <li class="topnav overflow-toggle-menu">
-                        <span class="notCurrentTabLeft">&nbsp;</span>
-                        <span class="dropdown-toggle headerlinks notCurrentTab"><a href="#">{$APP.LBL_MORE}</a></span>
-                        <span class="notCurrentTabRight">&nbsp;</span>
-                        <ul id="overflow-menu" class="dropdown-menu" role="menu">
-                            <!--nav items without actions -->
-                            {foreach from=$modules.extra item=submodulename key=submodule}
-                                <li class="topnav without-actions">
-                                    <span class=" notCurrentTab"> <a href="{sugar_link module=$submodule link_only=1 extraparams=$extraparams}">{$submodulename}</a> </span>
-                                </li>
-                            {/foreach}
-                        </ul>
-                    </li>
+                    {if count($moduleExtraMenu) > 0}
+                        <li class="topnav overflow-toggle-menu">
+                            <span class="notCurrentTabLeft">&nbsp;</span>
+                            <span class="dropdown-toggle headerlinks notCurrentTab"><a href="#">{$APP.LBL_MORE}</a></span>
+                            <span class="notCurrentTabRight">&nbsp;</span>
+                            <ul id="overflow-menu" class="dropdown-menu" role="menu">
+                                <!--nav items without actions -->
+                                    {foreach from=$modules.extra item=submodulename key=submodule}
+                                        <li class="topnav without-actions">
+                                            <span class=" notCurrentTab"> <a href="{sugar_link module=$submodule link_only=1 extraparams=$extraparams}">{$submodulename}</a> </span>
+                                        </li>
+                                    {/foreach}
+                            </ul>
+                        </li>
+                    {/if}
                 </ul>
                 <div class="hidden hidden-actions"></div>
                 {* Hide nav items when the window size is too small to display them *}
@@ -455,10 +457,11 @@
                                 $navItems.last().prependTo('#overflow-menu');
                                 $navItems.splice(-1,1);
                             }
-
-                            navItemMoreLeft = $('.navbar-horizontal-fluid .overflow-toggle-menu').offset().left;
-                            navOverflowWidth = $('#overflow-menu').width();
-                            offset = navItemMoreLeft + navItemMoreWidth - navOverflowWidth;
+                            if(typeof $navItemMoreLeft !== "undefined") {
+                                navItemMoreLeft = $('.navbar-horizontal-fluid .overflow-toggle-menu').offset().left;
+                                navOverflowWidth = $('#overflow-menu').width();
+                                offset = navItemMoreLeft + navItemMoreWidth - navOverflowWidth;
+                            }
                         };
                         $(window).resize(windowResize);
                         windowResize();
@@ -725,10 +728,10 @@
     <div id='sidebar_container' class="container-fluid sidebar_container">
 
         <a id="buttontoggle" class="buttontoggle"><span></span></a>
-                
+
              <div {if $smarty.cookies.sidebartoggle == 'collapsed'}style="display:none"{/if}
              class="sidebar">
-                
+
                 <div id="actionMenuSidebar" class="actionMenuSidebar">
                     {foreach from=$moduleTopMenu item=module key=name name=moduleList}
                         {if $name == $MODULE_TAB}
@@ -755,7 +758,7 @@
                         {/if}
                     {/foreach}
                 </div>
-                
+
                 <div id="recentlyViewedSidebar" class="recentlyViewedSidebar">
                     {if is_array($recentRecords) && count($recentRecords) > 0}
                     <h2 class="recent_h3">{$APP.LBL_LAST_VIEWED}</h2>


### PR DESCRIPTION
## Description
Fixes #2117 - an issue where the more menu item within SuiteP is displayed regardless if the menu item has child elements or not.

## Motivation and Context
This change resolves the 'More' menu item from displaying regardless if the menu item has child elements or not.

## How To Test This

1. Login to SuiteCRM
2. Navigate to the user profile -> Advanced
3. Uncheck the 'Module Menu Filter' option
4. Observe the number of child list items in the 'More' item menu
5. Ensure that there is at least one child list item. If there is not, the 'More' menu item should not show

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->