### PR TITLE
API: Replace faulty string difference function

### DIFF
--- a/lib/API/JsonApi/v1/Filters/Parsers/FilterParser.php
+++ b/lib/API/JsonApi/v1/Filters/Parsers/FilterParser.php
@@ -335,9 +335,9 @@ class FilterParser
     }
 
     /**
-     * @param $string
-     * @param $operators
-     * @return mixed
+     * @param string $string
+     * @param string[] $operatorsArray
+     * @return string
      */
     private function removeOperators($string, $operatorsArray)
     {

--- a/lib/API/JsonApi/v1/Filters/Parsers/FilterParser.php
+++ b/lib/API/JsonApi/v1/Filters/Parsers/FilterParser.php
@@ -279,7 +279,7 @@ class FilterParser
                 }
 
                 $parsedValues = $operatorsArray;
-                $diff = $this->removeOperators($value, $operators);
+                $diff = $this->removeOperators($value, $operatorsArray);
                 if (empty($diff) === false) {
                     // add operands to the end or data structure
                     $parsedValues[] = $diff;
@@ -339,10 +339,9 @@ class FilterParser
      * @param $operators
      * @return mixed
      */
-    private function removeOperators($string, $operators)
+    private function removeOperators($string, $operatorsArray)
     {
-        $operatorArray = explode('*', str_replace(']][[', ']]*[[', $operators));
-        foreach ($operatorArray as $operator) {
+        foreach ($operatorsArray as $operator) {
             $string = str_replace($operator, '', $string);
         }
         return $string;

--- a/lib/API/JsonApi/v1/Filters/Parsers/FilterParser.php
+++ b/lib/API/JsonApi/v1/Filters/Parsers/FilterParser.php
@@ -279,7 +279,7 @@ class FilterParser
                 }
 
                 $parsedValues = $operatorsArray;
-                $diff = $this->stringDifference($value, $operators);
+                $diff = $this->removeOperators($value, $operators);
                 if (empty($diff) === false) {
                     // add operands to the end or data structure
                     $parsedValues[] = $diff;
@@ -335,16 +335,17 @@ class FilterParser
     }
 
     /**
-     * @param string $a
-     * @param string $b
-     * @return string
+     * @param $string
+     * @param $operators
+     * @return mixed
      */
-    private function stringDifference($a, $b)
+    private function removeOperators($string, $operators)
     {
-        $aArray = str_split($a);
-        $bArray = str_split($b);
-        $arrayDiff = array_diff($aArray, $bArray);
-        return implode('', $arrayDiff);
+        $operatorArray = explode('*', str_replace(']][[', ']]*[[', $operators));
+        foreach ($operatorArray as $operator) {
+            $string = str_replace($operator, '', $string);
+        }
+        return $string;
     }
 
     /**


### PR DESCRIPTION
Fixes a function that was removing too many characters from filtering strings, effectively breaking filtering by strings.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Related to Issue #6074

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Send an API request containing the same letters in the filters string as in the operator. Example: `filter[Contacts.name]=[[eq]]test`
2. Without this patch, `test` gets changed to `tst` because array_diff removes all letters found in the operand (e, q)
3. With this change the query correctly returns Contacts named `test`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->