### PR TITLE
Fix PDF templates from setting no value when 0.00 is entered

### DIFF
--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -102,7 +102,7 @@ class templateParser
 
         foreach ($repl_arr as $name => $value) {
             if (strpos($name, 'product_discount') !== false) {
-                if ($value != '' && is_string($value)) {
+                if ($value !== '' && is_string($value)) {
                     if (strtolower($repl_arr['aos_products_quotes_discount']) == 'percentage' || strtolower($repl_arr['aos_products_quotes_discount']) == 'pct' || strtolower($repl_arr['aos_products_quotes_discount']) == 'percent') {
                         $sep = get_number_seperators();
                         $value = rtrim(rtrim(format_number($value), '0'), $sep[1]) . $app_strings['LBL_PERCENTAGE_SYMBOL'];

--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -102,7 +102,7 @@ class templateParser
 
         foreach ($repl_arr as $name => $value) {
             if (strpos($name, 'product_discount') !== false) {
-                if ($value != '' && $value != '0.00') {
+                if ($value != '' && is_string($value)) {
                     if (strtolower($repl_arr['aos_products_quotes_discount']) == 'percentage' || strtolower($repl_arr['aos_products_quotes_discount']) == 'pct' || strtolower($repl_arr['aos_products_quotes_discount']) == 'percent') {
                         $sep = get_number_seperators();
                         $value = rtrim(rtrim(format_number($value), '0'), $sep[1]) . $app_strings['LBL_PERCENTAGE_SYMBOL'];

--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -102,7 +102,7 @@ class templateParser
 
         foreach ($repl_arr as $name => $value) {
             if (strpos($name, 'product_discount') !== false) {
-                if ($value !== '' && is_string($value)) {
+                if ($value !== '') {
                     if (strtolower($repl_arr['aos_products_quotes_discount']) == 'percentage' || strtolower($repl_arr['aos_products_quotes_discount']) == 'pct' || strtolower($repl_arr['aos_products_quotes_discount']) == 'percent') {
                         $sep = get_number_seperators();
                         $value = rtrim(rtrim(format_number($value), '0'), $sep[1]) . $app_strings['LBL_PERCENTAGE_SYMBOL'];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix PDF templates from setting no value when 0.00 is entered (for 7.8.x)
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to 'Product - Categories' and create a product category.
2. Then go to 'Products' and create a product.
3. Next, go to 'PDF - Templates' and create a template, make sure you put the variable in the body 
    ($aos_products_quotes_product_discount), and then save the template.
4. Then go to 'Quotes' and create a new quote.
5. Go to 'Line Items' and click 'Add group'. 
6. Add the product you just made and then change the 'Discount' price to "0.00" and save.
7. Once save, Click 'Print as PDF' and then open the PDF.
8. See that the value is now "0%" instead of  " ".

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->