### PR TITLE
Fix link to testing documentation. [ci-skip]

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -3,6 +3,6 @@ SuiteCRM Automated Testing Framework
 
 Automated testing provides a means to ensure that the quality of the product is kept to a high standard. By working with a consistent testing framework, it helps to ensure that each contributor continues to work in harmony, The concept is that everyone shares tests with the changes being made in the product. Generally speaking, The more code is covered by high quality automated tests, the more likely the quality of the product is good.
 
-To learn how to use the framework in your contributions, please check out the [SuiteCRM Automated Testing Framework Documentation](https://docs.suitecrm.com/developer/appendix-c---automated-testing/).
+To learn how to use the framework in your contributions, please check out the [SuiteCRM Automated Testing Framework Documentation](https://docs.suitecrm.com/developer/appendix-c-automated-testing/).
 
 


### PR DESCRIPTION
The documentation was linking to https://docs.suitecrm.com/developer/appendix-c---automated-testing when the actual URL is https://docs.suitecrm.com/developer/appendix-c-automated-testing