### PR TITLE
Fixed #6998 - cron.php fails because there is no check whether ElasticSearch is enabled

### DIFF
--- a/lib/Search/ElasticSearch/ElasticSearchHooks.php
+++ b/lib/Search/ElasticSearch/ElasticSearchHooks.php
@@ -73,7 +73,9 @@ class ElasticSearchHooks
     {
         $this->action = 'index';
 
-        $this->reIndexSafe($bean);
+        if (ElasticSearchIndexer::isEnabled() !== false) {
+            $this->reIndexSafe($bean);
+        }
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixes an issue where the callback for save beans in the ElasticSearchHooks would trigger regardless of whether elasticsearch was enabled.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #6998 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Disable elasticsearch.
2. Refresh the homepage and check the log, you should no longer see elasticsearch errors.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->