### PR TITLE
Fixed #6185 - Top menu mouse out does not close sub

### DIFF
--- a/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -275,8 +275,7 @@
                         {capture name=extraparams assign=extraparams}parentTab={$group}{/capture}
                         <li class="topnav {if $smarty.foreach.groupList.last}all{/if}">
                             <span class="notCurrentTabLeft">&nbsp;</span><span class="notCurrentTab">
-                            <a href="#" id="grouptab_{$smarty.foreach.groupList.index}" class="dropdown-toggle grouptab"
-                               data-toggle="dropdown">{$group}</a>
+                            <a href="#" id="grouptab_{$smarty.foreach.groupList.index}" class="dropdown-toggle grouptab">{$group}</a>
                             <span class="notCurrentTabRight">&nbsp;</span>
                             <ul class="dropdown-menu" role="menu" {if $smarty.foreach.groupList.last} class="All"{/if}>
                                 {foreach from=$modules.modules item=module key=modulekey}


### PR DESCRIPTION
## Description
Fixes #6185 - an issue where, if the group tabs menu type is set within the users' profile, the drop down toggle option results in the drop down sub menu remaining on the page if the user clicks a list item within the top navigation such as 'Sales'.

## Motivation and Context
This change resolves the drop down toggle option resulting in the drop down sub menu remaining on the page if the user clicks a list item within the top navigation such as 'Sales'.

## How To Test This

1. Login to SuiteCRM
2. Navigate to the user profile -> Layout Options
3. Ensure the 'Module Menu Filter' option is checked
4. Click on a list item within the top navigation menu such as 'Sales'
5. Hover over the top menu list items
6. Observe that the child drop down of the list item that was clicked, does not retract/remove when there is no focus on that element

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->