### PR TITLE
Increase minimum recommended memory to 64Mb (for 7.10.x)

### DIFF
--- a/install/ready.php
+++ b/install/ready.php
@@ -102,7 +102,7 @@ if (empty($memory_limit)) {
     $memory_limit = "-1";
 }
 if (!defined('SUGARCRM_MIN_MEM')) {
-    define('SUGARCRM_MIN_MEM', 40*1024*1024);
+    define('SUGARCRM_MIN_MEM', 64*1024*1024);
 }
 $sugarMinMem = constant('SUGARCRM_MIN_MEM');
 // logic based on: http://us2.php.net/manual/en/ini.core.php#ini.memory-limit


### PR DESCRIPTION
## Description

As discussed in chat with @Dillon-Brown and @willrennie

## Motivation and Context

It seems our current minimum of 40Mb was letting some people down:
suitecrm.com/suitecrm/forum/installation-upgrade-help/22026-after-suitecrm-7-11-2-fresh-install-get-database-failure

## How to test this
1. Make your `memory_limit` in `php.ini` be 64Mb
2. Restart web server and verify that this took effect
3. Install SuiteCRM, it should install correctly and without any message about memory limits

Then
1. Make your `memory_limit` in `php.ini` be 63Mb
2. Restart web server and verify that this took effect
3. Try to install SuiteCRM, it should install give a message about memory limits
