### PR TITLE
Fix random unittest error in SugarControllerTest

### DIFF
--- a/tests/unit/phpunit/include/MVC/Controller/SugarControllerTest.php
+++ b/tests/unit/phpunit/include/MVC/Controller/SugarControllerTest.php
@@ -170,6 +170,7 @@ class SugarControllerTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $state = new SuiteCRM\StateSaver();
         $state->pushTable('aod_index');
         $state->pushTable('tracker');
+        $state->pushTable('user_preferences');
         
         if (isset($_SESSION)) {
             $session = $_SESSION;
@@ -209,6 +210,7 @@ class SugarControllerTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $query = "UPDATE users SET date_modified = '$testUserDateModified' WHERE id = '$testUserId' LIMIT 1";
         DBManagerFactory::getInstance()->query($query);
         
+        $state->popTable('user_preferences');
         $state->popTable('tracker');
         $state->popTable('aod_index');
     }


### PR DESCRIPTION
## Description

testaction_save() changes the DB and depending on the test order this resulted
in other tests failing.

Save and restore the "user_preferences" table in testaction_save() to fix this.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.