### PR TITLE
Fix Content-Type header missing in some cases for the getImage entry point

### DIFF
--- a/include/SugarTheme/SugarTheme.php
+++ b/include/SugarTheme/SugarTheme.php
@@ -278,13 +278,29 @@ class SugarTheme
     private $_clearCacheOnDestroy = false;
 
     private $imageExtensions = array(
-            'svg',
-            'gif',
-            'png',
-            'jpg',
-            'tif',
-            'bmp',
+            'svg' => 'image/svg+xml',
+            'gif' => 'image/gif',
+            'png' => 'image/png',
+            'jpg' => 'image/jpeg',
+            'tif' => 'image/tiff',
+            'bmp' => 'image/bmp',
     );
+
+    /**
+     * Returns the mime type for the image extension in case it is supported.
+     * In case the extension isn't supported returns null.
+     *
+     * @param $extension The extension name, e.g. 'png'
+     * @return string|null
+     */
+    public function getMimeType($extension)
+    {
+        if (!isset($this->imageExtensions[$extension])) {
+            return null;
+        }
+
+        return $this->imageExtensions[$extension];
+    }
 
     /**
      * Constructor
@@ -964,7 +980,7 @@ EOHTML;
             return $imageName;
         }
         $pathParts = pathinfo($imageName);
-        foreach ($this->imageExtensions as $extension) {
+        foreach (array_keys($this->imageExtensions) as $extension) {
             if (isset($pathParts['extension'])) {
                 if (($extension != $pathParts['extension'])
                         && is_file($pathParts['dirname'].'/'.$pathParts['filename'].'.'.$extension)) {

--- a/include/SugarTheme/getImage.php
+++ b/include/SugarTheme/getImage.php
@@ -79,8 +79,8 @@ $filename_arr = explode('?', $filename);
 $filename = $filename_arr[0];
 $file_ext = substr($filename, -3);
 
-$extensions = SugarThemeRegistry::current()->imageExtensions;
-if (!in_array($file_ext, $extensions)) {
+$mime_type = SugarThemeRegistry::current()->getMimeType($file_ext);
+if (is_null($mime_type)) {
     header($_SERVER["SERVER_PROTOCOL"].' 404 Not Found');
     die;
 }
@@ -110,13 +110,7 @@ if (($ifmod || $iftag) && ($ifmod !== false && $iftag !== false)) {
 }
 
 header("Last-Modified: ".gmdate('D, d M Y H:i:s \G\M\T', $last_modified_time));
-
-// now send the content
-if (substr($filename, -3) == 'gif') {
-    header("Content-Type: image/gif");
-} elseif (substr($filename, -3) == 'png') {
-    header("Content-Type: image/png");
-}
+header('Content-Type: ' . $mime_type);
 
 if (!defined('TEMPLATE_URL')) {
     if (!file_exists($filename)) {

--- a/tests/unit/phpunit/include/SugarTheme/SugarThemeTest.php
+++ b/tests/unit/phpunit/include/SugarTheme/SugarThemeTest.php
@@ -1,0 +1,13 @@
+<?php
+
+class SugarThemeTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
+{
+    public function testGetMimeType()
+    {
+        $theme = SugarThemeRegistry::current();
+        $this->assertEquals($theme->getMimeType('svg'), 'image/svg+xml');
+        $this->assertEquals($theme->getMimeType('gif'), 'image/gif');
+        $this->assertEquals($theme->getMimeType('png'), 'image/png');
+        $this->assertEquals($theme->getMimeType('notanextension'), null);
+    }
+}


### PR DESCRIPTION
## Description

The getImage entry point only handled setting the correct mime type for
gif and png images. In case of svg images (for example the icon left of attachments in
the email template editor) the returned content type was text which made firefox
show an error and not display the image.

Fix this by adding mime types for all supported image extensions in SugarTheme
and using that in the getImage end point.

This also adds some basic tests for this new API.

## Motivation and Context

In the email template editor the attachments had broken images

## How To Test This

* Access `index.php?entryPoint=getImage&themeName=SuiteP&imageName=Accounts.svg`
* Check the returned content type

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
