### PR TITLE
EmailTemplates: Only show subpanels in the DetailView

### DIFF
--- a/modules/EmailTemplates/views/view.classic.php
+++ b/modules/EmailTemplates/views/view.classic.php
@@ -54,12 +54,17 @@ class EmailTemplatesViewClassic extends ViewClassic
 {
     public function __construct()
     {
+    }
 
+    public function display()
+    {
         /* BEGIN - SECURITY GROUPS - The whole file is custom but the purpose is the following code */
         //turn on normal display of subpanels
-        $this->options['show_subpanels'] = true;
+        if ($this->action == 'DetailView') {
+            $this->options['show_subpanels'] = true;
+        }
         /* END - SECURITY GROUPS */
-        parent::__construct();
+        return parent::display();
     }
 
     /**


### PR DESCRIPTION
## Description

The EmailTemplates modules force enables the subpanels (security groups)
for every view, but the security group sub panel only works in the DetailView
and is broken in others (adding/removing groups doesn't do anything)

To fix this only enable it in the DetailView, like is the case with other modules.

## Motivation and Context

Don't show buttons to users which are broken.

## How To Test This

1) Create an email template and save
2) Edit it
3) See the security groups subpanel with non-working actions or see no subpanels with this patch

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.