### PR TITLE
Fixed #5662 - EmailTemplate: Fix images URLs not being converted with mozaik

### DIFF
--- a/modules/EmailTemplates/EmailTemplate.php
+++ b/modules/EmailTemplates/EmailTemplate.php
@@ -904,7 +904,7 @@ class EmailTemplate extends SugarBean
     {
         global $sugar_config;
         $domain = $sugar_config['site_url'] . '/';
-        $ret = $this->body_html = preg_replace('/(&lt;img src=&quot;)(public\/[^.]*.(jpg|jpeg|png|gif|bmp))(&quot;)/', "$1" . $domain . "$2$4", $this->body_html);
+        $ret = $this->body_html = preg_replace('/(src=&quot;)(public\/[^.]*.(jpg|jpeg|png|gif|bmp))(&quot;)/', "$1" . $domain . "$2$4", $this->body_html);
         return $ret;
     }
 

--- a/tests/unit/phpunit/modules/EmailTemplates/EmailTemplateTest.php
+++ b/tests/unit/phpunit/modules/EmailTemplates/EmailTemplateTest.php
@@ -11,6 +11,21 @@ class EmailTemplateTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $current_user = new User();
     }
 
+    public function testaddDomainToRelativeImagesSrc()
+    {
+        global $sugar_config;
+
+        $template = new EmailTemplate();
+        $html = '<img style="font-family:Arial, Helvetica, sans-serif;font-size:14px;line-height:22.4px;color:#444444;padding:0px;margin:0px;" src="public/c1270a2d-a083-495e-7c61-5c8a9046ec0d.png" alt="c1270a2d-a083-495e-7c61-5c8a9046ec0d.png" width="267" height="200">';
+        $template->body_html = to_html($html);
+        $sugar_config['site_url'] = 'https://foobar.com';
+
+        $template->addDomainToRelativeImagesSrc();
+
+        $result = from_html($template->body_html);
+        $this->assertContains('src="https://foobar.com/public/c1270a2d-a083-495e-7c61-5c8a9046ec0d.png" alt="c1270a2d-a083-495e-7c61-5c8a9046ec0d.png"', $result);
+    }
+
     public function testEmailTemplate()
     {
 


### PR DESCRIPTION
## Description

addDomainToRelativeImagesSrc() is supposed to convert images elements of the form
"public/UUID.png" to absolute URLs including the site URL. The regex used here
didn't work because the mozaik editor includes a style attribute at the beginning resulting
in nothing getting replaced.

This makes the regex less strict to handle that case and adds some tests while at it.

## Motivation and Context

Fixes #5662

## How To Test This

* Create a email template
* Include an image
* Save
* In the preview check that the image URLs are not relative

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
