### PR TITLE
Give cookie a default value to stop from throwing notices

### DIFF
--- a/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -729,7 +729,7 @@
 
         <a id="buttontoggle" class="buttontoggle"><span></span></a>
 
-             <div {if $smarty.cookies.sidebartoggle == 'collapsed'}style="display:none"{/if}
+             <div {if $smarty.cookies.sidebartoggle|default:'' == 'collapsed'}style="display:none"{/if}
              class="sidebar">
 
                 <div id="actionMenuSidebar" class="actionMenuSidebar">

--- a/themes/SuiteP/tpls/header.tpl
+++ b/themes/SuiteP/tpls/header.tpl
@@ -62,7 +62,7 @@
 <!-- Start of page content -->
 {if $AUTHENTICATED}
 <div id="bootstrap-container"
-     class="{if $THEME_CONFIG.display_sidebar && $smarty.cookies.sidebartoggle != 'collapsed'}col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2{/if} main bootstrap-container">
+     class="{if $THEME_CONFIG.display_sidebar && $smarty.cookies.sidebartoggle|default:'' != 'collapsed'}col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2{/if} main bootstrap-container">
     <div id="content" class="content">
         <div id="pagecontent" class=".pagecontent">
 {/if}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Currently I'm seeing a lot of notices in my install when show traces is on due to the index not being set in `$_COOKIE['sidebar']`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I don't want to see warnings for unset indexes

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Turn on traces.
Make sure you haven't previously set this cookie (e.g. clear your cookies)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [X] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->