### PR TITLE
Fixed #3911 - LDAPAutheticate warnings in log

### DIFF
--- a/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php
+++ b/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php
@@ -122,10 +122,10 @@ class LDAPAuthenticateUser extends SugarAuthenticateUser
             //add the group user attribute that we will compare to the group attribute for membership validation if group membership is turned on
             if (!empty($GLOBALS['ldap_config']->settings['ldap_group'])
                 && !empty($GLOBALS['ldap_config']->settings['ldap_group_user_attr'])
-                && !empty($GLOBALS['ldap_config']->settings['ldap_group_attr'])) {
-                if (!in_array($attrs, $GLOBALS['ldap_config']->settings['ldap_group_user_attr'])) {
-                    $attrs[] = $GLOBALS['ldap_config']->settings['ldap_group_user_attr'];
-                }
+                && !empty($GLOBALS['ldap_config']->settings['ldap_group_attr'])
+                && !in_array($GLOBALS['ldap_config']->settings['ldap_group_user_attr'], $attrs, false)
+            ) {
+                $attrs[] = $GLOBALS['ldap_config']->settings['ldap_group_user_attr'];
             }
 
             $GLOBALS['log']->debug(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
```
PHP Warning: in_array() expects parameter 2 to be array, string given in /var/www/suitecrm/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php on line 124
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #3911

## How To Test This
<!--- Please describe in detail how to test your changes. -->
See http://php.net/manual/en/function.in-array.php

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->