### PR TITLE
[optimize] max(id) and joining with self will always return one row

### DIFF
--- a/modules/Trackers/Tracker.php
+++ b/modules/Trackers/Tracker.php
@@ -113,8 +113,8 @@ class Tracker extends SugarBean
 	           $module_query = is_array($modules) ? ' AND module_name IN (\'' . implode("','" , $modules) . '\')' :  ' AND module_name = \'' . $modules . '\'';
 	        }
 
-	        $query = 'SELECT item_id, item_summary, module_name, id FROM ' . $this->table_name . ' WHERE user_id = \'' . $user_id . '\' AND deleted = 0 AND visible = 1' . $module_query . ' ORDER BY id DESC LIMIT 1';
-	        $result = $this->db->query($query,true,$query);
+	        $query = 'SELECT item_id, item_summary, module_name, id FROM ' . $this->table_name . ' WHERE user_id = \'' . $user_id . '\' AND deleted = 0 AND visible = 1' . $module_query . ' ORDER BY id DESC ';
+	        $result = $this->db->limitQuery($query,0,1,true,$query);
 	        while(($row = $this->db->fetchByAssoc($result))) {
 	               $breadCrumb->push($row);
 	        }

--- a/modules/Trackers/Tracker.php
+++ b/modules/Trackers/Tracker.php
@@ -110,14 +110,11 @@ class Tracker extends SugarBean
 			$breadCrumb = $_SESSION['breadCrumbs'];
 	        $module_query = '';
 	        if(!empty($modules)) {
-	           $history_max_viewed = 10;
 	           $module_query = is_array($modules) ? ' AND module_name IN (\'' . implode("','" , $modules) . '\')' :  ' AND module_name = \'' . $modules . '\'';
-	        } else {
-	           $history_max_viewed = (!empty($GLOBALS['sugar_config']['history_max_viewed']))? $GLOBALS['sugar_config']['history_max_viewed'] : 50;
 	        }
 
-	        $query = 'SELECT item_id, item_summary, module_name, id FROM ' . $this->table_name . ' WHERE id = (SELECT MAX(id) as id FROM ' . $this->table_name . ' WHERE user_id = \'' . $user_id . '\' AND deleted = 0 AND visible = 1' . $module_query . ')';
-	        $result = $this->db->limitQuery($query,0,$history_max_viewed,true,$query);
+	        $query = 'SELECT item_id, item_summary, module_name, id FROM ' . $this->table_name . ' WHERE user_id = \'' . $user_id . '\' AND deleted = 0 AND visible = 1' . $module_query . ' ORDER BY id DESC LIMIT 1';
+	        $result = $this->db->query($query,true,$query);
 	        while(($row = $this->db->fetchByAssoc($result))) {
 	               $breadCrumb->push($row);
 	        }


### PR DESCRIPTION
"... WHERE id = (SELECT MAX(id) as id FROM ..."
MAX(id) will always be one row, so the query will be always one row. 
Rewriting the query without subquery is 10x faster for me.

It seems like in history it was used differently, but i can not see at all where this one row of the tracker is used. Maybe these code parts are totally useless, but still get called.