### PR TITLE
EmailTemplates: Fix undefined property error when creating a new template

### DIFF
--- a/modules/EmailTemplates/EditView.php
+++ b/modules/EmailTemplates/EditView.php
@@ -110,10 +110,7 @@ if (empty($focus->id)) {
 
 echo getClassicModuleTitle($focus->module_dir, $params, true);
 
-if (!$focus->ACLAccess('EditView')) {
-    ACLController::displayNoAccess(true);
-    sugar_cleanup(true);
-} elseif (!is_admin($current_user) && $focus->type === 'system') {
+if (!$focus->ACLAccess('EditView') || (!is_admin($current_user) && isset($focus->type) && $focus->type === 'system')) {
     ACLController::displayNoAccess(true);
     sugar_cleanup(true);
 }


### PR DESCRIPTION
## Description

When a non-admin user creates a new template the "type" property isn't set resulting
in a PHP error.

Add a check to to prevent that and merge the two identical branches while at it.

## How To Test This

1) Log in as a non-admin user
2) Go to Email Templates
3) Try creating a new template
4) Check PHP logs

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->