### PR TITLE
StateChecker: Don't save hash debug traces (unused, slow and memory intensive)

### DIFF
--- a/include/StateChecker.php
+++ b/include/StateChecker.php
@@ -112,24 +112,9 @@ class StateChecker
             throw new StateCheckerException('Incompatible DB type, only supported: mysqli');
         }
         $this->resetHashes();
-        
-        if (StateCheckerConfig::get('redefineMemoryLimit')) {
-            $this->memoryLimit = ini_get('memory_limit');
-            ini_set('memory_limit', -1);
-        }
                 
         if (StateCheckerConfig::get('autoRun')) {
             $this->getStateHash();
-        }
-    }
-
-    /**
-     *
-     */
-    public function __destruct()
-    {
-        if (StateCheckerConfig::get('redefineMemoryLimit')) {
-            ini_set('memory_limit', $this->memoryLimit);
         }
     }
 

--- a/include/StateChecker.php
+++ b/include/StateChecker.php
@@ -86,13 +86,7 @@ class StateChecker
      * @var string
      */
     protected $lastHash;
-    
-    /**
-     *
-     * @var array
-     */
-    protected $traces;
-    
+
     /**
      *
      * @var integer
@@ -118,7 +112,6 @@ class StateChecker
             throw new StateCheckerException('Incompatible DB type, only supported: mysqli');
         }
         $this->resetHashes();
-        $this->resetTraces();
         
         if (StateCheckerConfig::get('redefineMemoryLimit')) {
             $this->memoryLimit = ini_get('memory_limit');
@@ -129,20 +122,7 @@ class StateChecker
             $this->getStateHash();
         }
     }
-    
-    /**
-     *
-     * @return array traces
-     * @throws StateCheckerException
-     */
-    public function getTraces()
-    {
-        if (StateCheckerConfig::get('saveTraces')) {
-            throw new StateCheckerException('Trace information is not saved, use StateCheckerConfig::get(\'saveTraces\') as true');
-        }
-        return $this->traces;
-    }
-    
+
     /**
      *
      */
@@ -151,14 +131,6 @@ class StateChecker
         if (StateCheckerConfig::get('redefineMemoryLimit')) {
             ini_set('memory_limit', $this->memoryLimit);
         }
-    }
-    
-    /**
-     * resetTraces
-     */
-    protected function resetTraces()
-    {
-        $this->traces = [];
     }
 
     /**
@@ -226,10 +198,6 @@ class StateChecker
 
         if (!$this->checkHash($hash, $key)) {
             throw new StateCheckerException('Hash doesn\'t match at key "' . $key . '".');
-        }
-        
-        if (StateCheckerConfig::get('saveTraces')) {
-            $this->traces[$key][] = debug_backtrace();
         }
         
         return $hash;

--- a/include/StateCheckerConfig.php
+++ b/include/StateCheckerConfig.php
@@ -116,15 +116,8 @@ class StateCheckerConfig
     protected static $autoRun = true;
     
     /**
-     * Save trace info on state-hash mismatch
-     * (Slow working but give more information about the error location, use in development only)
-     * @var boolean
-     */
-    protected static $saveTraces = true;
-    
-    /**
      * Redefine memory limit
-     * (For more memory expensive task, for e.g collection stack trace information when $saveTraces is ON, use in development only)
+     * (For more memory expensive task, use in development only)
      * @var boolean
      */
     protected static $redefineMemoryLimit = false;
@@ -215,11 +208,6 @@ class StateCheckerConfig
             isset($sugar_config['state_checker']['auto_run']) ?
                 $sugar_config['state_checker']['auto_run'] :
                 self::$autoRun;
-        
-        self::$saveTraces =
-            isset($sugar_config['state_checker']['save_traces']) ?
-                $sugar_config['state_checker']['save_traces'] :
-                self::$saveTraces;
         
         self::$redefineMemoryLimit =
             isset($sugar_config['state_checker']['redefine_memory_limit']) ?

--- a/include/StateCheckerConfig.php
+++ b/include/StateCheckerConfig.php
@@ -116,13 +116,6 @@ class StateCheckerConfig
     protected static $autoRun = true;
     
     /**
-     * Redefine memory limit
-     * (For more memory expensive task, use in development only)
-     * @var boolean
-     */
-    protected static $redefineMemoryLimit = false;
-    
-    /**
      * Store more information about hash-mismatch,
      * which part having state of globals/filesys/database.
      * (Slow working but give more information about the error location, use in development only)
@@ -208,11 +201,6 @@ class StateCheckerConfig
             isset($sugar_config['state_checker']['auto_run']) ?
                 $sugar_config['state_checker']['auto_run'] :
                 self::$autoRun;
-        
-        self::$redefineMemoryLimit =
-            isset($sugar_config['state_checker']['redefine_memory_limit']) ?
-                $sugar_config['state_checker']['redefine_memory_limit'] :
-                self::$redefineMemoryLimit;
         
         self::$storeDetails =
             isset($sugar_config['state_checker']['store_details']) ?

--- a/include/StateCheckerTrait.php
+++ b/include/StateCheckerTrait.php
@@ -82,7 +82,7 @@ trait StateCheckerTrait
                 $hash = self::$stateChecker->getStateHash();
                 return $hash;
             } catch (StateCheckerException $e) {
-                $message = 'Incorrect state hash (in PHPUnitTest): ' . $e->getMessage() . (StateCheckerConfig::get('saveTraces') ? "\nTrace:\n" . $e->getTraceAsString() . "\n" : '');
+                $message = 'Incorrect state hash (in PHPUnitTest): ' . $e->getMessage() . ("\nTrace:\n" . $e->getTraceAsString() . "\n");
                 if (StateCheckerConfig::get('testsUseAssertionFailureOnError')) {
                     throw new StateCheckerException($message, $e->getCode(), $e);
                 } else {


### PR DESCRIPTION
## Description

On every state hash check the StateChecker saved the whole debug_backtrace() and never
removed it again, resulting in slow execution and ever growing memory usage.

Since it wasn't used anywhere just remove it.

This reduces the test time by ~10% and the memory usage by ~70% (on travis-ci)

The second commit removes the now unneeded "redefineMemoryLimit" option in "StateCheckerConfig".

## Motivation and Context

I couldn't run the full test suite on my local machine because they needed too much
memory (>16GB)

## How To Test This

Run the unit tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

This requires documentation changes for https://github.com/salesagility/SuiteDocs/blob/master/content/developer/Appendix%20C%20-%20Automated%20Testing.adoc

I will look into that if this change gets approved.