### PR TITLE
Fixed #4297 - Error in Listview : Pagination - Bulk Action disabled a…

### DIFF
--- a/jssource/src_files/include/javascript/sugar_3.js
+++ b/jssource/src_files/include/javascript/sugar_3.js
@@ -1996,9 +1996,9 @@ sugarListView.prototype.confirm_action = function (del) {
 
 }
 sugarListView.get_num_selected = function () {
-  var selectCount = $("input[name='selectCount[]']:first");
-  if (selectCount.length > 0)
-    return parseInt(selectCount.val().replace("+", ""));
+  var selectCount = sugarListView.get_checks_count();
+  if (selectCount > 0)
+        return selectCount;
   return 0;
 
 }


### PR DESCRIPTION
Fixed #4297 - Error in Listview : Pagination - wrong "Selected" count

## Motivation and Context
When I changed page in ListView, the "Selected" count didn't follow and the bulk action was not active.

## How To Test This
Go to a ListView (like Campaigns for example), check many items and change page. See if the count is OK.