### PR TITLE
Preserve dates properly when restoring a filter's query parameters

### DIFF
--- a/modules/MySettings/StoreQuery.php
+++ b/modules/MySettings/StoreQuery.php
@@ -53,8 +53,8 @@ class StoreQuery
     /**
      * SaveQuery
      *
-     * This function handles saving the query parameters to the user preferences
-     * SavedSearch.php does something very similar when saving saved searches as well
+     * This function handles saving the query parameters to the user preferences.
+     * SavedSearch.php does something very similar when saving saved searches as well.
      *
      * @see SavedSearch
      * @param $name String name  to identify this query
@@ -73,7 +73,14 @@ class StoreQuery
                             $type = $bean->field_defs[$field]['type'];
 
                             if (($type == 'date' || $type == 'datetime' || $type == 'datetimecombo') && !preg_match('/^\[.*?\]$/', $value)) {
-                                $db_format = $timedate->to_db_date($value, false);
+                                // If the value is already in the db date format (e.g. '2019-03-21'), don't re-convert
+                                // it as that causes $db_format to be set to nothing. If the value isn't in
+                                // the format that the db wants (e.g. '3/21/2019'), then we can convert it.
+                                if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
+                                    $db_format = $value;
+                                } else {
+                                    $db_format = $timedate->to_db_date($value, false);
+                                }
                                 $this->query[$key] = $db_format;
                             } elseif ($type == 'int' || $type == 'currency' || $type == 'decimal' || $type == 'float') {
                                 if (preg_match('/[^\d]/', $value)) {


### PR DESCRIPTION
## Description
Fixes #3857 and #5936. Credit to @frappuccino284 for suggesting the fix to this issue in #3857.

This adds proper handling in the `storeQuery.php` file for the case where the date is already provided in 'database' format (e.g. '2019-03-21').

I applied this fix to our fork of the CRM and can confirm it fixes the problem :)

## Motivation and Context
Date-related filters weren't preserved because the `TimeDate->to_db_format` method returns `''` if you give it a date that's already in db format. (Arguably that should be what's fixed here, but I'm not sure if that'd be a big breaking change so I'm just fixing this specific issue instead).

## How To Test This
You can test this with any module that has a filterable date property by filtering by that date property, clicking on a result, then returning to the listview for the module and checking that the filter retains the date filter info.

Or, if you want a specific example:
- In the Admin panel go to Studio > Contacts > Layouts > Filter > Quick Filter
- Add "Date Entered" or "Date Modified" to default, click "Save and Deploy"
- Go to the Contacts module, do a basic search/filter and set "Date Created" to any value, and then click on any result.
- Go back to the Contacts list view, hover over the filter button and note that the date property has been preserved in the filter.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.