### PR TITLE
Fix obscured milestone radio buttons in Project Templates

### DIFF
--- a/modules/AM_ProjectTemplates/css/style.css
+++ b/modules/AM_ProjectTemplates/css/style.css
@@ -359,7 +359,7 @@
     padding: .4em;
 }
 #Milestone, #Milestone_label, #Subtask, #Subtask_label {
-    display: inline!important;
+    display: inline-block!important;
 }
 #Duration, #Lag {
     display: inline!important;


### PR DESCRIPTION
## Description
From the forums:
https://suitecrm.com/suitecrm/forum/suitecrm-7-0-discussion/22160-add-new-task

Adding and editing Project Template tasks is broken.

## How To Test This
1. Create Project Template, and add a task to it.
2. In the Template's detail view, try to a) add a task or b) edit an existing task
3. In the pop-up dialog box, there is a radio button to select between `Task` and `Milestone` which is hidden under the words (use browser console to figure it out), and therefore unusable.

My proposed change makes it visible and usable again.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

I tried this on SuiteCRM 7.11.2.