### PR TITLE
Remove debug flags from codecept run commands in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
       - stage: codecoverage
         if: type IN (pull_request) OR branch in (master, develop, hotfix)
         php: 7.0
-        script: ./vendor/bin/codecept run install --env travis-ci-hub -f -d --ext DotReporter; echo "\$sugar_config['state_checker']['test_state_check_mode'] = 1;" >> config_override.php  ; ./vendor/bin/robo -vvv code:coverage; cat codeception.yml; bash <(curl -s https://codecov.io/bash) -f ./_output/coverage.xml
+        script: ./vendor/bin/codecept run install --env travis-ci-hub -f --ext DotReporter; echo "\$sugar_config['state_checker']['test_state_check_mode'] = 1;" >> config_override.php  ; ./vendor/bin/robo code:coverage; cat codeception.yml; bash <(curl -s https://codecov.io/bash) -f ./_output/coverage.xml
 sudo: required
 dist: trusty
 services:
@@ -67,11 +67,11 @@ before_script:
 script:
   # Run the wizard installer
   - echo "using install wizard"
-  - ./vendor/bin/codecept run install --env travis-ci-hub -f -d --ext DotReporter
+  - ./vendor/bin/codecept run install --env travis-ci-hub -f --ext DotReporter
   - ./build/push_output.sh
   
   # Run the unit tests
-  # - ./vendor/bin/codecept run unit --steps -f -vvv -d
+  # - ./vendor/bin/codecept run unit --steps -f
   - cd tests
   - ../vendor/bin/phpunit --stop-on-failure --stop-on-error --colors --configuration $(pwd)/phpunit.xml.dist ./tests/unit/phpunit
   - cd ..
@@ -88,10 +88,10 @@ script:
   - sudo chmod 600 Api/V8/OAuth2/p*.key
   # - sudo chown www-data:www-data Api/V8/OAuth2/p*.key
   # Run API functional tests
-  - ./vendor/bin/codecept run tests/api/V8/ -f -d --ext DotReporter
+  - ./vendor/bin/codecept run tests/api/V8/ -f --ext DotReporter
   # RUN Basic Acceptance test
   - echo "\$sugar_config['imap_test'] = true;" >> config_override.php
-  - ./vendor/bin/codecept run acceptance --env travis-ci-hub -f -d --ext DotReporter
+  - ./vendor/bin/codecept run acceptance --env travis-ci-hub -f --ext DotReporter
 
 after_script:
   - ./build/push_output.sh


### PR DESCRIPTION
This should significantly reduce the test output in CI by removing the debug flag (and removing some verbosity flags that were missed in #6907).

Per `./vendor/bin/codecept run --help`, the `-d` flag 'Shows debug and scenario output'. It should still give debug info if the test fails, it just won't print a bunch of logging for every successful test (which is essentially just noise).

~~I also turned off the `verbose` option in the phpunit XML config file, since that was the majority of the CI log once the debug flag was removed for the other test types.~~ This didn't fix the PHPUnit output. Unfortunately since we're on such an old version of PHPUnit and I'm not able to get the test suite to run locally, I'm not sure how to even improve the PHPUnit output. We can leave that for another PR.

## Description
This helps resolve #6844 and is a follow-up to #6907.

## Motivation and Context
It makes the test output less verbose so it's easier to look through the CI logs.

## How To Test This
Look at Travis CI and see that it still works :)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.