### PR TITLE
phpunit: Reduce test noise & make output test methods work

### DIFF
--- a/include/StateCheckerPHPUnitTestCaseAbstract.php
+++ b/include/StateCheckerPHPUnitTestCaseAbstract.php
@@ -65,9 +65,9 @@ abstract class StateCheckerPHPUnitTestCaseAbstract extends PHPUnit_Framework_Tes
     {
         if (self::$verbose) {
             $currentTestName = get_class($this) . '::' . $this->getName(false);
-            echo "\t" . $currentTestName  . " ..";
+            fwrite(STDOUT, "\t" . $currentTestName  . " ..");
             for ($i = 60; $i > strlen($currentTestName); $i--) {
-                echo ".";
+                fwrite(STDOUT,".");
             }
         }
         
@@ -84,7 +84,7 @@ abstract class StateCheckerPHPUnitTestCaseAbstract extends PHPUnit_Framework_Tes
         $this->afterStateCheck();
         
         if (self::$verbose) {
-            echo " [done]\n";
+            fwrite(STDOUT, " [done]\n");
         }
     }
 }

--- a/tests/unit/phpunit/include/MVC/Controller/SugarControllerTest.php
+++ b/tests/unit/phpunit/include/MVC/Controller/SugarControllerTest.php
@@ -67,7 +67,10 @@ class SugarControllerTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $state = new \SuiteCRM\StateSaver();
         $state->pushTable('tracker');
         $state->pushGlobals();
-        
+
+        // suppress output during the test
+        $this->setOutputCallback(function() {});
+
         // test
         
         

--- a/tests/unit/phpunit/include/MVC/View/views/view.vcardTest.php
+++ b/tests/unit/phpunit/include/MVC/View/views/view.vcardTest.php
@@ -19,7 +19,7 @@ class ViewVcardTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $view = new ViewVcard();
         $view->module = 'Contacts';
         $view->bean = new Contact();
-
+        $this->expectOutputRegex('/.*BEGIN:VCARD.*/');
         //execute the method and test if it works and does not throws an exception other than headers output exception.
         try {
             $view->display();


### PR DESCRIPTION
## Description

phpunit provides helpers for testing and redirecting test output but this is broken
by the added code in the test base class which prints test context during the tests
and gets treated as test output by phpunit.

To work around this write straight to STDOUT instead of going through the output buffer
for the test context.

This also adds some calls to setOutputCallback() and expectOutputRegex() to remove
the output/noise of some tests.

## Motivation and Context

* Noisy output
* Not being able to use expectOutputRegex()/expectOutputString() etc.

## How To Test This

* Run the test suite

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.