### PR TITLE
phpunit: Various fixes for running with StateCheckerConfig::RUN_PER_TESTS

### DIFF
--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -7747,7 +7747,7 @@ eoq;
 
     public function saveMailBoxValueOfInboundEmail()
     {
-        $query = "update Inbound_email set mailbox = '{$this->email_user}'";
+        $query = "update inbound_email set mailbox = '{$this->mailbox}' where id ='{$this->id}'";
         $this->db->query($query);
     }
 

--- a/tests/unit/phpunit/data/SugarBeanTest.php
+++ b/tests/unit/phpunit/data/SugarBeanTest.php
@@ -570,7 +570,8 @@ class SugarBeanTest extends SuitePHPUnit_Framework_TestCase
     public function testPopulateDefaultValues()
     {
         $testBean1 = BeanFactory::getBean('Users');
-        ;
+        $origFieldDefs = $testBean1->field_defs;
+
         $testBean1->field_defs = null;
         /** @noinspection PhpVoidFunctionResultUsedInspection */
         $results = $testBean1->populateDefaultValues();
@@ -637,6 +638,8 @@ class SugarBeanTest extends SuitePHPUnit_Framework_TestCase
         ), $bean->field_defs);
         $field = 'test';
         self::assertEquals('', $bean->$field);
+
+        $bean->field_defs = $origFieldDefs;
     }
 
     /**
@@ -2286,6 +2289,11 @@ class SugarBeanTest extends SuitePHPUnit_Framework_TestCase
         $state = new \SuiteCRM\StateSaver();
         $state->pushTable('tracker');
         $state->pushTable('aod_index');
+        $state->pushTable('users');
+        $state->pushGlobals();
+
+        $userFieldDefs = BeanFactory::getBean('Users')->field_defs;
+        $contactFieldDefs = BeanFactory::getBean('Contacts')->field_defs;
 
         // test
         
@@ -2329,7 +2337,7 @@ class SugarBeanTest extends SuitePHPUnit_Framework_TestCase
         $isValidator = new \SuiteCRM\Utility\SuiteValidator();
         self::assertFalse($isValidator->isValidId($results));
 
-        self::assertEquals(true, $bean->in_save);
+        self::assertEquals(false, $bean->in_save);
         self::assertEquals($current_user->id, $bean->modified_user_id);
         self::assertEquals($current_user->user_name, $bean->modified_by_name);
         self::assertEquals(0, $bean->deleted);
@@ -2354,7 +2362,7 @@ class SugarBeanTest extends SuitePHPUnit_Framework_TestCase
         }
         self::assertFalse($isValidator->isValidId($results));
 
-        self::assertEquals(true, $bean->in_save);
+        self::assertEquals(false, $bean->in_save);
         
         self::assertEquals($current_user->id, $bean->modified_user_id);
         
@@ -2566,7 +2574,11 @@ class SugarBeanTest extends SuitePHPUnit_Framework_TestCase
         $this->db->query("DELETE FROM email_addresses WHERE email_address LIKE 'testbean1@email.com'");
         
         // clean up
-        
+        BeanFactory::getBean('Users')->field_defs = $userFieldDefs;
+        BeanFactory::getBean('Contacts')->field_defs = $contactFieldDefs;
+
+        $state->popGlobals();
+        $state->popTable('users');
         $state->popTable('aod_index');
         $state->popTable('tracker');
     }

--- a/tests/unit/phpunit/include/MVC/Controller/SugarControllerTest.php
+++ b/tests/unit/phpunit/include/MVC/Controller/SugarControllerTest.php
@@ -67,6 +67,7 @@ class SugarControllerTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $state = new \SuiteCRM\StateSaver();
         $state->pushTable('tracker');
         $state->pushGlobals();
+        $state->pushPHPConfigOptions();
 
         // suppress output during the test
         $this->setOutputCallback(function() {});
@@ -101,7 +102,8 @@ class SugarControllerTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $this->assertTrue(true);
         
         // clean up
-        
+
+        $state->popPHPConfigOptions();
         $state->popGlobals();
         $state->popTable('tracker');
     }
@@ -173,6 +175,7 @@ class SugarControllerTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $state = new SuiteCRM\StateSaver();
         $state->pushTable('aod_index');
         $state->pushTable('tracker');
+        $state->pushTable('users');
         $state->pushTable('user_preferences');
         
         if (isset($_SESSION)) {
@@ -214,6 +217,7 @@ class SugarControllerTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         DBManagerFactory::getInstance()->query($query);
         
         $state->popTable('user_preferences');
+        $state->popTable('users');
         $state->popTable('tracker');
         $state->popTable('aod_index');
     }

--- a/tests/unit/phpunit/include/MVC/View/SugarViewTest.php
+++ b/tests/unit/phpunit/include/MVC/View/SugarViewTest.php
@@ -41,6 +41,7 @@ class SugarViewTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $state = new \SuiteCRM\StateSaver();
         $state->pushTable('tracker');
         $state->pushGlobals();
+        $state->pushPHPConfigOptions();
 
         // test
         
@@ -65,7 +66,8 @@ class SugarViewTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         }
         
         // clean up
-        
+
+        $state->popPHPConfigOptions();
         $state->popGlobals();
         $state->popTable('tracker');
     }

--- a/tests/unit/phpunit/include/SugarEmailAddress/SugarEmailAddressTest.php
+++ b/tests/unit/phpunit/include/SugarEmailAddress/SugarEmailAddressTest.php
@@ -736,9 +736,8 @@ class SugarEmailAddressTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
      */
     public function testPopulateAddresses()
     {
-        if (!empty($_REQUEST)) {
-            $req = $_REQUEST;
-        }
+        $state = new \SuiteCRM\StateSaver();
+        $state->pushGlobals();
 
         $logger = $GLOBALS['log'];
         $GLOBALS['log'] = new TestLogger();
@@ -956,11 +955,7 @@ class SugarEmailAddressTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
         $GLOBALS['log'] = $logger;
 
-        if (!empty($req)) {
-            $_REQUEST = $req;
-        } else {
-            unset($_REQUEST);
-        }
+        $state->popGlobals();
     }
 
     /**

--- a/tests/unit/phpunit/modules/AOR_Reports/AOR_ReportTest.php
+++ b/tests/unit/phpunit/modules/AOR_Reports/AOR_ReportTest.php
@@ -129,6 +129,7 @@ class AOR_ReportTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
     public function testload_report_beans()
     {
         $state = new SuiteCRM\StateSaver();
+        $state->pushGlobals();
         
         
         
@@ -145,6 +146,7 @@ class AOR_ReportTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         }
         
         // clean up
+        $state->popGlobals();
     }
 
     public function testgetReportFields()

--- a/tests/unit/phpunit/modules/InboundEmail/InboundEmailTest.php
+++ b/tests/unit/phpunit/modules/InboundEmail/InboundEmailTest.php
@@ -6,6 +6,21 @@ require_once __DIR__ . '/../../../../../modules/InboundEmail/InboundEmail.php';
 
 class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 {
+    public static $class_state = null;
+
+    public static function setUpBeforeClass()
+    {
+        // FIXME: The tests here depend on the email_cache table staying around and the right test order.
+        // Until that is fixed (run with RUN_PER_TESTS to see the problem) we at least restore after the class is done.
+        self::$class_state = new SuiteCRM\StateSaver();
+        self::$class_state->pushTable('email_cache');
+    }
+
+    public static function tearDownAfterClass()
+    {
+        self::$class_state->popTable('email_cache');
+    }
+
     protected function storeStateAll()
     {
         // save state
@@ -229,6 +244,9 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
     public function testFindOptimumSettingsFalsePositive()
     {
+        $state = new SuiteCRM\StateSaver();
+        $state->pushGlobals();
+
         $fake = new ImapHandlerFakeData();
         $fake->add('isAvailable', null, [true]);  // <-- when the code calls ImapHandlerInterface::isAvailable([null]), it will return true
         $fake->add('setTimeout', [1, 60], [true]);
@@ -261,6 +279,8 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $fake->add('getLastError', null, ["Mailbox is empty"]);
         $ret = $inboundEmail->findOptimumSettings();
         $this->assertEquals($exp, $ret);
+
+        $state->popGlobals();
     }
 
     public function testFindOptimumSettingsFail()
@@ -310,6 +330,9 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
     public function testFindOptimumSettingsOk()
     {
+        $state = new SuiteCRM\StateSaver();
+        $state->pushGlobals();
+
         $fake = new ImapHandlerFakeData();
         $fake->add('isAvailable', null, [true]);  // <-- when the code calls ImapHandlerInterface::isAvailable([null]), it will return true
         $fake->add('setTimeout', [1, 60], [true]);
@@ -334,6 +357,8 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
             'serial' => '::::::::novalidate-cert::notls::secure',
             'service' => 'foo/notls/novalidate-cert/secure',
         ], $ret);
+
+        $state->popGlobals();
     }
 
     public function testFindOptimumSettingsNoImap()

--- a/tests/unit/phpunit/modules/SchedulersJobs/SchedulersJobTest.php
+++ b/tests/unit/phpunit/modules/SchedulersJobs/SchedulersJobTest.php
@@ -426,7 +426,7 @@ class SchedulersJobTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
         $schedulersJob->target = 'function::processAOW_Workflow';
         $result = $schedulersJob->runJob();
-        $this->assertEquals(false, $result);
+        $this->assertEquals(true, $result);
         $schedulersJob->mark_deleted($schedulersJob->id);
 
         //test with valid user


### PR DESCRIPTION
## Description

This tries to improve the tests to be less dependent on the order they are run in.
Motivated by them failing a lot locally on my machine.

saveMailBoxValueOfInboundEmail: only used in the tests and failed due to wrong casing
and copy/paste errors (not sure why it worked on travis, maybe less strict mysql)

Properly save/restore User::field_defs. This made various tests later on fail because
User beans fetched from the DB were incomplete and only partially saved back, due to
the missing field defs.

Various state save/restore needed for passing with RUN_PER_TESTS.

The only remaining test class not passing with RUN_PER_TESTS is InboundEmailTest because
it depends on the test methods running in a specific order and fixing this would have
been too much code change. This adds a class level StateSaver so it at least doesn't
impact other unrelated test classes.

## Motivation and Context

I want to be able to run the unit tests locally. Including running only a
small part of them.

## How To Test This

Run the tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.