### PR TITLE
travis-ci: Switch the PHP 7.x jobs to Ubuntu 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,32 @@
 language: php
-php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
+os: linux
+sudo: required
 
 matrix:
   fast_finish: true
-jobs:
   include:
-      - stage: codecoverage
-        if: type IN (pull_request) OR branch in (master, develop, hotfix)
-        php: 7.0
-        script: ./vendor/bin/codecept run install --env travis-ci-hub -f --ext DotReporter; echo "\$sugar_config['state_checker']['test_state_check_mode'] = 1;" >> config_override.php  ; ./vendor/bin/robo code:coverage; cat codeception.yml; bash <(curl -s https://codecov.io/bash) -f ./_output/coverage.xml
-sudo: required
-dist: trusty
+    - name: "PHP 5.5 / MySQL 5.6"
+      php: "5.5"
+      dist: trusty
+    - name: "PHP 5.6 / MySQL 5.6"
+      php: "5.6"
+      dist: trusty
+    - name: "PHP 7.0 / MySQL 5.7"
+      php: "7.0"
+      dist: xenial
+    - name: "PHP 7.1 / MySQL 5.7"
+      php: "7.1"
+      dist: xenial
+    - name: "PHP 7.2 / MySQL 5.7"
+      php: "7.2"
+      dist: xenial
+    - stage: codecoverage
+      if: type IN (pull_request) OR branch in (master, develop, hotfix)
+      php: "7.0"
+      dist: xenial
+      script: ./vendor/bin/codecept run install --env travis-ci-hub -f --ext DotReporter; echo "\$sugar_config['state_checker']['test_state_check_mode'] = 1;" >> config_override.php  ; ./vendor/bin/robo code:coverage; cat codeception.yml; bash <(curl -s https://codecov.io/bash) -f ./_output/coverage.xml
+
+
 services:
   - mysql
 addons:
@@ -42,6 +53,8 @@ before_script:
   - mysql -e "CREATE DATABASE automated_tests CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;"
   - mysql -u root -e "CREATE USER 'automated_tests'@'localhost' IDENTIFIED BY 'automated_tests';"
   - mysql -u root -e "GRANT ALL PRIVILEGES ON automated_tests.* TO 'automated_tests'@'localhost';"
+  # FIXME: https://github.com/salesagility/SuiteCRM/issues/7107
+  - mysql -u root -e "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode, 'STRICT_TRANS_TABLES', ''));"
   # Install apache - images with PHP 7 or above
   - sudo apt-get update
   - sudo apt-get install apache2 libapache2-mod-fastcgi


### PR DESCRIPTION
## Description

Currently all tests are running with Ubuntu 14.04 which includes MySQL 5.6
which is unlikely to be used by any newer setup.

Assuming that systems with a newer PHP version also use a newer MySQL switch the
PHP 7.x jobs to Ubuntu Xenial and thus to use MySQL 5.7 instead.

The unittests currently have problems with the default MySQL 5.7 configuration,
see #7107, so force unset the strict sql mode in the travis setup script for now.

This should make it easier to test the fix for #7107 and to prevent similar issues
in the future.

## Motivation and Context

Make sure SuiteCRM works with MySQL 5.7 as advertised in the compatibility matrix.

## How To Test This

Let travis-ci do its thing.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.