### PR TITLE
Campaigns: escape subscribe()/unsubscribe() IDs and add tests

### DIFF
--- a/modules/Campaigns/utils.php
+++ b/modules/Campaigns/utils.php
@@ -618,7 +618,7 @@ function process_subscriptions($subscription_string_to_parse)
 
         //--grab all the lists for the passed in campaign id
         $pl_qry ="select id, list_type from prospect_lists where id in (select prospect_list_id from prospect_list_campaigns ";
-        $pl_qry .= "where campaign_id = '$campaign') and deleted = 0 ";
+        $pl_qry .= "where campaign_id = " . $focus->db->quoted($campaign) . ") and deleted = 0 ";
         $GLOBALS['log']->debug("In Campaigns Util: subscribe function, about to run query: ".$pl_qry);
         $pl_qry_result = $focus->db->query($pl_qry);
 
@@ -630,7 +630,7 @@ function process_subscriptions($subscription_string_to_parse)
 
         //--grab all the prospect_lists this user belongs to
         $curr_pl_qry ="select prospect_list_id, related_id  from prospect_lists_prospects ";
-        $curr_pl_qry .="where related_id = '$focus->id'  and deleted = 0 ";
+        $curr_pl_qry .="where related_id = " . $focus->db->quoted($focus->id) . " and deleted = 0 ";
         $GLOBALS['log']->debug("In Campaigns Util: subscribe function, about to run query: ".$curr_pl_qry);
         $curr_pl_qry_result = $focus->db->query($curr_pl_qry);
 
@@ -710,7 +710,7 @@ function process_subscriptions($subscription_string_to_parse)
         $relationship = strtolower($focus->getObjectName()).'s';
         //--grab all the list for this campaign id
         $pl_qry ="select id, list_type from prospect_lists where id in (select prospect_list_id from prospect_list_campaigns ";
-        $pl_qry .= "where campaign_id = '$campaign') and deleted = 0 ";
+        $pl_qry .= "where campaign_id = " . $focus->db->quoted($campaign) . ") and deleted = 0 ";
         $pl_qry_result = $focus->db->query($pl_qry);
         //build the array with list information
         $pl_arr = array();


### PR DESCRIPTION
## Description

While the functions are not exposed right now escaping things can't hurt.

I noticed that these functions weren't tested, so this adds some basic tests
for subscribing/unsubscribing a lead to/from a newsletter campaign.

## Motivation and Context

I'd like to use these in an entry point.

## How To Test This

Run the tests suite

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.