### PR TITLE
Add href mailto for email links even when using internal email client

### DIFF
--- a/jssource/src_files/include/javascript/EmailsComposeViewModal.js
+++ b/jssource/src_files/include/javascript/EmailsComposeViewModal.js
@@ -116,6 +116,9 @@
   $.fn.openComposeViewModal = function (source) {
     "use strict";
 
+    window.event.preventDefault();
+    window.event.stopImmediatePropagation();
+
     var self = this;
     self.emailComposeView = null;
     var opts = $.extend({}, $.fn.EmailsComposeViewModal.defaults);

--- a/modules/Emails/EmailUI.php
+++ b/modules/Emails/EmailUI.php
@@ -435,18 +435,20 @@ eoq;
         global $current_user;
 
         if ($current_user->getEmailClient() == 'sugar') {
-            return '<a class="email-link"'
-                . ' onclick="$(document).openComposeViewModal(this);"'
-                . ' data-module="' . $module_name
-                . '" data-record-id="' . $record_id
-                . '" data-module-name="' . $name
-                . '" data-email-address="' . $addr  . '">'
-                . $text . '</a>';
+            $html =<<<HTML
+            <a class="email-link" href="mailto:{$addr}"
+                    onclick="$(document).openComposeViewModal(this);"
+                    data-module="{$module_name}" data-record-id="{$record_id}"
+                    data-module-name="{$name}" data-email-address="{$addr}"
+                >{$text}</a>
+HTML;
+        } else {
+            $html =<<<HTML
+                <a class="email-link" href="mailto:{$addr}">{$text}</a>
+HTML;
         }
 
-        return '<a class="email-link"'
-            . ' href="mailto:' .  $addr . '">'
-            . $text . '</a>';
+        return $html;
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Currently when a user has set their email client to internal (Mozaik) then the email's displayed with a link to some javascript for the popup. This means you can't simple right click on the link and "copy email address".

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I would like it to be easier to copy the email address

## How To Test This
<!--- Please describe in detail how to test your changes. -->
* Set email client to Mozaik
** Click the link and see a pop-up of the internal email client
** Right click the link and see "Copy Email Address"
* Set email client to external
** Click the link and see that your operating system handles the email address

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] New feature (non-breaking change which adds functionality)


### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->