### PR TITLE
Fix API relationship links

### DIFF
--- a/Api/V8/JsonApi/Helper/RelationshipObjectHelper.php
+++ b/Api/V8/JsonApi/Helper/RelationshipObjectHelper.php
@@ -32,10 +32,10 @@ class RelationshipObjectHelper
         asort($relationships);
 
         $relationshipsLinks = [];
-        foreach (array_unique($relationships) as $module) {
+        foreach (array_unique($relationships) as $relationshipName => $module) {
             $linkResponse = new LinksResponse();
             $linkResponse->setRelated(
-                sprintf('/%s/%s/%s', $uriPath, 'relationships', strtolower($module))
+                sprintf('/%s/%s/%s', $uriPath, 'relationships', $relationshipName)
             );
 
             $relationshipsLinks[$module] = ['links' => $linkResponse];


### PR DESCRIPTION
Replace the lower case module names in the relationship links in API responses by the actual relationship identifiers.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Previously the response structure for records contained relationship links which were broken in those cases where the relationship identifier wasn't the same as the lower case module name.

Fixes #7121 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Make an API call to get a single record (example Contacts)
2. In the list of relationships, select one where the relationship identifier is NOT the same as the related module name (example FP_events, AM_ProjectTemplates - NOT Accounts)
3. Follow the link and make sure it returns a list of related records

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->