### PR TITLE
Fix API list total pages display

### DIFF
--- a/Api/V8/JsonApi/Repository/Filter.php
+++ b/Api/V8/JsonApi/Repository/Filter.php
@@ -80,7 +80,7 @@ class Filter
      * @param array $params
      * @return array
      */
-    protected function addDeletedParameter(array $params): array
+    protected function addDeletedParameter(array $params)
     {
         if (!array_key_exists('deleted', $params)) {
             $params['deleted'] = [

--- a/Api/V8/JsonApi/Repository/Filter.php
+++ b/Api/V8/JsonApi/Repository/Filter.php
@@ -43,6 +43,8 @@ class Filter
             unset($params['operator']);
         }
 
+        $params = $this->addDeletedParameter($params);
+
         $where = [];
         foreach ($params as $field => $expr) {
             if (!property_exists($bean, $field)) {
@@ -70,6 +72,23 @@ class Filter
         }
 
         return implode(sprintf(' %s ', $operator), $where);
+    }
+
+    /**
+     * Only return deleted records if they were explicitly requested
+     *
+     * @param array $params
+     * @return array
+     */
+    protected function addDeletedParameter(array $params): array
+    {
+        if (!array_key_exists('deleted', $params)) {
+            $params['deleted'] = [
+                'eq' => 0
+            ];
+        }
+
+        return $params;
     }
 
     /**

--- a/Api/V8/Param/Options/Filter.php
+++ b/Api/V8/Param/Options/Filter.php
@@ -14,6 +14,10 @@ class Filter extends BaseOption
     public function add(OptionsResolver $resolver)
     {
         $resolver
+            ->setDefaults(['filter' => [
+                'deleted' => [
+                    'eq' => 0
+                ]]])
             ->setDefined('filter')
             ->setAllowedTypes('filter', 'array')
             ->setAllowedValues('filter', $this->validatorFactory->createClosure([


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes an issue where API filtering includes deleted records by default.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Adds a default filter parameter to use when no filters are specified.
Injects a deleted = 0 filter parameter when the list of filter parameters doesn't specifically include deleted records.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Most API operations are unaffected by this issue because we use a Bean function to actually retrieve records, so deleted records are filtered.

However, for the `[meta][total-pages]` a count query is run which does not include the deleted = 0 parameter, and thus returns a number of pages based on the total rows in the db, deleted or not.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Make sure your Accounts db table contains deleted records as well as non deleted records.
2. Do a call to `Accounts?fields[Account]=name,account_type&page[number]=1&page[size]=1`
3. Observe the `[meta][total-pages]` is accurate for the data in the db.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->