### PR TITLE
Api - fix relate fields not populating on get_list

### DIFF
--- a/Api/V8/BeanDecorator/BeanListRequest.php
+++ b/Api/V8/BeanDecorator/BeanListRequest.php
@@ -41,7 +41,7 @@ class BeanListRequest
     /**
      * @var boolean
      */
-    private $singleSelect = false;
+    private $singleSelect = true;
 
     /**
      * @var array


### PR DESCRIPTION
Use singleSelect for the underlying call to `SugarBean->get_list` from API get modules endpoint

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

When passing singleSelect = false to the `SugarBean->get_list` function, relate fields are not filled out correctly but padded with empty spaces.

Regular ListView in CRM passes singleSelect = true to this function, therefore the API should too.

Example json response diff:

![image](https://user-images.githubusercontent.com/34056696/55617444-63a45080-5794-11e9-8ce1-c47e44a777e1.png)

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Choose a module that has a relate field ( Example Contacts )
2. Do a getModules API call `/V8/module/Contacts`
3. In the result json, make sure the relate fields contain id and name of the related record

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->