### PR TITLE
Fix #6689 Task date_due not displaying in Activities subpanel

### DIFF
--- a/modules/Tasks/metadata/subpanels/ForActivities.php
+++ b/modules/Tasks/metadata/subpanels/ForActivities.php
@@ -73,11 +73,11 @@ $subpanel_layout = array(
              'vname' => 'LBL_LIST_CONTACT',
              'width' => '11%',
         ),
-        'date_due'=>array(
-             'vname' => 'LBL_LIST_DUE_DATE',
-             'width' => '10%',
-             'alias' => 'date_start',
-             'sort_by' => 'date_start',
+        'date_due' => array(
+            'vname' => 'LBL_LIST_DUE_DATE',
+            'width' => '10%',
+            'alias' => 'date_end',
+            'sort_by' => 'date_end',
         ),
         'assigned_user_name' => array(
             'name' => 'assigned_user_name',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
For the collection subpanel, date_due was aliased to date_start, while it should be displayed in the date_end field.

Fixes #6689 

## How To Test This
<!--- Please describe in detail how to test your changes. -->

    1. Create Opportunity
    2. Create Task with due date
    3. Due date shows up in Subpanel


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->