### PR TITLE
Fixes SugarPHPMailer encountered an error: Could not access file

### DIFF
--- a/include/SugarPHPMailer.php
+++ b/include/SugarPHPMailer.php
@@ -303,7 +303,7 @@ eoq;
         //Replace any embeded images using the secure entryPoint for src url.
         $this->replaceImageByRegex(
             "(?:{$sugar_config['site_url']})?index.php[?]entryPoint=download&(?:amp;)?[^\"]+?id=",
-            'upload://',
+            'upload/',
             true
         );
 
@@ -322,13 +322,13 @@ eoq;
                     $filename = $note->file->original_file_name;
                     $mime_type = $note->file->mime_type;
                 } else {
-                    $file_location = "upload://{$note->id}";
+                    $file_location = "upload/{$note->id}";
                     $filename = $note->id . $note->filename;
                     $mime_type = $note->file_mime_type;
                 }
             } elseif ($note->object_name === 'DocumentRevision') { // from Documents
                 $filename = $note->id . $note->filename;
-                $file_location = "upload://$filename";
+                $file_location = "upload/$filename";
                 $mime_type = $note->file_mime_type;
             }
 


### PR DESCRIPTION
 (SugarPHPMailer.php)

<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a continuation of https://github.com/salesagility/SuiteCRM/issues/6932 which in Suitecrm 7.11.3 is still not fixed. The bug should be reopened.

## Motivation and Context
Check original https://github.com/salesagility/SuiteCRM/issues/6932 . Basically in our scenario campaigns are sent without attachments.

## How To Test This
Try to send a campaign with an attachment and monitor suitecrm.log.
A message like:
```
SugarPHPMailer encountered an error: Could not access file: upload://63534f9e-c81e-b9ff-1f52-5ca76adc945e
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->