### PR TITLE
Fixed #6452 - Api/V8 create record does not support unicode and space in attributes

### DIFF
--- a/Api/V8/Param/Options/Attributes.php
+++ b/Api/V8/Param/Options/Attributes.php
@@ -10,7 +10,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class Attributes extends BaseOption
 {
-    const REGEX_ATTRIBUTE_PATTERN = '/[\b\B]/';
+    const REGEX_ATTRIBUTE_PATTERN = '/\b\B/';
 
     /**
      * @inheritdoc

--- a/Api/V8/Param/Options/Attributes.php
+++ b/Api/V8/Param/Options/Attributes.php
@@ -10,6 +10,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class Attributes extends BaseOption
 {
+    // Paradox regex that accepts everything (Match at beginning/end of each word and don't match at beginning/of each word).
     const REGEX_ATTRIBUTE_PATTERN = '/\b\B/';
 
     /**

--- a/Api/V8/Param/Options/Attributes.php
+++ b/Api/V8/Param/Options/Attributes.php
@@ -10,7 +10,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class Attributes extends BaseOption
 {
-    // Paradox regex that accepts everything (Match at beginning/end of each word and don't match at beginning/of each word).
+    // Paradox regex that accepts everything (Match at beginning/end of each word and don't match at beginning/end of each word).
     const REGEX_ATTRIBUTE_PATTERN = '/\b\B/';
 
     /**

--- a/Api/V8/Param/Options/Attributes.php
+++ b/Api/V8/Param/Options/Attributes.php
@@ -9,6 +9,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class Attributes extends BaseOption
 {
+    const REGEX_FIELD_PATTERN = '/[\b\B]/';
+
     /**
      * @inheritdoc
      *
@@ -22,7 +24,7 @@ class Attributes extends BaseOption
             ->setAllowedValues('attributes', $this->validatorFactory->createClosureForIterator([
                 new Assert\NotBlank(),
                 new Assert\Regex([
-                    'pattern' => Fields::REGEX_FIELD_PATTERN,
+                    'pattern' => self::REGEX_FIELD_PATTERN,
                     'match' => false,
                 ]),
             ]))

--- a/Api/V8/Param/Options/Attributes.php
+++ b/Api/V8/Param/Options/Attributes.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Api\V8\Param\Options;
 
 use InvalidArgumentException;
@@ -9,7 +10,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class Attributes extends BaseOption
 {
-    const REGEX_FIELD_PATTERN = '/[\b\B]/';
+    const REGEX_ATTRIBUTE_PATTERN = '/[\b\B]/';
 
     /**
      * @inheritdoc
@@ -22,15 +23,14 @@ class Attributes extends BaseOption
             ->setDefined('attributes')
             ->setAllowedTypes('attributes', 'array')
             ->setAllowedValues('attributes', $this->validatorFactory->createClosureForIterator([
-                new Assert\NotBlank(),
                 new Assert\Regex([
-                    'pattern' => self::REGEX_FIELD_PATTERN,
+                    'pattern' => self::REGEX_ATTRIBUTE_PATTERN,
                     'match' => false,
                 ]),
             ]))
             ->setNormalizer('attributes', function (Options $options, $values) {
                 $bean = $this->beanManager->newBeanSafe($options->offsetGet('type'));
-                
+
                 foreach ($values as $attribute => $value) {
                     $invalidProperty =
                         !property_exists($bean, $attribute) &&


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
The `Attributes.php` parameter uses the `Fields.php` parameter's regex pattern to verify that attributes were formatted correctly. I've added a new regex to `Attributes.php` as the `fields` parameter validation shouldn't be re-used in the attributes class since while the `fields` parameter needs to restrict spaces and Unicode, attributes doesn't. 

I've also removed the ```Assert\NotBlank``` validation as we shouldn't need to exclude blank values.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It is currently impossible to create/edit a record with a space or Unicode character in any of the fields due to the attributes validation using ```REGEX_FIELD_PATTERN = '/[^\w-,]/'```.

Issue reference: #6452 
Issue reference: #6893 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
```
POST SuiteCRM/Api/V8/module
BODY {
  "data": {
    "type": "Accounts",
    "attributes": {
      "name": "Cocacola company",
      "description": "very friendly account"
    }
  }
}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [X] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->