### PR TITLE
Links returned in the API should be relative to the base_uri

### DIFF
--- a/Api/V8/JsonApi/Helper/PaginationObjectHelper.php
+++ b/Api/V8/JsonApi/Helper/PaginationObjectHelper.php
@@ -55,6 +55,6 @@ class PaginationObjectHelper
         $queryParams = $request->getQueryParams();
         $queryParams['page']['number'] = $number;
 
-        return sprintf('/%s?%s', $request->getUri()->getPath(), urldecode(http_build_query($queryParams)));
+        return sprintf('%s?%s', $request->getUri()->getPath(), urldecode(http_build_query($queryParams)));
     }
 }

--- a/Api/V8/JsonApi/Helper/RelationshipObjectHelper.php
+++ b/Api/V8/JsonApi/Helper/RelationshipObjectHelper.php
@@ -35,7 +35,7 @@ class RelationshipObjectHelper
         foreach (array_unique($relationships) as $module) {
             $linkResponse = new LinksResponse();
             $linkResponse->setRelated(
-                sprintf('/%s/%s/%s', $uriPath, 'relationships', strtolower($module))
+                sprintf('%s/%s/%s', $uriPath, 'relationships', strtolower($module))
             );
 
             $relationshipsLinks[$module] = ['links' => $linkResponse];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

The new API states the base_uri should `https://crm.example.org/Api/`.
This means all links returned from the API need to be relative to this `base_uri`.

According to [Guzzle explanation of RFC 3986](http://docs.guzzlephp.org/en/stable/quickstart.html#making-a-request) the `base_uri` with a path should end with `/` and the relative link should start without a `/`.

Full Example usage of this would

```php
<?php
$client = new \GuzzleHttp\Client([
    'base_uri' => 'https://crm.example.org/Api/',
]);

$url = 'V8/module/Notes?page[size]=20';
do {
    $response = $client->request('GET', $url);

    $body = json_decode((string)$response->getBody());

    $data = $body->data;
    // Do something with data

    $url = property_exists($body, 'links')
            && property_exists($body->links, 'next')
            && !is_null($body->links->next) ? $body->links->next : null;
} while ($url);
```

fixes #7095

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Simplify the API actual usage without needing complex logic to modify urls passed back and forth.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Apply the PR and try the code above in example usage.

Previously the `links` returned in the response would be

```
// links object
stdClass::__set_state(array(
   'first' => NULL,
   'prev' => NULL,
   'next' => '/V8/module/Notes?page[size]=20&page[number]=1',
   'last' => '/V8/module/Notes?page[size]=20&page[number]=148',
))
```

it should now be

```
// links object
stdClass::__set_state(array(
   'first' => NULL,
   'prev' => NULL,
   'next' => 'V8/module/Notes?page[size]=20&page[number]=1',
   'last' => 'V8/module/Notes?page[size]=20&page[number]=148',
))
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
*Note* this is not a breaking change due to the changes already made for the `base_uri` in previous changes.

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
*Note* I think it would be a good idea to add the above example to the docs.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->