### PR TITLE
Fixed #7166 - Upgrade to 7.11.3 version email body is empty

### DIFF
--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -5616,6 +5616,7 @@ class InboundEmail extends SugarBean
                     'MIXED',
                     'ALTERNATIVE',
                     'RELATED',
+                    'REPORT',
                     'HTML'
                 ];
 

--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -5612,7 +5612,14 @@ class InboundEmail extends SugarBean
 
                 $structure = $this->getImap()->fetchStructure($uid, FT_UID);
 
-                if ($structure->subtype === 'HTML') {
+                $subtypeArray = [
+                    'MIXED',
+                    'ALTERNATIVE',
+                    'RELATED',
+                    'HTML'
+                ];
+
+                if (in_array(strtoupper($structure->subtype), $subtypeArray, true)) {
                     $email->description_html = $this->getMessageTextWithUid(
                         $uid,
                         'HTML',
@@ -5620,7 +5627,7 @@ class InboundEmail extends SugarBean
                         $fullHeader,
                         true
                     );
-                } else {
+                } elseif ($structure->subtype === 'PLAIN') {
                     $email->description = $this->getMessageTextWithUid(
                         $uid,
                         'PLAIN',
@@ -5628,6 +5635,8 @@ class InboundEmail extends SugarBean
                         $fullHeader,
                         true
                     );
+                } else {
+                    $log->warn('Unknown MIME subtype in fetch request');
                 }
             } else {
                 $log->warn('Missing viewdefs in request');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixes an issue where the email body of non-imported emails would appear to be blank when the email imap subtype was not html or plain.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #7166 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Setup inbound email.
2. Check the body of imported and non-imported emails is visible.
3. Check that the body is visible in emails with different IMAP types (HTML, PLAIN, etc)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->