### PR TITLE
Fix V8 API authorization header passing with apache+php-fpm

### DIFF
--- a/Api/Core/app.php
+++ b/Api/Core/app.php
@@ -10,6 +10,13 @@ if (!defined('sugarEntry')) {
 }
 // @codingStandardsIgnoreEnd
 
+// For php-fpm we pass the "Authorization" header through HTTP_AUTHORIZATION
+// using .htaccess rewrite rules. The rewrite rules result in apache prefixing
+// the env var which gives us REDIRECT_HTTP_AUTHORIZATION.
+if (!isset($_SERVER['HTTP_AUTHORIZATION']) && isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
+    $_SERVER['HTTP_AUTHORIZATION'] = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
+}
+
 chdir(__DIR__ . '/../../');
 require_once __DIR__ . '/../../include/entryPoint.php';
 

--- a/install/install_utils.php
+++ b/install/install_utils.php
@@ -1001,13 +1001,13 @@ EOQ;
     RewriteRule ^cache/jsLanguage/(\w*)/(.._..).js$ index.php?entryPoint=jslang&modulename=$1&lang=$2 [L,QSA]
 
     # --------- DEPRECATED --------
-    RewriteRule ^api/(.*?)$ lib/API/public/index.php/$1 [L]
     RewriteRule ^api/(.*)$ - [env=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+    RewriteRule ^api/(.*?)$ lib/API/public/index.php/$1 [L]
     # -----------------------------
 
+    RewriteRule ^Api/(.*)$ - [env=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
     RewriteRule ^Api/access_token$ Api/index.php/access_token [L]
     RewriteRule ^Api/V8/(.*?)$ Api/index.php/V8/$1 [L]
-    RewriteRule ^Api/(.*)$ - [env=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 </IfModule>
 <FilesMatch "\.(jpg|png|gif|js|css|ico)$">
         <IfModule mod_headers.c>

--- a/modules/Administration/UpgradeAccess.php
+++ b/modules/Administration/UpgradeAccess.php
@@ -72,13 +72,13 @@ RedirectMatch 403 {$ignoreCase}/+files\.md5\$
     RewriteRule ^cache/jsLanguage/(\w*)/(.._..).js$ index.php?entryPoint=jslang&module=$1&lang=$2 [L,QSA]
 
     # --------- DEPRECATED --------
-    RewriteRule ^api/(.*?)$ lib/API/public/index.php/$1 [L]
     RewriteRule ^api/(.*)$ - [env=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+    RewriteRule ^api/(.*?)$ lib/API/public/index.php/$1 [L]
     # -----------------------------
 
+    RewriteRule ^Api/(.*)$ - [env=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
     RewriteRule ^Api/access_token$ Api/index.php/access_token [L]
     RewriteRule ^Api/V8/(.*?)$ Api/index.php/V8/$1 [L]
-    RewriteRule ^Api/(.*)$ - [env=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 </IfModule>
 <IfModule mod_rewrite.c>
         RewriteEngine On


### PR DESCRIPTION
## Description

With apache+php-fpm the authorization header gets stripped and never
reaches the app. The .htaccess already includes some rules to pass them through
with an env var, but because of the rule order this is never applied.

Fix the rewrite rules by moving the env var rules before the rules marked as [L]ast.

Passing an env var with a rewrite rule results in apache prefixing the env
var with "REDIRECT_". To work around this copy REDIRECT_HTTP_AUTHORIZATION to
HTTP_AUTHORIZATION in case only the former is set.

## Motivation and Context

I wanted to try the API, but it didn't work.

I also found similar issues in the forum (which inspired this patch):

* https://suitecrm.com/suitecrm/forum/installation-upgrade-help/21465-missing-authorization-header
* https://suitecrm.com/suitecrm/forum/suitecrm-7-0-discussion/19783-missing-authorization-header-issue

## How To Test This

* Use the API with APache and php-fpm

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
