### PR TITLE
Fixed #5746 - Unable to order results descending on get_relationships API method

### DIFF
--- a/service/v4_1/SugarWebServiceUtilv4_1.php
+++ b/service/v4_1/SugarWebServiceUtilv4_1.php
@@ -133,13 +133,14 @@ class SugarWebServiceUtilv4_1 extends SugarWebServiceUtilv4
                 $params['where'] = $optional_where;
             }
 
+            if (!empty($order_by)) {
+                $params['order_by'] = $order_by;
+            }
+
             $related_beans = $bean->$link_field_name->getBeans($params);
             //Create a list of field/value rows based on $link_module_fields
             $list = array();
             $filterFields = array();
-            if (!empty($order_by) && !empty($related_beans)) {
-                $related_beans = order_beans($related_beans, $order_by);
-            }
             foreach ($related_beans as $id => $bean) {
                 if (empty($filterFields) && !empty($link_module_fields)) {
                     $filterFields = $this->filter_fields($bean, $link_module_fields);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Using V4_1 API, get_relationships with ```$order_by = 'date_entered desc'``` causes the returned results to be in a random order instead of desc. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #5746

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Call get_relationships using V4_1 with $order_by = 'date_entered desc'.
2. Check that the returned results are correct.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->