### PR TITLE
Fixed #6455 - The V8 API does not allow filtering by custom fields

### DIFF
--- a/Api/V8/JsonApi/Repository/Filter.php
+++ b/Api/V8/JsonApi/Repository/Filter.php
@@ -45,7 +45,7 @@ class Filter
 
         $where = [];
         foreach ($params as $field => $expr) {
-            if (!property_exists($bean, $field)) {
+            if (empty($bean->field_defs[$field])) {
                 throw new \InvalidArgumentException(sprintf(
                     'Filter field %s in %s module is not found',
                     $field,

--- a/Api/V8/JsonApi/Repository/Sort.php
+++ b/Api/V8/JsonApi/Repository/Sort.php
@@ -18,12 +18,12 @@ class Sort
     public function parseOrderBy(\SugarBean $bean, $value)
     {
         $orderBy = self::ORDER_BY_ASC;
-        if ($value[0] === '-') {
+        if (strpos($value, '-') === 0) {
             $orderBy = self::ORDER_BY_DESC;
             $value = ltrim($value, '-');
         }
 
-        if (!property_exists($bean, $value)) {
+        if (empty($bean->field_defs[$value])) {
             throw new \InvalidArgumentException(sprintf(
                 'Sort field %s in %s module is not found',
                 $value,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
As custom fields are not explicitly defined as properties, you were unable to filter with them. With this fix, we use the field definitions instead of the properties.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #6455 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. With the V8 API, check that using a custom field as a filter works as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->