### PR TITLE
Add php-cs-fixer to composer.json as a dev dependency.

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -35,7 +35,6 @@ $finder = PhpCsFixer\Finder::create()
     ->exclude('modules/AOR_Charts/lib')
     ->exclude('install/demoData.en_us.php')
     ->exclude('include/SugarObjects/templates')
-    ->exclude('include/SugarObjects/templates')
     ->in($paths->getProjectPath());
 
 return PhpCsFixer\Config::create()

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -34,6 +34,8 @@ $finder = PhpCsFixer\Finder::create()
     ->exclude('modules/Users/authentication/SAML2Authenticate/lib')
     ->exclude('modules/AOR_Charts/lib')
     ->exclude('install/demoData.en_us.php')
+    ->exclude('include/SugarObjects/templates')
+    ->exclude('include/SugarObjects/templates')
     ->in($paths->getProjectPath());
 
 return PhpCsFixer\Config::create()

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,8 @@
     "leafo/scssphp": "^0.7.7",
     "mikey179/vfsstream": "1.6.*",
     "mockery/mockery": "^1.1.0",
-    "roave/security-advisories": "dev-master"
+    "roave/security-advisories": "dev-master",
+    "friendsofphp/php-cs-fixer": "^2.14"
   },
   "scripts": {
     "post-install-cmd": [

--- a/lib/Robo/Plugin/Commands/CodingStandardCommands.php
+++ b/lib/Robo/Plugin/Commands/CodingStandardCommands.php
@@ -78,6 +78,19 @@ class CodingStandardCommands extends \Robo\Tasks
     }
 
     /**
+     * Lints the codebase without modifying any files.
+     */
+    public function stylePHPCSFixerDryRun()
+    {
+        $this->say('Coding Standards: PSR2');
+
+        $paths = new Paths();
+        $result = $this->_exec('php vendor/bin/php-cs-fixer fix --dry-run --path-mode=intersection ' . $paths->getProjectPath() . ' --verbose --show-progress=run-in --config=' . $paths->getProjectPath() . '/.php_cs.dist');
+
+        return $result;
+    }
+
+    /**
      * A tool to automatically fix all PHP coding standards issues in modified files.
      */
     public function stylePHPCSFixerModified()

--- a/lib/Robo/Plugin/Commands/CodingStandardCommands.php
+++ b/lib/Robo/Plugin/Commands/CodingStandardCommands.php
@@ -50,23 +50,6 @@ class CodingStandardCommands extends \Robo\Tasks
     use RoboTrait;
 
     /**
-     * Configure environment.
-     */
-    public function styleConfigurePHPCSFixer()
-    {
-        $this->say('Configure PHPCSFixer');
-
-        if ($this->_exec('which composer') === null) {
-            throw new Exception('Could not find composer');
-        }
-
-        $this->taskComposerConfig()->set('bin-dir', 'vendor/bin/')->run();
-
-        $this->taskComposerRequire()->dependency('friendsofphp/php-cs-fixer')->dev()->run();
-        $this->taskComposerInstall()->dev()->run();
-    }
-
-    /**
      * A tool to automatically fix all PHP coding standards issues.
      */
     public function stylePHPCSFixer()


### PR DESCRIPTION
## Description
Adds the php-cs-fixer package to the `composer.json` explicitly.

I'm opening this as a PR into hotfix because php-cs-fixer doesn't support PHP 5.5, which SuiteCRM 7.8.x and 7.10.x both still support.

## Motivation and Context
The `composer.json` didn't specify php-cs-fixer despite the fact that we use it for the Robo style check command. This commit adds it explicitly to the `composer.json` so it will be installed by default for developers and so everyone will be able to use the same version of the package.

## How To Test This
Run `composer install` and run the phpcsfixer Robo task with `./vendor/bin/robo style:phpcsfixer`, if it lints files and fixes any issues, it works.

## Types of changes
I guess this is a bug fix?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.