### PR TITLE
 Fixed #7080 - API returns wrong module string address for email addresses

### DIFF
--- a/Api/V8/Config/services/beanAliases.php
+++ b/Api/V8/Config/services/beanAliases.php
@@ -30,6 +30,7 @@ return [
             Document::class => 'Documents',
             FieldsMetaData::class => 'DynamicFields',
             Email::class => 'Emails',
+            EmailAddress::class => 'EmailAddresses',
             EmailTemplate::class => 'EmailTemplates',
             Employee::class => 'Employees',
             UsersLastImport::class => 'Import',

--- a/Api/V8/Param/Options/Attributes.php
+++ b/Api/V8/Param/Options/Attributes.php
@@ -34,7 +34,7 @@ class Attributes extends BaseOption
 
                 foreach ($values as $attribute => $value) {
                     $invalidProperty =
-                        !property_exists($bean, $attribute) &&
+                        empty($bean->field_defs[$attribute]) &&
                         !array_key_exists($attribute, $bean->field_defs) &&
                         !array_key_exists($attribute, $bean->field_name_map);
                     if ($invalidProperty) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Maps the EmailAddress class to EmailAddresses.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #7080 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Call with V8 API: ```{{suitecrm.url}}/V8/module/EmailAddress```

Before fix:
```
{
    "errors": {
        "status": 400,
        "title": null,
        "detail": "Module EmailAddress does not exist"
    }
}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->