### PR TITLE
Remove hardcoded encryption key

### DIFF
--- a/Api/Core/Config/ApiConfig.php
+++ b/Api/Core/Config/ApiConfig.php
@@ -18,7 +18,7 @@ class ApiConfig
 
     const OAUTH2_PRIVATE_KEY = 'Api/V8/OAuth2/private.key';
     const OAUTH2_PUBLIC_KEY = 'Api/V8/OAuth2/public.key';
-    const OAUTH2_ENCRYPTION_KEY = 'KcWedk/XtvWgtuf7UHx6ayHnrIaMC/t4RjZrdVBY2Ho=';
+    const OAUTH2_ENCRYPTION_KEY = '';
     
     /**
      *

--- a/Api/V8/Config/services/middlewares.php
+++ b/Api/V8/Config/services/middlewares.php
@@ -33,6 +33,22 @@ return CustomLoader::mergeCustomArray([
             sprintf('file://%s/%s', $baseDir, ApiConfig::OAUTH2_PRIVATE_KEY),
             sprintf('file://%s/%s', $baseDir, ApiConfig::OAUTH2_PUBLIC_KEY)
         );
+
+        if (empty(ApiConfig::OAUTH2_ENCRYPTION_KEY)) {
+            $oldKey = ApiConfig::OAUTH2_ENCRYPTION_KEY;
+            $key = base64_encode(random_bytes(32));
+            $apiConfig = file_get_contents('Api/Core/Config/ApiConfig.php');
+
+            $configFileContents = str_replace(
+                $oldKey,
+                $key,
+                $apiConfig
+            );
+            file_put_contents(
+                'Api/Core/Config/ApiConfig.php', $configFileContents, LOCK_EX
+            );
+        }
+
         $server->setEncryptionKey(ApiConfig::OAUTH2_ENCRYPTION_KEY);
 
         // Client credentials grant

--- a/Api/V8/Config/services/middlewares.php
+++ b/Api/V8/Config/services/middlewares.php
@@ -35,8 +35,8 @@ return CustomLoader::mergeCustomArray([
         );
 
         if (empty(ApiConfig::OAUTH2_ENCRYPTION_KEY)) {
-            $oldKey = ApiConfig::OAUTH2_ENCRYPTION_KEY;
-            $key = base64_encode(random_bytes(32));
+            $oldKey = "OAUTH2_ENCRYPTION_KEY = '" . ApiConfig::OAUTH2_ENCRYPTION_KEY;
+            $key = "OAUTH2_ENCRYPTION_KEY = '" . base64_encode(random_bytes(32));
             $apiConfig = file_get_contents('Api/Core/Config/ApiConfig.php');
 
             $configFileContents = str_replace(

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     "league/oauth2-server": "^5.1",
     "league/url": "^3.3",
     "onelogin/php-saml": "^3.0.0",
+    "paragonie/random_compat": "^2.0",
     "psr/log": "^1.0",
     "slim/slim": "^3.8",
     "soundasleep/html2text": "~0.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "340a9d0ddf826306d4f268e19f4bdc9e",
+    "content-hash": "75f4a21dfc0edb24bbc88cd13eb6ee20",
     "packages": [
         {
             "name": "consolidation/annotated-command",
@@ -2613,6 +2613,55 @@
                 "psr-7"
             ],
             "time": "2018-04-03T06:12:18+00:00"
+        },
+        {
+            "name": "wikimedia/composer-merge-plugin",
+            "version": "v1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wikimedia/composer-merge-plugin.git",
+                "reference": "81c6ac72a24a67383419c7eb9aa2b3437f2ab100"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wikimedia/composer-merge-plugin/zipball/81c6ac72a24a67383419c7eb9aa2b3437f2ab100",
+                "reference": "81c6ac72a24a67383419c7eb9aa2b3437f2ab100",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0.0",
+                "jakub-onderka/php-parallel-lint": "~0.8",
+                "phpunit/phpunit": "~4.8|~5.0",
+                "squizlabs/php_codesniffer": "~2.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                },
+                "class": "Wikimedia\\Composer\\MergePlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Wikimedia\\Composer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Davis",
+                    "email": "bd808@wikimedia.org"
+                }
+            ],
+            "description": "Composer plugin to merge multiple composer.json files",
+            "time": "2017-04-25T02:31:25+00:00"
         }
     ],
     "packages-dev": [

--- a/install/install_utils.php
+++ b/install/install_utils.php
@@ -2198,6 +2198,23 @@ function create_writable_dir($dirname)
 }
 
 /**
+ * Create default OAuth2 encryption key
+ * @throws Exception
+ */
+function createEncryptionKey() {
+    $key = "OAUTH2_ENCRYPTION_KEY = '" . base64_encode(random_bytes(32));
+    $apiConfig = file_get_contents('Api/Core/Config/ApiConfig.php');
+    $configFileContents = str_replace(
+        "OAUTH2_ENCRYPTION_KEY = '",
+        $key,
+        $apiConfig
+    );
+    file_put_contents(
+        'Api/Core/Config/ApiConfig.php', $configFileContents, LOCK_EX
+    );
+}
+
+/**
  * Enable the InsideView connector for the four default modules.
  */
 function enableInsideViewConnector()

--- a/install/language/en_us.lang.php
+++ b/install/language/en_us.lang.php
@@ -229,6 +229,7 @@ $mod_strings = array(
     'LBL_LICENSE_CHKDB_HEADER' => 'Verifying DB Credentials.',
     'LBL_LICENSE_CHECK_PASSED' => 'System passed check for compatibility.',
     'LBL_CREATE_CACHE' => 'Preparing to Install...',
+    'LBL_CREATE_DEFAULT_ENC_KEY' => 'Creating default encryption key...',
     'LBL_LICENSE_REDIRECT' => 'Redirecting in ',
     'LBL_LICENSE_I_ACCEPT' => 'I Accept',
     'LBL_LICENSE_PRINTABLE' => ' Printable View ',

--- a/install/performSetup.php
+++ b/install/performSetup.php
@@ -368,6 +368,10 @@ installStatus($mod_strings['STAT_CREATE_DEFAULT_SETTINGS']);
     installerHook('post_createDefaultSchedulers');
 
 
+installLog($mod_strings['LBL_CREATE_DEFAULT_ENC_KEY']);
+createEncryptionKey();
+
+
     echo $mod_strings['LBL_PERFORM_DONE'];
 
 

--- a/modules/Administration/QuickRepairAndRebuild.php
+++ b/modules/Administration/QuickRepairAndRebuild.php
@@ -1,14 +1,11 @@
 <?php
-if (!defined('sugarEntry') || !sugarEntry) {
-    die('Not A Valid Entry Point');
-}
 /**
  *
  * SugarCRM Community Edition is a customer relationship management program developed by
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
  *
  * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
- * Copyright (C) 2011 - 2018 SalesAgility Ltd.
+ * Copyright (C) 2011 - 2019 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the
@@ -40,7 +37,11 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * reasonably feasible for technical reasons, the Appropriate Legal Notices must
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
 
+use Api\Core\Config\ApiConfig;
 
 class RepairAndClear
 {
@@ -117,6 +118,9 @@ class RepairAndClear
                 $this->clearExternalAPICache();
                 $this->rebuildExtensions();
                 $this->rebuildAuditTables();
+                if (empty(ApiConfig::OAUTH2_ENCRYPTION_KEY)) {
+                    $this->rebuildEncryptionKey();
+                }
                 $this->repairDatabase();
                 break;
         }
@@ -448,6 +452,36 @@ class RepairAndClear
     ///////////////////////////////////////////////////////////////
     ////END REPAIR AUDIT TABLES
 
+    /**
+     * Rebuilds the OAuth2 encryption key
+     * @throws Exception
+     */
+    private function rebuildEncryptionKey()
+    {
+        $oldKey = "OAUTH2_ENCRYPTION_KEY = '" . ApiConfig::OAUTH2_ENCRYPTION_KEY;
+        $key = "OAUTH2_ENCRYPTION_KEY = '" . base64_encode(random_bytes(32));
+        $apiConfig = 'Api/Core/Config/ApiConfig.php';
+
+        if (is_writable($apiConfig)) {
+            $configContents = file_get_contents($apiConfig);
+
+            $configFileContents = str_replace(
+                $oldKey,
+                $key,
+                $configContents
+            );
+
+            $result = file_put_contents(
+                'Api/Core/Config/ApiConfig.php', $configFileContents, LOCK_EX
+            );
+
+            if ($result === false) {
+                LoggerManager::getLogger()->warn('QRR: Failed to update OAUTH2_ENCRYPTION_KEY');
+            }
+        } else {
+            LoggerManager::getLogger()->warn('QRR: API Config not writable: ' . $apiConfig);
+        }
+    }
 
     ///////////////////////////////////////////////////////////////
     //// Recursively unlink all files of the given $extension in the given $thedir.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
- Removes the hardcoded ```OAUTH2_ENCRYPTION_KEY``` from APIConfig and generates it if empty. 
- Generate ```OAUTH2_ENCRYPTION_KEY``` through Repair&Rebuild if empty.
- Generate ```OAUTH2_ENCRYPTION_KEY``` on install.
- Explicitly require [```paragonie/random_compat```](https://github.com/paragonie/random_compat) in composer. This allows us to use the PHP 7 functions ```random_bytes()``` and ```random_int()``` in PHP 5 and above. We are already using these functions in the v8 API with this lib being pulled down as a dependency of other libs, this just makes sure it won't get removed accidentally.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Call ```{{suitecrm.url}}/V8/module/Accounts/.```
2. Go to ```Api/Core/Config/ApiConfig.php``` -> ```const OAUTH2_ENCRYPTION_KEY``` and check that the value has been updated.
3. Replace ```OAUTH2_ENCRYPTION_KEY``` with an empty string, run Repair&Rebuild and check that the value is replaced.
4. Install fresh instance and check ```OAUTH2_ENCRYPTION_KEY``` has been generated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [X] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->