### PR TITLE
EmailTemplates: Improve image url replacement

### DIFF
--- a/modules/EmailTemplates/EmailTemplate.php
+++ b/modules/EmailTemplates/EmailTemplate.php
@@ -922,15 +922,16 @@ class EmailTemplate extends SugarBean
 
         // repair the images url at entry points, change to a public direct link for remote email clients..
 
-        $siteUrlQuoted = str_replace(array(':', '/'), array('\:', '\/'), $sugar_config['site_url']);
-        $regex = '/&lt;img src=&quot;(' . $siteUrlQuoted . '\/index\.php\?entryPoint=download&type=Notes&id=([a-f0-9]{8}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{12})&filename=[^&]+)&quot;/';
+        $html = from_html($this->body_html);
+        $siteUrl = $sugar_config['site_url'];
+        $regex = '#<img[^>]*[\s]+src=[\s]*["\'](' . preg_quote($siteUrl) . '\/index\.php\?entryPoint=download&type=Notes&id=([a-f0-9]{8}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{12})&filename=.+?)["\']#si';
 
-        if (preg_match($regex, $this->body_html, $match)) {
+        if (preg_match($regex, $html, $match)) {
             $splits = explode('.', $match[1]);
             $fileExtension = end($splits);
             $this->makePublicImage($match[2], $fileExtension);
-            $directLink = '&lt;img src=&quot;' . $sugar_config['site_url'] . '/public/' . $match[2] . '.' . $fileExtension . '&quot;';
-            $this->body_html = str_replace($match[0], $directLink, $this->body_html);
+            $newSrc = $sugar_config['site_url'] . '/public/' . $match[2] . '.' . $fileExtension;
+            $this->body_html = to_html(str_replace($match[1], $newSrc, $html));
             $this->imageLinkReplaced = true;
             $this->repairEntryPointImages();
         }

--- a/modules/EmailTemplates/Save.php
+++ b/modules/EmailTemplates/Save.php
@@ -58,7 +58,7 @@ require_once('modules/EmailTemplates/EmailTemplateFormBase.php');
 $form = new EmailTemplateFormBase();
 sugar_cache_clear('select_array:'.$focus->object_name.'namebase_module=\''. (isset($focus->base_module) ? $focus->base_module : null).'\'name');
 if (isset($_REQUEST['inpopupwindow']) and $_REQUEST['inpopupwindow'] == true) {
-    $focus=$form->handleSave('', false, false); //do not redirect.
+    $focus=$form->handleSave('', false, false, true, 'download', true); //do not redirect.
     $body1 = "
 		<script type='text/javascript'>
 			function refreshTemplates() {
@@ -70,5 +70,5 @@ if (isset($_REQUEST['inpopupwindow']) and $_REQUEST['inpopupwindow'] == true) {
 		</script>";
     echo  $body1;
 } else {
-    $form->handleSave('', true, false, true, 'download');
+    $form->handleSave('', true, false, true, 'download', true);
 }

--- a/tests/unit/phpunit/modules/EmailTemplates/EmailTemplateTest.php
+++ b/tests/unit/phpunit/modules/EmailTemplates/EmailTemplateTest.php
@@ -26,6 +26,44 @@ class EmailTemplateTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $this->assertContains('src="https://foobar.com/public/c1270a2d-a083-495e-7c61-5c8a9046ec0d.png" alt="c1270a2d-a083-495e-7c61-5c8a9046ec0d.png"', $result);
     }
 
+    public function testrepairEntryPointImages()
+    {
+        global $sugar_config;
+
+        $state = new SuiteCRM\StateSaver();
+        $state->pushTable('email_templates');
+        $state->pushTable('aod_index');
+
+        $sugar_config['site_url'] = 'https://foobar.com';
+
+        $ids = [create_guid(), create_guid()];
+        $html = '<img src="https://foobar.com/index.php?entryPoint=download&type=Notes&id=' . $ids[0] . '&filename=test2.png" alt="" style="font-size:14px;" width="381" height="339">';
+        $html .= '<img alt="test.png" src="https://foobar.com/index.php?entryPoint=download&type=Notes&id=' . $ids[1] . '&filename=test.png" width="118" height="105">';
+
+        foreach ($ids as $id) {
+            file_put_contents('upload/' . $id, 'IAmAnImage:' . $id);
+        }
+
+        $template = new EmailTemplate();
+        $template->body_html = to_html($html);
+        $template->new_with_id = true;
+        $template->save();
+        $this->assertNotNull($template->retrieve($template->id));
+
+        foreach ($ids as $id) {
+            $this->assertTrue(is_file('public/' . $id . '.png'));
+            unlink('public/' . $id . '.png');
+            unlink('upload/' . $id);
+        }
+
+        $expected = '<img src="https://foobar.com/public/' . $ids[0] . '.png" alt="" style="font-size:14px;" width="381" height="339" />';
+        $expected .= '<img alt="test.png" src="https://foobar.com/public/' . $ids[1] . '.png" width="118" height="105" />';
+        $this->assertEquals($expected, from_html($template->body_html));
+
+        $state->popTable('aod_index');
+        $state->popTable('email_templates');
+    }
+
     public function testEmailTemplate()
     {
 


### PR DESCRIPTION
## Description

This contains three commits which should make including images in email
templates a bit less buggy:

1) Fix the unittest state saver so that the email_templates table can be
   pushed/popped in tests.
2) Extend repairEntryPointImages() to handle all types of img tags, not just
   some common mozaik ones.
3) When saving the template move images to public/ instead of depending
   on repairEntryPointImages() to fix it later.

## Motivation and Context

* Sometimes including images in mozaik will result in download entry point URLs
  which are not public.
* I'm currently testing CKEditor which always triggered this because the img
  tags have a different default attribute order there.

## How To Test This

* Create an email template
* Upload an image and include it
* Save
* The image src should be an absolute URL using the public/ dir.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
