### PR TITLE
Image not found because "s" is added

### DIFF
--- a/modules/Alerts/templates/default.tpl
+++ b/modules/Alerts/templates/default.tpl
@@ -8,7 +8,7 @@
         <a class="alert-link text-{if $result->type != null}{$result->type}{else}info{/if}" href="index.php?module=Alerts&action=redirect&record={$result->id}">
         {/if}
             {if $result->target_module != null }
-                <img src="index.php?entryPoint=getImage&themeName=SuiteR+&imageName={$result->target_module}s.gif"/>
+                <img src="index.php?entryPoint=getImage&themeName=SuiteR+&imageName={$result->target_module}.gif"/>
                 <strong class="text-{if $result->type != null}{$result->type}{else}info{/if}">{$result->target_module}</strong>
             {else}
                 <strong class="text-{if $result->type != null}{$result->type}{else}info{/if}">Alert</strong>


### PR DESCRIPTION
I do not know, if anybody else has this.
For me, Suite tries to load an  image "Meetingss.gif". So double ss in the end. The gif of course is named "Meetings.gif"
I know that at some places (at least in the past), plural of module names were handled differently, but do not know if that is the reason for the additional "s".

Same problem should exist in every version of SuiteCRM.
I found that problem by looking at the webserver log, or the network log in the browser.