### PR TITLE
Add return to function

### DIFF
--- a/include/SubPanel/SubPanelDefinitions.php
+++ b/include/SubPanel/SubPanelDefinitions.php
@@ -448,6 +448,7 @@ class aSubPanel
                 }
             }
         }
+        return $display_fields;
     }
 
     function isDatasourceFunction ()


### PR DESCRIPTION
Did not find at which point it was fixed for 7.10, but should be backportet to 7.8.x

https://github.com/salesagility/SuiteCRM/blob/1892b13ecfcd9a9e3cd575c8b4b3336188e86f28/include/SubPanel/SubPanelDefinitions.php#L432
