### PR TITLE
Replace $db global variable in a bunch of files

### DIFF
--- a/modules/Charts/Dashlets/OpportunitiesByLeadSourceDashlet/OpportunitiesByLeadSourceDashlet.php
+++ b/modules/Charts/Dashlets/OpportunitiesByLeadSourceDashlet/OpportunitiesByLeadSourceDashlet.php
@@ -206,7 +206,8 @@ EOD;
 
     public function getChartData($query)
     {
-        global $app_list_strings, $db;
+        global $app_list_strings;
+        $db = DBManagerFactory::getInstance();
         $dataSet = [];
         $result = $db->query($query);
 

--- a/modules/Emails/EmailUI.php
+++ b/modules/Emails/EmailUI.php
@@ -2585,7 +2585,7 @@ eoq;
      */
     public function getRelatedEmail($beanType, $whereArr, $relatedBeanInfoArr = '')
     {
-        global $beanList, $current_user, $app_strings, $db;
+        global $beanList, $current_user, $app_strings;
         $finalQuery = '';
         $searchBeans = null;
         if ($beanType === 'LBL_DROPDOWN_LIST_ALL') {

--- a/modules/Leads/views/view.convertlead.php
+++ b/modules/Leads/views/view.convertlead.php
@@ -669,7 +669,8 @@ class ViewConvertLead extends SugarView
             return;
         }
 
-        global $beanList, $db;
+        global $beanList;
+        $db = DBManagerFactory::getInstance();
 
         $activitesList = array("Calls", "Tasks", "Meetings", "Emails", "Notes");
         $activities = array();

--- a/modules/Project/Project.php
+++ b/modules/Project/Project.php
@@ -336,7 +336,8 @@ class Project extends SugarBean
 
     public function save($check_notify = false)
     {
-        global $current_user, $db;
+        global $current_user;
+        $db = DBManagerFactory::getInstance();
         $focus = $this;
 
         //--- check if project template is same or changed.

--- a/modules/Project/chart.php
+++ b/modules/Project/chart.php
@@ -68,7 +68,8 @@ class chart
 
     public function draw($start_date, $end_date, $sel_projects, $sel_users, $sel_contacts, $resources, $chart_type)
     {
-        global $current_user, $db, $mod_strings;
+        global $current_user, $mod_strings;
+        $db = DBManagerFactory::getInstance();
 
         if ($chart_type == "monthly") {
             list($time_span, $day_count) = $this->year_week($start_date, $end_date);

--- a/modules/Project/controller.php
+++ b/modules/Project/controller.php
@@ -89,7 +89,8 @@ class ProjectController extends SugarController
     //Create new project task
     public function action_update_GanttChart()
     {
-        global $current_user, $db;
+        global $current_user;
+        $db = DBManagerFactory::getInstance();
 
         $task_name = $_POST['task_name'];
         $project_id = $_POST['project_id'];


### PR DESCRIPTION
## Description
Fixes a lot of cases of the `$db` global variable from #7241.

## Motivation and Context
See [this commit](https://github.com/salesagility/SuiteCRM/commit/98e8b6e5d8125f2b268a9975cf3d472edebbd98a#diff-3577c448a121183734986b4b6f848826) and [this PR](https://github.com/salesagility/SuiteCRM/pull/5718), where these were originally changed.

## How To Test This
Make sure the test suite passes and that the queries I've changed still work.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
