### PR TITLE
fix SQL query leading to broken "Pipeline by sales stage" on 7.8.x

### DIFF
--- a/modules/Charts/Dashlets/PipelineBySalesStageDashlet/PipelineBySalesStageDashlet.php
+++ b/modules/Charts/Dashlets/PipelineBySalesStageDashlet/PipelineBySalesStageDashlet.php
@@ -322,14 +322,11 @@ EOD;
         $conversion_rate = $this->currency->conversion_rate;
         $query = "  SELECT opportunities.sales_stage,
                         count(*) AS opp_count,
-                        sum(amount_usdollar/1000) AS total
                         sum((amount_usdollar*".$conversion_rate.")/1000) AS total
                     FROM users,opportunities  ";
-        $query .= " WHERE opportunities.date_closed >= ". db_convert("'".$this->pbss_date_start."'", 'date').
-            " AND opportunities.date_closed <= ".db_convert("'".$this->pbss_date_end."'", 'date') .
-            $query .= " WHERE opportunities.date_closed >= ". db_convert("'".$this->pbss_date_start."'",'date').
-                " AND opportunities.date_closed <= ".db_convert("'".$this->pbss_date_end."'",'date') .
-                " AND opportunities.assigned_user_id = users.id  AND opportunities.deleted=0 ";
+        $query .= " WHERE opportunities.date_closed >= ". db_convert("'".$this->pbss_date_start."'", 'date') .
+                        " AND opportunities.date_closed <= ". db_convert("'".$this->pbss_date_end."'", 'date') .
+                        " AND opportunities.assigned_user_id = users.id AND opportunities.deleted=0 ";
         $query .= " GROUP BY opportunities.sales_stage";
         return $query;
     }


### PR DESCRIPTION

## Description

The SQL query was broken, maybe due to a merge. The WHERE statement was doubled, and so was selecting `total` with a missing comma.

It fixes #6736 

## Motivation and Context

It fixes the "Pipeline by sales stage" dashlet which shows "No result" currently.

## How To Test This

Add the dashlet to your dashboard. Before the fix there is "no result", afterwards you see your grpahs es expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->