### PR TITLE
install.php: Syntax error upload logo

### DIFF
--- a/install.php
+++ b/install.php
@@ -266,7 +266,7 @@ if (isset($_REQUEST['sugar_body_only']) && $_REQUEST['sugar_body_only'] == "1") 
 
         // TODO--low: validate file size & image width/height and save, show status result to client js
 
-        if (!empty($_REQUEST['callback'] === 'uploadLogoCallback')) {
+        if (isset($_REQUEST['callback']) && $_REQUEST['callback'] === 'uploadLogoCallback') {
             echo "<script>window.top.window.uploadLogoCallback" . json_encode($result) . ");</script>";
         }
 


### PR DESCRIPTION
## Description
Corrects syntax error in install.php:

SuiteCRM]$ php -l install.php 
PHP Parse error:  syntax error, unexpected '===' (T_IS_IDENTICAL), expecting ')' in install.php on line 269
Errors parsing install.php
