### PR TITLE
Fixed #6445 - Campaign Wizard: Assign current user when creating a new template

### DIFF
--- a/modules/EmailTemplates/EmailTemplateData.php
+++ b/modules/EmailTemplates/EmailTemplateData.php
@@ -82,6 +82,7 @@ if (preg_match('/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/
                     $newBean->$key = $bean->$key;
                 }
             }
+            $newBean->assigned_user_id = $GLOBALS['current_user']->id;
             if ($newBean->save()) {
                 $msgs[] = 'LBL_TEMPLATE_SAVED';
             }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -42,6 +42,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 /* bootstrap sugarcrm */
 //echo "CWD:" . getcwd() . "\n";
+error_reporting(E_ALL);
 chdir('../');
 define('sugarEntry', true);
 global $sugar_config, $db;

--- a/tests/unit/phpunit/modules/EmailTemplates/EmailTemplateTest.php
+++ b/tests/unit/phpunit/modules/EmailTemplates/EmailTemplateTest.php
@@ -11,6 +11,37 @@ class EmailTemplateTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $current_user = new User();
     }
 
+    public function testcreateCopyTemplate()
+    {
+        global $current_user;
+
+        $state = new SuiteCRM\StateSaver();
+        $state->pushTable('aod_index');
+        $state->pushTable('email_templates');
+        $state->pushGlobals();
+
+        $this->setOutputCallback(function($msg) {});
+
+        $current_user->id = create_guid();
+        $_REQUEST['func'] = 'createCopy';
+        $_POST['name'] = 'Name';
+        $_POST['subject'] = 'Subject';
+        $_POST['body_html'] = 'BodyHTML';
+        require('modules/EmailTemplates/EmailTemplateData.php');
+
+        $output = json_decode($this->getActualOutput(), true);
+        $this->assertNotEmpty($output['data']);
+        $this->assertNotEmpty($output['data']['id']);
+        $template = new EmailTemplate();
+        $this->assertNotNull($template->retrieve($output['data']['id']));
+
+        $this->assertEquals($current_user->id, $template->assigned_user_id);
+
+        $state->popTable('email_templates');
+        $state->popTable('aod_index');
+        $state->popGlobals();
+    }
+
     public function testaddDomainToRelativeImagesSrc()
     {
         global $sugar_config;


### PR DESCRIPTION
## Description

Usually when creating a record where it's not possible to assign a user the current
user is assigned instead.

This didn't happen in the campaign wizard when copying or creating a new email template.

This assigns the current user and adds a unit test while at it.

Fixes #6445

## How To Test This

* Create a new marketing entry in a campaign
* Copy any existing template or save a new one
* The new template should be assigned to you

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.