### PR TITLE
Fixed #6420 - Campaigns: don't send test emails to lists no longer linked to the campaign

### DIFF
--- a/modules/EmailMan/EmailManDelivery.php
+++ b/modules/EmailMan/EmailManDelivery.php
@@ -105,6 +105,7 @@ if ($test) {
     $select_query .= " join prospect_list_campaigns plc on em.campaign_id = plc.campaign_id";
     $select_query .= " join prospect_lists pl on pl.id = plc.prospect_list_id ";
     $select_query .= " WHERE em.list_id = pl.id and pl.list_type = 'test'";
+    $select_query .= " AND pl.deleted = 0 AND plc.deleted = 0 AND em.deleted = 0";
     $select_query .= " AND em.send_date_time <= " . $db->now();
     $select_query .= " AND (em.in_queue ='0' OR em.in_queue IS NULL OR (em.in_queue ='1' AND em.in_queue_date <= " . $db->convert($db->quoted($timedate->fromString("-1 day")->asDb()), "datetime") . "))";
     $select_query .= " AND em.campaign_id='{$campaign_id}'";
@@ -117,6 +118,7 @@ if ($test) {
     $select_query = " SELECT *";
     $select_query .= " FROM $emailman->table_name";
     $select_query .= " WHERE send_date_time <= " . $db->now();
+    $select_query .= " AND deleted = 0";
     $select_query .= " AND (in_queue ='0' OR in_queue IS NULL OR ( in_queue ='1' AND in_queue_date <= " . $db->convert($db->quoted($timedate->fromString("-1 day")->asDb()), "datetime") . ")) " . ($confirmOptInEnabled ? ' OR related_confirm_opt_in = 1 ' : ' AND related_confirm_opt_in = 0');
 
     if (!empty($campaign_id)) {


### PR DESCRIPTION
## Description

When querying the emailman table the code didn't take deleted records and links into
account which could result in test emails being sent to persons no longer linked to
the campaign.

This adds deleted checks to the query.
Also adds a deleted check for the emailman entries for both test and non-test cases
while at it.

Fixes #6420 

## Motivation and Context

Moving test lists around shouldn't result in weird email sending behavior.

## How To Test This

* Create a newsletter campaign
* Add yourself to the test list
* Remove the test list from the campaign and add it back again
* Send a test mail
* The mail should only be sent once

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.