### PR TITLE
fixes #7308 - Sub-Theme changes don't always update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ Desktop.ini
 *.sln
 *.suo
 *.phpproj
+# Microsoft Visual Studio Code
+.vscode
 # Disytel
 lang_cmp.php
 .kdev4/

--- a/lib/Robo/Plugin/Commands/BuildCommands.php
+++ b/lib/Robo/Plugin/Commands/BuildCommands.php
@@ -102,10 +102,10 @@ class BuildCommands extends \Robo\Tasks
             while(false !== ($file = readdir($dir))) {
                 if (filetype($directory . $file) === 'dir' && file_exists($directory .     $file . "/style.scss")) {
                     if (file_exists($directory . $file . "/style.css")) {
-                        $this->say("Found stlye.css for {$file}, Removing");
+                        $this->say("Found style.css for {$file}, Removing");
                         unlink($directory . $file . "/style.css");
                     }
-                    $this->say("Found stlye.scss for {$file}, Compiling");
+                    $this->say("Found style.scss for {$file}, Compiling");
                     $this->buildSuitePColorScheme($file, $directory);
                 }
             }

--- a/lib/Robo/Plugin/Commands/BuildCommands.php
+++ b/lib/Robo/Plugin/Commands/BuildCommands.php
@@ -48,44 +48,67 @@ class BuildCommands extends \Robo\Tasks
     use loadTasks;
     use RoboTrait;
     // define public methods as commands
-
     /**
      * Build SuiteP theme
-     * @params array $opts optional command line arguments
+     * @param array $opts optional command line arguments
      * color_scheme - set which color scheme you wish to build
      * @throws \RuntimeException
      */
     public function buildSuitep(array $opts = ['color_scheme' => ''])
     {
         $this->say('Compile SuiteP Theme (SASS)');
-        if (empty($this->opts['color_scheme'])) {
-            $this->buildSuitePColorScheme('Dawn');
-            $this->buildSuitePColorScheme('Day');
-            $this->buildSuitePColorScheme('Dusk');
-            $this->buildSuitePColorScheme('Night');
-        } elseif (is_array($this->opts['color_scheme'])) {
-            foreach ($this->opts['color_scheme'] as $colorScheme) {
+        if (empty($this->$opts['color_scheme'])) {
+            /** Look for Subthemes in the SuiteP theme Dir **/
+            $std = "themes/SuiteP/css/";
+            $this->locateSubTheme($std);
+            /** Look for Subthemes in the custom/theme Dir **/
+            // Good opportunity to refactor here.
+            // Does the same as above just looks in the custom directory.
+            $ctd = 'custom/themes/SuiteP/css/';
+            $this->locateSubTheme($ctd);
+            return;
+          
+        } elseif (is_array($this->$opts['color_scheme'])) {
+            foreach ($this->$opts['color_scheme'] as $colorScheme) {
                 $this->buildSuitePColorScheme($colorScheme);
             }
-        } else {
-            $this->buildSuitePColorScheme($this->opts['color_scheme']);
+            return;
         }
+        $this->buildSuitePColorScheme($this->$opts['color_scheme']);
         $this->say('Compile SuiteP Theme (SASS) Complete');
     }
 
     /**
      * @param string $colorScheme eg Dawn
+     * @param string $location eg Directory to work from
      * @throws \RuntimeException
      */
-    private function buildSuitePColorScheme($colorScheme)
+    private function buildSuitePColorScheme($colorScheme, $location = 'themes/    SuiteP/css/')
     {
         $os = new OperatingSystem();
         $command =
             $os->toOsPath("./vendor/bin/pscss")
             . " -f compressed "
-            . $os->toOsPath("themes/SuiteP/css/{$colorScheme}/style.scss")
+            . $os->toOsPath("{$location}{$colorScheme}/style.scss")
             . " > "
-            . $os->toOsPath("themes/SuiteP/css/{$colorScheme}/style.css");
+            . $os->toOsPath("{$location}{$colorScheme}/style.css");
         $this->_exec($command);
+    }
+    /**
+     * @param string $directory
+     */
+    private function locateSubTheme($directory) {
+        if (is_dir($directory) && $dir = opendir($directory)) {
+            while(false !== ($file = readdir($dir))) {
+                if (filetype($directory . $file) === 'dir' && file_exists($directory .     $file . "/style.scss")) {
+                    if (file_exists($directory . $file . "/style.css")) {
+                        $this->say("Found stlye.css for {$file}, Removing");
+                        unlink($directory . $file . "/style.css");
+                    }
+                    $this->say("Found stlye.scss for {$file}, Compiling");
+                    $this->buildSuitePColorScheme($file, $directory);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Removes old style sheets for sub-themes of SuiteP. Gets dynamic with searching the stock SuiteP dir and `/custom/them` dir.
fixes #7308

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

Removed the hardcoded sub-theme references and dynamically search the `theme/SuiteP/css/` directory for any possible directories that may contain any `style.css` or `style.scss` indicating they are a subtheme definition. If a `style.css` file is found remove it in prep for the new file to be compiled. This goes the same for the `custom/theme/` directory also. Theme directories are stored in variables so they can be updated later or possibly specified as params in the future.

Updated the `buildSuitePColorScheme()` function to accept an additional `$location` parameter with a default definition. This allows flexibility when directing what subthemes to compile.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Recently ran into multiple issues with themes not compiling style sheets properly and custom themes not compiling into an actual theme. Initially for either permission reasons or some other error `style.css` was not being overwritten after it had been compiled from scratch, I found the simplest solution to be, remove the file and then recompile. I also noticed the automated build task would not recognize any custom subthemes I had created in either the `custom/themes` dir or in the stock `themes` dir. I found the issues with the custom subtheme dir only after I had "forgotten" a custom theme had been created there and then left and never recompiled to the new changes.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Create a copy of an existing subtheme, or make changes to a subtheme's SASS files, then run the robo task `build:suitep` all changes should take hold.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->