### PR TITLE
StateChecker: Don't save hash debug traces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ script:
   # Run the unit tests
   - sudo chmod -R 777 .
   - echo "\$sugar_config['state_checker']['save_traces'] = false;" >> config_override.php
-  - echo "\$sugar_config['state_checker']['redefine_memory_limit'] = false;
+  - echo "\$sugar_config['state_checker']['redefine_memory_limit'] = false;" >> config_override.php
   - cd tests
   - ../vendor/bin/phpunit --stop-on-failure --stop-on-error --colors --configuration $(pwd)/phpunit.xml.dist ./tests/unit/phpunit
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ script:
   
   # Run the unit tests
   - sudo chmod -R 777 .
-  - echo "\$sugar_config['state_checker']['save_traces'] = false;
+  - echo "\$sugar_config['state_checker']['save_traces'] = false;" >> config_override.php
   - echo "\$sugar_config['state_checker']['redefine_memory_limit'] = false;
   - cd tests
   - ../vendor/bin/phpunit --stop-on-failure --stop-on-error --colors --configuration $(pwd)/phpunit.xml.dist ./tests/unit/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,9 @@ script:
   - ./build/push_output.sh
   
   # Run the unit tests
-  # - ./vendor/bin/codecept run unit --steps -f
+  - sudo chmod -R 777 .
+  - echo "\$sugar_config['state_checker']['save_traces'] = false;
+  - echo "\$sugar_config['state_checker']['redefine_memory_limit'] = false;
   - cd tests
   - ../vendor/bin/phpunit --stop-on-failure --stop-on-error --colors --configuration $(pwd)/phpunit.xml.dist ./tests/unit/phpunit
   - cd ..


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
An alternative to #7087 to disable storing hash debug traces while running the tests but without removing the functionality altogether.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Run the unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->