### PR TITLE
Fix zero padding issue with openssl decryption

### DIFF
--- a/service/core/SoapHelperWebService.php
+++ b/service/core/SoapHelperWebService.php
@@ -1218,7 +1218,9 @@ class SoapHelperWebServices
             $key = substr(md5($key), 0, 24);
             $iv = "password";
             $GLOBALS['log']->info('End: SoapHelperWebServices->decrypt_string');
-            return openssl_decrypt(pack("H*", $buffer), 'des-ede3-cbc', $key, OPENSSL_NO_PADDING, $iv);
+            $decrypted = openssl_decrypt(pack("H*", $buffer), 'des-ede3-cbc', $key, OPENSSL_RAW_DATA|OPENSSL_ZERO_PADDING, $iv);
+            $decrypted = str_replace("\0", "", $decrypted);
+            return $decrypted;
         }
         $GLOBALS['log']->info('End: SoapHelperWebServices->decrypt_string');
         return $string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixes an issue where strings with zero padding still have it when decrypted which causes issues when logging in via ldap.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To solve issues with logging in via api via ldap.
## How To Test This
<!--- Please describe in detail how to test your changes. -->
Login via api ensuring you are using a string which is zero padded. See that it will not work. Try again with fix applied

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->