### PR TITLE
Fix #5173 by disabling linebreak replacement on email fields during inline edit

### DIFF
--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -443,19 +443,27 @@ function handleSave(field,id,module,type){
         parent_type = $('#parent_type').val();
     }
     var output_value = saveFieldHTML(field,module,id,value, parent_type);
-    var output = setValueClose(output_value);
+    // If the field type is email, we don't want to handle linebreaks in the output.
+    if (field === 'email1') {
+        setValueClose(output_value, false);
+    } else {
+        setValueClose(output_value);
+    }
 }
 
 /**
  * Takes the value and places it inside the td, also inputs the edit icon stuff as this was removed when the field was retrieved.
  * Calls buildEditField() to re add the on dblclick event.
  * @param value
+ * @param replaceLinebreaks Whether or not to replace linebreaks in the value with <br> elements.
  */
 
-function setValueClose(value){
+function setValueClose(value, replaceLinebreaks = true) {
     $.get('themes/'+SUGAR.themes.theme_name+'/images/inline_edit_icon.svg', function(data) {
         // Fix for #3136 - replace new line characters with <br /> for html on close.
-        value = value.replace(/(?:\r\n|\r|\n)/g, '<br />');
+        if (replaceLinebreaks) {
+            value = value.replace(/(?:\r\n|\r|\n)/g, '<br />');
+        }
 
         $(".inlineEditActive").html("");
         $(".inlineEditActive").html(value + '<div class="inlineEditIcon">' + inlineEditIcon + '</div>');


### PR DESCRIPTION
Don't replace linebreaks on email fields when inline-editing.

## Description
Fixes #5173.

## Motivation and Context

When inline-editing and then saving an email field, linebreaks (`\n`) inside the string returned by the backend were turned into `<br/>` elements, which caused the anchor tag to close early and display the HTML attributes as plaintext:

![image](https://user-images.githubusercontent.com/2977353/59052251-e6f12980-884b-11e9-900b-97c1e75e5cba.png)

## How To Test This
- Open the Contacts view
- Create a Contact with an email
- Go back to the Contacts list view
- Double click the email of the contact to inline-edit it
- Modify the email address
- Hit the checkmark to save
- Note that the email is rendered properly, instead of being rendered like the screenshot above.

You can also test inline-editing a field with linebreaks to verify that this change doesn't cause a regression to the problem described in #3136.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.