### PR TITLE
Get ChromeDriver's latest release in Robo task.

### DIFF
--- a/lib/Robo/Plugin/Commands/TestEnvironmentCommands.php
+++ b/lib/Robo/Plugin/Commands/TestEnvironmentCommands.php
@@ -123,7 +123,7 @@ class TestEnvironmentCommands extends \Robo\Tasks
      * @option bool $reinstall Forces the Chrome WebDriver executable to be reinstalled, can be used to get a newer version.
      * @usage chromedriver:install --reinstall
      */
-    public function chromedriverInstall($opts = ['reinstall' => false])
+    public function chromeDriverInstall($opts = ['reinstall' => false])
     {
         $this->say('Installing ChromeDriver...');
         $os = new OperatingSystem();
@@ -162,7 +162,7 @@ class TestEnvironmentCommands extends \Robo\Tasks
      * @param array $opts
      * @option string $url_base The base URL from which the WebDriver will be run.
      */
-    public function chromedriverRun($opts = ['url_base' => '/wd/hub'])
+    public function chromeDriverRun($opts = ['url_base' => '/wd/hub'])
     {
         $this->say('Running ChromeDriver...');
         $os = new OperatingSystem();

--- a/lib/Robo/Plugin/Commands/TestEnvironmentCommands.php
+++ b/lib/Robo/Plugin/Commands/TestEnvironmentCommands.php
@@ -133,12 +133,12 @@ class TestEnvironmentCommands extends \Robo\Tasks
         $basePath = $os->toOsPath($paths->getProjectPath() . '/build/tmp/');
 
         if (!file_exists($basePath)) {
-            if (mkdir($basePath, 0777, true) === false) {
+           if (mkdir($basePath, 0777, true) || is_dir($basePath)) {
                 throw new \RuntimeException('Unable to create file structure ' . $basePath);
             }
-        } else if ($opts['reinstall']) {
+        } elseif ($opts['reinstall']) {
             $this->_deleteDir($basePath);
-            if (mkdir($basePath, 0777, true) === false) {
+            if (mkdir($basePath, 0777, true) || is_dir($basePath)) {
                 throw new \RuntimeException('Unable to create file structure ' . $basePath);
             }
         }

--- a/lib/Robo/Plugin/Commands/TestEnvironmentCommands.php
+++ b/lib/Robo/Plugin/Commands/TestEnvironmentCommands.php
@@ -149,11 +149,10 @@ class TestEnvironmentCommands extends \Robo\Tasks
             $this->say('Downloading ChromeDriver.');
             $this->download($url, $zipPath);
             $this->unzip($zipPath, $unzippedPath);
+            $this->say('ChromeDriver install completed.');
         } else {
             $this->say('ChromeDriver has already been downloaded.');
         }
-
-        $this->say('ChromeDriver install completed');
     }
 
     /**

--- a/lib/Robo/Plugin/Commands/TestEnvironmentCommands.php
+++ b/lib/Robo/Plugin/Commands/TestEnvironmentCommands.php
@@ -117,29 +117,6 @@ class TestEnvironmentCommands extends \Robo\Tasks
     }
 
     /**
-     * Run ChromeDriver.
-     * @command chromedriver:run
-     * @param array $opts
-     * @option string $url_base 
-     */
-    public function chromedriverRun($opts = ['url_base' => '/wd/hub'])
-    {
-        $this->say('Running ChromeDriver...');
-        $os = new OperatingSystem();
-        $paths = new Paths();
-        $basePath = $os->toOsPath($paths->getProjectPath() . '/build/tmp/');
-
-        $unzippedPath = $basePath . DIRECTORY_SEPARATOR . 'webdriver';
-
-        if (!file_exists($unzippedPath)) {
-            throw new \RuntimeException('ChromeDriver is not installed in ' . $unzippedPath);
-        }
-
-        $this->runChromeWebDriver($unzippedPath, $opts['url_base']);
-    }
-
-
-    /**
      * Download and install ChromeDriver.
      * @command chromedriver:install
      * @param array $opts
@@ -177,6 +154,28 @@ class TestEnvironmentCommands extends \Robo\Tasks
         }
 
         $this->say('ChromeDriver install completed');
+    }
+
+    /**
+     * Run ChromeDriver.
+     * @command chromedriver:run
+     * @param array $opts
+     * @option string $url_base The base URL from which the WebDriver will be run.
+     */
+    public function chromedriverRun($opts = ['url_base' => '/wd/hub'])
+    {
+        $this->say('Running ChromeDriver...');
+        $os = new OperatingSystem();
+        $paths = new Paths();
+        $basePath = $os->toOsPath($paths->getProjectPath() . '/build/tmp/');
+
+        $unzippedPath = $basePath . DIRECTORY_SEPARATOR . 'webdriver';
+
+        if (!file_exists($unzippedPath)) {
+            throw new \RuntimeException('ChromeDriver is not installed in ' . $unzippedPath);
+        }
+
+        $this->runChromeWebDriver($unzippedPath, $opts['url_base']);
     }
 
     /**

--- a/lib/Robo/Plugin/Commands/TestEnvironmentCommands.php
+++ b/lib/Robo/Plugin/Commands/TestEnvironmentCommands.php
@@ -117,20 +117,29 @@ class TestEnvironmentCommands extends \Robo\Tasks
     }
 
     /**
-     * Download and run the chrome web driver
+     * Download and run the Chrome WebDriver.
+     * @command driver:run-chrome
      * @param array $opts
+     * @option string $url_base 
+     * @option bool $reinstall Forces the Chrome WebDriver executable to be reinstalled, can be used to get a newer version.
+     * @usage driver:run-chrome --reinstall
      */
-    public function driverRunChrome($opts = ['url_base' => '/wd/hub'])
+    public function driverRunChrome($opts = ['url_base' => '/wd/hub', 'reinstall' => false])
     {
         $this->say('Driver Run Chrome');
         $os = new OperatingSystem();
         $paths = new Paths();
         $url = $this->getChromeWebDriverUrl();
-        $basePath = $os->toOsPath($paths->getProjectPath().'/build/tmp/');
+        $basePath = $os->toOsPath($paths->getProjectPath() . '/build/tmp/');
 
         if (!file_exists($basePath)) {
             if (mkdir($basePath, 0777, true) === false) {
-                throw  new \RuntimeException('Unable to create file structure ' . $basePath);
+                throw new \RuntimeException('Unable to create file structure ' . $basePath);
+            }
+        } else if ($opts['reinstall']) {
+            $this->_deleteDir($basePath);
+            if (mkdir($basePath, 0777, true) === false) {
+                throw new \RuntimeException('Unable to create file structure ' . $basePath);
             }
         }
 
@@ -138,6 +147,7 @@ class TestEnvironmentCommands extends \Robo\Tasks
         $unzippedPath = $basePath . DIRECTORY_SEPARATOR . 'webdriver';
 
         if (!file_exists($unzippedPath)) {
+            $this->say('Downloading Chrome WebDriver.');
             $this->download($url, $zipPath);
             $this->unzip($zipPath, $unzippedPath);
         }
@@ -370,6 +380,7 @@ class TestEnvironmentCommands extends \Robo\Tasks
      */
     private function unzip($zipPath, $unzippedPath)
     {
+        $this->say("Unzipping {$zipPath}.");
         $zip = new \ZipArchive();
         $res = $zip->open($zipPath);
         if ($res === true) {

--- a/lib/Robo/Plugin/Commands/TestEnvironmentCommands.php
+++ b/lib/Robo/Plugin/Commands/TestEnvironmentCommands.php
@@ -117,16 +117,38 @@ class TestEnvironmentCommands extends \Robo\Tasks
     }
 
     /**
-     * Download and run the Chrome WebDriver.
-     * @command driver:run-chrome
+     * Run ChromeDriver.
+     * @command chromedriver:run
      * @param array $opts
      * @option string $url_base 
-     * @option bool $reinstall Forces the Chrome WebDriver executable to be reinstalled, can be used to get a newer version.
-     * @usage driver:run-chrome --reinstall
      */
-    public function driverRunChrome($opts = ['url_base' => '/wd/hub', 'reinstall' => false])
+    public function chromedriverRun($opts = ['url_base' => '/wd/hub'])
     {
-        $this->say('Driver Run Chrome');
+        $this->say('Running ChromeDriver...');
+        $os = new OperatingSystem();
+        $paths = new Paths();
+        $basePath = $os->toOsPath($paths->getProjectPath() . '/build/tmp/');
+
+        $unzippedPath = $basePath . DIRECTORY_SEPARATOR . 'webdriver';
+
+        if (!file_exists($unzippedPath)) {
+            throw new \RuntimeException('ChromeDriver is not installed in ' . $unzippedPath);
+        }
+
+        $this->runChromeWebDriver($unzippedPath, $opts['url_base']);
+    }
+
+
+    /**
+     * Download and install ChromeDriver.
+     * @command chromedriver:install
+     * @param array $opts
+     * @option bool $reinstall Forces the Chrome WebDriver executable to be reinstalled, can be used to get a newer version.
+     * @usage chromedriver:install --reinstall
+     */
+    public function chromedriverInstall($opts = ['reinstall' => false])
+    {
+        $this->say('Installing ChromeDriver...');
         $os = new OperatingSystem();
         $paths = new Paths();
         $url = $this->getChromeWebDriverUrl();
@@ -147,14 +169,14 @@ class TestEnvironmentCommands extends \Robo\Tasks
         $unzippedPath = $basePath . DIRECTORY_SEPARATOR . 'webdriver';
 
         if (!file_exists($unzippedPath)) {
-            $this->say('Downloading Chrome WebDriver.');
+            $this->say('Downloading ChromeDriver.');
             $this->download($url, $zipPath);
             $this->unzip($zipPath, $unzippedPath);
+        } else {
+            $this->say('ChromeDriver has already been downloaded.');
         }
 
-        $this->runChromeWebDriver($unzippedPath, $opts['url_base']);
-
-        $this->say('Driver Run Chrome Completed');
+        $this->say('ChromeDriver install completed');
     }
 
     /**

--- a/lib/Robo/Plugin/Commands/TestEnvironmentCommands.php
+++ b/lib/Robo/Plugin/Commands/TestEnvironmentCommands.php
@@ -98,8 +98,8 @@ class TestEnvironmentCommands extends \Robo\Tasks
         } elseif ($os->isOsLinux()) {
             $this->say('Linux detected');
             $this->installUnixEnvironmentVariables($opts);
-        } elseif ($os->isOsMacOsX()) {
-            $this->say('Mac OS X detected');
+        } elseif ($os->isOsMacOSX()) {
+            $this->say('macOS detected');
             $this->installUnixEnvironmentVariables($opts);
         } elseif ($os->isOsBSD()) {
             $this->say('BSD detected');
@@ -172,8 +172,8 @@ class TestEnvironmentCommands extends \Robo\Tasks
         } elseif ($os->isOsLinux()) {
             $this->say('Linux detected');
             $this->installUnixEnvironmentVariables($opts);
-        } elseif ($os->isOsMacOsX()) {
-            $this->say('Mac OS X detected');
+        } elseif ($os->isOsMacOSX()) {
+            $this->say('macOS detected');
             $this->installUnixEnvironmentVariables($opts);
         } elseif ($os->isOsBSD()) {
             $this->say('BSD detected');
@@ -182,9 +182,9 @@ class TestEnvironmentCommands extends \Robo\Tasks
             $this->say('Solaris detected');
             $this->installUnixEnvironmentVariables($opts);
         } elseif ($os->isOsUnknown()) {
-            throw new \DomainException('Unknown Operating system');
+            throw new \DomainException('Unknown operating system');
         } else {
-            throw new \DomainException('Unable to detect Operating system');
+            throw new \DomainException('Unable to detect operating system');
         }
 
         $this->say('Fake Travis Environment Complete');
@@ -318,31 +318,34 @@ class TestEnvironmentCommands extends \Robo\Tasks
 
 
     /**
-     * @param string $version
+     * Gets the URL for installing the latest version of ChromeDriver.
      * @return string url
      */
-    private function getChromeWebDriverUrl($version = '2.38')
+    private function getChromeWebDriverUrl()
     {
         $os = new OperatingSystem();
+        $latestRelease = file_get_contents('https://chromedriver.storage.googleapis.com/LATEST_RELEASE', false);
+
         if ($os->isOsWindows()) {
             $this->say('Windows detected');
-            return 'https://chromedriver.storage.googleapis.com/' . $version . '/chromedriver_win32.zip';
+            return 'https://chromedriver.storage.googleapis.com/' . $latestRelease . '/chromedriver_win32.zip';
         } elseif ($os->isOsLinux()) {
             $this->say('Linux detected');
-            return 'https://chromedriver.storage.googleapis.com/' . $version . '/chromedriver_linux64.zip';
-        } elseif ($os->isOsMacOsX()) {
-            $this->say('Mac OS X detected');
-            return 'https://chromedriver.storage.googleapis.com/' . $version . '/chromedriver_mac64.zip';
+            return 'https://chromedriver.storage.googleapis.com/' . $latestRelease . '/chromedriver_linux64.zip';
+        } elseif ($os->isOsMacOSX()) {
+            $this->say('macOS detected');
+            return 'https://chromedriver.storage.googleapis.com/' . $latestRelease . '/chromedriver_mac64.zip';
         } elseif ($os->isOsBSD()) {
             $this->say('BSD detected');
-            throw new \DomainException('Unsupported Operating system');
+            throw new \DomainException('Unsupported operating system');
         } elseif ($os->isOsSolaris()) {
             $this->say('Solaris detected');
-            throw new \DomainException('Unsupported Operating system');
+            throw new \DomainException('Unsupported operating system');
         } elseif ($os->isOsUnknown()) {
-            throw new \DomainException('Unknown Operating system');
+            throw new \DomainException('Unknown operating system');
+        } else {
+            throw new \DomainException('Unable to detect operating system');
         }
-        throw new \DomainException('Unable to detect Operating system');
     }
 
     /**
@@ -395,29 +398,30 @@ class TestEnvironmentCommands extends \Robo\Tasks
                 . DIRECTORY_SEPARATOR
                 . 'chromedriver';
             chmod($binPath, 100);
-        } elseif ($os->isOsMacOsX()) {
+        } elseif ($os->isOsMacOSX()) {
+            $this->say('macOS detected');
             $binPath = $basePath
                 . DIRECTORY_SEPARATOR
                 . 'chromedriver';
             chmod($binPath, 100);
         } elseif ($os->isOsBSD()) {
             $this->say('BSD detected');
-            throw new \DomainException('Unsupported Operating system');
+            throw new \DomainException('Unsupported operating system');
         } elseif ($os->isOsSolaris()) {
             $this->say('Solaris detected');
-            throw new \DomainException('Unsupported Operating system');
+            throw new \DomainException('Unsupported operating system');
         } elseif ($os->isOsUnknown()) {
-            throw new \DomainException('Unknown Operating system');
+            throw new \DomainException('Unknown operating system');
         } else {
-            throw new \DomainException('Unable to detect Operating system');
+            throw new \DomainException('Unable to detect operating system');
         }
 
         if (!file_exists($binPath)) {
-            throw new \RuntimeException('Unable to find chrome driver ' . $binPath);
+            throw new \RuntimeException('Unable to find ChromeDriver ' . $binPath);
         }
 
-        $this->say('Hint: open terminal and run `'.$os->toOsPath('./vendor/bin/codecept').'run [test suite] --env chrome-driver`');
-        $this->say('Starting Chrome Driver');
+        $this->say('Hint: open terminal and run `'.$os->toOsPath('./vendor/bin/codecept').' run [test suite] --env chrome-driver`');
+        $this->say('Starting ChromeDriver');
         $this->_exec(
             $binPath
             . ' --url-base='

--- a/lib/Robo/Plugin/Commands/TestEnvironmentCommands.php
+++ b/lib/Robo/Plugin/Commands/TestEnvironmentCommands.php
@@ -129,15 +129,15 @@ class TestEnvironmentCommands extends \Robo\Tasks
         $os = new OperatingSystem();
         $paths = new Paths();
         $url = $this->getChromeWebDriverUrl();
-        $basePath = $os->toOsPath($paths->getProjectPath() . '/build/tmp/');
+        $basePath = $os->toOsPath($paths->getProjectPath() . '/build/tmp');
 
         if (!file_exists($basePath)) {
-           if (mkdir($basePath, 0777, true) || is_dir($basePath)) {
+           if (mkdir($basePath, 0777, true) === false) {
                 throw new \RuntimeException('Unable to create file structure ' . $basePath);
             }
         } elseif ($opts['reinstall']) {
             $this->_deleteDir($basePath);
-            if (mkdir($basePath, 0777, true) || is_dir($basePath)) {
+            if (mkdir($basePath, 0777, true) === false) {
                 throw new \RuntimeException('Unable to create file structure ' . $basePath);
             }
         }


### PR DESCRIPTION
## Description
This resolves one of the problems in #7344.

The Robo task will now automatically install the latest version of ChromeDriver instead of installing a static version.

Also improves wording/grammar in various places.

## Motivation and Context
The ChromeDriver Robo task was stuck at an older version of ChromeDriver, `2.38`. This isn't compatible with the latest release of Chrome, so it doesn't work unless you're on an older version of Chrome.

The `LATEST_RELEASE` URL system is based on how [the webdrivers gem](https://github.com/titusfortner/webdrivers) installs ChromeDriver, and also based on the ChromeDriver documentation.

## How To Test This
Install ChromeDriver with the Robo task (`./vendor/bin/robo chromedriver:install`) and then make sure it runs properly (`./vendor/bin/robo chromedriver:run`). It should install ChromeDriver 75. You'll need to delete the existing `build/tmp/webdrivers/` directory if you have one, or use `./vendor/bin/robo chromedriver:install --reinstall` to delete the existing directory.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.