### PR TITLE
Run PHPUnit outside the tests directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,9 +89,7 @@ script:
   - sudo chmod -R 777 .
   - echo "\$sugar_config['state_checker']['save_traces'] = false;" >> config_override.php
   - echo "\$sugar_config['state_checker']['redefine_memory_limit'] = false;" >> config_override.php
-  - cd tests
-  - ../vendor/bin/phpunit --stop-on-failure --stop-on-error --colors --configuration $(pwd)/phpunit.xml.dist ./tests/unit/phpunit
-  - cd ..
+  - ./vendor/bin/phpunit --stop-on-failure --stop-on-error --colors --configuration ./tests/phpunit.xml.dist ./tests/unit/phpunit
   # Install OAuth2 demo data
   - mysql -u root -D automated_tests -v -e "source tests/_data/api_data.sql"
   # Install demo user data

--- a/lib/Robo/Plugin/Commands/CodeCoverageCommands.php
+++ b/lib/Robo/Plugin/Commands/CodeCoverageCommands.php
@@ -80,7 +80,7 @@ class CodeCoverageCommands extends \Robo\Tasks
 
     /**
      * @return array|false|string git commit range from travis ci
-     * eg 3b762531a80e768c2b303f4cce0189386a9f71d4...921bd12b282b0a984a83cc3d7e2a43bc21f2694f
+     * e.g. 3b762531a80e768c2b303f4cce0189386a9f71d4...921bd12b282b0a984a83cc3d7e2a43bc21f2694f
      */
     private function getCommitRangeForTravisCi()
     {
@@ -114,13 +114,10 @@ class CodeCoverageCommands extends \Robo\Tasks
 
     private function getCodeCoverageCommand()
     {
-        //$paths = new Paths();
         $os = new OperatingSystem();
-        //$projectPath = $os->toOsPath($paths->getProjectPath());
         $command =
-            'cd tests/ ; ' //. projectPath
-            . $os->toOsPath('../vendor/bin/phpunit')
-            . ' --configuration $(pwd)/phpunit.xml.dist --coverage-clover ./_output/coverage.xml ./tests/unit/phpunit';
+            $os->toOsPath('./vendor/bin/phpunit')
+            . ' --configuration ./tests/phpunit.xml.dist --coverage-clover ./tests/_output/coverage.xml ./tests/unit/phpunit';
         return $command;
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -38,17 +38,15 @@
  */
 
 /* bootstrap composer's autoloader */
-require_once __DIR__ . '/../vendor/autoload.php';
+require_once dirname(__FILE__) . '/../vendor/autoload.php';
 
 /* bootstrap sugarcrm */
-//echo "CWD:" . getcwd() . "\n";
 error_reporting(E_ALL);
-chdir('../');
 define('sugarEntry', true);
 global $sugar_config, $db;
-require_once 'include/utils.php';
-require_once 'include/modules.php';
-require_once 'include/entryPoint.php';
+require_once dirname(__FILE__) . '/../include/utils.php';
+require_once dirname(__FILE__) . '/../include/modules.php';
+require_once dirname(__FILE__) . '/../include/entryPoint.php';
 //Oddly entry point loads app_strings but not app_list_strings, manually do this here.
 $GLOBALS['app_list_strings'] = return_app_list_strings_language($GLOBALS['current_language']);
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -38,15 +38,15 @@
  */
 
 /* bootstrap composer's autoloader */
-require_once dirname(__FILE__) . '/../vendor/autoload.php';
+require_once __DIR__ . '/../vendor/autoload.php';
 
 /* bootstrap sugarcrm */
 error_reporting(E_ALL);
 define('sugarEntry', true);
 global $sugar_config, $db;
-require_once dirname(__FILE__) . '/../include/utils.php';
-require_once dirname(__FILE__) . '/../include/modules.php';
-require_once dirname(__FILE__) . '/../include/entryPoint.php';
+require_once __DIR__ . '/../include/utils.php';
+require_once __DIR__ . '/../include/modules.php';
+require_once __DIR__ . '/../include/entryPoint.php';
 //Oddly entry point loads app_strings but not app_list_strings, manually do this here.
 $GLOBALS['app_list_strings'] = return_app_list_strings_language($GLOBALS['current_language']);
 

--- a/tests/unit/phpunit/lib/SuiteCRM/Robo/Commands/CodeCoverageCommandsTest.php
+++ b/tests/unit/phpunit/lib/SuiteCRM/Robo/Commands/CodeCoverageCommandsTest.php
@@ -77,14 +77,7 @@ class CodeCoverageCommandsTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstr
 
     public function testGetCodeCoverageCommand()
     {
-        $paths = new \SuiteCRM\Utility\Paths();
-        $os = new \SuiteCRM\Utility\OperatingSystem();
-        // original
-//        $commandExpected =  $os->toOsPath($paths->getProjectPath())
-//            . DIRECTORY_SEPARATOR
-//            . $os->toOsPath('vendor/bin/codecept')
-//            . ' run unit --coverage-xml';
-        $commandExpected = 'cd tests/ ; ../vendor/bin/phpunit --configuration $(pwd)/phpunit.xml.dist --coverage-clover ./_output/coverage.xml ./tests/unit/phpunit';
+        $commandExpected = './vendor/bin/phpunit --configuration ./tests/phpunit.xml.dist --coverage-clover ./tests/_output/coverage.xml ./tests/unit/phpunit';
         // Run tests
         $reflection = new ReflectionClass(CodeCoverageCommands::class);
         $method = $reflection->getMethod('getCodeCoverageCommand');


### PR DESCRIPTION
## Description
This changes the PHPUnit configuration to allow PHPUnit to be run from
outside the tests directory.

There's not really a good reason to require it be run from `./tests/`.

## Motivation and Context
This changes the PHPUnit test suite to be runnable from the root directory instead of needing to be within the `tests/` directory. This is a backport from my GitLab CI PR.

## How To Test This
Verify that Travis CI still works. Also verify that the code coverage in Travis CI still works. I'm not 100% sure on that one.

I don't know if this needs a documentation change?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.