### PR TITLE
Configurable elasticsearch host in acceptance test

### DIFF
--- a/tests/_support/Helper/WebDriverHelper.php
+++ b/tests/_support/Helper/WebDriverHelper.php
@@ -193,6 +193,27 @@ class WebDriverHelper extends \Codeception\Module
     }
 
     /**
+     * Gets the 'INSTANCE_ELASTIC_SEARCH_HOST' environment variable or 'instance_elastic_search_host' in a yaml file.
+     * @return string
+     */
+    public function getElasticSearchHost()
+    {
+        $envElasticSearchHost = getenv('INSTANCE_ELASTIC_SEARCH_HOST');
+        if ($envElasticSearchHost === false) {
+            $webDriver = $this->moduleContainer->getModule('\SuiteCRM\Test\Driver\WebDriver');
+            $config = $webDriver->_getConfig();
+            if (empty($config['INSTANCE_ELASTIC_SEARCH_HOST'])) {
+                // return default
+                return 'localhost';
+            } else {
+                return $config['instance_elastic_search_host'];
+            }
+        } else {
+            return $envElasticSearchHost;
+        }
+    }
+
+    /**
      * Gets the 'BROWSERSTACK_USERNAME' environment variable or 'browserstack.user' in a yaml file.
      * @url https://www.browserstack.com/automate/codeception
      * @return string.

--- a/tests/acceptance/lib/Search/ElasticsearchCest.php
+++ b/tests/acceptance/lib/Search/ElasticsearchCest.php
@@ -56,8 +56,7 @@ class ElasticsearchCest
      * @param WebDriverHelper $helper
      */
     public function testSearchSetup(AcceptanceTester $I, WebDriverHelper $helper)
-    {
-        
+    {        
         // login..
         
         $I->amOnUrl($helper->getInstanceURL());
@@ -77,7 +76,7 @@ class ElasticsearchCest
 
         $I->click('#elastic_search');
         $I->checkOption('#es-enabled');
-        $I->fillField('#es-host', 'localhost');
+        $I->fillField('#es-host', $helper->getElasticSearchHost());
         $I->fillField('#es-user', 'admin');
         $I->fillField('#es-password', 'admin');
 


### PR DESCRIPTION
## Description
The ElasticSearchCest had the hostname hard-coded to `localhost`. This was a problem I ran into with #7328, so I'm backporting it.

ElasticSearch didn't exist prior to 7.11.x, so it only needs to be merged into `hotfix`.

## How To Test This
Make sure the Acceptance tests continue to pass in Travis.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.