### PR TITLE
Fixed #7357 - Home module index page loading bad MySugar file location

### DIFF
--- a/modules/Home/index.php
+++ b/modules/Home/index.php
@@ -318,16 +318,16 @@ $mySugarResources = $sugarChart->getMySugarChartResources();
 $sugar_smarty->assign('chartResources', $resources);
 $sugar_smarty->assign('mySugarChartResources', $mySugarResources);
 
-if (file_exists("custom/themes/" . $theme ."/tpls/MySugar.tpl")) {
+if (file_exists('custom/themes/' . $theme . '/tpls/MySugar.tpl')) {
     echo $sugar_smarty->fetch('custom/themes/' . $theme . '/tpls/MySugar.tpl');
 } elseif (file_exists('custom/include/MySugar/tpls/MySugar.tpl')) {
     echo $sugar_smarty->fetch('custom/include/MySugar/tpls/MySugar.tpl');
-} elseif (file_exists("themes/" . $theme ."/tpls/MySugar.tpl")) {
-    echo $sugar_smarty->fetch("themes/" . $theme ."/tpls/MySugar.tpl");
+} elseif (file_exists('themes/' . $theme . '/tpls/MySugar.tpl')) {
+    echo $sugar_smarty->fetch('themes/' . $theme . '/tpls/MySugar.tpl');
 } elseif (file_exists('include/MySugar/tpls/MySugar.tpl')) {
     echo $sugar_smarty->fetch('include/MySugar/tpls/MySugar.tpl');
-} elseif (file_exists("custom/themes/" . $theme .'include/MySugar/tpls/MySugar.tpl')) {
-    echo $sugar_smarty->fetch('custom/themes/' . $theme . 'include/MySugar/tpls/MySugar.tpl');
+} elseif (file_exists('custom/themes/' . $theme . '/include/MySugar/tpls/MySugar.tpl')) {
+    echo $sugar_smarty->fetch('custom/themes/' . $theme . '/include/MySugar/tpls/MySugar.tpl');
 } else {
     $GLOBALS['log']->fatal('MySugar.tpl not found');
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixes an issue where a custom MySugar.tpl is never loaded due to a missing slash.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #7357 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create the custom file ```custom/themes/' . $theme . '/include/MySugar/tpls/MySugar.tpl```.
2. Check that this file is loaded in home module index.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->