### PR TITLE
Fix issue #7370

### DIFF
--- a/modules/AOR_Reports/aor_utils.php
+++ b/modules/AOR_Reports/aor_utils.php
@@ -147,21 +147,21 @@ function requestToUserParameters($reportBean = null)
                             'id' => $parameterId,
                             'operator' => $_REQUEST['parameter_operator'][$key],
                             'type' => $_REQUEST['parameter_type'][$key],
-                            'value' => convertToDateTime($_REQUEST['parameter_value'][$key])->format('Y-m-d H:i:s'),
+                            'value' => $value,
                         );
                     } elseif (strpos($paramValue, '-') === 2 || strpos($paramValue, '-') === 4) {
                         $params[$parameterId] = array(
                             'id' => $parameterId,
                             'operator' => $_REQUEST['parameter_operator'][$key],
                             'type' => $_REQUEST['parameter_type'][$key],
-                            'value' => convertToDateTime($_REQUEST['parameter_value'][$key])->format('Y-m-d H:i:s'),
+                            'value' => $value,
                         );
                     } elseif (strpos($paramValue, '.') === 2 || strpos($paramValue, '.') === 4) {
                         $params[$parameterId] = array(
                             'id' => $parameterId,
                             'operator' => $_REQUEST['parameter_operator'][$key],
                             'type' => $_REQUEST['parameter_type'][$key],
-                            'value' => convertToDateTime($_REQUEST['parameter_value'][$key])->format('Y-m-d H:i:s'),
+                            'value' => $value,
                         );
                     }
                 }

--- a/modules/AOW_WorkFlow/aow_utils.php
+++ b/modules/AOW_WorkFlow/aow_utils.php
@@ -622,7 +622,11 @@ function getModuleField(
         } else {
             if (isset($fieldlist[$fieldname]['type']) && ($fieldlist[$fieldname]['type'] == 'datetimecombo' || $fieldlist[$fieldname]['type'] == 'datetime' || $fieldlist[$fieldname]['type'] == 'date')) {
                 $value = $focus->convertField($value, $fieldlist[$fieldname]);
-                $displayValue = $timedate->to_display_date_time($value);
+                if($fieldlist[$fieldname]['type'] == 'date') {
+                    $displayValue = $timedate->to_display_date($value, false);
+                }else{
+                    $displayValue = $timedate->to_display_date_time($value, true, true);
+                }
                 $fieldlist[$fieldname]['value'] = $fieldlist[$aow_field]['value'] = $displayValue;
                 $fieldlist[$fieldname]['name'] = $aow_field;
             } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
If a timezone is set in the users profile to negative GMT - America/New York (GMT -4:00) for example, when saving a report with a date condition, the condition is saved as the previous day.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
See #7370 
## How To Test This
<!--- Please describe in detail how to test your changes. -->
Set user profile time zone to America/New York
Create a report with a date field condition set to: Equal to -> Value -> 15/05/2019
Save report
Records returned will be for the 14/05/2019
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->