### PR TITLE
Robo test-running commands

### DIFF
--- a/lib/Robo/Plugin/Commands/TestRunCommands.php
+++ b/lib/Robo/Plugin/Commands/TestRunCommands.php
@@ -44,15 +44,15 @@ class TestRunCommands extends \Robo\Tasks
     use \SuiteCRM\Robo\Traits\RoboTrait;
 
     /**
-     * Run install test suite.
+     * Run install test suite with the custom env.
      * @param array $opts
      * @option boolean debug Whether to set the test suite to output extra information.
      * @option boolean fail-fast Stop after first failure.
      */
     public function TestsInstall($opts = ['debug' => false, 'fail-fast' => false]) {
-      $this->say('Running Install Test Suite.');
+      $this->say('Running Codeception Install Test Suite.');
 
-      $command = './vendor/bin/codecept run install --env chrome-driver';
+      $command = './vendor/bin/codecept run install --env custom';
 
       if ($opts['debug']) {
         $command .= ' -vvv -d';
@@ -71,7 +71,7 @@ class TestRunCommands extends \Robo\Tasks
      * @option boolean fail-fast Stop after first failure.
      */
     public function TestsAPI($opts = ['debug' => false, 'fail-fast' => false]) {
-      $this->say('Running API Test Suite.');
+      $this->say('Running Codeception API Test Suite.');
 
       $command = './vendor/bin/codecept run api';
 
@@ -86,15 +86,15 @@ class TestRunCommands extends \Robo\Tasks
     }
 
     /**
-     * Run acceptance test suite.
+     * Run acceptance test suite with the custom env.
      * @param array $opts
-     * @option boolean verdebugbose Whether to set the test suite to output extra information.
+     * @option boolean debug Whether to set the test suite to output extra information.
      * @option boolean fail-fast Stop after first failure.
      */
     public function TestsAcceptance($opts = ['debug' => false, 'fail-fast' => false]) {
       $this->say('Running Codeception Acceptance Test Suite.');
 
-      $command = './vendor/bin/codecept run acceptance --env chrome-driver';
+      $command = './vendor/bin/codecept run acceptance --env custom';
 
       if ($opts['debug']) {
         $command .= ' -vvv -d';

--- a/lib/Robo/Plugin/Commands/TestRunCommands.php
+++ b/lib/Robo/Plugin/Commands/TestRunCommands.php
@@ -46,15 +46,15 @@ class TestRunCommands extends \Robo\Tasks
     /**
      * Run install test suite.
      * @param array $opts
-     * @option boolean verbose Whether to set the test suite to output extra information. Good for debugging.
+     * @option boolean debug Whether to set the test suite to output extra information.
      * @option boolean fail-fast Stop after first failure.
      */
-    public function TestsInstall($opts = ['verbose' => false, 'fail-fast' => false]) {
+    public function TestsInstall($opts = ['debug' => false, 'fail-fast' => false]) {
       $this->say('Running Install Test Suite.');
 
       $command = './vendor/bin/codecept run install --env chrome-driver';
 
-      if ($opts['verbose']) {
+      if ($opts['debug']) {
         $command .= ' -vvv -d';
       }
       if ($opts['fail-fast']) {
@@ -67,15 +67,15 @@ class TestRunCommands extends \Robo\Tasks
     /**
      * Run API test suite.
      * @param array $opts
-     * @option boolean verbose Whether to set the test suite to output extra information. Good for debugging.
+     * @option boolean debug Whether to set the test suite to output extra information.
      * @option boolean fail-fast Stop after first failure.
      */
-    public function TestsAPI($opts = ['verbose' => false, 'fail-fast' => false]) {
+    public function TestsAPI($opts = ['debug' => false, 'fail-fast' => false]) {
       $this->say('Running API Test Suite.');
 
       $command = './vendor/bin/codecept run api';
 
-      if ($opts['verbose']) {
+      if ($opts['debug']) {
         $command .= ' -vvv -d';
       }
       if ($opts['fail-fast']) {
@@ -88,15 +88,15 @@ class TestRunCommands extends \Robo\Tasks
     /**
      * Run acceptance test suite.
      * @param array $opts
-     * @option boolean verbose Whether to set the test suite to output extra information. Good for debugging.
+     * @option boolean verdebugbose Whether to set the test suite to output extra information.
      * @option boolean fail-fast Stop after first failure.
      */
-    public function TestsAcceptance($opts = ['verbose' => false, 'fail-fast' => false]) {
+    public function TestsAcceptance($opts = ['debug' => false, 'fail-fast' => false]) {
       $this->say('Running Codeception Acceptance Test Suite.');
 
       $command = './vendor/bin/codecept run acceptance --env chrome-driver';
 
-      if ($opts['verbose']) {
+      if ($opts['debug']) {
         $command .= ' -vvv -d';
       }
       if ($opts['fail-fast']) {
@@ -109,15 +109,15 @@ class TestRunCommands extends \Robo\Tasks
     /**
      * Run PHPUnit unit test suite.
      * @param array $opts
-     * @option boolean verbose Whether to set the test suite to output extra information. Good for debugging.
+     * @option boolean debug Whether to set the test suite to output extra information.
      * @option boolean fail-fast Stop after first failure.
      */
-    public function TestsUnit($opts = ['verbose' => false, 'fail-fast' => false]) {
+    public function TestsUnit($opts = ['debug' => false, 'fail-fast' => false]) {
       $this->say('Running PHPUnit Unit Test Suite.');
 
       $command = './vendor/bin/phpunit --colors --configuration ./tests/phpunit.xml.dist ./tests/unit/phpunit';
       
-      if ($opts['verbose']) {
+      if ($opts['debug']) {
         $command .= ' -v --debug';
       }
       if ($opts['fail-fast']) {

--- a/lib/Robo/Plugin/Commands/TestRunCommands.php
+++ b/lib/Robo/Plugin/Commands/TestRunCommands.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ *
+ * SugarCRM Community Edition is a customer relationship management program developed by
+ * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2019 SalesAgility Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License version 3 as published by the
+ * Free Software Foundation with the addition of the following permission added
+ * to Section 15 as permitted in Section 7(a): FOR ANY PART OF THE COVERED WORK
+ * IN WHICH THE COPYRIGHT IS OWNED BY SUGARCRM, SUGARCRM DISCLAIMS THE WARRANTY
+ * OF NON INFRINGEMENT OF THIRD PARTY RIGHTS.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program; if not, see http://www.gnu.org/licenses or write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ *
+ * You can contact SugarCRM, Inc. headquarters at 10050 North Wolfe Road,
+ * SW2-130, Cupertino, CA 95014, USA. or at email address contact@sugarcrm.com.
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "Powered by
+ * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
+namespace SuiteCRM\Robo\Plugin\Commands;
+
+class TestRunCommands extends \Robo\Tasks
+{
+    use \SuiteCRM\Robo\Traits\RoboTrait;
+
+    /**
+     * Run install test suite.
+     * @param array $opts
+     * @option boolean verbose Whether to set the test suite to output extra information. Good for debugging.
+     * @option boolean fail-fast Stop after first failure.
+     */
+    public function TestsInstall($opts = ['verbose' => false, 'fail-fast' => false]) {
+      $this->say('Running Install Test Suite.');
+
+      $command = './vendor/bin/codecept run install --env chrome-driver';
+
+      if ($opts['verbose']) {
+        $command .= ' -vvv -d';
+      }
+      if ($opts['fail-fast']) {
+        $command .= ' -f';
+      }
+      
+      $this->_exec($command);
+    }
+
+    /**
+     * Run API test suite.
+     * @param array $opts
+     * @option boolean verbose Whether to set the test suite to output extra information. Good for debugging.
+     * @option boolean fail-fast Stop after first failure.
+     */
+    public function TestsAPI($opts = ['verbose' => false, 'fail-fast' => false]) {
+      $this->say('Running API Test Suite.');
+
+      $command = './vendor/bin/codecept run api';
+
+      if ($opts['verbose']) {
+        $command .= ' -vvv -d';
+      }
+      if ($opts['fail-fast']) {
+        $command .= ' -f';
+      }
+      
+      $this->_exec($command);
+    }
+
+    /**
+     * Run acceptance test suite.
+     * @param array $opts
+     * @option boolean verbose Whether to set the test suite to output extra information. Good for debugging.
+     * @option boolean fail-fast Stop after first failure.
+     */
+    public function TestsAcceptance($opts = ['verbose' => false, 'fail-fast' => false]) {
+      $this->say('Running Codeception Acceptance Test Suite.');
+
+      $command = './vendor/bin/codecept run acceptance --env chrome-driver';
+
+      if ($opts['verbose']) {
+        $command .= ' -vvv -d';
+      }
+      if ($opts['fail-fast']) {
+        $command .= ' -f';
+      }
+      
+      $this->_exec($command);
+    }
+
+    /**
+     * Run PHPUnit unit test suite.
+     * @param array $opts
+     * @option boolean verbose Whether to set the test suite to output extra information. Good for debugging.
+     * @option boolean fail-fast Stop after first failure.
+     */
+    public function TestsUnit($opts = ['verbose' => false, 'fail-fast' => false]) {
+      $this->say('Running PHPUnit Unit Test Suite.');
+
+      $command = './vendor/bin/phpunit --colors --configuration ./tests/phpunit.xml.dist ./tests/unit/phpunit';
+      
+      if ($opts['verbose']) {
+        $command .= ' -v --debug';
+      }
+      if ($opts['fail-fast']) {
+        $command .= ' --stop-on-error --stop-on-failure';
+      }
+
+      $this->_exec($command);
+    }
+}

--- a/lib/Robo/Plugin/Commands/TestRunCommands.php
+++ b/lib/Robo/Plugin/Commands/TestRunCommands.php
@@ -45,14 +45,20 @@ class TestRunCommands extends \Robo\Tasks
 
     /**
      * Run install test suite with the custom env.
+     * 
+     * @param string $fileOrDirectory Provide a path to a file or directory to
+     *   run a specific test/specific directory of tests.
      * @param array $opts
-     * @option boolean debug Whether to set the test suite to output extra information.
-     * @option boolean fail-fast Stop after first failure.
+     * @option debug Whether to have the test suite output extra information.
+     * @option fail-fast Stop after first failure.
+     * @usage tests:install
+     * @usage tests:install ./tests/install/UserWizardCest.php
+     * @usage tests:install --debug ./tests/install/UserWizardCest.php
      */
-    public function TestsInstall($opts = ['debug' => false, 'fail-fast' => false]) {
+    public function TestsInstall($fileOrDirectory = null, $opts = ['debug' => false, 'fail-fast' => false]) {
       $this->say('Running Codeception Install Test Suite.');
 
-      $command = './vendor/bin/codecept run install --env custom';
+      $command = "./vendor/bin/codecept run install --env custom {$fileOrDirectory}";
 
       if ($opts['debug']) {
         $command .= ' -vvv -d';
@@ -66,14 +72,21 @@ class TestRunCommands extends \Robo\Tasks
 
     /**
      * Run API test suite.
+     * 
+     * @param string $fileOrDirectory Provide a path to a file or directory to
+     *   run a specific test/specific directory of tests.
      * @param array $opts
-     * @option boolean debug Whether to set the test suite to output extra information.
-     * @option boolean fail-fast Stop after first failure.
+     * @option debug Whether to have the test suite output extra information.
+     * @option fail-fast Stop after first failure.
+     * @usage tests:api
+     * @usage tests:api ./tests/api/V8/GetFieldsMetaCest.php
+     * @usage tests:api ./tests/api/V8/
+     * @usage tests:api --debug ./tests/api/V8/GetFieldsMetaCest.php
      */
-    public function TestsAPI($opts = ['debug' => false, 'fail-fast' => false]) {
+    public function TestsAPI($fileOrDirectory = null, $opts = ['debug' => false, 'fail-fast' => false]) {
       $this->say('Running Codeception API Test Suite.');
 
-      $command = './vendor/bin/codecept run api';
+      $command = "./vendor/bin/codecept run api {$fileOrDirectory}";
 
       if ($opts['debug']) {
         $command .= ' -vvv -d';
@@ -87,14 +100,21 @@ class TestRunCommands extends \Robo\Tasks
 
     /**
      * Run acceptance test suite with the custom env.
+     * 
+     * @param string $fileOrDirectory Provide a path to a file or directory to
+     *   run a specific test/specific directory of tests.
      * @param array $opts
-     * @option boolean debug Whether to set the test suite to output extra information.
-     * @option boolean fail-fast Stop after first failure.
+     * @option debug Whether to have the test suite output extra information.
+     * @option fail-fast Stop after first failure.
+     * @usage tests:acceptance
+     * @usage tests:acceptance ./tests/acceptance/modules/Calendar/CalendarCest.php
+     * @usage tests:acceptance ./tests/acceptance/modules/
+     * @usage tests:acceptance --debug ./tests/acceptance/modules/Calendar/CalendarCest.php
      */
-    public function TestsAcceptance($opts = ['debug' => false, 'fail-fast' => false]) {
+    public function TestsAcceptance($fileOrDirectory = null, $opts = ['debug' => false, 'fail-fast' => false]) {
       $this->say('Running Codeception Acceptance Test Suite.');
 
-      $command = './vendor/bin/codecept run acceptance --env custom';
+      $command = "./vendor/bin/codecept run acceptance --env custom {$fileOrDirectory}";
 
       if ($opts['debug']) {
         $command .= ' -vvv -d';
@@ -108,14 +128,21 @@ class TestRunCommands extends \Robo\Tasks
 
     /**
      * Run PHPUnit unit test suite.
+     * 
+     * @param string $fileOrDirectory Provide a path to a file or directory to
+     *   run a specific test/specific directory of tests.
      * @param array $opts
-     * @option boolean debug Whether to set the test suite to output extra information.
-     * @option boolean fail-fast Stop after first failure.
+     * @option debug Whether to have the test suite output extra information.
+     * @option fail-fast Stop after first failure.
+     * @usage tests:unit
+     * @usage tests:unit ./tests/unit/phpunit/modules/Favorites/FavoritesTest.php
+     * @usage tests:unit ./tests/unit/phpunit/modules/
+     * @usage tests:unit --debug ./tests/unit/phpunit/modules/Favorites/FavoritesTest.php
      */
-    public function TestsUnit($opts = ['debug' => false, 'fail-fast' => false]) {
+    public function TestsUnit($fileOrDirectory = './tests/unit/phpunit', $opts = ['debug' => false, 'fail-fast' => false]) {
       $this->say('Running PHPUnit Unit Test Suite.');
 
-      $command = './vendor/bin/phpunit --colors --configuration ./tests/phpunit.xml.dist ./tests/unit/phpunit';
+      $command = "./vendor/bin/phpunit --colors --configuration ./tests/phpunit.xml.dist {$fileOrDirectory}";
       
       if ($opts['debug']) {
         $command .= ' -v --debug';


### PR DESCRIPTION
## Description
Part of #7344. This adds Robo tasks for easily running the four different test suites in a consistent way. 

- `./vendor/bin/robo tests:install`
- `./vendor/bin/robo tests:acceptance`
- `./vendor/bin/robo tests:api`
- `./vendor/bin/robo tests:unit`

## Motivation and Context

The test commands are pretty long and annoying to type, and also hard to discover. This PR makes Robo commands that make running the tests simple and consistent.

I intend to update the automated testing documentation to incorporate these changes and simplify the general process of a developer running the test suite locally.

You'll need to set up the `tests/_envs/custom.yml` codeception config file (see https://docs.suitecrm.com/developer/automatedtesting/). You'll also need to either uncomment the part of the config with the background ChromeDriver process to have it run automatically with the tests, or otherwise run ChromeDriver in the background with `./vendor/bin/robo chromedriver:run` when running the install/acceptance tests.

## How To Test This
Pull down this branch and try running the various test suites:

- `./vendor/bin/robo tests:install`
- `./vendor/bin/robo tests:acceptance`
- `./vendor/bin/robo tests:api`
- `./vendor/bin/robo tests:unit`

Each of these have `--verbose` and `--fail-fast` flags that allow you to run the given test suite with extra debug output or with the command stopping as soon as an error or failure occurs.

They also all allow you to specify what tests you want to run - either by file or by directory - e.g. `./vendor/bin/robo tests:unit ./tests/unit/phpunit/modules/`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.