### PR TITLE
tests: change the test config default date format to match the unit tests

### DIFF
--- a/tests/travis_config_si.php
+++ b/tests/travis_config_si.php
@@ -1,7 +1,7 @@
 <?php
 $sugar_config_si  = array(
     'dbUSRData' => 'create',
-    'default_date_format' => 'Y-m-d',
+    'default_date_format' => 'd/m/Y',
     'default_decimal_seperator' => '.',
     'default_export_charset' => 'ISO-8859-1',
     'default_language' => 'en_us',


### PR DESCRIPTION
## Description

The test suite gained new tests (callTest.php) which depend on the date format
being 'd/m/Y'.

This changes the date in travis_config_si.php so that test setups using
tests/testinstall.php continue to work as before.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
a