### PR TITLE
Fix #6343 handling posix not allowed on some Linux systems

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -55,8 +55,11 @@ if (substr($sapi_type, 0, 3) != 'cli') {
 if (!is_windows()) {
     require_once 'include/utils.php';
     $cronUser = getRunningUser();
-
-    if (array_key_exists('cron', $sugar_config) && array_key_exists('allowed_cron_users', $sugar_config['cron'])) {
+ 
+    if ($cronUser == '') {
+        $GLOBALS['log']->warning('cron.php: can\'t determine running user. No cron user checks will occur.');
+    } 
+    elseif (array_key_exists('cron', $sugar_config) && array_key_exists('allowed_cron_users', $sugar_config['cron'])) {
         if (!in_array($cronUser, $sugar_config['cron']['allowed_cron_users'])) {
             $GLOBALS['log']->fatal("cron.php: running as $cronUser is not allowed in allowed_cron_users ".
                                    "in config.php. Exiting.");
@@ -67,7 +70,8 @@ if (!is_windows()) {
             }
             sugar_die('cron.php running with user that is not in allowed_cron_users in config.php');
         }
-    } else {
+    } 
+    else {
         $GLOBALS['log']->warning('cron.php: missing expected allowed_cron_users entry in config.php. ' .
                                  'No cron user checks will occur.');
     }

--- a/include/utils.php
+++ b/include/utils.php
@@ -444,14 +444,15 @@ function get_sugar_config_defaults()
  */
 function getRunningUser()
 {
-    // works on Windows and Linux, but might return null on systems that include exec in
+    // works on Windows and Linux, but might return null on systems that include "exec" in
     // disabled_functions in php.ini (typical in shared hosting)
     $runningUser = exec('whoami');
 
     if ($runningUser == null) {  // matches null, false and ""
         if (is_windows()) {
-            $runningUser = getenv('USERDOMAIN') . '\\' . getenv('USERNAME');
-        } else {
+            $runningUser = getenv('USERDOMAIN').'\\'.getenv('USERNAME');
+        }
+        elseif (function_exists('posix_getpwuid') && function_exists('posix_geteuid')) {
             $usr = posix_getpwuid(posix_geteuid());
             $runningUser = $usr['name'];
         }

--- a/modules/UpgradeWizard/systemCheck.php
+++ b/modules/UpgradeWizard/systemCheck.php
@@ -98,8 +98,8 @@ foreach ($files as $file) {
             // don't warn yet - we're going to use this to check against replacement files
             $filesNotWritable[$i] = $file;
             $filesNWPerms[$i] = substr(sprintf('%o', fileperms($file)), -4);
-            $owner = posix_getpwuid(fileowner($file));
-            $group = posix_getgrgid(filegroup($file));
+            $owner = function_exists('posix_getpwuid') ? posix_getpwuid(fileowner($file)) : $mod_strings['ERR_UW_CANNOT_DETERMINE_USER'];
+	    $group = function_exists('posix_getgrgid') ? posix_getgrgid(filegroup($file)) : $mod_strings['ERR_UW_CANNOT_DETERMINE_GROUP'];
             $filesOut .= "<tr>".
                             "<td><span class='error'>{$file}</span></td>".
                             "<td>{$filesNWPerms[$i]}</td>".

--- a/modules/UpgradeWizard/uw_ajax.php
+++ b/modules/UpgradeWizard/uw_ajax.php
@@ -892,8 +892,8 @@ function systemCheckJsonCheckFiles($persistence)
                 // don't warn yet - we're going to use this to check against replacement files
                 $filesNotWritable[$i] = $file;
                 $filesNWPerms[$i] = substr(sprintf('%o', fileperms($file)), -4);
-                $owner = posix_getpwuid(fileowner($file));
-                $group = posix_getgrgid(filegroup($file));
+                $owner = function_exists('posix_getpwuid') ? posix_getpwuid(fileowner($file)) : $mod_strings['ERR_UW_CANNOT_DETERMINE_USER'];
+	        $group = function_exists('posix_getgrgid') ? posix_getgrgid(filegroup($file)) : $mod_strings['ERR_UW_CANNOT_DETERMINE_GROUP'];
                 $filesOut .= "<tr>".
                                 "<td valign='top'><span class='error'>{$file}</span></td>".
                                 "<td valign='top'>{$filesNWPerms[$i]}</td>".

--- a/modules/UpgradeWizard/uw_utils.php
+++ b/modules/UpgradeWizard/uw_utils.php
@@ -2653,8 +2653,8 @@ function checkFiles($files, $echo=false)
                 // don't warn yet - we're going to use this to check against replacement files
                 $filesNotWritable[$i] = $file;
                 $filesNWPerms[$i] = substr(sprintf('%o', fileperms($file)), -4);
-                $owner = posix_getpwuid(fileowner($file));
-                $group = posix_getgrgid(filegroup($file));
+                $owner = function_exists('posix_getpwuid') ? posix_getpwuid(fileowner($file)) : $mod_strings['ERR_UW_CANNOT_DETERMINE_USER'];
+	        $group = function_exists('posix_getgrgid') ? posix_getgrgid(filegroup($file)) : $mod_strings['ERR_UW_CANNOT_DETERMINE_GROUP'];
                 $filesOut .= "<tr>".
                     "<td><span class='error'>{$file}</span></td>".
                     "<td>{$filesNWPerms[$i]}</td>".


### PR DESCRIPTION
## Description
According to the previous discussion on #6344, I examined 8 places in the code and decided to update 5 of them, the others aren't necessary.

## Instances of `posix` calls, and of places calling `getRunninguser`

1. https://github.com/salesagility/SuiteCRM/blob/master/modules/UpgradeWizard/systemCheck.php

2. https://github.com/salesagility/SuiteCRM/blob/master/modules/UpgradeWizard/uw_ajax.php

3. https://github.com/salesagility/SuiteCRM/blob/master/modules/UpgradeWizard/uw_utils.php

These 3 instances are only using this to output a message to the user. I guarded the code for the case where `posix` functions are disabled, and made sure the output made sense.

4. https://github.com/salesagility/SuiteCRM/blob/master/cron.php
Added an if before the others, so that a proper message is logged.

5. https://github.com/salesagility/SuiteCRM/blob/master/install/performSetup.php
No change done here. The call won't have any effect. When cron.php checks, it will report with the new log message added in 4.

6. https://github.com/salesagility/SuiteCRM/blob/master/install/ready.php
No change. Will output a generic message: `sudo crontab -e -u  <web_server_user>`. This was already there before the `allowed_cron_users` mechanism was introduced.

7. https://github.com/salesagility/SuiteCRM/blob/master/modules/Schedulers/Scheduler.php
Same as above.

8. https://github.com/salesagility/SuiteCRM/blob/master/include/utils.php
Added a check for the existence of the `posix` functions.

## How To Test This
For each situation below, test **with** and **without** `posix` functions active in Linux. This can be done with `disable_functions` in php.ini, or with `--disable-posix` flag in command-line.

1. Installation

2. Post-install, visit screens
  - Admin / Schedulers
  - Admin / Upgrade Wizard, run permissions check

3. Execute cron.php and check logs

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

