### PR TITLE
StateChecker: disable save_traces by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,8 +87,6 @@ script:
   
   # Run the unit tests
   - sudo chmod -R 777 .
-  - echo "\$sugar_config['state_checker']['save_traces'] = false;" >> config_override.php
-  - echo "\$sugar_config['state_checker']['redefine_memory_limit'] = false;" >> config_override.php
   - ./vendor/bin/phpunit --stop-on-failure --stop-on-error --colors --configuration ./tests/phpunit.xml.dist ./tests/unit/phpunit
   # Install OAuth2 demo data
   - mysql -u root -D automated_tests -v -e "source tests/_data/api_data.sql"

--- a/include/StateCheckerConfig.php
+++ b/include/StateCheckerConfig.php
@@ -120,7 +120,7 @@ class StateCheckerConfig
      * (Slow working but give more information about the error location, use in development only)
      * @var boolean
      */
-    protected static $saveTraces = true;
+    protected static $saveTraces = false;
     
     /**
      * Redefine memory limit

--- a/include/StateCheckerTrait.php
+++ b/include/StateCheckerTrait.php
@@ -82,7 +82,7 @@ trait StateCheckerTrait
                 $hash = self::$stateChecker->getStateHash();
                 return $hash;
             } catch (StateCheckerException $e) {
-                $message = 'Incorrect state hash (in PHPUnitTest): ' . $e->getMessage() . (StateCheckerConfig::get('saveTraces') ? "\nTrace:\n" . $e->getTraceAsString() . "\n" : '');
+                $message = 'Incorrect state hash (in PHPUnitTest): ' . $e->getMessage() . ("\nTrace:\n" . $e->getTraceAsString() . "\n");
                 if (StateCheckerConfig::get('testsUseAssertionFailureOnError')) {
                     throw new StateCheckerException($message, $e->getCode(), $e);
                 } else {


### PR DESCRIPTION
## Description

* Makes save_traces default to false
* Print stacktraces always
* Remove the travis config override which is no longer needed now

This is a better version of #7087

## Motivation and Context

I couldn't run the full test suite on my local machine because they needed too much
memory (>16GB)

## How To Test This

Run the unit tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.