### PR TITLE
Fixed #7107 - MysqliManager: always remove STRICT_TRANS_TABLES from sql_mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,6 @@ before_script:
   - mysql -e "CREATE DATABASE automated_tests CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;"
   - mysql -u root -e "CREATE USER 'automated_tests'@'localhost' IDENTIFIED BY 'automated_tests';"
   - mysql -u root -e "GRANT ALL PRIVILEGES ON automated_tests.* TO 'automated_tests'@'localhost';"
-  # FIXME: https://github.com/salesagility/SuiteCRM/issues/7107
-  - mysql -u root -e "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode, 'STRICT_TRANS_TABLES', ''));"
   # Install apache - images with PHP 7 or above
   - sudo apt-get update
   - sudo apt-get install apache2 libapache2-mod-fastcgi

--- a/include/database/MysqliManager.php
+++ b/include/database/MysqliManager.php
@@ -356,6 +356,11 @@ class MysqliManager extends MysqlManager
         }
         mysqli_set_charset($this->database, "utf8");
 
+        // https://github.com/salesagility/SuiteCRM/issues/7107
+        // MySQL 5.7 is stricter regarding missing values in SQL statements and makes some tests fail.
+        // Remove STRICT_TRANS_TABLES from sql_mode so we get the old behaviour again.
+        mysqli_query($this->database, "SET SESSION sql_mode=(SELECT REPLACE(@@sql_mode, 'STRICT_TRANS_TABLES', ''))");
+
         if ($this->checkError('Could Not Connect', $dieOnError)) {
             $GLOBALS['log']->info("connected to db");
         }


### PR DESCRIPTION
## Description

STRICT_TRANS_TABLES is enabled by default with MySQL 5.7 and some tests
fail with it due to missing values in SQL insert/update statements.

Given that our test coverage isn't that high there might be more issues
not covered by the tests, so better disable STRICT_TRANS_TABLES to get the same
behavior as with MySQL 5.6 for now.

Fixes #7107

## Motivation and Context

Make the test suite pass with MySQL 5.7

## How To Test This

Run the test suite (see travis-ci)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.