### PR TITLE
Remove explicit timeouts in acceptance tests.

### DIFF
--- a/tests/_support/Step/Acceptance/Calls.php
+++ b/tests/_support/Step/Acceptance/Calls.php
@@ -35,7 +35,7 @@ class Calls extends \AcceptanceTester
         $I->fillField('#date_start_date', '01/19/2038');
         $I->fillField('#description', $faker->text());
 
-        $I->waitForElementVisible('#date_start_hours', 120);
+        $I->waitForElementVisible('#date_start_hours');
 
         $I->clickSaveButton();
         $DetailView->waitForDetailViewVisible();
@@ -68,7 +68,7 @@ class Calls extends \AcceptanceTester
         }
 
 
-        $I->waitForElementVisible('#date_start_hours', 120);
+        $I->waitForElementVisible('#date_start_hours');
 
 
         $I->selectOption('#parent_type', $module);

--- a/tests/_support/Step/Acceptance/Dashboard.php
+++ b/tests/_support/Step/Acceptance/Dashboard.php
@@ -12,7 +12,7 @@ class Dashboard extends Tester
     public function waitForDashboardVisible()
     {
         $I = $this;
-        $I->waitForElementVisible('.dashboard', 120);
-        $I->waitForElementVisible('.dashletcontainer', 5);
+        $I->waitForElementVisible('.dashboard');
+        $I->waitForElementVisible('.dashletcontainer');
     }
 }

--- a/tests/_support/Step/Acceptance/DetailView.php
+++ b/tests/_support/Step/Acceptance/DetailView.php
@@ -20,7 +20,7 @@ class DetailView extends Tester
         $I = $this;
 
         $I->click('ACTIONS', '#tab-actions');
-        $I->waitForElementVisible('#tab-actions > .dropdown-menu', 120);
+        $I->waitForElementVisible('#tab-actions > .dropdown-menu');
 
         $I->click($link, '#tab-actions > .dropdown-menu');
     }
@@ -31,6 +31,6 @@ class DetailView extends Tester
     public function waitForDetailViewVisible()
     {
         $I = $this;
-        $I->waitForElementVisible('.detail-view', 120);
+        $I->waitForElementVisible('.detail-view');
     }
 }

--- a/tests/_support/Step/Acceptance/EditView.php
+++ b/tests/_support/Step/Acceptance/EditView.php
@@ -12,7 +12,7 @@ class EditView extends Tester
     public function waitForEditViewVisible()
     {
         $I = $this;
-        $I->waitForElementVisible('#EditView', 120);
+        $I->waitForElementVisible('#EditView');
     }
 
     public function clickSaveButton()

--- a/tests/_support/Step/Acceptance/ListView.php
+++ b/tests/_support/Step/Acceptance/ListView.php
@@ -13,7 +13,7 @@ class ListView extends Tester
     public function clickNameLink($name)
     {
         $I = $this;
-        $I->waitForElementVisible('//*[@id="MassUpdate"]', 10);
+        $I->waitForElementVisible('//*[@id="MassUpdate"]');
         $I->click($name, '//*[@id="MassUpdate"]/div[3]/table');
     }
 
@@ -47,18 +47,18 @@ class ListView extends Tester
     public function waitForListViewVisible()
     {
         $I = $this;
-        $I->waitForElementVisible('.listViewBody', 120);
+        $I->waitForElementVisible('.listViewBody');
     }
 
     public function waitForFilterModalVisible()
     {
         $I = $this;
-        $I->waitForElementVisible('#searchDialog', 120);
+        $I->waitForElementVisible('#searchDialog');
     }
 
     public function waitForFilterModalNotVisible()
     {
         $I = $this;
-        $I->waitForElementNotVisible('#searchDialog', 120);
+        $I->waitForElementNotVisible('#searchDialog');
     }
 }

--- a/tests/_support/Step/Acceptance/Meetings.php
+++ b/tests/_support/Step/Acceptance/Meetings.php
@@ -33,7 +33,7 @@ class Meetings extends \AcceptanceTester
         $I->fillField('#description', $faker->text());
         $I->fillField('#location', $faker->city());
 
-        $I->waitForElementVisible('#date_start_hours', 120);
+        $I->waitForElementVisible('#date_start_hours');
 
         $I->selectOption('#duration', '15 minutes');
         $I->selectOption('#status', 'Held');

--- a/tests/_support/Step/Acceptance/ModuleBuilder.php
+++ b/tests/_support/Step/Acceptance/ModuleBuilder.php
@@ -95,9 +95,9 @@ class ModuleBuilder extends Administration
 
         // Go To Module Builder
         $I->click('#moduleBuilder');
-        $I->waitForElementVisible('.bodywrapper', 30);
+        $I->waitForElementVisible('.bodywrapper');
         $I->click($packageName, '.bodywrapper');
-        $I->waitForElementVisible(['name' => 'author'], 30);
+        $I->waitForElementVisible(['name' => 'author']);
     }
 
 
@@ -113,19 +113,19 @@ class ModuleBuilder extends Administration
 
         // Go To Module Builder
         $I->click('#moduleBuilder');
-        $I->waitForElementVisible('.bodywrapper', 30);
+        $I->waitForElementVisible('.bodywrapper');
         $I->click($packageName, '.bodywrapper');
-        $I->waitForElementVisible(['name' => 'author'], 30);
+        $I->waitForElementVisible(['name' => 'author']);
         $I->click($moduleName, '#package_modules');
-        $I->waitForElementVisible(['name' => 'savebtn'], 30);
+        $I->waitForElementVisible(['name' => 'savebtn']);
     }
 
 
     public function closePopupSuccess()
     {
         $I = $this;
-        $I->waitForElementVisible('#sugarMsgWindow_mask', 30);
-        $I->waitForText('This operation is completed successfully', 30, '#sugarMsgWindow_c');
+        $I->waitForElementVisible('#sugarMsgWindow_mask');
+        $I->waitForText('This operation is completed successfully', null, '#sugarMsgWindow_c');
         $I->click('.container-close');
     }
 
@@ -143,7 +143,7 @@ class ModuleBuilder extends Administration
 
         // Go To Module Builder
         $I->click('#moduleBuilder');
-        $I->waitForElementVisible('.bodywrapper', 30);
+        $I->waitForElementVisible('.bodywrapper');
         $I->click($packageName, '.bodywrapper');
         $I->waitForElementVisible('[name="name"]');
         $I->click('Deploy');
@@ -156,6 +156,6 @@ class ModuleBuilder extends Administration
         $I->closePopupSuccess();
 
         // Wait for page to refresh and look for new package link
-        $I->waitForElement('#newPackageLink', 360);
+        $I->waitForElement('#newPackageLink', 30);
     }
 }

--- a/tests/_support/Step/Acceptance/NavigationBar.php
+++ b/tests/_support/Step/Acceptance/NavigationBar.php
@@ -88,38 +88,38 @@ class NavigationBar extends Tester
         switch ($breakpoint) {
             case DesignBreakPoint::lg:
                 $allMenuButton = '#toolbar.desktop-toolbar  > ul.nav.navbar-nav > li.topnav.all';
-                $I->waitForElementVisible($allMenuButton, 30);
+                $I->waitForElementVisible($allMenuButton);
                 $I->wait(1);
                 $I->click('All', $allMenuButton);
                 $allMenu = $allMenuButton . ' > span.notCurrentTab > ul.dropdown-menu';
-                $I->waitForElementVisible($allMenu, 120);
+                $I->waitForElementVisible($allMenu);
                 $I->click($link, $allMenu);
                 break;
             case DesignBreakPoint::md:
                 $allMenuButton = 'div.navbar-header > button.navbar-toggle';
-                $I->waitForElementVisible($allMenuButton, 30);
+                $I->waitForElementVisible($allMenuButton);
                 $I->wait(1);
                 $I->click($allMenuButton);
                 $allMenu = 'div.navbar-header > #mobile_menu';
-                $I->waitForElementVisible($allMenu, 120);
+                $I->waitForElementVisible($allMenu);
                 $I->click($link, $allMenu);
                 break;
             case DesignBreakPoint::sm:
                 $allMenuButton = 'div.navbar-header > button.navbar-toggle';
-                $I->waitForElementVisible($allMenuButton, 30);
+                $I->waitForElementVisible($allMenuButton);
                 $I->wait(1);
                 $I->click($allMenuButton);
                 $allMenu = 'div.navbar-header > #mobile_menu';
-                $I->waitForElementVisible($allMenu, 120);
+                $I->waitForElementVisible($allMenu);
                 $I->click($link, $allMenu);
                 break;
             case DesignBreakPoint::xs:
                 $allMenuButton = 'div.navbar-header > button.navbar-toggle';
-                $I->waitForElementVisible($allMenuButton, 30);
+                $I->waitForElementVisible($allMenuButton);
                 $I->wait(1);
                 $I->click($allMenuButton);
                 $allMenu = 'div.navbar-header > #mobile_menu';
-                $I->waitForElementVisible($allMenu, 120);
+                $I->waitForElementVisible($allMenu);
                 $I->click($link, $allMenu);
                 break;
         }
@@ -146,25 +146,25 @@ class NavigationBar extends Tester
         switch ($breakpoint) {
             case DesignBreakPoint::lg:
                 $I->moveMouseOver('//*[@id="toolbar"]/ul/li[2]/span[2]/a');
-                $I->waitForElementVisible('#toolbar.desktop-toolbar  > ul.nav.navbar-nav > li.topnav ul.dropdown-menu > li.current-module-action-links > ul', 30);
+                $I->waitForElementVisible('#toolbar.desktop-toolbar  > ul.nav.navbar-nav > li.topnav ul.dropdown-menu > li.current-module-action-links > ul');
                 $I->waitForText($link, 30, '#toolbar.desktop-toolbar  > ul.nav.navbar-nav > li.topnav > ul.dropdown-menu > li.current-module-action-links');
                 $I->click($link, '#toolbar.desktop-toolbar  > ul.nav.navbar-nav > li.topnav > ul.dropdown-menu > li.current-module-action-links');
                 break;
             case DesignBreakPoint::md:
                 $I->click('div#mobileheader > div#modulelinks > .modulename > a');
-                $I->waitForElementVisible('div#mobileheader > div#modulelinks > ul.dropdown-menu > li.mobile-current-actions > ul.mobileCurrentTab', 30);
+                $I->waitForElementVisible('div#mobileheader > div#modulelinks > ul.dropdown-menu > li.mobile-current-actions > ul.mobileCurrentTab');
                 $I->waitForText($link, 30, 'div#mobileheader > div#modulelinks > ul.dropdown-menu > li.mobile-current-actions > ul.mobileCurrentTab');
                 $I->click($link, 'div#mobileheader > div#modulelinks > ul.dropdown-menu > li.mobile-current-actions > ul.mobileCurrentTab');
                 break;
             case DesignBreakPoint::sm:
                 $I->click('div#mobileheader > div#modulelinks > .modulename > a');
                 $I->waitForElementVisible('#modulelinks > ul.dropdown-menu');
-                $I->waitForText($link, 30, 'div#mobileheader > div#modulelinks > ul.dropdown-menu > li.mobile-current-actions > ul.mobileCurrentTab', 30);
+                $I->waitForText($link, 30, 'div#mobileheader > div#modulelinks > ul.dropdown-menu > li.mobile-current-actions > ul.mobileCurrentTab');
                 $I->click($link, 'div#mobileheader > div#modulelinks > ul.dropdown-menu > li.mobile-current-actions > ul.mobileCurrentTab');
                 break;
             case DesignBreakPoint::xs:
                 $I->click('div#mobileheader > div#modulelinks > .modulename > a');
-                $I->waitForElementVisible('div#mobileheader > div#modulelinks > ul.dropdown-menu > li.mobile-current-actions > ul.mobileCurrentTab', 30);
+                $I->waitForElementVisible('div#mobileheader > div#modulelinks > ul.dropdown-menu > li.mobile-current-actions > ul.mobileCurrentTab');
                 $I->waitForText($link, 30, 'div#mobileheader > div#modulelinks > ul.dropdown-menu > li.mobile-current-actions > ul.mobileCurrentTab');
                 $I->click($link, 'div#mobileheader > div#modulelinks > ul.dropdown-menu > li.mobile-current-actions > ul.mobileCurrentTab');
                 break;

--- a/tests/_support/Step/Acceptance/Workflow.php
+++ b/tests/_support/Step/Acceptance/Workflow.php
@@ -34,10 +34,10 @@ class Workflow extends Tester
 
     public function setConditionOperator($row, $operator, $type)
     {
-        $this->waitForElementVisible('#aow_conditions_operator[' . $row . ']', 10);
+        $this->waitForElementVisible('#aow_conditions_operator[' . $row . ']');
         $this->selectOption('#aow_conditions_operator[' . $row . ']', $operator);
 
-        $this->waitForElementVisible('#aow_conditions_value_type[' . $row . ']', 10);
+        $this->waitForElementVisible('#aow_conditions_value_type[' . $row . ']');
         $this->selectOption('#aow_conditions_value_type[' . $row . ']', $type);
     }
 
@@ -49,7 +49,7 @@ class Workflow extends Tester
         $calendarField = '#aow_conditions_value'.$row.'_date';
         $calendarDialog = '#aow_conditions_value'.$row.'_trigger_div';
         $this->click($calendarButton);
-        $this->waitForElementVisible($calendarDialog, 10);
+        $this->waitForElementVisible($calendarDialog);
         $this->click('.today > .selector', $calendarDialog);
         $this->cantSeeInField($calendarField, '');
     }

--- a/tests/acceptance/Core/ModuleBuilderFieldsCest.php
+++ b/tests/acceptance/Core/ModuleBuilderFieldsCest.php
@@ -101,20 +101,20 @@ class ModuleBuilderFieldsCest
         $I->click(['name' => 'viewfieldsbtn']);
 
         // Close popup
-        $I->waitForElementVisible('#sugarMsgWindow_mask', 30);
+        $I->waitForElementVisible('#sugarMsgWindow_mask');
         $I->waitForText('This operation is completed successfully', 30, '#sugarMsgWindow_c');
         $I->click('.container-close');
 
         // Add field button
-        $I->waitForElementVisible(['name' => 'addfieldbtn'], 30);
+        $I->waitForElementVisible(['name' => 'addfieldbtn']);
         $I->click(['name' => 'addfieldbtn']);
 
         // Fill in edit field tab
-        $I->waitForElementVisible('#type', 30);
+        $I->waitForElementVisible('#type');
         $I->selectOption('#type', 'relate');
 
         $I->wait(1);
-        $I->waitForElementVisible('#field_name_id', 30);
+        $I->waitForElementVisible('#field_name_id');
         $I->fillField('#field_name_id', 'test_relate_field');
 
         // Module Builder auto writes the label fields when you click of the name field
@@ -137,9 +137,9 @@ class ModuleBuilderFieldsCest
         $moduleBuilder->closePopupSuccess();
 
         // Click Edit View
-        $I->waitForElementVisible('.bodywrapper', 30);
+        $I->waitForElementVisible('.bodywrapper');
         $I->click('Edit View', '.bodywrapper');
-        $I->waitForElementVisible('#layoutEditor', 30);
+        $I->waitForElementVisible('#layoutEditor');
 
         // Drag a new row into the last panel
         $I->dragAndDrop('.le_row.special:not(#ygddfdiv)', '.le_panel:last-of-type');
@@ -186,20 +186,20 @@ class ModuleBuilderFieldsCest
         $I->click(['name' => 'viewfieldsbtn']);
 
         // Close popup
-        $I->waitForElementVisible('#sugarMsgWindow_mask', 30);
+        $I->waitForElementVisible('#sugarMsgWindow_mask');
         $I->waitForText('This operation is completed successfully', 30, '#sugarMsgWindow_c');
         $I->click('.container-close');
 
         // Add field button
-        $I->waitForElementVisible(['name' => 'addfieldbtn'], 30);
+        $I->waitForElementVisible(['name' => 'addfieldbtn']);
         $I->click(['name' => 'addfieldbtn']);
 
         // Fill in edit field tab
-        $I->waitForElementVisible('#type', 30);
+        $I->waitForElementVisible('#type');
         $I->selectOption('#type', 'HTML');
 
         $I->wait(1);
-        $I->waitForElementVisible('#field_name_id', 30);
+        $I->waitForElementVisible('#field_name_id');
         $I->fillField('#field_name_id', 'test_html_field');
 
         // Module Builder auto writes the label fields when you click of the name field
@@ -221,9 +221,9 @@ class ModuleBuilderFieldsCest
         $moduleBuilder->closePopupSuccess();
 
         // Click Edit View
-        $I->waitForElementVisible('.bodywrapper', 30);
+        $I->waitForElementVisible('.bodywrapper');
         $I->click('Edit View', '.bodywrapper');
-        $I->waitForElementVisible('#layoutEditor', 30);
+        $I->waitForElementVisible('#layoutEditor');
 
         // Drag a new row into the last panel
         $I->dragAndDrop('.le_row.special:not(#ygddfdiv)', '.le_panel:last-of-type');
@@ -313,11 +313,11 @@ class ModuleBuilderFieldsCest
         $navigationBar->clickCurrentMenuItem('Create ' . \Page\ModuleFields::$NAME);
 
         // Create an account to relate to
-        $I->waitForElementVisible('#name', 30);
+        $I->waitForElementVisible('#name');
         $editView->fillField('#name', $company);
         $relateFieldId = 'test_relate_field';
         $editView->fillField('#'.$relateFieldId, $company);
-        $editView->waitForElementNotVisible('#EditView_'.$relateFieldId.' > .yui-ac-content', 30);
+        $editView->waitForElementNotVisible('#EditView_'.$relateFieldId.' > .yui-ac-content');
         $editView->fillField('#test_int_field', $this->fakeData->numberBetween(0, 1000));
 
         $editView->clickSaveButton();

--- a/tests/acceptance/modules/Accounts/AccountsCest.php
+++ b/tests/acceptance/modules/Accounts/AccountsCest.php
@@ -158,7 +158,7 @@ class AccountsCest
 
         // Click on Member Organizations subpanel
         $I->click(['id' => 'subpanel_title_accounts']);
-        $I->waitForElementVisible('#member_accounts_create_button', 60);
+        $I->waitForElementVisible('#member_accounts_create_button');
 
         // Add child account
         $accountName = 'Test_' . $this->fakeData->company();

--- a/tests/acceptance/modules/Activities/ActivitiesCest.php
+++ b/tests/acceptance/modules/Activities/ActivitiesCest.php
@@ -85,7 +85,7 @@ class ActivitiesCest
 
         //Click on Activites subpanel
         $I->click(['id'=>'subpanel_title_activities']);
-        $I->waitForElementVisible('#Activities_createtask_button', 60);
+        $I->waitForElementVisible('#Activities_createtask_button');
         $I->expect('the due date is visible');
         $I->seeInSource('01/19/2038');
 

--- a/tests/acceptance/modules/History/HistoryCest.php
+++ b/tests/acceptance/modules/History/HistoryCest.php
@@ -85,7 +85,7 @@ class HistoryCest
 
         //Click on History subpanel
         $I->click(['id'=>'subpanel_title_history']);
-        $I->waitForElementVisible('#History_createnoteorattachment_button', 60);
+        $I->waitForElementVisible('#History_createnoteorattachment_button');
         $I->expect('the due date is visible');
         $I->seeInSource('01/19/2038');
 


### PR DESCRIPTION
## Description
Part of #7344.

This removes explicit timeouts from all calls to waitForElementVisible in the acceptance test suite. If a page failed to load, the test would wait for the entire timeout before failing. This made running the test suite locally pretty painful, especially when a test would fail. It would also make the test suite take significantly longer than normal when a change introduced failures.

Generally, most of these should never take more than the default 10 second timeout, so they're unnecessary.

## How To Test This
Make sure Travis passes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.