### PR TITLE
Remove repetitive instance URL visits from tests

### DIFF
--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -40,6 +40,7 @@ class AcceptanceTester extends \Codeception\Actor
     {
         $I = $this;
 
+        $I->amOnUrl($I->getInstanceURL());
         $I->waitForElementVisible('#loginform');
         $I->fillField('#user_name', $username);
         $I->fillField('#username_password', $password);

--- a/tests/acceptance/Core/BasicModuleCest.php
+++ b/tests/acceptance/Core/BasicModuleCest.php
@@ -57,10 +57,6 @@ class BasicModuleCest
     ) {
         $I->wantTo('Create a basic module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         $I->loginAsAdmin();
 
         $moduleBuilder->createModule(
@@ -89,10 +85,6 @@ class BasicModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('View Basic Test Module');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         $I->loginAsAdmin();
 
@@ -123,9 +115,6 @@ class BasicModuleCest
     ) {
         $I->wantTo('Create Basic Test Module Record');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
         $I->loginAsAdmin();
 
         // Go to Basic Test Module
@@ -162,10 +151,6 @@ class BasicModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Select Record from list view');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         $I->loginAsAdmin();
 
@@ -206,9 +191,6 @@ class BasicModuleCest
     ) {
         $I->wantTo('Edit Basic Test Module Record from detail view');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
         $I->loginAsAdmin();
 
         // Go to Basic Test Module
@@ -255,9 +237,6 @@ class BasicModuleCest
     ) {
         $I->wantTo('Duplicate Basic Test Module Record from detail view');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
         $I->loginAsAdmin();
 
         // Go to Basic Test Module
@@ -309,9 +288,6 @@ class BasicModuleCest
     ) {
         $I->wantTo('Delete Basic Test Module Record from detail view');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
         $I->loginAsAdmin();
 
         // Go to Basic Test Module

--- a/tests/acceptance/Core/CompanyModuleCest.php
+++ b/tests/acceptance/Core/CompanyModuleCest.php
@@ -58,11 +58,6 @@ class CompanyModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create a company module for testing');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         $I->loginAsAdmin();
 
         $moduleBuilder->createModule(
@@ -90,9 +85,6 @@ class CompanyModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('View Company Test Module');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         $I->loginAsAdmin();
 
@@ -124,9 +116,6 @@ class CompanyModuleCest
     ) {
         $I->wantTo('Create Company Test Module Record');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
         $I->loginAsAdmin();
 
         // Go to Company Test Module
@@ -179,9 +168,6 @@ class CompanyModuleCest
     ) {
         $I->wantTo('Select Record from list view');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
         $I->loginAsAdmin();
 
         // Go to Company Test Module
@@ -223,9 +209,6 @@ class CompanyModuleCest
     ) {
         $I->wantTo('Edit Company Test Module Record from detail view');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
         $I->loginAsAdmin();
 
         // Go to Company Test Module
@@ -272,10 +255,6 @@ class CompanyModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Duplicate Company Test Module Record from detail view');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
         $I->loginAsAdmin();
 
 
@@ -329,9 +308,6 @@ class CompanyModuleCest
     ) {
         $I->wantTo('Delete Company Test Module Record from detail view');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
         $I->loginAsAdmin();
 
         // Go to Company Test Module

--- a/tests/acceptance/Core/FileModuleCest.php
+++ b/tests/acceptance/Core/FileModuleCest.php
@@ -56,10 +56,6 @@ class FileModuleCest
     ) {
         $I->wantTo('Create a file module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         $I->loginAsAdmin();
 
         $moduleBuilder->createModule(
@@ -87,10 +83,6 @@ class FileModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('View File Test Module');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         $I->loginAsAdmin();
 
         // Navigate to module
@@ -120,9 +112,6 @@ class FileModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create File Test Module Record');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
         $I->loginAsAdmin();
 
         // Go to File Test Module
@@ -169,9 +158,6 @@ class FileModuleCest
     ) {
         $I->wantTo('Select Record from list view');
         
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
         $I->loginAsAdmin();
 
         // Go to File Test Module
@@ -211,9 +197,6 @@ class FileModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Edit File Test Module Record from detail view');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
         $I->loginAsAdmin();
 
         // Go to File Test Module
@@ -258,9 +241,6 @@ class FileModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Duplicate File Test Module Record from detail view');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
         $I->loginAsAdmin();
 
         // Go to File Test Module
@@ -311,9 +291,6 @@ class FileModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Delete File Test Module Record from detail view');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
         $I->loginAsAdmin();
 
         // Go to File Test Module

--- a/tests/acceptance/Core/IssueModuleCest.php
+++ b/tests/acceptance/Core/IssueModuleCest.php
@@ -56,11 +56,6 @@ class IssueModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create a issue module for testing');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         $I->loginAsAdmin();
 
         $moduleBuilder->createModule(
@@ -88,10 +83,6 @@ class IssueModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('View Issue Test Module');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         $I->loginAsAdmin();
 
         // Navigate to module
@@ -121,10 +112,6 @@ class IssueModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create Issue Test Module Record');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         $I->loginAsAdmin();
 
         // Go to Issue Test Module
@@ -161,10 +148,6 @@ class IssueModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Select Record from list view');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         $I->loginAsAdmin();
 
         // Go to Issue Test Module
@@ -203,9 +186,6 @@ class IssueModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Edit Issue Test Module Record from detail view');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
         $I->loginAsAdmin();
 
         // Go to Issue Test Module
@@ -251,9 +231,6 @@ class IssueModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Duplicate Issue Test Module Record from detail view');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
         $I->loginAsAdmin();
 
         // Go to Issue Test Module
@@ -304,9 +281,6 @@ class IssueModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Delete Issue Test Module Record from detail view');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
         $I->loginAsAdmin();
 
         // Go to Issue Test Module

--- a/tests/acceptance/Core/ModuleBuilderFieldsCest.php
+++ b/tests/acceptance/Core/ModuleBuilderFieldsCest.php
@@ -60,10 +60,6 @@ class ModuleBuilderFieldsCest
     ) {
         $I->wantTo('Create a module for testing fields');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         $I->loginAsAdmin();
 
         $moduleBuilder->createModule(
@@ -88,10 +84,6 @@ class ModuleBuilderFieldsCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Add relate field');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         $I->loginAsAdmin();
 
@@ -173,10 +165,6 @@ class ModuleBuilderFieldsCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Add html field');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         $I->loginAsAdmin();
 
@@ -290,14 +278,6 @@ class ModuleBuilderFieldsCest
     ) {
         return; // test failing behaviour is not similar in different environments
         $I->wantTo('Relate a record to accounts');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         $I->loginAsAdmin();
 

--- a/tests/acceptance/Core/PersonModuleCest.php
+++ b/tests/acceptance/Core/PersonModuleCest.php
@@ -57,10 +57,6 @@ class PersonModuleCest
     ) {
         $I->wantTo('Create a person module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         $I->loginAsAdmin();
 
         $moduleBuilder->createModule(
@@ -88,9 +84,6 @@ class PersonModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('View Person Test Module');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         $I->loginAsAdmin();
 
@@ -121,10 +114,6 @@ class PersonModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create Person Test Module Record');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         $I->loginAsAdmin();
 
         // Go to Person Test Module
@@ -186,9 +175,6 @@ class PersonModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Select Record from list view');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         $I->loginAsAdmin();
 
@@ -234,9 +220,6 @@ class PersonModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Edit Person Test Module Record from detail view');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         $I->loginAsAdmin();
 
@@ -290,10 +273,6 @@ class PersonModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Duplicate Person Test Module Record from detail view');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         $I->loginAsAdmin();
 
@@ -350,9 +329,6 @@ class PersonModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Delete Person Test Module Record from detail view');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         $I->loginAsAdmin();
 
@@ -404,10 +380,6 @@ class PersonModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create a Person Record using a vcard');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
 
         // Create VCard for test
         $vcard = new VCard();

--- a/tests/acceptance/Core/SaleModuleCest.php
+++ b/tests/acceptance/Core/SaleModuleCest.php
@@ -52,10 +52,6 @@ class SaleModuleCest
     ) {
         $I->wantTo('Create a sale module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         $I->loginAsAdmin();
 
         $moduleBuilder->createModule(
@@ -81,10 +77,6 @@ class SaleModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('View Sale Test Module');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         $I->loginAsAdmin();
 
         // Navigate to module
@@ -113,9 +105,6 @@ class SaleModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create Sale Test Module Record');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         $I->loginAsAdmin();
 
@@ -156,9 +145,6 @@ class SaleModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Select Record from list view');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         $I->loginAsAdmin();
 
@@ -196,10 +182,6 @@ class SaleModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Edit Sale Test Module Record from detail view');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         $I->loginAsAdmin();
 
         // Go to Sale Test Module
@@ -245,9 +227,6 @@ class SaleModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Duplicate Sale Test Module Record from detail view');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         $I->loginAsAdmin();
 
@@ -298,9 +277,6 @@ class SaleModuleCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Delete Sale Test Module Record from detail view');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         $I->loginAsAdmin();
 

--- a/tests/acceptance/LoginCest.php
+++ b/tests/acceptance/LoginCest.php
@@ -24,12 +24,8 @@ class LoginCest
     // tests
     public function testScenarioLoginAsAdministrator(AcceptanceTester $I, \Helper\WebDriverHelper $webDriverHelper)
     {
-        $I->wantTo('Login into SuiteCRM as an administrator');
-        $I->amOnUrl($webDriverHelper->getInstanceURL());
+        $I->wantTo('Login as an administrator');
         // Login as Administrator
-        $I->login(
-            $webDriverHelper->getAdminUser(),
-            $webDriverHelper->getAdminPassword()
-        );
+        $I->loginAsAdmin();
     }
 }

--- a/tests/acceptance/modules/AM_Project_Templates/AM_Project_TemplatesCest.php
+++ b/tests/acceptance/modules/AM_Project_Templates/AM_Project_TemplatesCest.php
@@ -42,11 +42,6 @@ class AM_Project_TemplatesCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('View the projectTemplates module for testing');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to projectTemplates list-view
         $I->loginAsAdmin();
         $projectTemplates->gotoProjectTemplates();
@@ -73,10 +68,6 @@ class AM_Project_TemplatesCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create a project template');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to project templates list-view
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/AOK_KnowledgeBase/AOK_KnowledgeBaseCest.php
+++ b/tests/acceptance/modules/AOK_KnowledgeBase/AOK_KnowledgeBaseCest.php
@@ -43,10 +43,6 @@ class AOK_KnowledgeBaseCest
     ) {
         $I->wantTo('View the knowledgeBase module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to knowledgeBase list-view
         $I->loginAsAdmin();
         $knowledgeBase->gotoKnowledgeBase();
@@ -73,10 +69,6 @@ class AOK_KnowledgeBaseCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create a Knowledge Base');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to Knowledge Base list-view
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/AOK_Knowledge_Base_Categories/AOK_Knowledge_Base_CategoriesCest.php
+++ b/tests/acceptance/modules/AOK_Knowledge_Base_Categories/AOK_Knowledge_Base_CategoriesCest.php
@@ -43,10 +43,6 @@ class AOK_Knowledge_Base_CategoriesCest
     ) {
         $I->wantTo('View the knowledgeBaseCategory module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to knowledgeBaseCategory list-view
         $I->loginAsAdmin();
         $knowledgeBaseCategory->gotoKnowledgeBaseCategories();
@@ -73,10 +69,6 @@ class AOK_Knowledge_Base_CategoriesCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create KnowledgeBaseCategory');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to knowledge base category list-view
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/AOR_Reports/AOR_ReportsCest.php
+++ b/tests/acceptance/modules/AOR_Reports/AOR_ReportsCest.php
@@ -43,10 +43,6 @@ class AOR_ReportsCest
     ) {
         $I->wantTo('View the reports module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to reports list-view
         $I->loginAsAdmin();
         $reports->gotoReports();
@@ -77,10 +73,6 @@ class AOR_ReportsCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create a Report');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to reports list-view
         $I->loginAsAdmin();
@@ -124,10 +116,6 @@ class AOR_ReportsCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Select Report from list view');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to reports list-view
         $I->loginAsAdmin();
@@ -179,10 +167,6 @@ class AOR_ReportsCest
     ) {
         $I->wantTo('Edit a Report from the detail view');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to a report
         $I->loginAsAdmin();
         $reports->gotoReports();
@@ -233,10 +217,6 @@ class AOR_ReportsCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Duplicate Report from detail view');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to a report
         $I->loginAsAdmin();
@@ -290,10 +270,6 @@ class AOR_ReportsCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Delete Report from detail view');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to a report
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/AOS_PDF_Templates/AOS_PDF_TemplatesCest.php
+++ b/tests/acceptance/modules/AOS_PDF_Templates/AOS_PDF_TemplatesCest.php
@@ -43,10 +43,6 @@ class AOS_PDF_TemplatesCest
     ) {
         $I->wantTo('View the pdfTemplates module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to pdfTemplates list-view
         $I->loginAsAdmin();
         $pdfTemplates->gotoPDFTemplates();
@@ -73,10 +69,6 @@ class AOS_PDF_TemplatesCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create a PDF Template');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to PDF Template list-view
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/AOS_Product_Categories/AOS_Product_CategoriesCest.php
+++ b/tests/acceptance/modules/AOS_Product_Categories/AOS_Product_CategoriesCest.php
@@ -43,10 +43,6 @@ class AOS_Product_CategoriesCest
     ) {
         $I->wantTo('View the productCategories module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to productCategories list-view
         $I->loginAsAdmin();
         $productCategories->gotoProductCategories();
@@ -73,10 +69,6 @@ class AOS_Product_CategoriesCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create a product category');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to product category list-view
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/AOS_Products/AOS_ProductsCest.php
+++ b/tests/acceptance/modules/AOS_Products/AOS_ProductsCest.php
@@ -43,10 +43,6 @@ class ProductsCest
     ) {
         $I->wantTo('View the products module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to products list-view
         $I->loginAsAdmin();
         $products->gotoProducts();
@@ -73,10 +69,6 @@ class ProductsCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create a product');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to products list-view
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/AOW_Workflow/AOW_WorkflowCest.php
+++ b/tests/acceptance/modules/AOW_Workflow/AOW_WorkflowCest.php
@@ -54,13 +54,9 @@ class AOW_WorkflowCest
         \Step\Acceptance\Workflow $workflow
     ) {
         $I->wantTo('Create a workflow for accounts');
-        $I->amOnUrl($webDriverHelper->getInstanceURL());
 
         // Login as Administrator
-        $I->login(
-            $webDriverHelper->getAdminUser(),
-            $webDriverHelper->getAdminPassword()
-        );
+        $I->loginAsAdmin();
 
         $dashboard->waitForDashboardVisible();
         $workflow->navigateToWorkflow($navigationBar, $listView);

--- a/tests/acceptance/modules/Accounts/AccountsCest.php
+++ b/tests/acceptance/modules/Accounts/AccountsCest.php
@@ -43,10 +43,6 @@ class AccountsCest
     ) {
         $I->wantTo('View the accounts module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to accounts list-view
         $I->loginAsAdmin();
         $accounts->gotoAccounts();
@@ -74,9 +70,6 @@ class AccountsCest
     ) {
         $I->wantTo('Create an Account');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to accounts list-view
         $I->loginAsAdmin();
@@ -109,10 +102,6 @@ class AccountsCest
     ) {
         $I->wantTo('Inline edit an account on the list-view');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to accounts list-view
         $I->loginAsAdmin();
         $accounts->gotoAccounts();
@@ -141,10 +130,6 @@ class AccountsCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create an Account');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to accounts list-view
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/Activities/ActivitiesCest.php
+++ b/tests/acceptance/modules/Activities/ActivitiesCest.php
@@ -49,10 +49,6 @@ class ActivitiesCest
     ) {
         $I->wantTo('See the due date field on Account Activities subpanel');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to accounts list-view
         $I->loginAsAdmin();
         $accounts->gotoAccounts();

--- a/tests/acceptance/modules/Calendar/CalendarCest.php
+++ b/tests/acceptance/modules/Calendar/CalendarCest.php
@@ -41,10 +41,6 @@ class CalendarCest
     ) {
         $I->wantTo('View the calendar module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to calendar list-view
         $I->loginAsAdmin();
         $calendar->gotoCalendar();

--- a/tests/acceptance/modules/Calls/CallsCest.php
+++ b/tests/acceptance/modules/Calls/CallsCest.php
@@ -41,10 +41,6 @@ class CallsCest
     ) {
         $I->wantTo('View the calls module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to calls list-view
         $I->loginAsAdmin();
         $calls->gotoCalls();
@@ -72,10 +68,6 @@ class CallsCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create a call');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to Calls
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/Campaigns/CampaignsCest.php
+++ b/tests/acceptance/modules/Campaigns/CampaignsCest.php
@@ -43,10 +43,6 @@ class CampaignsCest
     ) {
         $I->wantTo('View the campaigns module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to campaigns list-view
         $I->loginAsAdmin();
         $campaigns->gotoCampaigns();
@@ -73,10 +69,6 @@ class CampaignsCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create Non-Email Campaign');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to campaigns list-view
         $I->loginAsAdmin();
@@ -124,10 +116,6 @@ class CampaignsCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create Newsletter Campaign');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
 //        $I->loginAsAdmin();
 //

--- a/tests/acceptance/modules/Cases/CasesCest.php
+++ b/tests/acceptance/modules/Cases/CasesCest.php
@@ -43,10 +43,6 @@ class CasesCest
     ) {
         $I->wantTo('View the cases module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to cases list-view
         $I->loginAsAdmin();
         $cases->gotoCases();
@@ -75,10 +71,6 @@ class CasesCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create a Case');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to accounts list-view
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/Contacts/ContactsCest.php
+++ b/tests/acceptance/modules/Contacts/ContactsCest.php
@@ -43,10 +43,6 @@ class ContactsCest
     ) {
         $I->wantTo('View the contacts module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to contacts list-view
         $I->loginAsAdmin();
         $contacts->gotoContacts();
@@ -73,10 +69,6 @@ class ContactsCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create a Contact');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to contacts list-view
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/Contracts/ContractsCest.php
+++ b/tests/acceptance/modules/Contracts/ContractsCest.php
@@ -43,10 +43,6 @@ class ContractsCest
     ) {
         $I->wantTo('View the contracts module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to contracts list-view
         $I->loginAsAdmin();
         $contracts->gotoContracts();
@@ -75,10 +71,6 @@ class ContractsCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create a Contract');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to accounts list-view
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/Documents/DocumentsCest.php
+++ b/tests/acceptance/modules/Documents/DocumentsCest.php
@@ -43,10 +43,6 @@ class DocumentsCest
     ) {
         $I->wantTo('View the documents module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to documents list-view
         $I->loginAsAdmin();
         $documents->gotoDocuments();

--- a/tests/acceptance/modules/EmailMan/EmailManCest.php
+++ b/tests/acceptance/modules/EmailMan/EmailManCest.php
@@ -37,9 +37,6 @@ class EmailManCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Save an outgoing email configuration');
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to email configuration and save settings
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/EmailTemplates/EmailTemplatesCest.php
+++ b/tests/acceptance/modules/EmailTemplates/EmailTemplatesCest.php
@@ -43,10 +43,6 @@ class EmailTemplatesCest
     ) {
         $I->wantTo('View the emailTemplate module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to emailTemplate list-view
         $I->loginAsAdmin();
         $emailTemplate->gotoEmailTemplates();

--- a/tests/acceptance/modules/Emails/EmailsCest.php
+++ b/tests/acceptance/modules/Emails/EmailsCest.php
@@ -48,10 +48,6 @@ class EmailsCest
     ) {
         $I->wantTo('View the emails module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to emails list-view
         $I->loginAsAdmin();
         $emails->gotoEmails();
@@ -74,10 +70,6 @@ class EmailsCest
         // TODO: Refactor
 
         $I->wantTo('View the HTML of two emails');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         $I->loginAsAdmin();
 

--- a/tests/acceptance/modules/FP_Event_Locations/FP_Event_LocationsCest.php
+++ b/tests/acceptance/modules/FP_Event_Locations/FP_Event_LocationsCest.php
@@ -43,10 +43,6 @@ class LocationsCest
     ) {
         $I->wantTo('View the locations module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to locations list-view
         $I->loginAsAdmin();
         $locations->gotoLocations();
@@ -73,10 +69,6 @@ class LocationsCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create a Location');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to locations list-view
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/FP_Events/FP_EventsCest.php
+++ b/tests/acceptance/modules/FP_Events/FP_EventsCest.php
@@ -43,10 +43,6 @@ class EventsCest
     ) {
         $I->wantTo('View the events module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to events list-view
         $I->loginAsAdmin();
         $events->gotoEvents();
@@ -75,10 +71,6 @@ class EventsCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create an Event');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to locations list-view
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/History/HistoryCest.php
+++ b/tests/acceptance/modules/History/HistoryCest.php
@@ -49,10 +49,6 @@ class HistoryCest
     ) {
         $I->wantTo('See the due date field on Account History subpanel');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to accounts list-view
         $I->loginAsAdmin();
         $accounts->gotoAccounts();

--- a/tests/acceptance/modules/Home/HomeCest.php
+++ b/tests/acceptance/modules/Home/HomeCest.php
@@ -43,10 +43,6 @@ class HomeCest
     ) {
         $I->wantTo('Create a chart dashlet on the dashboard');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to dashboard
         $I->loginAsAdmin();
         $dashboard->waitForDashboardVisible();

--- a/tests/acceptance/modules/Invoices/InvoicesCest.php
+++ b/tests/acceptance/modules/Invoices/InvoicesCest.php
@@ -43,10 +43,6 @@ class InvoicesCest
     ) {
         $I->wantTo('View the invoices module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to invoices list-view
         $I->loginAsAdmin();
         $invoices->gotoInvoices();
@@ -73,10 +69,6 @@ class InvoicesCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create an Invoice');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to invoices list-view
         $I->loginAsAdmin();
@@ -112,10 +104,6 @@ class InvoicesCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create an Invoice');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to invoices list-view
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/Leads/LeadsCest.php
+++ b/tests/acceptance/modules/Leads/LeadsCest.php
@@ -43,10 +43,6 @@ class LeadsCest
     ) {
         $I->wantTo('View the leads module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to leads list-view
         $I->loginAsAdmin();
         $leads->gotoLeads();
@@ -73,10 +69,6 @@ class LeadsCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create a Lead');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to leads list-view
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/Meetings/MeetingsCest.php
+++ b/tests/acceptance/modules/Meetings/MeetingsCest.php
@@ -43,10 +43,6 @@ class MeetingsCest
     ) {
         $I->wantTo('View the meetings module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to meetings list-view
         $I->loginAsAdmin();
         $meetings->gotoMeetings();
@@ -73,10 +69,6 @@ class MeetingsCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create a meeting');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to meetings list-view
         $I->loginAsAdmin();
@@ -110,10 +102,6 @@ class MeetingsCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create a meeting');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to meetings list-view
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/Notes/NotesCest.php
+++ b/tests/acceptance/modules/Notes/NotesCest.php
@@ -43,10 +43,6 @@ class NotesCest
     ) {
         $I->wantTo('View the notes module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to notes list-view
         $I->loginAsAdmin();
         $notes->gotoNotes();

--- a/tests/acceptance/modules/Opportunities/OpportunitiesCest.php
+++ b/tests/acceptance/modules/Opportunities/OpportunitiesCest.php
@@ -43,10 +43,6 @@ class OpportunitiesCest
     ) {
         $I->wantTo('View the opportunities module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to opportunities list-view
         $I->loginAsAdmin();
         $opportunities->gotoOpportunities();
@@ -75,10 +71,6 @@ class OpportunitiesCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create an opportunity');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to accounts list-view
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/Projects/ProjectsCest.php
+++ b/tests/acceptance/modules/Projects/ProjectsCest.php
@@ -43,10 +43,6 @@ class ProjectsCest
     ) {
         $I->wantTo('View the projects module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to projects list-view
         $I->loginAsAdmin();
         $projects->gotoProjects();
@@ -73,10 +69,6 @@ class ProjectsCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create a Project');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to projects list-view
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/Quotes/QuotesCest.php
+++ b/tests/acceptance/modules/Quotes/QuotesCest.php
@@ -43,10 +43,6 @@ class QuotesCest
     ) {
         $I->wantTo('View the quotes module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to quotes list-view
         $I->loginAsAdmin();
         $quotes->gotoQuotes();

--- a/tests/acceptance/modules/Spots/SpotsCest.php
+++ b/tests/acceptance/modules/Spots/SpotsCest.php
@@ -43,10 +43,6 @@ class SpotsCest
     ) {
         $I->wantTo('View the spots module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to spots list-view
         $I->loginAsAdmin();
         $spots->gotoSpots();

--- a/tests/acceptance/modules/Surveys/SurveysCest.php
+++ b/tests/acceptance/modules/Surveys/SurveysCest.php
@@ -43,10 +43,6 @@ class SurveysCest
     ) {
         $I->wantTo('View the surveys module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to surveys list-view
         $I->loginAsAdmin();
         $surveys->gotoSurveys();

--- a/tests/acceptance/modules/TargetLists/TargetListsCest.php
+++ b/tests/acceptance/modules/TargetLists/TargetListsCest.php
@@ -43,10 +43,6 @@ class TargetListsCest
     ) {
         $I->wantTo('View the targets module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to targets list-view
         $I->loginAsAdmin();
         $targetList->gotoTargetList();

--- a/tests/acceptance/modules/Targets/TargetsCest.php
+++ b/tests/acceptance/modules/Targets/TargetsCest.php
@@ -43,10 +43,6 @@ class TargetsCest
     ) {
         $I->wantTo('View the targets module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to targets list-view
         $I->loginAsAdmin();
         $targets->gotoTargets();

--- a/tests/acceptance/modules/Tasks/TasksCest.php
+++ b/tests/acceptance/modules/Tasks/TasksCest.php
@@ -43,10 +43,6 @@ class TasksCest
     ) {
         $I->wantTo('View the tasks module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to tasks list-view
         $I->loginAsAdmin();
         $tasks->gotoTasks();

--- a/tests/acceptance/modules/Users/UsersCest.php
+++ b/tests/acceptance/modules/Users/UsersCest.php
@@ -36,8 +36,6 @@ class UsersCest
     
     public function testEmailSettingsMailAccountAdd(AcceptanceTester $I, UsersTester $Users, WebDriverHelper $webDriverHelper)
     {
-        $instanceUrl = $webDriverHelper->getInstanceURL();
-        $I->amOnUrl($instanceUrl);
         $I->loginAsAdmin();
         $Users->gotoProfile();
         $I->see('User Profile', '.panel-heading');
@@ -64,10 +62,6 @@ class UsersCest
         WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('View the collapsed subpanel hints on Accounts');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to Users list-view
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/jjwg_Address_Cache/jjwg_Address_CacheCest.php
+++ b/tests/acceptance/modules/jjwg_Address_Cache/jjwg_Address_CacheCest.php
@@ -43,10 +43,6 @@ class jjwg_Address_CacheCest
     ) {
         $I->wantTo('View the mapsAddressCache module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to mapsAddressCache list-view
         $I->loginAsAdmin();
         $mapsAddressCache->gotoMapsAddressCache();
@@ -73,10 +69,6 @@ class jjwg_Address_CacheCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create maps address cache');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to maps address cache list-view
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/jjwg_Areas/jjwg_AreasCest.php
+++ b/tests/acceptance/modules/jjwg_Areas/jjwg_AreasCest.php
@@ -42,13 +42,9 @@ class jjwg_AreasCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('View the mapsAreas module for testing');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
-        // Navigate to mapsAreas list-view
+        
         $I->loginAsAdmin();
+        // Navigate to mapsAreas list-view
         $mapsAreas->gotoMapsAreas();
         $listView->waitForListViewVisible();
 

--- a/tests/acceptance/modules/jjwg_Maps/jjwg_MapsCest.php
+++ b/tests/acceptance/modules/jjwg_Maps/jjwg_MapsCest.php
@@ -43,10 +43,6 @@ class jjwg_MapsCest
     ) {
         $I->wantTo('View the maps module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to maps list-view
         $I->loginAsAdmin();
         $maps->gotoMaps();
@@ -75,10 +71,6 @@ class jjwg_MapsCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create a Map');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to accounts list-view
         $I->loginAsAdmin();

--- a/tests/acceptance/modules/jjwg_Markers/jjwg_MarkersCest.php
+++ b/tests/acceptance/modules/jjwg_Markers/jjwg_MarkersCest.php
@@ -43,10 +43,6 @@ class jjwg_MarkersCest
     ) {
         $I->wantTo('View the mapsMarkers module for testing');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
-
         // Navigate to mapsMarkers list-view
         $I->loginAsAdmin();
         $mapsMarkers->gotoMapsMarkers();
@@ -73,10 +69,6 @@ class jjwg_MarkersCest
         \Helper\WebDriverHelper $webDriverHelper
     ) {
         $I->wantTo('Create a Map Marker');
-
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
 
         // Navigate to map markers list-view
         $I->loginAsAdmin();

--- a/tests/install/UserWizardCest.php
+++ b/tests/install/UserWizardCest.php
@@ -52,9 +52,6 @@ class UserWizardCest
         // ---------- Email Settings ---------------
         
         $I2->wantTo('Save an outgoing email configuration');
-        $I2->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
         // Navigate to email configuration and save settings
         $I2->loginAsAdmin();
         $I2->createEmailSettings();


### PR DESCRIPTION
## Description
I noticed every usage of the `loginAsAdmin` function in the acceptance test suite was preceded by a visiting the root instance URL, so I moved the instance URL visit into the login function for simplicity.

This removes `$I->amOnUrl($webDriverHelper->getInstanceURL())` from all files where it precedes the `loginAsAdmin` function, since it's now in the `loginAsAdmin` function.

## How To Test This
Make sure the tests pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.