### PR TITLE
Simplify the acceptance and install suite configs.

### DIFF
--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -16,6 +16,3 @@ modules:
         \SuiteCRM\Test\Driver\WebDriver:
             url: "https://demo.suiteondemand.com"
             browser: chrome
-            restart: false
-            clear_cookies: false
-            wait: 3

--- a/tests/install.suite.yml
+++ b/tests/install.suite.yml
@@ -11,6 +11,3 @@ modules:
         browser: chrome
         restart: true
         wait: 1
-        # XGA Resolution / iPad 2 resolution (horizontal)
-        width: 1280
-        height: 720


### PR DESCRIPTION
These are unnecessary since they're handled by the travis config.

The only problem this would cause is if a custom env isn't used, but the acceptance and install suites using different settings by default when run locally is also bad. I'd say this is probably better than the current situation, and #7433 will help with this as well.