### PR TITLE
Fix #4116 Prevent download files from being cached

### DIFF
--- a/download.php
+++ b/download.php
@@ -226,8 +226,9 @@ if ((!isset($_REQUEST['isProfile']) && empty($_REQUEST['id'])) || empty($_REQUES
             $name = str_replace("+", "_", $name);
         }
 
-        header("Pragma: public");
-        header("Cache-Control: maxage=1, post-check=0, pre-check=0");
+        header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+        header('Cache-Control: post-check=0, pre-check=0', false);
+        header('Pragma: no-cache');
         if (isset($_REQUEST['isTempFile']) && ($_REQUEST['type'] == "SugarFieldImage")) {
             $mime = getimagesize($download_location);
             if (!empty($mime)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Change the headers being sent for file downloads.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Previous downloaded files could get cached by browsers (or other intermediaries) due to the cache headers not being strict enough.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes #4116 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
This issue only appear on some browsers. I haven't been able to reproduce the issue myself, but the person who brought the issue to my attention followed these steps (Which are the same as were reported in #4116 ):

1. Clear browser cache
2. Go to import records into any module
3. Make sure your import.csv contains at least one error
4. Do the import
5. Download the error.csv
6. Change your import import.csv so it triggers different errors
7. Do the import of the updated csv
8. Download the error.csv
9. See the downloaded error.csv contains the errors from the second import instead of the first, so no cached file is being served.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->