### PR TITLE
Replace most instances of $I->wait(n) with waitForX. 

### DIFF
--- a/tests/_support/Step/Acceptance/Calls.php
+++ b/tests/_support/Step/Acceptance/Calls.php
@@ -75,7 +75,6 @@ class Calls extends \AcceptanceTester
         $I->fillField('#parent_name', $module_name);
 
         $I->wait(2);
-
         $I->clickSaveButton();
         $DetailView->waitForDetailViewVisible();
     }

--- a/tests/_support/Step/Acceptance/Campaigns.php
+++ b/tests/_support/Step/Acceptance/Campaigns.php
@@ -57,7 +57,7 @@ class Campaigns extends \AcceptanceTester
         $I->click('#wiz_submit_finish_button');
 
         // Step 4
-        $I->wait(3);
+        $I->waitForText('You have no associated targets in your selected target list(s) for this campaign. You can populate your list after finishing.');
         $I->see('You have no associated targets in your selected target list(s) for this campaign. You can populate your list after finishing.');
         $Sidebar->clickSideBarAction('View Campaigns');
     }
@@ -113,16 +113,16 @@ class Campaigns extends \AcceptanceTester
         $I->click('#next_button_div');
 
         // Step 5
-        $I->wait(3);
+        $I->waitForElementVisible('#marketing_name');
         $I->fillField('#marketing_name', $faker->email);
         $I->selectOption('#inbound_email_id', 'Test_BounceHandling');
         $I->click('#date_start_trigger');
         $I->click('#callnav_today');
-        $I->wait(3);
+        $I->waitForElementVisible('#wiz_submit_button');
         $I->click('#wiz_submit_button');
 
         // Step 6
-        $I->wait(3);
+        $I->waitForText('You cannot send a marketing email until your subscription list has at least one entry. You can populate your list after finishing.');
         $I->see('You cannot send a marketing email until your subscription list has at least one entry. You can populate your list after finishing.');
 
         // Populate target list
@@ -130,11 +130,11 @@ class Campaigns extends \AcceptanceTester
         $listView->waitForListViewVisible();
         $I->click($name . ' Subscription List');
         $detailView->waitForDetailViewVisible();
-        $I->wait(3);
+        $I->waitForElementVisible('#whole_subpanel_contacts');
         $I->click('#whole_subpanel_contacts');
-        $I->wait(3);
+        $I->waitForElementVisible('#prospect_list_contacts_create_button');
         $I->click('#prospect_list_contacts_create_button');
-        $I->wait(3);
+        $I->waitForElementVisible('#last_name');
         $I->fillField('#last_name', $faker->name);
         $I->click('Save');
 
@@ -142,11 +142,11 @@ class Campaigns extends \AcceptanceTester
         $listView->waitForListViewVisible();
         $I->click($name . ' Unsubscription List');
         $detailView->waitForDetailViewVisible();
-        $I->wait(3);
+        $I->waitForElementVisible('#whole_subpanel_contacts');
         $I->click('#whole_subpanel_contacts');
-        $I->wait(3);
+        $I->waitForElementVisible('#prospect_list_contacts_create_button');
         $I->click('#prospect_list_contacts_create_button');
-        $I->wait(3);
+        $I->waitForElementVisible('#last_name');
         $I->fillField('#last_name', $faker->name);
         $I->click('Save');
 
@@ -154,11 +154,11 @@ class Campaigns extends \AcceptanceTester
         $listView->waitForListViewVisible();
         $I->click($name . ' Test List');
         $detailView->waitForDetailViewVisible();
-        $I->wait(3);
+        $I->waitForElementVisible('#whole_subpanel_contacts');
         $I->click('#whole_subpanel_contacts');
-        $I->wait(3);
+        $I->waitForElementVisible('#prospect_list_contacts_create_button');
         $I->click('#prospect_list_contacts_create_button');
-        $I->wait(3);
+        $I->waitForElementVisible('#last_name');
         $I->fillField('#last_name', $faker->name);
         $I->click('Save');
     }

--- a/tests/_support/Step/Acceptance/EditView.php
+++ b/tests/_support/Step/Acceptance/EditView.php
@@ -19,6 +19,7 @@ class EditView extends Tester
     {
         $I = $this;
         $I->executeJS('window.scrollTo(0,0); return true;');
+        $I->waitForText('Save');
         $I->click('Save');
     }
 }

--- a/tests/_support/Step/Acceptance/EditView.php
+++ b/tests/_support/Step/Acceptance/EditView.php
@@ -19,7 +19,6 @@ class EditView extends Tester
     {
         $I = $this;
         $I->executeJS('window.scrollTo(0,0); return true;');
-        $I->waitForText('Save');
         $I->click('Save');
     }
 }

--- a/tests/_support/Step/Acceptance/ListView.php
+++ b/tests/_support/Step/Acceptance/ListView.php
@@ -23,7 +23,7 @@ class ListView extends Tester
     public function clickFilterButton()
     {
         $I = $this;
-        $I->waitForElementVisible('.searchLink a.glyphicon-filter');
+        // TODO: Might be able to use waitForElementClickable here in the future when we're on a higher version of Codeception?
         $I->click('a.glyphicon-filter', '.searchLink');
         $I->waitForFilterModalVisible();
     }

--- a/tests/_support/Step/Acceptance/ListView.php
+++ b/tests/_support/Step/Acceptance/ListView.php
@@ -23,6 +23,7 @@ class ListView extends Tester
     public function clickFilterButton()
     {
         $I = $this;
+        $I->waitForElementVisible('a.glyphicon-filter', '.searchLink');
         $I->click('a.glyphicon-filter', '.searchLink');
         $I->waitForFilterModalVisible();
     }

--- a/tests/_support/Step/Acceptance/ListView.php
+++ b/tests/_support/Step/Acceptance/ListView.php
@@ -23,7 +23,7 @@ class ListView extends Tester
     public function clickFilterButton()
     {
         $I = $this;
-        $I->waitForElementVisible('a.glyphicon-filter', '.searchLink');
+        $I->waitForElementVisible('.searchLink a.glyphicon-filter');
         $I->click('a.glyphicon-filter', '.searchLink');
         $I->waitForFilterModalVisible();
     }

--- a/tests/_support/Step/Acceptance/ModuleBuilder.php
+++ b/tests/_support/Step/Acceptance/ModuleBuilder.php
@@ -156,6 +156,6 @@ class ModuleBuilder extends Administration
         $I->closePopupSuccess();
 
         // Wait for page to refresh and look for new package link
-        $I->waitForElement('#newPackageLink', 30);
+        $I->waitForElement('#newPackageLink');
     }
 }

--- a/tests/_support/Step/Acceptance/NavigationBar.php
+++ b/tests/_support/Step/Acceptance/NavigationBar.php
@@ -89,7 +89,6 @@ class NavigationBar extends Tester
             case DesignBreakPoint::lg:
                 $allMenuButton = '#toolbar.desktop-toolbar  > ul.nav.navbar-nav > li.topnav.all';
                 $I->waitForElementVisible($allMenuButton);
-                $I->wait(1);
                 $I->click('All', $allMenuButton);
                 $allMenu = $allMenuButton . ' > span.notCurrentTab > ul.dropdown-menu';
                 $I->waitForElementVisible($allMenu);
@@ -98,7 +97,6 @@ class NavigationBar extends Tester
             case DesignBreakPoint::md:
                 $allMenuButton = 'div.navbar-header > button.navbar-toggle';
                 $I->waitForElementVisible($allMenuButton);
-                $I->wait(1);
                 $I->click($allMenuButton);
                 $allMenu = 'div.navbar-header > #mobile_menu';
                 $I->waitForElementVisible($allMenu);
@@ -107,7 +105,6 @@ class NavigationBar extends Tester
             case DesignBreakPoint::sm:
                 $allMenuButton = 'div.navbar-header > button.navbar-toggle';
                 $I->waitForElementVisible($allMenuButton);
-                $I->wait(1);
                 $I->click($allMenuButton);
                 $allMenu = 'div.navbar-header > #mobile_menu';
                 $I->waitForElementVisible($allMenu);
@@ -116,7 +113,6 @@ class NavigationBar extends Tester
             case DesignBreakPoint::xs:
                 $allMenuButton = 'div.navbar-header > button.navbar-toggle';
                 $I->waitForElementVisible($allMenuButton);
-                $I->wait(1);
                 $I->click($allMenuButton);
                 $allMenu = 'div.navbar-header > #mobile_menu';
                 $I->waitForElementVisible($allMenu);

--- a/tests/acceptance/Core/ModuleBuilderFieldsCest.php
+++ b/tests/acceptance/Core/ModuleBuilderFieldsCest.php
@@ -106,7 +106,7 @@ class ModuleBuilderFieldsCest
         $I->click('.container-close');
 
         // Add field button
-        $I->waitForElementVisible(['name' => 'addfieldbtn']);
+        $I->waitForElementVisible('[name="addfieldbtn"]');
         $I->click(['name' => 'addfieldbtn']);
 
         // Fill in edit field tab
@@ -191,7 +191,7 @@ class ModuleBuilderFieldsCest
         $I->click('.container-close');
 
         // Add field button
-        $I->waitForElementVisible(['name' => 'addfieldbtn']);
+        $I->waitForElementVisible('[name="addfieldbtn"]');
         $I->click(['name' => 'addfieldbtn']);
 
         // Fill in edit field tab

--- a/tests/acceptance/Core/ModuleBuilderFieldsCest.php
+++ b/tests/acceptance/Core/ModuleBuilderFieldsCest.php
@@ -198,6 +198,8 @@ class ModuleBuilderFieldsCest
         $I->waitForElementVisible('#type');
         $I->selectOption('#type', 'HTML');
 
+        // Wait for 1 second to allow the field to become interactive.
+        $I->wait(1);
         $I->waitForElementVisible('#field_name_id');
         $I->fillField('#field_name_id', 'test_html_field');
 

--- a/tests/acceptance/Core/ModuleBuilderFieldsCest.php
+++ b/tests/acceptance/Core/ModuleBuilderFieldsCest.php
@@ -198,7 +198,6 @@ class ModuleBuilderFieldsCest
         $I->waitForElementVisible('#type');
         $I->selectOption('#type', 'HTML');
 
-        $I->wait(1);
         $I->waitForElementVisible('#field_name_id');
         $I->fillField('#field_name_id', 'test_html_field');
 

--- a/tests/acceptance/Core/PersonModuleCest.php
+++ b/tests/acceptance/Core/PersonModuleCest.php
@@ -447,7 +447,7 @@ class PersonModuleCest
         $I->waitForElementVisible('.import-vcard');
 
         $I->attachFile('#vcard_file', $fileName);
-        $I->waitForElementVisible('#import_vcard_button', '.import-vcard');
+        $I->waitForElementVisible('.import-vcard #import_vcard_button');
         $I->click('#import_vcard_button', '.import-vcard');
 
         $detailView->waitForDetailViewVisible();

--- a/tests/acceptance/Core/PersonModuleCest.php
+++ b/tests/acceptance/Core/PersonModuleCest.php
@@ -447,7 +447,7 @@ class PersonModuleCest
         $I->waitForElementVisible('.import-vcard');
 
         $I->attachFile('#vcard_file', $fileName);
-        $I->wait(1);
+        $I->waitForElementVisible('#import_vcard_button', '.import-vcard');
         $I->click('#import_vcard_button', '.import-vcard');
 
         $detailView->waitForDetailViewVisible();

--- a/tests/acceptance/modules/Activities/ActivitiesCest.php
+++ b/tests/acceptance/modules/Activities/ActivitiesCest.php
@@ -99,6 +99,7 @@ class ActivitiesCest
         $listView->waitForListViewVisible();
 
         // Select record from list view
+        $I->wait(3);
         $listView->clickFilterButton();
         $listView->click('Quick Filter');
         $listView->fillField('#name_basic', $callName);

--- a/tests/acceptance/modules/Activities/ActivitiesCest.php
+++ b/tests/acceptance/modules/Activities/ActivitiesCest.php
@@ -99,7 +99,6 @@ class ActivitiesCest
         $listView->waitForListViewVisible();
 
         // Select record from list view
-        $I->wait(4);
         $listView->clickFilterButton();
         $listView->click('Quick Filter');
         $listView->fillField('#name_basic', $callName);

--- a/tests/acceptance/modules/History/HistoryCest.php
+++ b/tests/acceptance/modules/History/HistoryCest.php
@@ -99,7 +99,6 @@ class HistoryCest
         $listView->waitForListViewVisible();
 
         // Select record from list view
-        $I->wait(4);
         $listView->clickFilterButton();
         $listView->click('Quick Filter');
         $listView->fillField('#name_basic', $callName);

--- a/tests/acceptance/modules/History/HistoryCest.php
+++ b/tests/acceptance/modules/History/HistoryCest.php
@@ -99,6 +99,7 @@ class HistoryCest
         $listView->waitForListViewVisible();
 
         // Select record from list view
+        $I->wait(3);
         $listView->clickFilterButton();
         $listView->click('Quick Filter');
         $listView->fillField('#name_basic', $callName);

--- a/tests/acceptance/modules/Home/HomeCest.php
+++ b/tests/acceptance/modules/Home/HomeCest.php
@@ -56,7 +56,8 @@ class HomeCest
         $I->click('All Opportunities By Lead Source By Outcome');
         $I->click('Close');
         $dashboard->waitForDashboardVisible();
-        $I->waitForText('All Opportunities By Lead Source By Outcome');
+        // This has to be uppercase because Codeception is case sensitive in waitForText... for some reason.
+        $I->waitForText('ALL OPPORTUNITIES BY LEAD SOURCE BY OUTCOME');
         $I->see('All Opportunities By Lead Source By Outcome');
         $dashboardID = $I->grabAttributeFrom('descendant-or-self::div[@class="dashletPanel"]', 'id');
         if ($dashboardID != "") {

--- a/tests/acceptance/modules/Home/HomeCest.php
+++ b/tests/acceptance/modules/Home/HomeCest.php
@@ -51,12 +51,12 @@ class HomeCest
         $I->loginAsAdmin();
         $dashboard->waitForDashboardVisible();
         $detailView->clickActionMenuItem('Add Dashlets');
-        $I->wait(1);
+        $I->waitForElementVisible('#chartCategory');
         $I->click('#chartCategory');
         $I->click('All Opportunities By Lead Source By Outcome');
         $I->click('Close');
         $dashboard->waitForDashboardVisible();
-        $I->wait(1);
+        $I->waitForText('All Opportunities By Lead Source By Outcome');
         $I->see('All Opportunities By Lead Source By Outcome');
         $dashboardID = $I->grabAttributeFrom('descendant-or-self::div[@class="dashletPanel"]', 'id');
         if ($dashboardID != "") {

--- a/tests/acceptance/modules/Meetings/MeetingsCest.php
+++ b/tests/acceptance/modules/Meetings/MeetingsCest.php
@@ -130,7 +130,7 @@ class MeetingsCest
         $I->selectOption('#date_start_hours', '01');
         $I->selectOption('#date_start_minutes', '00');
         $I->doubleClick('#inlineEditSaveButton');
-        $I->wait(3);
+        $I->waitForText('01/01/2000 01:00');
         $I->see('01/01/2000 01:00');
 
         // Delete meeting

--- a/tests/acceptance/modules/Users/UsersCest.php
+++ b/tests/acceptance/modules/Users/UsersCest.php
@@ -50,7 +50,7 @@ class UsersCest
         $I->fillField('email_user', 'testuser_name');
         $I->fillField('email_password', 'testuser_pass');
         $I->click('Test Settings');
-        $I->wait(20);
+        $I->waitForText('Connection completed successfully.');
         $I->see('Connection completed successfully.');
     }
 
@@ -77,7 +77,7 @@ class UsersCest
         $I->see('User Profile', '.panel-heading');
 
         $I->click("Layout Options");
-        $I->wait(5);
+        $I->waitForElementVisible('input', ['name' => 'user_count_collapsed_subpanels']);
         $I->seeElement('input', ['name' => 'user_count_collapsed_subpanels']);
         $I->checkOption(['name' => 'user_count_collapsed_subpanels']);
         $EditView->clickSaveButton();

--- a/tests/acceptance/modules/Users/UsersCest.php
+++ b/tests/acceptance/modules/Users/UsersCest.php
@@ -77,7 +77,7 @@ class UsersCest
         $I->see('User Profile', '.panel-heading');
 
         $I->click("Layout Options");
-        $I->waitForElementVisible('input', ['name' => 'user_count_collapsed_subpanels']);
+        $I->waitForElementVisible('input[name="user_count_collapsed_subpanels"]');
         $I->seeElement('input', ['name' => 'user_count_collapsed_subpanels']);
         $I->checkOption(['name' => 'user_count_collapsed_subpanels']);
         $EditView->clickSaveButton();

--- a/tests/acceptance/modules/jjwg_Maps/jjwg_MapsCest.php
+++ b/tests/acceptance/modules/jjwg_Maps/jjwg_MapsCest.php
@@ -108,6 +108,7 @@ class jjwg_MapsCest
         // Delete account
         $accounts->gotoAccounts();
         $listView->waitForListViewVisible();
+        $I->wait(5);
         $listView->clickFilterButton();
         $I->fillField('#name_basic', $account_name);
         $I->click('#search_form_submit');

--- a/tests/acceptance/modules/jjwg_Maps/jjwg_MapsCest.php
+++ b/tests/acceptance/modules/jjwg_Maps/jjwg_MapsCest.php
@@ -108,7 +108,6 @@ class jjwg_MapsCest
         // Delete account
         $accounts->gotoAccounts();
         $listView->waitForListViewVisible();
-        $I->wait(10);
         $listView->clickFilterButton();
         $I->fillField('#name_basic', $account_name);
         $I->click('#search_form_submit');


### PR DESCRIPTION
## Description
Part of #7344.

## Motivation and Context
This makes the tests faster by removing a lot of usages of `$I->wait(x)` with `$I->waitForElementVisible(x)` or `$I->waitForText(x)`. Essentially, the problem with using `$I->wait` is that it waits for the full x number of seconds even if the page loads in the mean time.

```php
// Waits 10 seconds no matter what.
$I->wait(10);
$I->click('button');

// Will wait up to 10 seconds if necessary, otherwise it will skip to the click as soon as the element is visible. 
$I->waitForElementVisible('button');
$I->click('button');
```

Individually, these usually only add a few seconds each. Once you add two dozen or more, though, it can unnecessarily add over a minute to the test suite.

It also introduces potential flakiness if the tests take longer on another machine than on Travis, because a page load may take less than a second on Travis, but on a slower laptop it could take more than a second, and the `$I->wait(1)` wouldn't be sufficient in that case. This is also true of the `waitForElementVisible` functions, but to a lesser degree since they wait for up to 10 seconds if they can't find the element. If a lot of tests fail, this can add a lot more time to the test suite, but generally since the tests _usually_ pass, this shouldn't be a concern.

This PR doesn't remove all the instances of `$I->wait(x)`, I tried removing as many as I could, but for some of them I wasn't able to figure out how to get the tests to pass.

## How To Test This
See if the tests continue to pass on Travis.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.