### PR TITLE
IMAP StateSaver test fix

### DIFF
--- a/include/Imap/ImapHandlerFactory.php
+++ b/include/Imap/ImapHandlerFactory.php
@@ -144,6 +144,17 @@ class ImapHandlerFactory
 
         return $testSettings;
     }
+
+    /**
+     * Delete's test settings file.
+     * @return void
+     */
+    public function deleteTestSettings()
+    {
+        if (file_exists(__DIR__ . self::SETTINGS_KEY_FILE)) {
+            unlink(__DIR__ . self::SETTINGS_KEY_FILE);
+        }
+    }
     
     /**
      *

--- a/tests/unit/phpunit/include/Imap/ImapHandlerFactoryTest.php
+++ b/tests/unit/phpunit/include/Imap/ImapHandlerFactoryTest.php
@@ -101,6 +101,7 @@ class ImapHandlerFactoryTest extends StateCheckerPHPUnitTestCaseAbstract
      */
     public function testSaveTestSettingsKeyOK()
     {
+        $state = new SuiteCRM\StateSaver();
         $settingsFile = __DIR__ . '/../../../../../include/Imap' . ImapHandlerFactory::SETTINGS_KEY_FILE;
         $factory = new ImapHandlerFactory();
         $existsBefore = file_exists($settingsFile);
@@ -108,8 +109,8 @@ class ImapHandlerFactoryTest extends StateCheckerPHPUnitTestCaseAbstract
         $results = $factory->saveTestSettingsKey('testCaseExample');
         $existsAfter = file_exists($settingsFile);
         $this->assertTrue($existsAfter);
-        $this->assertTrue(unlink($settingsFile));
         $this->assertTrue($results);
+        $factory->deleteTestSettings();
     }
     
     /**
@@ -120,5 +121,6 @@ class ImapHandlerFactoryTest extends StateCheckerPHPUnitTestCaseAbstract
         $factory = new ImapHandlerFactory();
         $results = $factory->getImapHandler();
         $this->assertInstanceOf(ImapHandlerInterface::class, $results);
+        $factory->deleteTestSettings();
     }
 }


### PR DESCRIPTION
The ImapTestSettings.txt file wasn't properly disposed-of, which caused testGetImapHandlerOk to fail.

## Description
The file was created by a function in `testGetImapHandlerOk` and it caused the test to fail because a file at `include/Imap/ImapTestSettings.txt` to not be deleted.

## Motivation and Context
This solves one of the state-related failures in the PHPUnit suite.

## How To Test This
Run the PHPUnit tests locally with the developerMode enabled and make sure the IMAP tests pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.