### PR TITLE
Remove some incomplete tests and miscellaneous formatting fixes for the unit test suite

### DIFF
--- a/tests/unit/phpunit/data/SugarBeanTest.php
+++ b/tests/unit/phpunit/data/SugarBeanTest.php
@@ -1256,15 +1256,6 @@ class SugarBeanTest extends SuitePHPUnit_Framework_TestCase
         $state->popTable('aod_index');
     }
 
-
-    /**
-     * @see SugarBean::_get_num_rows_in_query()
-     */
-    public function testGetNumRowsInQuery()
-    {
-        self::markTestIncomplete('already covered');
-    }
-
     /**
      * @see SugarBean::retrieve_parent_fields()
      */
@@ -1926,14 +1917,6 @@ class SugarBeanTest extends SuitePHPUnit_Framework_TestCase
     }
 
     /**
-     * @see SugarBean::load_relationships()
-     */
-    public function testLoadRelationships()
-    {
-        self::markTestIncomplete('already covered');
-    }
-
-    /**
      * @see SugarBean::get_linked_fields()
      */
     public function testGetLinkedFields()
@@ -2269,14 +2252,6 @@ class SugarBeanTest extends SuitePHPUnit_Framework_TestCase
         /** @noinspection PhpVoidFunctionResultUsedInspection */
         $results = $bean->create_audit_table();
         self::assertEquals(null, $results);
-    }
-
-    /**
-     * @see SugarBean::drop_tables()
-     */
-    public function testDropTables()
-    {
-        self::markTestIncomplete('need to implement');
     }
 
     /**
@@ -2933,14 +2908,6 @@ class SugarBeanTest extends SuitePHPUnit_Framework_TestCase
     }
 
     /**
-     * @see SugarBean::_checkOptimisticLocking()
-     */
-    public function testCheckOptimisticLocking()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::has_been_modified_since()
      */
     public function testHasBeenModifiedSince()
@@ -3062,690 +3029,95 @@ class SugarBeanTest extends SuitePHPUnit_Framework_TestCase
     }
 
     /**
+     * TODO: Tests that need to be written.
+     * @see SugarBean::load_relationships()
      * @see SugarBean::toArray()
-     */
-    public function testToArray()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::save_relationship_changes()
-     */
-    public function testSaveRelationshipChanges()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::set_relationship_info()
-     */
-    public function testSetRelationshipInfo()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::handle_preset_relationships()
-     */
-    public function testHandlePresetRelationships()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::handle_remaining_relate_fields()
-     */
-    public function testHandleRemainingRelateFields()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::update_parent_relationships()
-     */
-    public function testUpdateParentRelationships()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::handle_request_relate()
-     */
-    public function testHandleRequestRelate()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::call_custom_logic()
-     */
-    public function testCallCustomLogic()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::hasEmails()
-     */
-    public function testHasEmails()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::preprocess_fields_on_save()
-     */
-    public function testPreprocessFieldsOnSave()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::_sendNotifications()
-     */
-    public function testSendNotifications()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::get_notification_recipients()
-     */
-    public function testGetNotificationRecipients()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::send_assignment_notifications()
-     */
-    public function testSendAssignmentNotifications()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::create_notification_email()
-     */
-    public function testCreateNotificationEmail()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::track_view()
-     */
-    public function testTrackView()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::get_summary_text()
-     */
-    public function testGetSummaryText()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::add_list_count_joins()
-     */
-    public function testAddListCountJoins()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::get_list()
-     */
-    public function testGetList()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::getOwnerWhere()
-     */
-    public function testGetOwnerWhere()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::create_new_list_query()
-     */
-    public function testCreateNewListQuery()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::get_relationship_field()
-     */
-    public function testGetRelationshipField()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::is_relate_field()
-     */
-    public function testIsRelateField()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::process_order_by()
-     */
-    public function testProcessOrderBy()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::process_list_query()
-     */
-    public function testProcessListQuery()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::create_list_count_query()
-     */
-    public function testCreateListCountQuery()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::fill_in_additional_list_fields()
-     */
-    public function testFillInAdditionalListFields()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::get_detail()
-     */
-    public function testGetDetail()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::process_detail_query()
-     */
-    public function testProcessDetailQuery()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::retrieve()
-     */
-    public function testRetrieve()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::getCustomJoin()
-     */
-    public function testGetCustomJoin()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::convertRow()
-     */
-    public function testConvertRow()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::convertField()
-     */
-    public function testConvertField()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::populateFromRow()
-     */
-    public function testPopulateFromRow()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::populateCurrencyFields()
-     */
-    public function testPopulateCurrencyFields()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::check_date_relationships_load()
-     */
-    public function testCheckDateRelationshipsLoad()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::decrypt_after_retrieve()
-     */
-    public function testDecryptAfterRetrieve()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::fill_in_additional_detail_fields()
-     */
-    public function testFillInAdditionalDetailFields()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::fill_in_additional_parent_fields()
-     */
-    public function testFillInAdditionalParentFields()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::getRelatedFields()
-     */
-    public function testGetRelatedFields()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::fill_in_relationship_fields()
-     */
-    public function testFillInRelationshipFields()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::fill_in_link_field()
-     */
-    public function testFillInLinkField()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::get_related_fields()
-     */
-    public function testGetRelatedFieldsSnakeCase()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::get_related_list()
-     */
-    public function testGetRelatedList()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::get_full_list()
-     */
-    public function testGetFullList()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::process_full_list_query()
-     */
-    public function testProcessFullListQuery()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::create_index()
-     */
-    public function testCreateIndex()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::mark_deleted()
-     */
-    public function testMarkDeleted()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::mark_undeleted()
-     */
-    public function testMarkUndeleted()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::restoreFiles()
-     */
-    public function testRestoreFiles()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::haveFiles()
-     */
-    public function testHaveFiles()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::getFiles()
-     */
-    public function testGetFiles()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::getFilesFields()
-     */
-    public function testGetFilesFields()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::deleteFileDirectory()
-     */
-    public function testDeleteFileDirectory()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::mark_relationships_deleted()
-     */
-    public function testMarkRelationshipsDeleted()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::delete_linked()
-     */
-    public function testDeleteLinked()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::deleteFiles()
-     */
-    public function testDeleteFiles()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::build_related_list()
-     */
-    public function testBuildRelatedList()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::build_related_list_where()
-     */
-    public function testBuildRelatedListWhere()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::build_related_in()
-     */
-    public function testBuildRelatedIn()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::build_related_list2()
-     */
-    public function testBuildRelatedList2()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::list_view_parse_additional_sections()
-     */
-    public function testListViewParseAdditionalSections()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::get_list_view_data()
-     */
-    public function testGetListViewData()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::get_list_view_array()
-     */
-    public function testGetListViewArray()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::retrieve_by_string_fields()
-     */
-    public function testRetrieveByStringFields()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::get_where()
-     */
-    public function testGetWhere()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::fromArray()
-     */
-    public function testFromArray()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::process_special_fields()
-     */
-    public function testProcessSpecialFields()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::build_generic_where_clause()
-     */
-    public function testBuildGenericWhereClause()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::parse_additional_headers()
-     */
-    public function testParseAdditionalHeaders()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::assign_display_fields()
-     */
-    public function testAssignDisplayFields()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::set_relationship()
-     */
-    public function testSetRelationship()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::retrieve_relationships()
-     */
-    public function testRetrieveRelationships()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::loadLayoutDefs()
-     */
-    public function testLoadLayoutDefs()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::getRealKeyFromCustomFieldAssignedKey()
-     */
-    public function testGetRealKeyFromCustomFieldAssignedKey()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::getOwnerField()
-     */
-    public function testGetOwnerField()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::listviewACLHelper()
-     */
-    public function testListviewACLHelper()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::ACLAccess()
-     */
-    public function testACLAccess()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::loadFromRow()
-     */
-    public function testLoadFromRow()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::create_qualified_order_by()
-     */
-    public function testCreateQualifiedOrderBy()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::add_address_streets()
-     */
-    public function testAddAddressStreets()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::populateRelatedBean()
-     */
-    public function testPopulateRelatedBean()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::beforeImportSave()
-     */
-    public function testBeforeImportSave()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::afterImportSave()
-     */
-    public function testAfterImportSave()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::create_export_query()
-     */
-    public function testCreateExportQuery()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::auditBean()
-     */
-    public function testAuditBean()
-    {
-        self::markTestIncomplete('need to implement');
-    }
-
-    /**
      * @see SugarBean::createAuditRecord()
+     * @see SugarBean::_checkOptimisticLocking()
+     * @see SugarBean::drop_tables()
      */
-    public function testCreateAuditRecord()
-    {
-        self::markTestIncomplete('need to implement');
-    }
 }

--- a/tests/unit/phpunit/include/MVC/SugarApplicationTest.php
+++ b/tests/unit/phpunit/include/MVC/SugarApplicationTest.php
@@ -14,20 +14,21 @@ class SugarApplicationTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
     public function testexecute()
     {
-        $SugarApplication = new SugarApplication();
-
-        //execute the method and test if it works and does not throws an exception other than headers output exception.
-//        try {
-//            $SugarApplication->execute();
-//        } catch (Exception $e) {
-//            print_r($e->getMessage());
-//            $this->assertStringStartsWith('Cannot modify header information', $e->getMessage());
-//        }
-        $this->markTestIncomplete('Can Not be implemented');
+        $this->markTestIncomplete('Cannot be implemented');
+        
+        // execute the method and test if it works and does not throw an exception other than headers output exception.
+        //    $SugarApplication = new SugarApplication();
+        //    try {
+        //        $SugarApplication->execute();
+        //    } catch (Exception $e) {
+        //        print_r($e->getMessage());
+        //        $this->assertStringStartsWith('Cannot modify header information', $e->getMessage());
+        //    }
     }
 
     public function testloadUser()
     {
+        $this->markTestIncomplete('Cannot be implemented because the method uses die.');
 
         //cannot test this method as it uses die which stops execution of php unit as well
         /*
@@ -45,16 +46,11 @@ class SugarApplicationTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
         $this->assertTrue(TRUE);
         */
-        $this->markTestIncomplete('Can Not be implemented');
     }
 
     public function testACLFilter()
     {
         $state = new SuiteCRM\StateSaver();
-        
-        
-        
-        
         
         if (isset($_SESSION)) {
             $session = $_SESSION;
@@ -71,12 +67,7 @@ class SugarApplicationTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
         $this->assertTrue(true);
         
-        
-        
         // clean up
-        
-        
-        
         if (isset($session)) {
             $_SESSION = $session;
         } else {
@@ -87,10 +78,6 @@ class SugarApplicationTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
     public function testsetupResourceManagement()
     {
         $state = new SuiteCRM\StateSaver();
-        
-        
-        
-        
         
         $SugarApplication = new SugarApplication();
 
@@ -117,10 +104,6 @@ class SugarApplicationTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
     {
         $state = new SuiteCRM\StateSaver();
         
-        
-        
-        
-        
         $SugarApplication = new SugarApplication();
 
         //execute the method and test if it works and does not throws an exception.
@@ -139,10 +122,6 @@ class SugarApplicationTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
     {
         $state = new SuiteCRM\StateSaver();
         
-        
-        
-        
-        
         if (isset($_SESSION)) {
             $session = $_SESSION;
         }
@@ -159,12 +138,7 @@ class SugarApplicationTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
         $this->assertTrue(true);
         
-        
-        
         // clean up
-        
-        
-        
         if (isset($session)) {
             $_SESSION = $session;
         } else {
@@ -175,11 +149,7 @@ class SugarApplicationTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
     public function testhandleOfflineClient()
     {
         $state = new SuiteCRM\StateSaver();
-        
-        
-        
-        
-        
+
         $SugarApplication = new SugarApplication();
 
         //execute the method and test if it works and does not throws an exception.
@@ -212,10 +182,6 @@ class SugarApplicationTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
     {
         $state = new SuiteCRM\StateSaver();
         
-        
-        
-        
-        
         try {
             SugarApplication::preLoadLanguages();
 
@@ -234,10 +200,6 @@ class SugarApplicationTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
     public function testloadLanguages()
     {
         $state = new SuiteCRM\StateSaver();
-        
-        
-        
-        
         
         $SugarApplication = new SugarApplication();
         $SugarApplication->controller = new SugarController();
@@ -267,9 +229,6 @@ class SugarApplicationTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
     {
         self::markTestIncomplete('environment dependency');
         $state = new SuiteCRM\StateSaver();
-        //
-        
-        
 
         $SugarApplication = new SugarApplication();
 
@@ -282,19 +241,12 @@ class SugarApplicationTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $result = $SugarApplication->checkDatabaseVersion(false);
         $this->assertTrue($result);
         
-        
         // clean up
-        
-        //
     }
 
     public function testloadDisplaySettings()
     {
         $state = new SuiteCRM\StateSaver();
-        
-        
-        
-        
         
         $SugarApplication = new SugarApplication();
 
@@ -314,10 +266,6 @@ class SugarApplicationTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
     {
         $state = new SuiteCRM\StateSaver();
         
-        
-        
-        
-        
         $SugarApplication = new SugarApplication();
 
         //execute the method and test if it works and does not throws an exception.
@@ -336,10 +284,6 @@ class SugarApplicationTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
     {
         $state = new SuiteCRM\StateSaver();
         
-        
-        
-        
-        
         if (isset($_REQUEST)) {
             $request = $_REQUEST;
         }
@@ -356,11 +300,7 @@ class SugarApplicationTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
         $this->assertTrue(true);
         
-        
-        
         // clean up
-        
-        
         
         if (isset($request)) {
             $_REQUEST = $request;
@@ -424,6 +364,7 @@ class SugarApplicationTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
     public function testredirect()
     {
+        $this->markTestIncomplete('Cannot be implemented due to use of exit().');
         //this method uses exit() which stops execution of phpunit as well so it cannot be tested without additional --process-isolation commandline parameter.
         /*
         $SugarApplication = new SugarApplication();
@@ -442,7 +383,6 @@ class SugarApplicationTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
             $this->fail($e->getMessage() . "\nTrace:\n" . $e->getTraceAsString());
         }
         */
-        $this->markTestIncomplete('Can Not be implemented');
     }
 
     public function testappendErrorMessage()
@@ -495,10 +435,6 @@ class SugarApplicationTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
     public function testcreateLoginVars()
     {
         $state = new SuiteCRM\StateSaver();
-        
-        
-        
-        
         
         $SugarApplication = new SugarApplication();
 

--- a/tests/unit/phpunit/include/MVC/View/views/view.ajaxuiTest.php
+++ b/tests/unit/phpunit/include/MVC/View/views/view.ajaxuiTest.php
@@ -13,6 +13,7 @@ class ViewAjaxUITest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
     public function testdisplay()
     {
+        $this->markTestIncomplete('Cannot be implemented');
         $view = new ViewAjaxUI();
 
 //        //execute the method and test if it works and does not throws an exception other than headers output exception.
@@ -21,6 +22,5 @@ class ViewAjaxUITest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 //        } catch (Exception $e) {
 //            $this->assertStringStartsWith('Cannot modify header information', $e->getMessage());
 //        }
-        $this->markTestIncomplete('Can Not be implemented');
     }
 }

--- a/tests/unit/phpunit/include/MVC/View/views/view.classicTest.php
+++ b/tests/unit/phpunit/include/MVC/View/views/view.classicTest.php
@@ -36,9 +36,6 @@ class ViewClassicTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         }
         
         $state = new SuiteCRM\StateSaver();
-        
-        
-        //
 
         //test with a valid module but invalid action. it should return false.
         $view = new ViewClassic();
@@ -75,11 +72,7 @@ class ViewClassicTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $this->assertGreaterThan(0, strlen($renderedContent));
         $this->assertTrue($ret);
         
-        
         // clean up
-        
-        
-        
         if (isset($session)) {
             $_SESSION = $session;
         } else {

--- a/tests/unit/phpunit/include/MVC/View/views/view.detailTest.php
+++ b/tests/unit/phpunit/include/MVC/View/views/view.detailTest.php
@@ -48,16 +48,12 @@ class ViewDetailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
     public function testpreDisplay()
     {
-        
         // store state
-        
         $state = new SuiteCRM\StateSaver();
         $state->pushGlobals();
         $state->pushTable('email_addresses');
         
         // test
-        
-
         //execute the method with required attributes preset, it will initialize the dv(detail view) attribute.
         $view = new ViewDetail();
         $view->module = 'Users';
@@ -92,9 +88,6 @@ class ViewDetailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $state->pushTable('email_addresses');
         
         // test
-        
-
-        
 
         //execute the method with essential parameters set. it should return some html.
         $view = new ViewDetail();

--- a/tests/unit/phpunit/include/MVC/View/views/view.editTest.php
+++ b/tests/unit/phpunit/include/MVC/View/views/view.editTest.php
@@ -64,10 +64,7 @@
      public function testdisplay()
      {
          $state = new SuiteCRM\StateSaver();
-         
-         
-         //
-         
+
          //execute the method with essential parameters set. it should return some html.
          $view = new ViewEdit();
          $view->module = 'Users';

--- a/tests/unit/phpunit/include/MVC/View/views/view.importvcardsaveTest.php
+++ b/tests/unit/phpunit/include/MVC/View/views/view.importvcardsaveTest.php
@@ -14,10 +14,7 @@ class ViewImportvcardsaveTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstra
     //incomplete test. this method uses exit() so it cannot be tested.
     public function testdisplay()
     {
-        $state = new SuiteCRM\StateSaver();
-        
-        
-        
+        $this->markTestIncomplete('Cannot be implemented due to use of exit().');
 
         $view = new ViewImportvcardsave();
 
@@ -31,9 +28,6 @@ class ViewImportvcardsaveTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstra
         $this->assertGreaterThan(0,strlen($renderedContent));
         */
 
-        $this->markTestIncomplete('Can Not be implemented');
-        
-        
         // clean up
     }
 }

--- a/tests/unit/phpunit/include/MVC/View/views/view.sugarpdfTest.php
+++ b/tests/unit/phpunit/include/MVC/View/views/view.sugarpdfTest.php
@@ -52,12 +52,12 @@ class ViewSugarpdfTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
     //Incomplete test. SugarpdfFactory::loadSugarpdf throws fatal error. error needs to be resolved before testing.
     public function testpreDisplay()
     {
-        $this->markTestIncomplete('Can Not be implemented');
+        $this->markTestIncomplete('Cannot be implemented due to throwing fatal error.');
     }
 
     //Incomplete test.  SugarpdfFactory::loadSugarpdf throws fatal error. error needs to be resolved before testing.
     public function testdisplay()
     {
-        $this->markTestIncomplete('Can Not be implemented');
+        $this->markTestIncomplete('Cannot be implemented due to throwing fatal error.');
     }
 }

--- a/tests/unit/phpunit/lib/SuiteCRM/Exception/ExceptionTest.php
+++ b/tests/unit/phpunit/lib/SuiteCRM/Exception/ExceptionTest.php
@@ -24,8 +24,6 @@ class ExceptionTest extends \SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         }
     }
 
-
-
     public function testGetDetail()
     {
         $this->assertEquals(

--- a/tests/unit/phpunit/lib/SuiteCRM/Utility/CurrentLanguageTest.php
+++ b/tests/unit/phpunit/lib/SuiteCRM/Utility/CurrentLanguageTest.php
@@ -13,7 +13,6 @@ class CurrentLanguageTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
      */
     private static $language;
 
-
     public function setUp()
     {
         parent::setUp();
@@ -21,8 +20,6 @@ class CurrentLanguageTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
             self::$language = new \SuiteCRM\Utility\CurrentLanguage();
         }
     }
-
-
 
     public function testGetCurrentLanguage()
     {

--- a/tests/unit/phpunit/lib/SuiteCRM/Utility/ModuleLanguageTest.php
+++ b/tests/unit/phpunit/lib/SuiteCRM/Utility/ModuleLanguageTest.php
@@ -13,7 +13,6 @@ class ModuleLanguageTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
      */
     private static $language;
 
-
     public function setUp()
     {
         parent::setUp();
@@ -21,8 +20,6 @@ class ModuleLanguageTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
             self::$language = new \SuiteCRM\Utility\ModuleLanguage();
         }
     }
-
-
 
     public function testGetCurrentLanguage()
     {

--- a/tests/unit/phpunit/lib/SuiteCRM/Utility/PathsTest.php
+++ b/tests/unit/phpunit/lib/SuiteCRM/Utility/PathsTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 class PathsTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 {
     /**
@@ -29,8 +28,6 @@ class PathsTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
             self::$projectPath = dirname(dirname(dirname(dirname(dirname(dirname(__DIR__))))));
         }
     }
-
-
 
     public function testGetProjectPath()
     {

--- a/tests/unit/phpunit/lib/SuiteCRM/Utility/StringValidatorTest.php
+++ b/tests/unit/phpunit/lib/SuiteCRM/Utility/StringValidatorTest.php
@@ -9,8 +9,6 @@ class StringValidatorTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
      */
     protected $tester;
 
-
-
     public function testStartsWith()
     {
         $testString = 'foobarbaz';

--- a/tests/unit/phpunit/lib/SuiteCRM/Utility/SuiteLoggerTest.php
+++ b/tests/unit/phpunit/lib/SuiteCRM/Utility/SuiteLoggerTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 class SuiteLoggerTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 {
     /**

--- a/tests/unit/phpunit/modules/ACLActions/ACLActionTest.php
+++ b/tests/unit/phpunit/modules/ACLActions/ACLActionTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 class ACLActionTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 {
     public function setUp()
@@ -38,7 +37,6 @@ class ACLActionTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $this->assertAttributeEquals(true, 'disable_custom_fields', $aclAction);
         
         // clean up
-        
         $state->popGlobals();
         $state->popTable('acl_actions');
     }
@@ -50,8 +48,6 @@ class ACLActionTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $state = new SuiteCRM\StateSaver();
         $state->pushTable('acl_actions');
         $state->pushTable('aod_index');
-        
-        
 
         //take count of actions initially and then after method execution and test if action count increases
         $action_count = count(ACLAction::getDefaultActions());
@@ -67,7 +63,6 @@ class ACLActionTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
     public function testremoveActions()
     {
-
         //take count of actions initially and then after method execution and test if action count decreases
         $action_count = count(ACLAction::getDefaultActions());
         ACLAction::removeActions('Test');
@@ -77,15 +72,8 @@ class ACLActionTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
     public function testAccessName()
     {
-        $state = new SuiteCRM\StateSaver();
-        
-        
-        
-
         $this->assertFalse(ACLAction::AccessName('')); //test with invalid value
         $this->assertEquals('All', ACLAction::AccessName(90)); //test with a valid value
-        
-        // clean up
     }
 
     public function testgetDefaultActions()
@@ -106,11 +94,11 @@ class ACLActionTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
     public function testgetUserActions()
     {
-        $result1 = ACLAction::getUserActions('1');
-        $result2 = ACLAction::getUserActions('1', false, 'Accounts');
-        $result3 = ACLAction::getUserActions('1', false, 'Accounts', 'list');
-
         self::markTestIncomplete('Need to implement: verify that all three results returned are different.');
+        // $result1 = ACLAction::getUserActions('1');
+        // $result2 = ACLAction::getUserActions('1', false, 'Accounts');
+        // $result3 = ACLAction::getUserActions('1', false, 'Accounts', 'list');
+
         //verify that all three results returned are different
         //$this->assertNotSame($result1, $result2);
         //$this->assertNotSame($result1, $result3);
@@ -177,7 +165,6 @@ class ACLActionTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
     {
         self::markTestIncomplete('Need to fix checking user access. Hint: session is a system state perhaps its failing because the user session');
         
-
         //test with invalid values
         $this->assertFalse(ACLAction::userNeedsOwnership('', '', ''));
 

--- a/tests/unit/phpunit/modules/ACLActions/ACLActionTest.php
+++ b/tests/unit/phpunit/modules/ACLActions/ACLActionTest.php
@@ -110,8 +110,8 @@ class ACLActionTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $result2 = ACLAction::getUserActions('1', false, 'Accounts');
         $result3 = ACLAction::getUserActions('1', false, 'Accounts', 'list');
 
-        self::markTestIncomplete('Need to implement: verify that all three results retunred are different.');
-        //verify that all three results retunred are different
+        self::markTestIncomplete('Need to implement: verify that all three results returned are different.');
+        //verify that all three results returned are different
         //$this->assertNotSame($result1, $result2);
         //$this->assertNotSame($result1, $result3);
         //$this->assertNotSame($result2, $result3);

--- a/tests/unit/phpunit/modules/ACLRoles/ACLRoleTest.php
+++ b/tests/unit/phpunit/modules/ACLRoles/ACLRoleTest.php
@@ -59,11 +59,6 @@ class ACLRoleTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
     public function testmark_relationships_deleted()
     {
-        $state = new SuiteCRM\StateSaver();
-        
-        
-        
-
         $aclRole = new ACLRole();
 
         //take count of relationship initially and then after method execution and test if relationship count decreases
@@ -72,16 +67,11 @@ class ACLRoleTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $final_count = count($aclRole->retrieve_relationships('acl_roles_actions', array('role_id' => '1', 'action_id' => '1', 'access_override' => '90'), 'role_id'));
 
         $this->assertLessThanOrEqual($initial_count, $final_count, "values were: [$initial_count], [$final_count]");
-        
-        // clean up
     }
 
     public function testgetUserRoles()
     {
         $state = new SuiteCRM\StateSaver();
-        
-        
-        
 
         $aclRole = new ACLRole();
 
@@ -92,8 +82,6 @@ class ACLRoleTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         //test with flase getAsNameArray param value
         $result = $aclRole->getUserRoles('1', false);
         $this->assertTrue(is_array($result));
-        
-        // clean up
     }
 
     public function testgetUserRoleNames()

--- a/tests/unit/phpunit/modules/AOD_Index/AOD_IndexTest.php
+++ b/tests/unit/phpunit/modules/AOD_Index/AOD_IndexTest.php
@@ -100,11 +100,6 @@ class AOD_IndexTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
     public function testcommit()
     {
         self::markTestIncomplete('File \'modules/AOD_Index/Index/Index/segments_31\' is not readable.');
-        $state = new SuiteCRM\StateSaver();
-        
-        
-        
-        
         
         $aod_index = new AOD_Index();
         $aod_index->id = 1;
@@ -117,8 +112,6 @@ class AOD_IndexTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         } catch (Exception $e) {
             $this->fail($e->getMessage() . "\nTrace:\n" . $e->getTraceAsString());
         }
-        
-        // clean up
     }
 
     public function testisModuleSearchable()
@@ -161,12 +154,6 @@ class AOD_IndexTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
     {
         self::markTestIncomplete('File \'modules/AOD_Index/Index/Index/segments_31\' is not readable.');
         
-        $state = new SuiteCRM\StateSaver();
-        
-        
-        
-        
-        
         $aod_index = new AOD_Index();
         $aod_index->id = 1;
         $aod_index->location = 'modules/AOD_Index/Index/Index';
@@ -178,8 +165,6 @@ class AOD_IndexTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         } catch (Exception $e) {
             $this->fail($e->getMessage() . "\nTrace:\n" . $e->getTraceAsString());
         }
-        
-        // clean up
     }
 
     public function testgetIndexableModules()

--- a/tests/unit/phpunit/modules/AOP_Case_Updates/AOP_Case_UpdatesTest.php
+++ b/tests/unit/phpunit/modules/AOP_Case_Updates/AOP_Case_UpdatesTest.php
@@ -39,8 +39,6 @@ class AOP_Case_UpdatesTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $state->pushTable('aod_indexevent');
         $state->pushTable('aop_case_updates');
         $state->pushGlobals();
-        
-        
 
         $aopCaseUpdates = new AOP_Case_Updates();
         $aopCaseUpdates->name = 'test name';
@@ -57,7 +55,6 @@ class AOP_Case_UpdatesTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $aopCaseUpdates->mark_deleted($aopCaseUpdates->id);
         
         // clean up
-        
         $state->popGlobals();
         $state->popTable('aop_case_updates');
         $state->popTable('aod_indexevent');

--- a/tests/unit/phpunit/modules/AOR_Charts/AOR_ChartTest.php
+++ b/tests/unit/phpunit/modules/AOR_Charts/AOR_ChartTest.php
@@ -24,10 +24,8 @@ class AOR_ChartTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
     {
         $state = new SuiteCRM\StateSaver();
         
-        
         $this->markTestSkipped('Skipping AOR Charts Tests');
         
-
         $aorChart = new AOR_Chart();
 
         //preset the required data

--- a/tests/unit/phpunit/modules/AOR_Conditions/AOR_ConditionTest.php
+++ b/tests/unit/phpunit/modules/AOR_Conditions/AOR_ConditionTest.php
@@ -51,7 +51,6 @@ class AOR_ConditionTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         }
         
         // clean up
-        
         $state->popGlobals();
         $state->popTable('tracker');
         $state->popTable('aor_conditions');

--- a/tests/unit/phpunit/modules/AOR_Reports/AOR_ReportTest.php
+++ b/tests/unit/phpunit/modules/AOR_Reports/AOR_ReportTest.php
@@ -131,10 +131,6 @@ class AOR_ReportTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $state = new SuiteCRM\StateSaver();
         $state->pushGlobals();
         
-        
-        
-        
-        
         $aor_Report = new AOR_Report();
 
         //execute the method and test if it works and does not throws an exception.
@@ -151,7 +147,6 @@ class AOR_ReportTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
     public function testgetReportFields()
     {
-
         //execute the method and verify that it returns an array
         $aor_Report = new AOR_Report();
         $result = $aor_Report->getReportFields();
@@ -182,7 +177,6 @@ class AOR_ReportTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         }
         
         // clean up
-        
         unset($GLOBALS['_SESSION']);
         unset($GLOBALS['objectList']);
         unset($GLOBALS['mod_strings']);
@@ -204,7 +198,6 @@ class AOR_ReportTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $state->pushGlobals();
         
         // test
-        
         $aor_Report = new AOR_Report();
         $aor_Report->report_module = 'Accounts';
         $aor_Report->id = '1';
@@ -227,7 +220,6 @@ class AOR_ReportTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $this->assertNotEquals($html2, $html3);
         
         // clean up
-        
         $state->popGlobals();
     }
 
@@ -256,13 +248,11 @@ class AOR_ReportTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $this->assertContains('testidentifier', $html3);
         
         // clean up
-        
         $state->popGlobals();
     }
 
     public function testgetTotalHTML()
     {
-
         //execute the method with required data preset and verify it returns expected result
         $fields = array('label' => array('display' => 1, 'total' => 'SUM', 'label' => 'total'));
         $totals = array('label' => array(10, 20, 30));
@@ -276,7 +266,6 @@ class AOR_ReportTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
     public function testcalculateTotal()
     {
-
         //execute the method with data preset and verify it returns expected result
         $totals = array(10, 20, 30);
 
@@ -319,7 +308,6 @@ class AOR_ReportTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $this->assertGreaterThanOrEqual(0, strlen($actual));
         
         // clean up
-        
         $state->popGlobals();
     }
 
@@ -384,7 +372,6 @@ class AOR_ReportTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $this->assertEquals('', $result);
         
         // clean up
-        
         $state->popGlobals();
     }
 
@@ -402,7 +389,6 @@ class AOR_ReportTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $this->assertSame($expected, $actual);
         
         // clean up
-        
         $state->popGlobals();
     }
 }

--- a/tests/unit/phpunit/modules/AOR_Scheduled_Reports/AOR_Scheduled_ReportsTest.php
+++ b/tests/unit/phpunit/modules/AOR_Scheduled_Reports/AOR_Scheduled_ReportsTest.php
@@ -45,7 +45,6 @@ class AOR_Scheduled_ReportsTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbst
         unset($aorScheduledReports);
 
         // clean up
-                
         $state->popGlobals();
         $state->popTable('tracker');
         $state->popTable('aod_index');
@@ -71,22 +70,11 @@ class AOR_Scheduled_ReportsTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbst
 
     public function testbean_implements()
     {
-        $state = new SuiteCRM\StateSaver();
-        
-        
-
-        
-
         $aorScheduledReports = new AOR_Scheduled_Reports();
         $this->assertEquals(false, $aorScheduledReports->bean_implements('')); //test with blank value
         $this->assertEquals(false, $aorScheduledReports->bean_implements('test')); //test with invalid value
         $this->assertEquals(true, $aorScheduledReports->bean_implements('ACL')); //test with valid value
-        
-        // clean up
     }
-
-
-
 
     public function testshouldRun()
     {

--- a/tests/unit/phpunit/modules/AOS_Contracts/AOS_ContractsTest.php
+++ b/tests/unit/phpunit/modules/AOS_Contracts/AOS_ContractsTest.php
@@ -101,7 +101,6 @@ class AOS_ContractsTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $this->assertEquals(null, $result);
         
         // clean up
-        
         $state->popGlobals();
         $state->popTable('tracker');
         $state->popTable('vcals');

--- a/tests/unit/phpunit/modules/AOS_Invoices/AOS_InvoicesTest.php
+++ b/tests/unit/phpunit/modules/AOS_Invoices/AOS_InvoicesTest.php
@@ -13,7 +13,6 @@ class AOS_InvoicesTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
     public function testAOS_Invoices()
     {
-
         //execute the contructor and check for the Object type and  attributes
         $aosInvoices = new AOS_Invoices();
         $this->assertInstanceOf('AOS_Invoices', $aosInvoices);
@@ -35,8 +34,6 @@ class AOS_InvoicesTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $state->pushTable('aos_invoices');
         $state->pushTable('tracker');
         
-        
-
         $aosInvoices = new AOS_Invoices();
         $aosInvoices->name = 'test';
 
@@ -53,7 +50,6 @@ class AOS_InvoicesTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $this->assertEquals(null, $result);
         
         // clean up
-        
         $state->popTable('tracker');
         $state->popTable('aos_invoices');
     }

--- a/tests/unit/phpunit/modules/AOS_Line_Item_Groups/AOS_Line_Item_GroupsTest.php
+++ b/tests/unit/phpunit/modules/AOS_Line_Item_Groups/AOS_Line_Item_GroupsTest.php
@@ -13,7 +13,6 @@ class AOS_Line_Item_GroupsTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstr
 
     public function testAOS_Line_Item_Groups()
     {
-
         //execute the contructor and check for the Object type and  attributes
         $aosLineItemGroup = new AOS_Line_Item_Groups();
         $this->assertInstanceOf('AOS_Line_Item_Groups', $aosLineItemGroup);
@@ -37,8 +36,6 @@ class AOS_Line_Item_GroupsTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstr
         $state->pushTable('tracker');
         $state->pushTable('aod_index');
         
-        
-
         $aosLineItemGroup = new AOS_Line_Item_Groups();
 
         //populate required values
@@ -63,7 +60,6 @@ class AOS_Line_Item_GroupsTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstr
         }
         
         // clean up
-        
         $state->popTable('aod_index');
         $state->popTable('tracker');
         $state->popTable('aos_line_item_groups');
@@ -93,7 +89,6 @@ class AOS_Line_Item_GroupsTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstr
         $this->assertEquals(null, $result);
         
         // clean up
-        
         $state->popTable('tracker');
         $state->popTable('aos_line_item_groups');
     }

--- a/tests/unit/phpunit/modules/AOS_PDF_Templates/AOS_PDF_TemplatesTest.php
+++ b/tests/unit/phpunit/modules/AOS_PDF_Templates/AOS_PDF_TemplatesTest.php
@@ -13,7 +13,6 @@ class AOS_PDF_TemplatesTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
     public function testAOS_PDF_Templates()
     {
-
         //execute the contructor and check for the Object type and  attributes
         $aosPdfTemplates = new AOS_PDF_Templates();
         $this->assertInstanceOf('AOS_PDF_Templates', $aosPdfTemplates);

--- a/tests/unit/phpunit/modules/AOS_Products/AOS_ProductsTest.php
+++ b/tests/unit/phpunit/modules/AOS_Products/AOS_ProductsTest.php
@@ -13,7 +13,6 @@ class AOS_ProductsTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
     public function testAOS_Products()
     {
-
         //execute the contructor and check for the Object type and  attributes
         $aosProducts = new AOS_Products();
         $this->assertInstanceOf('AOS_Products', $aosProducts);
@@ -74,25 +73,25 @@ class AOS_ProductsTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
         //execute the method and verify that it returns expected results
         $expected = "SELECT * FROM (
- 				SELECT
-					aos_quotes.*,
-					accounts.id AS account_id,
-					accounts.name AS billing_account,
+                SELECT
+                    aos_quotes.*,
+                    accounts.id AS account_id,
+                    accounts.name AS billing_account,
 
-					opportunity_id AS opportunity,
-					billing_contact_id AS billing_contact,
-					'' AS created_by_name,
-					'' AS modified_by_name,
-					'' AS assigned_user_name
-				FROM
-					aos_products
+                    opportunity_id AS opportunity,
+                    billing_contact_id AS billing_contact,
+                    '' AS created_by_name,
+                    '' AS modified_by_name,
+                    '' AS assigned_user_name
+                FROM
+                    aos_products
 
-				JOIN aos_products_quotes ON aos_products_quotes.product_id = aos_products.id AND aos_products.id = '1' AND aos_products_quotes.deleted = 0 AND aos_products.deleted = 0
-				JOIN aos_quotes ON aos_quotes.id = aos_products_quotes.parent_id AND aos_quotes.stage = 'Closed Accepted' AND aos_quotes.deleted = 0
-				JOIN accounts ON accounts.id = aos_quotes.billing_account_id -- AND accounts.deleted = 0
+                JOIN aos_products_quotes ON aos_products_quotes.product_id = aos_products.id AND aos_products.id = '1' AND aos_products_quotes.deleted = 0 AND aos_products.deleted = 0
+                JOIN aos_quotes ON aos_quotes.id = aos_products_quotes.parent_id AND aos_quotes.stage = 'Closed Accepted' AND aos_quotes.deleted = 0
+                JOIN accounts ON accounts.id = aos_quotes.billing_account_id -- AND accounts.deleted = 0
 
-				GROUP BY accounts.id
-			) AS aos_quotes";
+                GROUP BY accounts.id
+            ) AS aos_quotes";
         $actual = $aosProducts->getCustomersPurchasedProductsQuery();
         $this->assertSame(trim($expected), trim($actual));
     }

--- a/tests/unit/phpunit/modules/Accounts/AccountTest.php
+++ b/tests/unit/phpunit/modules/Accounts/AccountTest.php
@@ -46,7 +46,6 @@ class AccountTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
     public function testAccount()
     {
-
         //execute the contructor and check for the Object type and type attribute
         $Account = new Account();
         $this->assertInstanceOf('Account', $Account);
@@ -58,11 +57,6 @@ class AccountTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
     public function testget_summary_text()
     {
-        $state = new SuiteCRM\StateSaver();
-        
-        
-        
-
         //test without name setting attribute
         $Account = new Account();
         $name = $Account->get_summary_text();
@@ -72,8 +66,6 @@ class AccountTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $Account->name = 'test account';
         $name = $Account->get_summary_text();
         $this->assertEquals('test account', $name);
-        
-        // clean up
     }
 
     public function testget_contacts()
@@ -87,22 +79,15 @@ class AccountTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
     public function testclear_account_case_relationship()
     {
+        $this->markTestIncomplete('Can Not be implemented - Query has a wrong column name which makes the function to die');
         //This method cannot be tested because Query has a wrong column name which makes the function to die.
 
         /*$Account = new Account();
         $Account->clear_account_case_relationship('','');*/
-
-        $this->markTestIncomplete('Can Not be implemented - Query has a wrong column name which makes the function to die');
     }
 
     public function testremove_redundant_http()
     {
-        $state = new SuiteCRM\StateSaver();
-        
-        
-        
-        
-        
         $Account = new Account();
 
         //this method has no implementation. so test for exceptions only.
@@ -112,18 +97,10 @@ class AccountTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         } catch (Exception $e) {
             $this->fail($e->getMessage() . "\nTrace:\n" . $e->getTraceAsString());
         }
-        
-        // clean up
     }
 
     public function testfill_in_additional_list_fields()
     {
-        $state = new SuiteCRM\StateSaver();
-        
-        
-        
-        
-        
         $Account = new Account('');
 
         //execute the method and test if it works and does not throws an exception.
@@ -133,18 +110,10 @@ class AccountTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         } catch (Exception $e) {
             $this->fail($e->getMessage() . "\nTrace:\n" . $e->getTraceAsString());
         }
-        
-        // clean up
     }
 
     public function testfill_in_additional_detail_fields()
     {
-        $state = new SuiteCRM\StateSaver();
-        
-        
-        
-        
-        
         $Account = new Account('');
 
         //execute the method and test if it works and does not throws an exception.
@@ -154,8 +123,6 @@ class AccountTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         } catch (Exception $e) {
             $this->fail($e->getMessage() . "\nTrace:\n" . $e->getTraceAsString());
         }
-        
-        // clean up
     }
 
     public function testget_list_view_data()

--- a/tests/unit/phpunit/modules/Alerts/AlertTest.php
+++ b/tests/unit/phpunit/modules/Alerts/AlertTest.php
@@ -31,17 +31,10 @@ class AlertTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 
     public function testbean_implements()
     {
-        $state = new SuiteCRM\StateSaver();
-        
-        
-        
-
         $alert = new Alert();
 
         $this->assertEquals(false, $alert->bean_implements('')); //test with empty value
         $this->assertEquals(false, $alert->bean_implements('test')); //test with invalid value
         $this->assertEquals(true, $alert->bean_implements('ACL')); //test with valid value
-        
-        // clean up
     }
 }


### PR DESCRIPTION
## Description
- Remove incomplete tests for SugarBean, incomplete tests cause the test suite to run significantly slower when the state checker runs with `RUN_PER_TEST` for no real reason. They're replaced by a comment listing all the functions that still need tests.
- Formatting fixes that remove excessive whitespace, and a few typo fixes.
- Remove unnecessary StateChecker invocations in a few tests where they aren't used.

## Motivation and Context
Improve unit suite speed when using the state checker, and also formatting and readability of tests.

Honestly the PHP CodeSniffer should just be backported to 7.10 and added to CI, but that's a whole other thing.

## How To Test This
Make sure the tests still pass on Travis and make sure the formatting changes look acceptable.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.