### PR TITLE
Add composer validate job in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,12 @@ matrix:
     - name: "PHP 7.3 / MySQL 5.7"
       php: "7.3"
       dist: xenial
+    # Run composer validate to make sure the composer.json and composer.lock are in sync.
+    - name: "composer validate"
+      php: "7.2"
+      dist: xenial
+      before_script: composer install
+      script: composer validate
     - stage: codecoverage
       if: type IN (pull_request) OR branch in (master, develop, hotfix)
       php: "7.0"


### PR DESCRIPTION
## Description
This adds a job to Travis that validates that the `composer.json` and `composer.lock` are in sync.

## Motivation and Context
I forgot to update the `composer.lock` when adding php-cs-fixer and had to fix it in #7450. This job shouldn't take very long to run and would fix this problem.

## How To Test This
Make sure Travis passes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.