### PR TITLE
Disable stopOnFailure and stopOnError in PHPUnit config.

### DIFF
--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -8,8 +8,8 @@
     convertWarningsToExceptions     = "true"
     convertErrorsToExceptions       = "true"
     processIsolation                = "false"
-    stopOnFailure                   = "true"
-    stopOnError                     = "true"
+    stopOnFailure                   = "false"
+    stopOnError                     = "false"
     syntaxCheck                     = "true"
     bootstrap                       = "bootstrap.php">
 


### PR DESCRIPTION
## Description
We use these options explicitly in Travis, and they make running the tests without stopOnFailure/Error enabled unnecessarily difficult.

Also, note that this is essentially a backport from #7374. If that's merged before this, this PR won't really be necessary.

## Motivation and Context
I want to run the PHPUnit suite to completion and it's not possible to do so locally without changing this file, which is annoying to do whenever I switch branches. Plus, we explicitly use the flags in CI so there's not really a reason to set them in the PHPUnit config.

## How To Test This
Run PHPUnit locally without `--stop-on-error` or `--stop-on-failure` and see if it stops on either of those cases occurring.

## Types of changes
This is technically a breaking change because people could have relied on the old behavior in scripts they'd written?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.