### PR TITLE
Cache Composer files in Travis. (hotfix-7.10.x PR)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,10 @@ services:
 addons:
   chrome: stable
 
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
 env:
   - INSTANCE_URL=http://localhost DATABASE_DRIVER=MYSQL DATABASE_NAME=automated_tests DATABASE_HOST=localhost DATABASE_USER=automated_tests DATABASE_PASSWORD=automated_tests INSTANCE_ADMIN_USER=admin INSTANCE_ADMIN_PASSWORD=admin1 COMPOSER_MEMORY_LIMIT=-1
 


### PR DESCRIPTION
## Description
This should speed up CI a bit. This is a backport from hotfix.

Original PR was #6834. There was also #6833 but it was closed, I'm not really sure why? @Dillon-Brown

## Motivation and Context
It makes Travis CI runs slightly faster. You can see it in action if you look at a job for a commit on hotfix vs. one for hotfix-7.10.x:
- hotfix: https://travis-ci.org/salesagility/SuiteCRM/jobs/548726541 (8 seconds spent on `composer install`, all dependencies pulled from cache)
- hotfix-7.10.x: https://travis-ci.org/salesagility/SuiteCRM/jobs/548779265 (40 seconds spent on `composer install`, needed to install all the dependencies)

I think we just forgot to backport it before? 🤷‍♂ 

## How To Test This
As long as Travis passes we should be good, it's the exact same change as the PRs mentioned above and those work fine.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.