### PR TITLE
Fixed #7156 - Slow SQL query in include/SugarFolders/SugarFolders.php…

### DIFF
--- a/include/SugarFolders/SugarFolders.php
+++ b/include/SugarFolders/SugarFolders.php
@@ -960,8 +960,6 @@ class SugarFolder
             }
             $label = ($a['name'] == 'My Email' ? $this->modStrings['LNK_MY_INBOX'] : $a['name']);
 
-            $unseen = $this->getCountNewItems($a['id'], array('field' => 'status', 'value' => 'unread'), $a);
-
             $folderNode = new ExtNode($a['id'], $label);
             $folderNode->dynamicloadfunction = '';
             $folderNode->expanded = false;
@@ -978,7 +976,6 @@ class SugarFolder
             $folderNode->set_property('is_group', ($a['is_group'] == 1) ? 'true' : 'false');
             $folderNode->set_property('is_dynamic', ($a['is_dynamic'] == 1) ? 'true' : 'false');
             $folderNode->set_property('mbox', $folderNode->_properties['id']);
-            $folderNode->set_property('unseen', $unseen);
             $folderNode->set_property('id', $a['id']);
             $folderNode->set_property('folder_type', $a['folder_type']);
             $folderNode->set_property('children', array());
@@ -1077,8 +1074,6 @@ class SugarFolder
             $label = $this->modStrings['LBL_LIST_TITLE_MY_SENT'];
         }
 
-        $unseen = $this->getCountNewItems($a['id'], array('field' => 'status', 'value' => 'unread'), $a);
-
         $folderNode = new ExtNode($a['id'], $label);
         $folderNode->dynamicloadfunction = '';
         $folderNode->expanded = false;
@@ -1103,7 +1098,6 @@ class SugarFolder
         $folderNode->set_property('mbox', $a['id']);
         $folderNode->set_property('is_group', ($a['is_group'] == 1) ? 'true' : 'false');
         $folderNode->set_property('is_dynamic', ($a['is_dynamic'] == 1) ? 'true' : 'false');
-        $folderNode->set_property('unseen', $unseen);
         $folderNode->set_property('folder_type', $a['folder_type']);
 
         if (in_array($a['id'], $subscriptions) && $a['has_child'] == 1) {


### PR DESCRIPTION
… causing slow emails interface in 7.10.x (and 7.11.x)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This query was taking up significant time in the email list-view for no apparent reason. As the returned data from this function doesn't appear to be used I've just removed it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #7156 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Setup emails and navigate around the email list-view.
2. Check that the unread/read functionality is unchanged.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->