### PR TITLE
Upgrade the minimum PHP version for SuiteCRM 7.10.x in composer.json to PHP 5.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
   "config": {
     "vendor-dir": "vendor",
     "platform": {
-      "php": "5.5.9"
+      "php": "5.6.0"
     },
     "optimize-autoloader": true,
     "sort-packages": true
   },
   "require": {
-    "php": ">=5.5.9",
+    "php": ">= 5.6.0",
     "ext-curl": "*",
     "ext-gd": "*",
     "ext-imap": "*",


### PR DESCRIPTION
## Description
See #7463. This removes support for PHP 5.5.

## Motivation and Context
My motivation is pretty much explained in #7463, 5.5 is limiting a lot of improvements I'd like to make to the test suite and overall code quality of the project (specifically upgrading codeception and using php-cs-fixer in CI), as well as making CI take longer.

I'd say it's pretty safe to assume very few users are still on PHP 5.5, and if they are they should upgrade to get the various security fixes since its EOL 3 years ago. Supporting such an old version is a maintenance burden that, in my opinion, is too costly to the overall health of the project.

## How To Test This
Make sure Travis passes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.