### PR TITLE
Fixed #5552 - Inbound Email Auto-reply send email without Attachments

### DIFF
--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -3495,6 +3495,9 @@ class InboundEmail extends SugarBean
                 $reply->description_html = $et->body_html;
                 $reply->reply_to_name = $replyToName;
                 $reply->reply_to_addr = $replyToAddr;
+                $attachments = $et->getAttachments();
+                $reply->attachments = array_merge($reply->attachments, $attachments);
+                $reply->handleAttachments();
 
                 $GLOBALS['log']->debug('saving and sending auto-reply email');
                 //$reply->save(); // don't save the actual email.

--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -3496,8 +3496,11 @@ class InboundEmail extends SugarBean
                 $reply->reply_to_name = $replyToName;
                 $reply->reply_to_addr = $replyToAddr;
                 $attachments = $et->getAttachments();
-                $reply->attachments = array_merge($reply->attachments, $attachments);
-                $reply->handleAttachments();
+
+                if (!empty($attachments)) {
+                    $reply->attachments = array_merge($reply->attachments, $attachments);
+                    $reply->handleAttachments();
+                }
 
                 $GLOBALS['log']->debug('saving and sending auto-reply email');
                 //$reply->save(); // don't save the actual email.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixed an issue with email auto-reply not sending attachments.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #5552 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create a group email account. 
2. Set Auto-reply template with attachment.
3. Send an email to the group email account.
4. Check that the auto-reply email has the attachment.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->