### PR TITLE
Remove unused webDriverHelper variables

### DIFF
--- a/tests/acceptance/Core/BasicModuleCest.php
+++ b/tests/acceptance/Core/BasicModuleCest.php
@@ -43,7 +43,6 @@ class BasicModuleCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ModuleBuilder $moduleBuilder
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to create and deploy a basic module so that I can test
      * that the basic functionality is working. Given that I have already created a module I expect to deploy
@@ -52,8 +51,7 @@ class BasicModuleCest
     public function testScenarioCreateBasicModule(
        \AcceptanceTester $I,
        \Step\Acceptance\ModuleBuilder $moduleBuilder,
-       \Step\Acceptance\Repair $repair,
-       \Helper\WebDriverHelper $webDriverHelper
+       \Step\Acceptance\Repair $repair
     ) {
         $I->wantTo('Create a basic module for testing');
 
@@ -73,7 +71,6 @@ class BasicModuleCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to view my basic test module so that I can see if it has been
      * deployed correctly.
@@ -81,8 +78,7 @@ class BasicModuleCest
     public function testScenarioViewBasicTestModule(
         \AcceptanceTester $I,
         \Step\Acceptance\NavigationBar $navigationBar,
-        \Step\Acceptance\ListView $listView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View Basic Test Module');
 
@@ -100,7 +96,6 @@ class BasicModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\EditView $editView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a record with my basic test module so that I can test
      * the standard fields.
@@ -110,8 +105,7 @@ class BasicModuleCest
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\EditView $editView,
-        \Step\Acceptance\DetailView $detailView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\DetailView $detailView
     ) {
         $I->wantTo('Create Basic Test Module Record');
 
@@ -138,8 +132,7 @@ class BasicModuleCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
-     * @param \Helper\WebDriverHelper $webDriverHelper
-     * @param \Helper\WebDriverHelper $webDriverHelper
+     * @param \Step\Acceptance\DetailView $detailView
      *
      * As administrative user I want to view the record by selecting it in the list view
      */
@@ -147,8 +140,7 @@ class BasicModuleCest
         \AcceptanceTester $I,
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\DetailView $detailView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\DetailView $detailView
     ) {
         $I->wantTo('Select Record from list view');
 
@@ -177,7 +169,6 @@ class BasicModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to edit the record by selecting it in the detail view
      */
@@ -186,8 +177,7 @@ class BasicModuleCest
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\DetailView $detailView,
-        \Step\Acceptance\EditView $editView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\EditView $editView
     ) {
         $I->wantTo('Edit Basic Test Module Record from detail view');
 
@@ -223,7 +213,6 @@ class BasicModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to duplicate the record
      */
@@ -232,8 +221,7 @@ class BasicModuleCest
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\DetailView $detailView,
-        \Step\Acceptance\EditView $editView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\EditView $editView
     ) {
         $I->wantTo('Duplicate Basic Test Module Record from detail view');
 
@@ -275,7 +263,6 @@ class BasicModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to delete the record by selecting it in the detail view
      */
@@ -283,8 +270,7 @@ class BasicModuleCest
         \AcceptanceTester $I,
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\DetailView $detailView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\DetailView $detailView
     ) {
         $I->wantTo('Delete Basic Test Module Record from detail view');
 

--- a/tests/acceptance/Core/CompanyModuleCest.php
+++ b/tests/acceptance/Core/CompanyModuleCest.php
@@ -46,7 +46,6 @@ class CompanyModuleCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ModuleBuilder $moduleBuilder
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to create and deploy a company module so that I can test
      * that the company functionality is working. Given that I have already created a module I expect to deploy
@@ -54,8 +53,7 @@ class CompanyModuleCest
      */
     public function testScenarioCreateCompanyModule(
        \AcceptanceTester $I,
-       \Step\Acceptance\ModuleBuilder $moduleBuilder,
-        \Helper\WebDriverHelper $webDriverHelper
+       \Step\Acceptance\ModuleBuilder $moduleBuilder
     ) {
         $I->wantTo('Create a company module for testing');
         $I->loginAsAdmin();
@@ -73,7 +71,6 @@ class CompanyModuleCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to view my company test module so that I can see if it has been
      * deployed correctly.
@@ -81,8 +78,7 @@ class CompanyModuleCest
     public function testScenarioViewCompanyTestModule(
         \AcceptanceTester $I,
         \Step\Acceptance\NavigationBar $navigationBar,
-        \Step\Acceptance\ListView $listView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View Company Test Module');
 
@@ -101,7 +97,6 @@ class CompanyModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\EditView $editView
      * @param \Step\Acceptance\DetailView $detailView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a record with my company test module so that I can test
      * the standard fields.
@@ -111,8 +106,7 @@ class CompanyModuleCest
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\EditView $editView,
-        \Step\Acceptance\DetailView $detailView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\DetailView $detailView
     ) {
         $I->wantTo('Create Company Test Module Record');
 
@@ -155,7 +149,6 @@ class CompanyModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to view the record by selecting it in the list view
      */
@@ -163,8 +156,7 @@ class CompanyModuleCest
         \AcceptanceTester $I,
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\DetailView $detailView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\DetailView $detailView
     ) {
         $I->wantTo('Select Record from list view');
 
@@ -195,7 +187,6 @@ class CompanyModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to edit the record by selecting it in the detail view
      */
@@ -204,8 +195,7 @@ class CompanyModuleCest
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\DetailView $detailView,
-        \Step\Acceptance\EditView $editView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\EditView $editView
     ) {
         $I->wantTo('Edit Company Test Module Record from detail view');
 
@@ -242,7 +232,6 @@ class CompanyModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to duplicate the record
      */
@@ -251,8 +240,7 @@ class CompanyModuleCest
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\DetailView $detailView,
-        \Step\Acceptance\EditView $editView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\EditView $editView
     ) {
         $I->wantTo('Duplicate Company Test Module Record from detail view');
         $I->loginAsAdmin();
@@ -295,7 +283,6 @@ class CompanyModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to delete the record by selecting it in the detail view
      */
@@ -303,8 +290,7 @@ class CompanyModuleCest
         \AcceptanceTester $I,
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\DetailView $detailView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\DetailView $detailView
     ) {
         $I->wantTo('Delete Company Test Module Record from detail view');
 

--- a/tests/acceptance/Core/FileModuleCest.php
+++ b/tests/acceptance/Core/FileModuleCest.php
@@ -43,7 +43,6 @@ class FileModuleCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ModuleBuilder $moduleBuilder
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to create and deploy a file module so that I can test
      * that the file functionality is working. Given that I have already created a module I expect to deploy
@@ -51,8 +50,7 @@ class FileModuleCest
      */
     public function testScenarioCreateFileModule(
        \AcceptanceTester $I,
-       \Step\Acceptance\ModuleBuilder $moduleBuilder,
-        \Helper\WebDriverHelper $webDriverHelper
+       \Step\Acceptance\ModuleBuilder $moduleBuilder
     ) {
         $I->wantTo('Create a file module for testing');
 
@@ -71,7 +69,6 @@ class FileModuleCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to view my file test module so that I can see if it has been
      * deployed correctly.
@@ -79,8 +76,7 @@ class FileModuleCest
     public function testScenarioViewFileTestModule(
         \AcceptanceTester $I,
         \Step\Acceptance\NavigationBar $navigationBar,
-        \Step\Acceptance\ListView $listView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View File Test Module');
         $I->loginAsAdmin();
@@ -98,7 +94,6 @@ class FileModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailview
      * @param \Step\Acceptance\EditView $editView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a record with my file test module so that I can test
      * the standard fields.
@@ -108,8 +103,7 @@ class FileModuleCest
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\DetailView $detailview,
-        \Step\Acceptance\EditView $editView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\EditView $editView
     ) {
         $I->wantTo('Create File Test Module Record');
         $I->loginAsAdmin();
@@ -145,7 +139,6 @@ class FileModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to view the record by selecting it in the list view
      */
@@ -153,8 +146,7 @@ class FileModuleCest
         \AcceptanceTester $I,
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\DetailView $detailView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\DetailView $detailView
     ) {
         $I->wantTo('Select Record from list view');
         
@@ -184,7 +176,6 @@ class FileModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to edit the record by selecting it in the detail view
      */
@@ -193,8 +184,7 @@ class FileModuleCest
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\DetailView $detailView,
-        \Step\Acceptance\EditView $editView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\EditView $editView
     ) {
         $I->wantTo('Edit File Test Module Record from detail view');
         $I->loginAsAdmin();
@@ -228,7 +218,6 @@ class FileModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to duplicate the record
      */
@@ -237,8 +226,7 @@ class FileModuleCest
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\DetailView $detailView,
-        \Step\Acceptance\EditView $editView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\EditView $editView
     ) {
         $I->wantTo('Duplicate File Test Module Record from detail view');
         $I->loginAsAdmin();
@@ -279,7 +267,6 @@ class FileModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to delete the record by selecting it in the detail view
      */
@@ -287,8 +274,7 @@ class FileModuleCest
         \AcceptanceTester $I,
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\DetailView $detailView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\DetailView $detailView
     ) {
         $I->wantTo('Delete File Test Module Record from detail view');
         $I->loginAsAdmin();

--- a/tests/acceptance/Core/IssueModuleCest.php
+++ b/tests/acceptance/Core/IssueModuleCest.php
@@ -44,7 +44,6 @@ class IssueModuleCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ModuleBuilder $moduleBuilder
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to create and deploy a issue module so that I can test
      * that the issue functionality is working. Given that I have already created a module I expect to deploy
@@ -52,8 +51,7 @@ class IssueModuleCest
      */
     public function testScenarioCreateIssueModule(
        \AcceptanceTester $I,
-       \Step\Acceptance\ModuleBuilder $moduleBuilder,
-        \Helper\WebDriverHelper $webDriverHelper
+       \Step\Acceptance\ModuleBuilder $moduleBuilder
     ) {
         $I->wantTo('Create a issue module for testing');
         $I->loginAsAdmin();
@@ -71,7 +69,6 @@ class IssueModuleCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to view my issue test module so that I can see if it has been
      * deployed correctly.
@@ -79,8 +76,7 @@ class IssueModuleCest
     public function testScenarioViewIssueTestModule(
         \AcceptanceTester $I,
         \Step\Acceptance\NavigationBar $navigationBar,
-        \Step\Acceptance\ListView $listView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View Issue Test Module');
         $I->loginAsAdmin();
@@ -98,7 +94,6 @@ class IssueModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\EditView $editView
      * @param \Step\Acceptance\DetailView $detailView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a record with my issue test module so that I can test
      * the standard fields.
@@ -108,8 +103,7 @@ class IssueModuleCest
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\EditView $editView,
-        \Step\Acceptance\DetailView $detailView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\DetailView $detailView
     ) {
         $I->wantTo('Create Issue Test Module Record');
         $I->loginAsAdmin();
@@ -136,7 +130,6 @@ class IssueModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to view the record by selecting it in the list view
      */
@@ -144,8 +137,7 @@ class IssueModuleCest
         \AcceptanceTester $I,
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\DetailView $detailView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\DetailView $detailView
     ) {
         $I->wantTo('Select Record from list view');
         $I->loginAsAdmin();
@@ -173,7 +165,6 @@ class IssueModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to edit the record by selecting it in the detail view
      */
@@ -182,8 +173,7 @@ class IssueModuleCest
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\DetailView $detailView,
-        \Step\Acceptance\EditView $editView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\EditView $editView
     ) {
         $I->wantTo('Edit Issue Test Module Record from detail view');
         $I->loginAsAdmin();
@@ -218,7 +208,6 @@ class IssueModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to duplicate the record
      */
@@ -227,8 +216,7 @@ class IssueModuleCest
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\DetailView $detailView,
-        \Step\Acceptance\EditView $editView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\EditView $editView
     ) {
         $I->wantTo('Duplicate Issue Test Module Record from detail view');
         $I->loginAsAdmin();
@@ -269,7 +257,6 @@ class IssueModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to delete the record by selecting it in the detail view
      */
@@ -277,8 +264,7 @@ class IssueModuleCest
         \AcceptanceTester $I,
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\DetailView $detailView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\DetailView $detailView
     ) {
         $I->wantTo('Delete Issue Test Module Record from detail view');
         $I->loginAsAdmin();

--- a/tests/acceptance/Core/ModuleBuilderFieldsCest.php
+++ b/tests/acceptance/Core/ModuleBuilderFieldsCest.php
@@ -47,7 +47,6 @@ class ModuleBuilderFieldsCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ModuleBuilder $moduleBuilder
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to create and deploy a basic module so that I can test
      * that the functionality of functionality each field is working. Given that I have already created a module I expect to deploy
@@ -55,8 +54,7 @@ class ModuleBuilderFieldsCest
      */
     public function testScenarioCreateFieldsModule(
        \AcceptanceTester $I,
-       \Step\Acceptance\ModuleBuilder $moduleBuilder,
-       \Helper\WebDriverHelper $webDriverHelper
+       \Step\Acceptance\ModuleBuilder $moduleBuilder
     ) {
         $I->wantTo('Create a module for testing fields');
 
@@ -74,14 +72,12 @@ class ModuleBuilderFieldsCest
     /**
      * @param AcceptanceTester $I
      * @param \Step\Acceptance\ModuleBuilder $moduleBuilder
-     * @param \Helper\WebDriverHelper $webDriverHelper
      * As an administrator I want to add a relate field to the basic module so that I can test relating records to the
      * accounts module
      */
     public function testScenarioAddRelateField(
         \AcceptanceTester $I,
-        \Step\Acceptance\ModuleBuilder $moduleBuilder,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\ModuleBuilder $moduleBuilder
     ) {
         $I->wantTo('Add relate field');
 
@@ -157,14 +153,12 @@ class ModuleBuilderFieldsCest
     /**
      * @param AcceptanceTester $I
      * @param \Step\Acceptance\ModuleBuilder $moduleBuilder
-     * @param \Helper\WebDriverHelper $webDriverHelper
      * As an administrator I want to add a html field to the basic module so that I can test relating records to the
      * accounts module
      */
     public function testScenarioAddHtmlField(
         \AcceptanceTester $I,
-        \Step\Acceptance\ModuleBuilder $moduleBuilder,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\ModuleBuilder $moduleBuilder
     ) {
         $I->wantTo('Add html field');
 
@@ -239,21 +233,16 @@ class ModuleBuilderFieldsCest
      * @param AcceptanceTester $I
      * @param \Step\Acceptance\ModuleBuilder $moduleBuilder
      * @param \Step\Acceptance\Repair $repair
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to test deploying a module
      */
     public function testScenarioDeployModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ModuleBuilder $moduleBuilder,
-        \Step\Acceptance\Repair $repair,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Repair $repair
     ) {
         $I->wantTo('Deploy Test Module');
 
-        $I->amOnUrl(
-            $webDriverHelper->getInstanceURL()
-        );
         $I->loginAsAdmin();
 
         $moduleBuilder->deployPackage(\Page\ModuleFields::$PACKAGE_NAME, true);
@@ -269,7 +258,6 @@ class ModuleBuilderFieldsCest
      * @param \Step\Acceptance\EditView $editView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\Accounts $accounts
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to test relating to the accounts module
      */
@@ -278,8 +266,7 @@ class ModuleBuilderFieldsCest
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\EditView $editView,
-        \Step\Acceptance\DetailView $detailView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\DetailView $detailView
     ) {
         return; // test failing behaviour is not similar in different environments
         $I->wantTo('Relate a record to accounts');

--- a/tests/acceptance/Core/PersonModuleCest.php
+++ b/tests/acceptance/Core/PersonModuleCest.php
@@ -44,7 +44,6 @@ class PersonModuleCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ModuleBuilder $moduleBuilder
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to create and deploy a person module so that I can test
      * that the person functionality is working. Given that I have already created a module I expect to deploy
@@ -52,8 +51,7 @@ class PersonModuleCest
      */
     public function testScenarioCreatePersonModule(
        \AcceptanceTester $I,
-       \Step\Acceptance\ModuleBuilder $moduleBuilder,
-        \Helper\WebDriverHelper $webDriverHelper
+       \Step\Acceptance\ModuleBuilder $moduleBuilder
     ) {
         $I->wantTo('Create a person module for testing');
 
@@ -72,7 +70,6 @@ class PersonModuleCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to view my person test module so that I can see if it has been
      * deployed correctly.
@@ -80,8 +77,7 @@ class PersonModuleCest
     public function testScenarioViewPersonTestModule(
         \AcceptanceTester $I,
         \Step\Acceptance\NavigationBar $navigationBar,
-        \Step\Acceptance\ListView $listView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View Person Test Module');
 
@@ -100,7 +96,6 @@ class PersonModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a record with my person test module so that I can test
      * the standard fields.
@@ -110,8 +105,7 @@ class PersonModuleCest
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\DetailView $detailView,
-        \Step\Acceptance\EditView $editView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\EditView $editView
     ) {
         $I->wantTo('Create Person Test Module Record');
         $I->loginAsAdmin();
@@ -163,7 +157,6 @@ class PersonModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to view the record by selecting it in the list view
      */
@@ -171,8 +164,7 @@ class PersonModuleCest
         \AcceptanceTester $I,
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\DetailView $detailView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\DetailView $detailView
     ) {
         $I->wantTo('Select Record from list view');
 
@@ -207,7 +199,6 @@ class PersonModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to edit the record by selecting it in the detail view
      */
@@ -216,8 +207,7 @@ class PersonModuleCest
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\DetailView $detailView,
-        \Step\Acceptance\EditView $editView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\EditView $editView
     ) {
         $I->wantTo('Edit Person Test Module Record from detail view');
 
@@ -260,7 +250,6 @@ class PersonModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to duplicate the record
      */
@@ -269,8 +258,7 @@ class PersonModuleCest
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\DetailView $detailView,
-        \Step\Acceptance\EditView $editView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\EditView $editView
     ) {
         $I->wantTo('Duplicate Person Test Module Record from detail view');
 
@@ -317,7 +305,6 @@ class PersonModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to delete the record by selecting it in the detail view
      */
@@ -325,8 +312,7 @@ class PersonModuleCest
         \AcceptanceTester $I,
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\DetailView $detailView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\DetailView $detailView
     ) {
         $I->wantTo('Delete Person Test Module Record from detail view');
 
@@ -367,7 +353,6 @@ class PersonModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to delete the record by selecting it in the detail view
      */
@@ -376,8 +361,7 @@ class PersonModuleCest
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\SideBar $sideBar,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\DetailView $detailView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\DetailView $detailView
     ) {
         $I->wantTo('Create a Person Record using a vcard');
 

--- a/tests/acceptance/Core/SaleModuleCest.php
+++ b/tests/acceptance/Core/SaleModuleCest.php
@@ -39,7 +39,6 @@ class SaleModuleCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ModuleBuilder $moduleBuilder
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to create and deploy a sale module so that I can test
      * that the sale functionality is working. Given that I have already created a module I expect to deploy
@@ -47,8 +46,7 @@ class SaleModuleCest
      */
     public function testScenarioCreateSaleModule(
        \AcceptanceTester $I,
-       \Step\Acceptance\ModuleBuilder $moduleBuilder,
-        \Helper\WebDriverHelper $webDriverHelper
+       \Step\Acceptance\ModuleBuilder $moduleBuilder
     ) {
         $I->wantTo('Create a sale module for testing');
 
@@ -65,7 +63,6 @@ class SaleModuleCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to view my sale test module so that I can see if it has been
      * deployed correctly.
@@ -73,8 +70,7 @@ class SaleModuleCest
     public function testScenarioViewSaleTestModule(
         \AcceptanceTester $I,
         \Step\Acceptance\NavigationBar $navigationBar,
-        \Step\Acceptance\ListView $listView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View Sale Test Module');
         $I->loginAsAdmin();
@@ -91,7 +87,6 @@ class SaleModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a record with my sale test module so that I can test
      * the standard fields.
@@ -101,8 +96,7 @@ class SaleModuleCest
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\DetailView $detailView,
-        \Step\Acceptance\EditView $editView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\EditView $editView
     ) {
         $I->wantTo('Create Sale Test Module Record');
 
@@ -134,15 +128,13 @@ class SaleModuleCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to view the record by selecting it in the list view
      */
     public function testScenarioViewRecordFromListView(
         \AcceptanceTester $I,
         \Step\Acceptance\NavigationBar $navigationBar,
-        \Step\Acceptance\ListView $listView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('Select Record from list view');
 
@@ -169,7 +161,6 @@ class SaleModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to edit the record by selecting it in the detail view
      */
@@ -178,8 +169,7 @@ class SaleModuleCest
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\DetailView $detailView,
-        \Step\Acceptance\EditView $editView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\EditView $editView
     ) {
         $I->wantTo('Edit Sale Test Module Record from detail view');
         $I->loginAsAdmin();
@@ -214,7 +204,6 @@ class SaleModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to duplicate the record
      */
@@ -223,8 +212,7 @@ class SaleModuleCest
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\DetailView $detailView,
-        \Step\Acceptance\EditView $editView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\EditView $editView
     ) {
         $I->wantTo('Duplicate Sale Test Module Record from detail view');
 
@@ -265,7 +253,6 @@ class SaleModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to delete the record by selecting it in the detail view
      */
@@ -273,8 +260,7 @@ class SaleModuleCest
         \AcceptanceTester $I,
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\DetailView $detailView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\DetailView $detailView
     ) {
         $I->wantTo('Delete Sale Test Module Record from detail view');
 

--- a/tests/acceptance/LoginCest.php
+++ b/tests/acceptance/LoginCest.php
@@ -22,7 +22,7 @@ class LoginCest
     }
 
     // tests
-    public function testScenarioLoginAsAdministrator(AcceptanceTester $I, \Helper\WebDriverHelper $webDriverHelper)
+    public function testScenarioLoginAsAdministrator(AcceptanceTester $I)
     {
         $I->wantTo('Login as an administrator');
         // Login as Administrator

--- a/tests/acceptance/modules/AM_Project_Templates/AM_Project_TemplatesCest.php
+++ b/tests/acceptance/modules/AM_Project_Templates/AM_Project_TemplatesCest.php
@@ -31,15 +31,13 @@ class AM_Project_TemplatesCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\ProjectTemplates $projectTemplates
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the projectTemplates module.
      */
     public function testScenarioViewProjectTemplatesModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\ProjectTemplates $projectTemplates,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\ProjectTemplates $projectTemplates
     ) {
         $I->wantTo('View the projectTemplates module for testing');
         // Navigate to projectTemplates list-view
@@ -55,7 +53,6 @@ class AM_Project_TemplatesCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\ProjectTemplates $projectTemplate
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a project template so that I can test
      * the standard fields.
@@ -64,8 +61,7 @@ class AM_Project_TemplatesCest
         \AcceptanceTester $I,
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\ProjectTemplates $projectTemplate,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\ProjectTemplates $projectTemplate
     ) {
         $I->wantTo('Create a project template');
 

--- a/tests/acceptance/modules/AOK_KnowledgeBase/AOK_KnowledgeBaseCest.php
+++ b/tests/acceptance/modules/AOK_KnowledgeBase/AOK_KnowledgeBaseCest.php
@@ -31,15 +31,13 @@ class AOK_KnowledgeBaseCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\KnowledgeBase $knowledgeBase
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the knowledgeBase module.
      */
     public function testScenarioViewKnowledgeBaseModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\KnowledgeBase $knowledgeBase,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\KnowledgeBase $knowledgeBase
     ) {
         $I->wantTo('View the knowledgeBase module for testing');
 
@@ -56,7 +54,6 @@ class AOK_KnowledgeBaseCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\KnowledgeBase $knowledgeBase
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a Knowledge Base so that I can test
      * the standard fields.
@@ -65,8 +62,7 @@ class AOK_KnowledgeBaseCest
         \AcceptanceTester $I,
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\KnowledgeBase $knowledgeBase,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\KnowledgeBase $knowledgeBase
     ) {
         $I->wantTo('Create a Knowledge Base');
 

--- a/tests/acceptance/modules/AOK_Knowledge_Base_Categories/AOK_Knowledge_Base_CategoriesCest.php
+++ b/tests/acceptance/modules/AOK_Knowledge_Base_Categories/AOK_Knowledge_Base_CategoriesCest.php
@@ -31,15 +31,13 @@ class AOK_Knowledge_Base_CategoriesCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\KnowledgeBaseCategories $knowledgeBaseCategory
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the knowledgeBaseCategory module.
      */
     public function testScenarioViewKnowledgeBaseCategoriesModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\KnowledgeBaseCategories $knowledgeBaseCategory,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\KnowledgeBaseCategories $knowledgeBaseCategory
     ) {
         $I->wantTo('View the knowledgeBaseCategory module for testing');
 
@@ -56,7 +54,6 @@ class AOK_Knowledge_Base_CategoriesCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\KnowledgeBaseCategories $knowledgeBaseCategories
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a knowledge base category so that I can test
      * the standard fields.
@@ -65,8 +62,7 @@ class AOK_Knowledge_Base_CategoriesCest
         \AcceptanceTester $I,
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\KnowledgeBaseCategories $knowledgeBaseCategories,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\KnowledgeBaseCategories $knowledgeBaseCategories
     ) {
         $I->wantTo('Create KnowledgeBaseCategory');
 

--- a/tests/acceptance/modules/AOR_Reports/AOR_ReportsCest.php
+++ b/tests/acceptance/modules/AOR_Reports/AOR_ReportsCest.php
@@ -31,15 +31,13 @@ class AOR_ReportsCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Reports $reports
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the reports module.
      */
     public function testScenarioViewReportsModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Reports $reports,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Reports $reports
     ) {
         $I->wantTo('View the reports module for testing');
 
@@ -58,7 +56,6 @@ class AOR_ReportsCest
      * @param \Step\Acceptance\SideBar $sidebar
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Reports $reports
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a report with the reports module so that I can test
      * the standard fields.
@@ -69,8 +66,7 @@ class AOR_ReportsCest
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\SideBar $sidebar,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Reports $reports,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Reports $reports
     ) {
         $I->wantTo('Create a Report');
 
@@ -102,7 +98,6 @@ class AOR_ReportsCest
      * @param \Step\Acceptance\SideBar $sidebar
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\Reports $reports
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to view the report by selecting it in the list view
      */
@@ -112,8 +107,7 @@ class AOR_ReportsCest
         \Step\Acceptance\EditView $editView,
         \Step\Acceptance\SideBar $sidebar,
         \Step\Acceptance\DetailView $detailView,
-        \Step\Acceptance\Reports $reports,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Reports $reports
     ) {
         $I->wantTo('Select Report from list view');
 
@@ -152,7 +146,6 @@ class AOR_ReportsCest
      * @param \Step\Acceptance\EditView $editView
      * @param \Step\Acceptance\SideBar $sidebar
      * @param \Step\Acceptance\Reports $reports
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to edit the record by selecting it in the detail view
      */
@@ -162,8 +155,7 @@ class AOR_ReportsCest
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\EditView $editView,
         \Step\Acceptance\SideBar $sidebar,
-        \Step\Acceptance\Reports $reports,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Reports $reports
     ) {
         $I->wantTo('Edit a Report from the detail view');
 
@@ -203,7 +195,6 @@ class AOR_ReportsCest
      * @param \Step\Acceptance\EditView $editView
      * @param \Step\Acceptance\SideBar $sidebar
      * @param \Step\Acceptance\Reports $reports
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to duplicate the report
      */
@@ -213,8 +204,7 @@ class AOR_ReportsCest
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\EditView $editView,
         \Step\Acceptance\SideBar $sidebar,
-        \Step\Acceptance\Reports $reports,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Reports $reports
     ) {
         $I->wantTo('Duplicate Report from detail view');
 
@@ -256,7 +246,6 @@ class AOR_ReportsCest
      * @param \Step\Acceptance\SideBar $sidebar
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\Reports $reports
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to delete the report by selecting it in the detail view
      */
@@ -266,8 +255,7 @@ class AOR_ReportsCest
         \Step\Acceptance\EditView $editView,
         \Step\Acceptance\SideBar $sidebar,
         \Step\Acceptance\DetailView $detailView,
-        \Step\Acceptance\Reports $reports,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Reports $reports
     ) {
         $I->wantTo('Delete Report from detail view');
 

--- a/tests/acceptance/modules/AOS_PDF_Templates/AOS_PDF_TemplatesCest.php
+++ b/tests/acceptance/modules/AOS_PDF_Templates/AOS_PDF_TemplatesCest.php
@@ -31,15 +31,13 @@ class AOS_PDF_TemplatesCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\PDFTemplates $pdfTemplates
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the pdfTemplates module.
      */
     public function testScenarioViewPDFTemplatesModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\PDFTemplates $pdfTemplates,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\PDFTemplates $pdfTemplates
     ) {
         $I->wantTo('View the pdfTemplates module for testing');
 
@@ -56,7 +54,6 @@ class AOS_PDF_TemplatesCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\PDFTemplates $pdfTemplate
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a PDF template so that I can test
      * the standard fields.
@@ -65,8 +62,7 @@ class AOS_PDF_TemplatesCest
         \AcceptanceTester $I,
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\PDFTemplates $pdfTemplate,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\PDFTemplates $pdfTemplate
     ) {
         $I->wantTo('Create a PDF Template');
 

--- a/tests/acceptance/modules/AOS_Product_Categories/AOS_Product_CategoriesCest.php
+++ b/tests/acceptance/modules/AOS_Product_Categories/AOS_Product_CategoriesCest.php
@@ -31,15 +31,13 @@ class AOS_Product_CategoriesCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\ProductCategories $productCategories
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the productCategories module.
      */
     public function testScenarioViewProductCategoriesModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\ProductCategories $productCategories,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\ProductCategories $productCategories
     ) {
         $I->wantTo('View the productCategories module for testing');
 
@@ -56,7 +54,6 @@ class AOS_Product_CategoriesCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\ProductCategories $productCategory
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a product category so that I can test
      * the standard fields.
@@ -65,8 +62,7 @@ class AOS_Product_CategoriesCest
         \AcceptanceTester $I,
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\ProductCategories $productCategory,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\ProductCategories $productCategory
     ) {
         $I->wantTo('Create a product category');
 

--- a/tests/acceptance/modules/AOS_Products/AOS_ProductsCest.php
+++ b/tests/acceptance/modules/AOS_Products/AOS_ProductsCest.php
@@ -31,15 +31,13 @@ class ProductsCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Products $products
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the products module.
      */
     public function testScenarioViewProductsModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Products $products,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Products $products
     ) {
         $I->wantTo('View the products module for testing');
 
@@ -56,7 +54,6 @@ class ProductsCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Products $product
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a product so that I can test
      * the standard fields.
@@ -65,8 +62,7 @@ class ProductsCest
         \AcceptanceTester $I,
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Products $product,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Products $product
     ) {
         $I->wantTo('Create a product');
 

--- a/tests/acceptance/modules/AOW_Workflow/AOW_WorkflowCest.php
+++ b/tests/acceptance/modules/AOW_Workflow/AOW_WorkflowCest.php
@@ -44,7 +44,6 @@ class AOW_WorkflowCest
     // tests
     public function testScenarioCreateWorkflow(
         AcceptanceTester $I,
-        \Helper\WebDriverHelper $webDriverHelper,
         \Step\Acceptance\NavigationBar $navigationBar,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\SideBar $sideBar,
@@ -112,7 +111,6 @@ class AOW_WorkflowCest
     // 
     // public function testScenarioDeleteWorkflow(
     //     AcceptanceTester $I,
-    //     \Helper\WebDriverHelper $webDriverHelper,
     //     \Step\Acceptance\NavigationBar $navigationBar,
     //     \Step\Acceptance\ListView $listView,
     //     \Step\Acceptance\SideBar $sideBar,

--- a/tests/acceptance/modules/Accounts/AccountsCest.php
+++ b/tests/acceptance/modules/Accounts/AccountsCest.php
@@ -31,15 +31,13 @@ class AccountsCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Accounts $accounts
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the accounts module.
      */
     public function testScenarioViewAccountsModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Accounts $accounts,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Accounts $accounts
     ) {
         $I->wantTo('View the accounts module for testing');
 
@@ -56,7 +54,6 @@ class AccountsCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Accounts $accounts
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a report with the reports module so that I can test
      * the standard fields.
@@ -65,8 +62,7 @@ class AccountsCest
         \AcceptanceTester $I,
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Accounts $accounts,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Accounts $accounts
     ) {
         $I->wantTo('Create an Account');
 
@@ -90,15 +86,13 @@ class AccountsCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Accounts $accounts
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to inline edit a field on the list-view
      */
     public function testScenarioInlineEditListView(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Accounts $accounts,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Accounts $accounts
     ) {
         $I->wantTo('Inline edit an account on the list-view');
 
@@ -126,8 +120,7 @@ class AccountsCest
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\EditView $editView,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Accounts $accounts,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Accounts $accounts
     ) {
         $I->wantTo('Create an Account');
 

--- a/tests/acceptance/modules/Activities/ActivitiesCest.php
+++ b/tests/acceptance/modules/Activities/ActivitiesCest.php
@@ -34,7 +34,6 @@ class ActivitiesCest
      * @param \Step\Acceptance\Accounts $accounts
      * @param \Step\Acceptance\Calls $calls
      * @param \Step\Acceptance\NavigationBar $NavigationBar
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As a user I want to see the due date on the activities module
      */
@@ -44,8 +43,7 @@ class ActivitiesCest
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\Accounts $accounts,
         \Step\Acceptance\Calls $calls,
-        \Step\Acceptance\NavigationBar $NavigationBar,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\NavigationBar $NavigationBar
     ) {
         $I->wantTo('See the due date field on Account Activities subpanel');
 

--- a/tests/acceptance/modules/Calendar/CalendarCest.php
+++ b/tests/acceptance/modules/Calendar/CalendarCest.php
@@ -30,14 +30,12 @@ class CalendarCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\Calendar $calendar
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the calendar module.
      */
     public function testScenarioViewCalendarModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\Calendar $calendar,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Calendar $calendar
     ) {
         $I->wantTo('View the calendar module for testing');
 

--- a/tests/acceptance/modules/Calls/CallsCest.php
+++ b/tests/acceptance/modules/Calls/CallsCest.php
@@ -29,15 +29,13 @@ class CallsCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Calls $calls
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the calls module.
      */
     public function testScenarioViewCallsModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Calls $calls,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Calls $calls
     ) {
         $I->wantTo('View the calls module for testing');
 
@@ -55,7 +53,6 @@ class CallsCest
      * @param \Step\Acceptance\NavigationBar $NavigationBar
      * @param \Step\Acceptance\Calls $calls
      * @param \Step\Acceptance\DetailView $detailView
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to verify the date field of a call
      */
@@ -64,8 +61,7 @@ class CallsCest
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\NavigationBar $NavigationBar,
         \Step\Acceptance\Calls $calls,
-        \Step\Acceptance\DetailView $detailView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\DetailView $detailView
     ) {
         $I->wantTo('Create a call');
 

--- a/tests/acceptance/modules/Campaigns/CampaignsCest.php
+++ b/tests/acceptance/modules/Campaigns/CampaignsCest.php
@@ -31,15 +31,13 @@ class CampaignsCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Campaigns $campaigns
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the campaigns module.
      */
     public function testScenarioViewCampaignsModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Campaigns $campaigns,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Campaigns $campaigns
     ) {
         $I->wantTo('View the campaigns module for testing');
 
@@ -56,7 +54,6 @@ class CampaignsCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Campaigns $campaign
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a non-emails campaign so that I can test
      * the standard fields.
@@ -65,8 +62,7 @@ class CampaignsCest
         \AcceptanceTester $I,
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Campaigns $campaign,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Campaigns $campaign
     ) {
         $I->wantTo('Create Non-Email Campaign');
 
@@ -100,8 +96,7 @@ class CampaignsCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Campaigns $campaign
      * @param \Step\Acceptance\InboundEmailTester $inboundEmailTester
-     * @param \Step\Acceptance\EmailMan $EmailManTester,
-     * @param \Helper\WebDriverHelper $webDriverHelper
+     * @param \Step\Acceptance\EmailMan $EmailManTester
      *
      * As administrative user I want to create a Newsletter campaign so that I can test
      * the standard fields.
@@ -112,8 +107,7 @@ class CampaignsCest
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\Campaigns $campaign,
         \Step\Acceptance\EmailManTester $EmailManTester,
-        \Step\Acceptance\InboundEmailTester $inboundEmailTester,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\InboundEmailTester $inboundEmailTester
     ) {
         $I->wantTo('Create Newsletter Campaign');
 

--- a/tests/acceptance/modules/Cases/CasesCest.php
+++ b/tests/acceptance/modules/Cases/CasesCest.php
@@ -31,15 +31,13 @@ class CasesCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Cases $cases
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the cases module.
      */
     public function testScenarioViewCasesModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Cases $cases,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Cases $cases
     ) {
         $I->wantTo('View the cases module for testing');
 
@@ -57,7 +55,6 @@ class CasesCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Cases $cases
      * @param \Step\Acceptance\Cases $account
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a case so that I can test
      * the standard fields.
@@ -67,8 +64,7 @@ class CasesCest
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\Cases $cases,
-        \Step\Acceptance\Accounts $account,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Accounts $account
     ) {
         $I->wantTo('Create a Case');
 

--- a/tests/acceptance/modules/Contacts/ContactsCest.php
+++ b/tests/acceptance/modules/Contacts/ContactsCest.php
@@ -31,15 +31,13 @@ class ContactsCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Contacts $contacts
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the contacts module.
      */
     public function testScenarioViewContactsModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Contacts $contacts,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Contacts $contacts
     ) {
         $I->wantTo('View the contacts module for testing');
 
@@ -56,7 +54,6 @@ class ContactsCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Contacts $contact
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a contact so that I can test
      * the standard fields.
@@ -65,8 +62,7 @@ class ContactsCest
         \AcceptanceTester $I,
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Contacts $contact,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Contacts $contact
     ) {
         $I->wantTo('Create a Contact');
 

--- a/tests/acceptance/modules/Contracts/ContractsCest.php
+++ b/tests/acceptance/modules/Contracts/ContractsCest.php
@@ -31,15 +31,13 @@ class ContractsCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Contracts $contracts
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the contracts module.
      */
     public function testScenarioViewContractsModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Contracts $contracts,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Contracts $contracts
     ) {
         $I->wantTo('View the contracts module for testing');
 
@@ -57,7 +55,6 @@ class ContractsCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Contracts $contract
      * @param \Step\Acceptance\Accounts $account
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a contract so that I can test
      * the standard fields.
@@ -67,8 +64,7 @@ class ContractsCest
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\Contracts $contract,
-        \Step\Acceptance\Accounts $account,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Accounts $account
     ) {
         $I->wantTo('Create a Contract');
 

--- a/tests/acceptance/modules/Documents/DocumentsCest.php
+++ b/tests/acceptance/modules/Documents/DocumentsCest.php
@@ -31,15 +31,13 @@ class DocumentsCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Documents $documents
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the documents module.
      */
     public function testScenarioViewDocumentsModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Documents $documents,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Documents $documents
     ) {
         $I->wantTo('View the documents module for testing');
 

--- a/tests/acceptance/modules/EmailMan/EmailManCest.php
+++ b/tests/acceptance/modules/EmailMan/EmailManCest.php
@@ -27,14 +27,12 @@ class EmailManCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\EmailManTester $emailMan
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to test outgoing mail configuration.
      */
     public function testScenarioAdminEmailSettings(
         \AcceptanceTester $I,
-        \Step\Acceptance\EmailManTester $emailMan,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\EmailManTester $emailMan
     ) {
         $I->wantTo('Save an outgoing email configuration');
 

--- a/tests/acceptance/modules/EmailTemplates/EmailTemplatesCest.php
+++ b/tests/acceptance/modules/EmailTemplates/EmailTemplatesCest.php
@@ -31,15 +31,13 @@ class EmailTemplatesCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\EmailTemplates $emailTemplate
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the emailTemplate module.
      */
     public function testScenarioViewEmailTemplatesModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\EmailTemplates $emailTemplate,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\EmailTemplates $emailTemplate
     ) {
         $I->wantTo('View the emailTemplate module for testing');
 

--- a/tests/acceptance/modules/Emails/EmailsCest.php
+++ b/tests/acceptance/modules/Emails/EmailsCest.php
@@ -36,15 +36,13 @@ class EmailsCest
      * @param AcceptanceTester $I
      * @param ListView $listView
      * @param EmailsTester $emails
-     * @param WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the emails module.
      */
     public function testScenarioViewEmailsModule(
         AcceptanceTester $I,
         ListView $listView,
-        EmailsTester $emails,
-        WebDriverHelper $webDriverHelper
+        EmailsTester $emails
     ) {
         $I->wantTo('View the emails module for testing');
 

--- a/tests/acceptance/modules/FP_Event_Locations/FP_Event_LocationsCest.php
+++ b/tests/acceptance/modules/FP_Event_Locations/FP_Event_LocationsCest.php
@@ -31,15 +31,13 @@ class LocationsCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Locations $locations
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the locations module.
      */
     public function testScenarioViewLocationsModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Locations $locations,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Locations $locations
     ) {
         $I->wantTo('View the locations module for testing');
 
@@ -56,7 +54,6 @@ class LocationsCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Locations $location
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a locations with the so that I can test
      * the standard fields.
@@ -65,8 +62,7 @@ class LocationsCest
         \AcceptanceTester $I,
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Locations $location,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Locations $location
     ) {
         $I->wantTo('Create a Location');
 

--- a/tests/acceptance/modules/FP_Events/FP_EventsCest.php
+++ b/tests/acceptance/modules/FP_Events/FP_EventsCest.php
@@ -31,15 +31,13 @@ class EventsCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Events $events
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the events module.
      */
     public function testScenarioViewEventsModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Events $events,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Events $events
     ) {
         $I->wantTo('View the events module for testing');
 
@@ -57,7 +55,6 @@ class EventsCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Events $event
      * @param \Step\Acceptance\Locations $location
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create an event so that I can test
      * the standard fields.
@@ -67,8 +64,7 @@ class EventsCest
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\Events $event,
-        \Step\Acceptance\Locations $location,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Locations $location
     ) {
         $I->wantTo('Create an Event');
 

--- a/tests/acceptance/modules/History/HistoryCest.php
+++ b/tests/acceptance/modules/History/HistoryCest.php
@@ -34,7 +34,6 @@ class HistoryCest
      * @param \Step\Acceptance\Accounts $accounts
      * @param \Step\Acceptance\Calls $calls
      * @param \Step\Acceptance\NavigationBar $NavigationBar
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As a user I want to see the due date on the activities module
      */
@@ -44,8 +43,7 @@ class HistoryCest
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\Accounts $accounts,
         \Step\Acceptance\Calls $calls,
-        \Step\Acceptance\NavigationBar $NavigationBar,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\NavigationBar $NavigationBar
     ) {
         $I->wantTo('See the due date field on Account History subpanel');
 

--- a/tests/acceptance/modules/Home/HomeCest.php
+++ b/tests/acceptance/modules/Home/HomeCest.php
@@ -31,15 +31,13 @@ class HomeCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\Dashboard $dashboard
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As a user I want to see a chart added to my dashboard
      */
     public function testCreateChartsDashlet(
         \AcceptanceTester $I,
         \Step\Acceptance\Dashboard $dashboard,
-        \Step\Acceptance\DetailView $detailView,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\DetailView $detailView
     ) {
         $I->wantTo('Create a chart dashlet on the dashboard');
 

--- a/tests/acceptance/modules/Invoices/InvoicesCest.php
+++ b/tests/acceptance/modules/Invoices/InvoicesCest.php
@@ -31,15 +31,13 @@ class InvoicesCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Invoices $invoices
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the invoices module.
      */
     public function testScenarioViewInvoicesModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Invoices $invoices,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Invoices $invoices
     ) {
         $I->wantTo('View the invoices module for testing');
 
@@ -56,7 +54,6 @@ class InvoicesCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Invoices $invoice
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create an invoice so that I can test
      * the standard fields.
@@ -65,8 +62,7 @@ class InvoicesCest
         \AcceptanceTester $I,
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Invoices $invoice,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Invoices $invoice
     ) {
         $I->wantTo('Create an Invoice');
 
@@ -91,7 +87,6 @@ class InvoicesCest
      * @param \Step\Acceptance\ListView $listView
      * @param \\Step\Acceptance\EditView $editView
      * @param \Step\Acceptance\Invoices $invoice
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create an invoice and check the number rounding
      */
@@ -100,8 +95,7 @@ class InvoicesCest
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\EditView $editView,
-        \Step\Acceptance\Invoices $invoice,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Invoices $invoice
     ) {
         $I->wantTo('Create an Invoice');
 

--- a/tests/acceptance/modules/Leads/LeadsCest.php
+++ b/tests/acceptance/modules/Leads/LeadsCest.php
@@ -31,15 +31,13 @@ class LeadsCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Leads $leads
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the leads module.
      */
     public function testScenarioViewLeadsModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Leads $leads,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Leads $leads
     ) {
         $I->wantTo('View the leads module for testing');
 
@@ -56,7 +54,6 @@ class LeadsCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Leads $lead
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a laed so that I can test
      * the standard fields.
@@ -65,8 +62,7 @@ class LeadsCest
         \AcceptanceTester $I,
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Leads $lead,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Leads $lead
     ) {
         $I->wantTo('Create a Lead');
 

--- a/tests/acceptance/modules/Meetings/MeetingsCest.php
+++ b/tests/acceptance/modules/Meetings/MeetingsCest.php
@@ -31,15 +31,13 @@ class MeetingsCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Meetings $meetings
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the meetings module.
      */
     public function testScenarioViewMeetingsModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Meetings $meetings,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Meetings $meetings
     ) {
         $I->wantTo('View the meetings module for testing');
 
@@ -56,7 +54,6 @@ class MeetingsCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Meetings $meeting
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a meeting so that I can test
      * the standard fields.
@@ -65,8 +62,7 @@ class MeetingsCest
         \AcceptanceTester $I,
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Meetings $meeting,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Meetings $meeting
     ) {
         $I->wantTo('Create a meeting');
 
@@ -90,7 +86,6 @@ class MeetingsCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Meetings $meeting
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to inline edit the start date
      */
@@ -98,8 +93,7 @@ class MeetingsCest
         \AcceptanceTester $I,
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Meetings $meeting,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Meetings $meeting
     ) {
         $I->wantTo('Create a meeting');
 

--- a/tests/acceptance/modules/Notes/NotesCest.php
+++ b/tests/acceptance/modules/Notes/NotesCest.php
@@ -31,15 +31,13 @@ class NotesCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Notes $notes
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the notes module.
      */
     public function testScenarioViewNotesModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Notes $notes,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Notes $notes
     ) {
         $I->wantTo('View the notes module for testing');
 

--- a/tests/acceptance/modules/Opportunities/OpportunitiesCest.php
+++ b/tests/acceptance/modules/Opportunities/OpportunitiesCest.php
@@ -31,15 +31,13 @@ class OpportunitiesCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Opportunities $opportunities
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the opportunities module.
      */
     public function testScenarioViewOpportunitiesModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Opportunities $opportunities,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Opportunities $opportunities
     ) {
         $I->wantTo('View the opportunities module for testing');
 
@@ -57,7 +55,6 @@ class OpportunitiesCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Opportunities $opportunities
      * @param \Step\Acceptance\Accounts $account
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create an opportunity so that I can test
      * the standard fields.
@@ -67,8 +64,7 @@ class OpportunitiesCest
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\Opportunities $opportunities,
-        \Step\Acceptance\Accounts $account,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Accounts $account
     ) {
         $I->wantTo('Create an opportunity');
 

--- a/tests/acceptance/modules/Projects/ProjectsCest.php
+++ b/tests/acceptance/modules/Projects/ProjectsCest.php
@@ -31,15 +31,13 @@ class ProjectsCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Projects $projects
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the projects module.
      */
     public function testScenarioViewProjectsModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Projects $projects,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Projects $projects
     ) {
         $I->wantTo('View the projects module for testing');
 
@@ -56,7 +54,6 @@ class ProjectsCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Projects $project
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a project so that I can test
      * the standard fields.
@@ -65,8 +62,7 @@ class ProjectsCest
         \AcceptanceTester $I,
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Projects $project,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Projects $project
     ) {
         $I->wantTo('Create a Project');
 

--- a/tests/acceptance/modules/Quotes/QuotesCest.php
+++ b/tests/acceptance/modules/Quotes/QuotesCest.php
@@ -31,15 +31,13 @@ class QuotesCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Quotes $quotes
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the quotes module.
      */
     public function testScenarioViewQuotesModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Quotes $quotes,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Quotes $quotes
     ) {
         $I->wantTo('View the quotes module for testing');
 

--- a/tests/acceptance/modules/Spots/SpotsCest.php
+++ b/tests/acceptance/modules/Spots/SpotsCest.php
@@ -31,15 +31,13 @@ class SpotsCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Spots $spots
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the spots module.
      */
     public function testScenarioViewSpotsModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Spots $spots,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Spots $spots
     ) {
         $I->wantTo('View the spots module for testing');
 

--- a/tests/acceptance/modules/Surveys/SurveysCest.php
+++ b/tests/acceptance/modules/Surveys/SurveysCest.php
@@ -31,15 +31,13 @@ class SurveysCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Surveys $surveys
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the surveys module.
      */
     public function testScenarioViewSurveysModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Surveys $surveys,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Surveys $surveys
     ) {
         $I->wantTo('View the surveys module for testing');
 

--- a/tests/acceptance/modules/TargetLists/TargetListsCest.php
+++ b/tests/acceptance/modules/TargetLists/TargetListsCest.php
@@ -31,15 +31,13 @@ class TargetListsCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\TargetList $targetList
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the targets module.
      */
     public function testScenarioViewTargetsModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\TargetList $targetList,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\TargetList $targetList
     ) {
         $I->wantTo('View the targets module for testing');
 

--- a/tests/acceptance/modules/Targets/TargetsCest.php
+++ b/tests/acceptance/modules/Targets/TargetsCest.php
@@ -31,15 +31,13 @@ class TargetsCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Targets $targets
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the targets module.
      */
     public function testScenarioViewTargetsModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Targets $targets,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Targets $targets
     ) {
         $I->wantTo('View the targets module for testing');
 

--- a/tests/acceptance/modules/Tasks/TasksCest.php
+++ b/tests/acceptance/modules/Tasks/TasksCest.php
@@ -31,15 +31,13 @@ class TasksCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Tasks $tasks
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the tasks module.
      */
     public function testScenarioViewTasksModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Tasks $tasks,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Tasks $tasks
     ) {
         $I->wantTo('View the tasks module for testing');
 

--- a/tests/acceptance/modules/Users/UsersCest.php
+++ b/tests/acceptance/modules/Users/UsersCest.php
@@ -2,7 +2,6 @@
 
 use Faker\Factory;
 use Faker\Generator;
-use Helper\WebDriverHelper;
 use Step\Acceptance\Accounts;
 use Step\Acceptance\DetailView;
 use Step\Acceptance\EditView;
@@ -34,7 +33,7 @@ class UsersCest
         $this->fakeData->seed($this->fakeDataSeed);
     }
     
-    public function testEmailSettingsMailAccountAdd(AcceptanceTester $I, UsersTester $Users, WebDriverHelper $webDriverHelper)
+    public function testEmailSettingsMailAccountAdd(AcceptanceTester $I, UsersTester $Users)
     {
         $I->loginAsAdmin();
         $Users->gotoProfile();
@@ -58,8 +57,7 @@ class UsersCest
         UsersTester $Users,
         ListView $listView,
         EditView $EditView,
-        Accounts $accounts,
-        WebDriverHelper $webDriverHelper
+        Accounts $accounts
     ) {
         $I->wantTo('View the collapsed subpanel hints on Accounts');
 

--- a/tests/acceptance/modules/jjwg_Address_Cache/jjwg_Address_CacheCest.php
+++ b/tests/acceptance/modules/jjwg_Address_Cache/jjwg_Address_CacheCest.php
@@ -31,15 +31,13 @@ class jjwg_Address_CacheCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\MapsAddressCache $mapsAddressCache
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the mapsAddressCache module.
      */
     public function testScenarioViewMapsAddressCacheModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\MapsAddressCache $mapsAddressCache,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\MapsAddressCache $mapsAddressCache
     ) {
         $I->wantTo('View the mapsAddressCache module for testing');
 
@@ -56,7 +54,6 @@ class jjwg_Address_CacheCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\MapsAddressCache $mapsAddressCache
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a maps address cache so that I can test
      * the standard fields.
@@ -65,8 +62,7 @@ class jjwg_Address_CacheCest
         \AcceptanceTester $I,
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\MapsAddressCache $mapsAddressCache,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\MapsAddressCache $mapsAddressCache
     ) {
         $I->wantTo('Create maps address cache');
 

--- a/tests/acceptance/modules/jjwg_Areas/jjwg_AreasCest.php
+++ b/tests/acceptance/modules/jjwg_Areas/jjwg_AreasCest.php
@@ -31,15 +31,13 @@ class jjwg_AreasCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\MapsAreas $mapsAreas
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the mapsAreas module.
      */
     public function testScenarioViewMapsAreasModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\MapsAreas $mapsAreas,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\MapsAreas $mapsAreas
     ) {
         $I->wantTo('View the mapsAreas module for testing');
         

--- a/tests/acceptance/modules/jjwg_Maps/jjwg_MapsCest.php
+++ b/tests/acceptance/modules/jjwg_Maps/jjwg_MapsCest.php
@@ -31,15 +31,13 @@ class jjwg_MapsCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Maps $maps
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the maps module.
      */
     public function testScenarioViewMapsModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Maps $maps,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Maps $maps
     ) {
         $I->wantTo('View the maps module for testing');
 
@@ -57,7 +55,6 @@ class jjwg_MapsCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Maps $map
      * @param \Step\Acceptance\Accounts $accounts
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a map so that I can test
      * the standard fields.
@@ -67,8 +64,7 @@ class jjwg_MapsCest
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\Maps $map,
-        \Step\Acceptance\Accounts $accounts,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\Accounts $accounts
     ) {
         $I->wantTo('Create a Map');
 

--- a/tests/acceptance/modules/jjwg_Markers/jjwg_MarkersCest.php
+++ b/tests/acceptance/modules/jjwg_Markers/jjwg_MarkersCest.php
@@ -31,15 +31,13 @@ class jjwg_MarkersCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\MapsMarkers $mapsMarkers
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As an administrator I want to view the mapsMarkers module.
      */
     public function testScenarioViewMapsMarkersModule(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\MapsMarkers $mapsMarkers,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\MapsMarkers $mapsMarkers
     ) {
         $I->wantTo('View the mapsMarkers module for testing');
 
@@ -56,7 +54,6 @@ class jjwg_MarkersCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\MapsMarkers $mapMarker
-     * @param \Helper\WebDriverHelper $webDriverHelper
      *
      * As administrative user I want to create a map marker so that I can test
      * the standard fields.
@@ -65,8 +62,7 @@ class jjwg_MarkersCest
         \AcceptanceTester $I,
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\MapsMarkers $mapMarker,
-        \Helper\WebDriverHelper $webDriverHelper
+        \Step\Acceptance\MapsMarkers $mapMarker
     ) {
         $I->wantTo('Create a Map Marker');
 


### PR DESCRIPTION
## Description
Throughout the acceptance test suite the webDriverHelper was unused. After #7418 removed repetitive URL visits throughout the test suite, it was no longer necessary in most cases.

This cleans all of those up.

## Motivation and Context
Getting rid of dead code.

## How To Test This
Make sure Travis CI passes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.