### PR TITLE
WIP: Try running the StateChecker in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,21 +5,18 @@ sudo: required
 matrix:
   fast_finish: true
   include:
-    - name: "PHP 5.5 / MySQL 5.6"
-      php: "5.5"
-      dist: trusty
-    - name: "PHP 5.6 / MySQL 5.6"
-      php: "5.6"
-      dist: trusty
-    - name: "PHP 7.0 / MySQL 5.7"
-      php: "7.0"
-      dist: xenial
-    - name: "PHP 7.1 / MySQL 5.7"
-      php: "7.1"
-      dist: xenial
-    - name: "PHP 7.2 / MySQL 5.7"
+    - name: "StateChecker PHPUnit"
       php: "7.2"
       dist: xenial
+      script:
+        - echo "using install wizard"
+        - ./vendor/bin/codecept run install --env travis-ci-hub -f --ext DotReporter
+        - ./build/push_output.sh
+        # Run the unit tests
+        - sudo chmod -R 777 .
+        - echo "\$sugar_config['developerMode'] = true;" >> config_override.php
+        - echo "\$sugar_config['state_checker']['test_state_check_mode'] = 2;" >> config_override.php
+        - ./vendor/bin/phpunit --colors --configuration ./tests/phpunit.xml.dist ./tests/unit/phpunit
     - name: "PHP 7.3 / MySQL 5.7"
       php: "7.3"
       dist: xenial


### PR DESCRIPTION
## Description
This is an attempt to run PHPUnit with the StateChecker enabled in CI, to make sure that the PHPUnit suite doesn't regress with state problems.

See #7445.

## Motivation and Context
Running the unit test suite with state checks enabled causes over 100 errors right now, many of them statechecker-related. This makes running the suite locally quite difficult.

I don't want to enable the StateChecker for every CI job, but having it enabled for just one should be sufficient to ensure we don't have state issues.

Right now, this PR removes most of the PHP versions we're testing to improve the speed of the feedback loop.

## How To Test This
See if Travis passes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.