### PR TITLE
FIXED #3756 - Popup Studio and Calendar don't auto-close

### DIFF
--- a/modules/ModuleBuilder/javascript/ModuleBuilder.js
+++ b/modules/ModuleBuilder/javascript/ModuleBuilder.js
@@ -658,10 +658,13 @@ if (typeof('console') == 'undefined') {
               title: SUGAR.language.get('ModuleBuilder', 'LBL_AJAX_RESPONSE_TITLE'),
               msg: SUGAR.language.get('ModuleBuilder', 'LBL_AJAX_RESPONSE_MESSAGE'),
               width: 500,
-              close: true
+              close: true,
+
             });
             ModuleBuilder.updateContent(o);
-          }
+            setTimeout(YAHOO.SUGAR.MessageBox.hide, 3000)
+
+          };
 
           onFailure = function (o) {
             YAHOO.SUGAR.MessageBox.hide();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When saving chaned labels in Studio, or when hovering over an event in the Calendar, a popup appears. This popup doesn't automatically disappear when expected.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://github.com/salesagility/SuiteCRM/issues/3756
## How To Test This
<!--- Please describe in detail how to test your changes. -->
Studio popups

1. Go to Labels of a module.
2. Make a change and click save.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->