### PR TITLE
Remove unnecessary test files

### DIFF
--- a/tests/_support/Step/Acceptance/Calendar.php
+++ b/tests/_support/Step/Acceptance/Calendar.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Step\Acceptance;
-
-class Calendar extends \AcceptanceTester
-{
-}

--- a/tests/_support/Step/Acceptance/Documents.php
+++ b/tests/_support/Step/Acceptance/Documents.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Step\Acceptance;
-
-class Documents extends \AcceptanceTester
-{
-}

--- a/tests/_support/Step/Acceptance/EmailTemplates.php
+++ b/tests/_support/Step/Acceptance/EmailTemplates.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Step\Acceptance;
-
-class EmailTemplates extends \AcceptanceTester
-{
-}

--- a/tests/_support/Step/Acceptance/EmailsTester.php
+++ b/tests/_support/Step/Acceptance/EmailsTester.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Step\Acceptance;
-
-class EmailsTester extends \AcceptanceTester
-{
-}

--- a/tests/_support/Step/Acceptance/MapsAreas.php
+++ b/tests/_support/Step/Acceptance/MapsAreas.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Step\Acceptance;
-
-class MapsAreas extends \AcceptanceTester
-{
-}

--- a/tests/_support/Step/Acceptance/Notes.php
+++ b/tests/_support/Step/Acceptance/Notes.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Step\Acceptance;
-
-class Notes extends \AcceptanceTester
-{
-}

--- a/tests/_support/Step/Acceptance/Quotes.php
+++ b/tests/_support/Step/Acceptance/Quotes.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Step\Acceptance;
-
-class Quotes extends \AcceptanceTester
-{
-}

--- a/tests/_support/Step/Acceptance/Spots.php
+++ b/tests/_support/Step/Acceptance/Spots.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Step\Acceptance;
-
-class Spots extends \AcceptanceTester
-{
-}

--- a/tests/_support/Step/Acceptance/Surveys.php
+++ b/tests/_support/Step/Acceptance/Surveys.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Step\Acceptance;
-
-class Surveys extends \AcceptanceTester
-{
-}

--- a/tests/_support/Step/Acceptance/TargetList.php
+++ b/tests/_support/Step/Acceptance/TargetList.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Step\Acceptance;
-
-class TargetList extends \AcceptanceTester
-{
-}

--- a/tests/_support/Step/Acceptance/Targets.php
+++ b/tests/_support/Step/Acceptance/Targets.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Step\Acceptance;
-
-class Targets extends \AcceptanceTester
-{
-}

--- a/tests/_support/Step/Acceptance/Tasks.php
+++ b/tests/_support/Step/Acceptance/Tasks.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Step\Acceptance;
-
-class Tasks extends \AcceptanceTester
-{
-}

--- a/tests/acceptance/modules/AM_Project_Templates/AM_Project_TemplatesCest.php
+++ b/tests/acceptance/modules/AM_Project_Templates/AM_Project_TemplatesCest.php
@@ -30,14 +30,12 @@ class AM_Project_TemplatesCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\ProjectTemplates $projectTemplates
      *
      * As an administrator I want to view the projectTemplates module.
      */
     public function testScenarioViewProjectTemplatesModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\ProjectTemplates $projectTemplates
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the projectTemplates module for testing');
         // Navigate to projectTemplates list-view

--- a/tests/acceptance/modules/AOK_KnowledgeBase/AOK_KnowledgeBaseCest.php
+++ b/tests/acceptance/modules/AOK_KnowledgeBase/AOK_KnowledgeBaseCest.php
@@ -30,14 +30,12 @@ class AOK_KnowledgeBaseCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\KnowledgeBase $knowledgeBase
      *
      * As an administrator I want to view the knowledgeBase module.
      */
     public function testScenarioViewKnowledgeBaseModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\KnowledgeBase $knowledgeBase
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the knowledgeBase module for testing');
 

--- a/tests/acceptance/modules/AOS_PDF_Templates/AOS_PDF_TemplatesCest.php
+++ b/tests/acceptance/modules/AOS_PDF_Templates/AOS_PDF_TemplatesCest.php
@@ -30,14 +30,12 @@ class AOS_PDF_TemplatesCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\PDFTemplates $pdfTemplates
      *
      * As an administrator I want to view the pdfTemplates module.
      */
     public function testScenarioViewPDFTemplatesModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\PDFTemplates $pdfTemplates
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the pdfTemplates module for testing');
 

--- a/tests/acceptance/modules/AOS_Product_Categories/AOS_Product_CategoriesCest.php
+++ b/tests/acceptance/modules/AOS_Product_Categories/AOS_Product_CategoriesCest.php
@@ -30,14 +30,12 @@ class AOS_Product_CategoriesCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\ProductCategories $productCategories
      *
      * As an administrator I want to view the productCategories module.
      */
     public function testScenarioViewProductCategoriesModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\ProductCategories $productCategories
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the productCategories module for testing');
 

--- a/tests/acceptance/modules/AOS_Products/AOS_ProductsCest.php
+++ b/tests/acceptance/modules/AOS_Products/AOS_ProductsCest.php
@@ -30,14 +30,12 @@ class ProductsCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Products $products
      *
      * As an administrator I want to view the products module.
      */
     public function testScenarioViewProductsModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Products $products
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the products module for testing');
 

--- a/tests/acceptance/modules/Accounts/AccountsCest.php
+++ b/tests/acceptance/modules/Accounts/AccountsCest.php
@@ -30,14 +30,12 @@ class AccountsCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Accounts $accounts
      *
      * As an administrator I want to view the accounts module.
      */
     public function testScenarioViewAccountsModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Accounts $accounts
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the accounts module for testing');
 

--- a/tests/acceptance/modules/Calendar/CalendarCest.php
+++ b/tests/acceptance/modules/Calendar/CalendarCest.php
@@ -29,13 +29,11 @@ class CalendarCest
 
     /**
      * @param \AcceptanceTester $I
-     * @param \Step\Acceptance\Calendar $calendar
      *
      * As an administrator I want to view the calendar module.
      */
     public function testScenarioViewCalendarModule(
-        \AcceptanceTester $I,
-        \Step\Acceptance\Calendar $calendar
+        \AcceptanceTester $I
     ) {
         $I->wantTo('View the calendar module for testing');
 

--- a/tests/acceptance/modules/Calls/CallsCest.php
+++ b/tests/acceptance/modules/Calls/CallsCest.php
@@ -28,14 +28,12 @@ class CallsCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Calls $calls
      *
      * As an administrator I want to view the calls module.
      */
     public function testScenarioViewCallsModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Calls $calls
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the calls module for testing');
 
@@ -50,7 +48,6 @@ class CallsCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\NavigationBar $NavigationBar
      * @param \Step\Acceptance\Calls $calls
      * @param \Step\Acceptance\DetailView $detailView
      *
@@ -59,7 +56,6 @@ class CallsCest
     public function testScenarioCallDate(
         \AcceptanceTester $I,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\NavigationBar $NavigationBar,
         \Step\Acceptance\Calls $calls,
         \Step\Acceptance\DetailView $detailView
     ) {

--- a/tests/acceptance/modules/Campaigns/CampaignsCest.php
+++ b/tests/acceptance/modules/Campaigns/CampaignsCest.php
@@ -30,14 +30,12 @@ class CampaignsCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Campaigns $campaigns
      *
      * As an administrator I want to view the campaigns module.
      */
     public function testScenarioViewCampaignsModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Campaigns $campaigns
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the campaigns module for testing');
 

--- a/tests/acceptance/modules/Cases/CasesCest.php
+++ b/tests/acceptance/modules/Cases/CasesCest.php
@@ -30,14 +30,12 @@ class CasesCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Cases $cases
      *
      * As an administrator I want to view the cases module.
      */
     public function testScenarioViewCasesModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Cases $cases
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the cases module for testing');
 

--- a/tests/acceptance/modules/Contacts/ContactsCest.php
+++ b/tests/acceptance/modules/Contacts/ContactsCest.php
@@ -30,14 +30,12 @@ class ContactsCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Contacts $contacts
      *
      * As an administrator I want to view the contacts module.
      */
     public function testScenarioViewContactsModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Contacts $contacts
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the contacts module for testing');
 

--- a/tests/acceptance/modules/Contracts/ContractsCest.php
+++ b/tests/acceptance/modules/Contracts/ContractsCest.php
@@ -30,14 +30,12 @@ class ContractsCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Contracts $contracts
      *
      * As an administrator I want to view the contracts module.
      */
     public function testScenarioViewContractsModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Contracts $contracts
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the contracts module for testing');
 

--- a/tests/acceptance/modules/Documents/DocumentsCest.php
+++ b/tests/acceptance/modules/Documents/DocumentsCest.php
@@ -30,14 +30,12 @@ class DocumentsCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Documents $documents
      *
      * As an administrator I want to view the documents module.
      */
     public function testScenarioViewDocumentsModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Documents $documents
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the documents module for testing');
 

--- a/tests/acceptance/modules/EmailTemplates/EmailTemplatesCest.php
+++ b/tests/acceptance/modules/EmailTemplates/EmailTemplatesCest.php
@@ -30,14 +30,12 @@ class EmailTemplatesCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\EmailTemplates $emailTemplate
      *
      * As an administrator I want to view the emailTemplate module.
      */
     public function testScenarioViewEmailTemplatesModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\EmailTemplates $emailTemplate
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the emailTemplate module for testing');
 

--- a/tests/acceptance/modules/Emails/EmailsCest.php
+++ b/tests/acceptance/modules/Emails/EmailsCest.php
@@ -35,14 +35,12 @@ class EmailsCest
     /**
      * @param AcceptanceTester $I
      * @param ListView $listView
-     * @param EmailsTester $emails
      *
      * As an administrator I want to view the emails module.
      */
     public function testScenarioViewEmailsModule(
         AcceptanceTester $I,
-        ListView $listView,
-        EmailsTester $emails
+        ListView $listView
     ) {
         $I->wantTo('View the emails module for testing');
 

--- a/tests/acceptance/modules/FP_Event_Locations/FP_Event_LocationsCest.php
+++ b/tests/acceptance/modules/FP_Event_Locations/FP_Event_LocationsCest.php
@@ -30,14 +30,12 @@ class LocationsCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Locations $locations
      *
      * As an administrator I want to view the locations module.
      */
     public function testScenarioViewLocationsModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Locations $locations
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the locations module for testing');
 

--- a/tests/acceptance/modules/FP_Events/FP_EventsCest.php
+++ b/tests/acceptance/modules/FP_Events/FP_EventsCest.php
@@ -30,14 +30,12 @@ class EventsCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Events $events
      *
      * As an administrator I want to view the events module.
      */
     public function testScenarioViewEventsModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Events $events
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the events module for testing');
 

--- a/tests/acceptance/modules/Invoices/InvoicesCest.php
+++ b/tests/acceptance/modules/Invoices/InvoicesCest.php
@@ -30,14 +30,12 @@ class InvoicesCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Invoices $invoices
      *
      * As an administrator I want to view the invoices module.
      */
     public function testScenarioViewInvoicesModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Invoices $invoices
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the invoices module for testing');
 

--- a/tests/acceptance/modules/Leads/LeadsCest.php
+++ b/tests/acceptance/modules/Leads/LeadsCest.php
@@ -30,14 +30,12 @@ class LeadsCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Leads $leads
      *
      * As an administrator I want to view the leads module.
      */
     public function testScenarioViewLeadsModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Leads $leads
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the leads module for testing');
 

--- a/tests/acceptance/modules/Meetings/MeetingsCest.php
+++ b/tests/acceptance/modules/Meetings/MeetingsCest.php
@@ -30,14 +30,12 @@ class MeetingsCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Meetings $meetings
      *
      * As an administrator I want to view the meetings module.
      */
     public function testScenarioViewMeetingsModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Meetings $meetings
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the meetings module for testing');
 

--- a/tests/acceptance/modules/Notes/NotesCest.php
+++ b/tests/acceptance/modules/Notes/NotesCest.php
@@ -30,14 +30,12 @@ class NotesCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Notes $notes
      *
      * As an administrator I want to view the notes module.
      */
     public function testScenarioViewNotesModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Notes $notes
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the notes module for testing');
 

--- a/tests/acceptance/modules/Opportunities/OpportunitiesCest.php
+++ b/tests/acceptance/modules/Opportunities/OpportunitiesCest.php
@@ -30,14 +30,12 @@ class OpportunitiesCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Opportunities $opportunities
      *
      * As an administrator I want to view the opportunities module.
      */
     public function testScenarioViewOpportunitiesModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Opportunities $opportunities
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the opportunities module for testing');
 

--- a/tests/acceptance/modules/Projects/ProjectsCest.php
+++ b/tests/acceptance/modules/Projects/ProjectsCest.php
@@ -30,14 +30,12 @@ class ProjectsCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Projects $projects
      *
      * As an administrator I want to view the projects module.
      */
     public function testScenarioViewProjectsModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Projects $projects
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the projects module for testing');
 

--- a/tests/acceptance/modules/Quotes/QuotesCest.php
+++ b/tests/acceptance/modules/Quotes/QuotesCest.php
@@ -30,14 +30,12 @@ class QuotesCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Quotes $quotes
      *
      * As an administrator I want to view the quotes module.
      */
     public function testScenarioViewQuotesModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Quotes $quotes
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the quotes module for testing');
 

--- a/tests/acceptance/modules/Spots/SpotsCest.php
+++ b/tests/acceptance/modules/Spots/SpotsCest.php
@@ -30,14 +30,12 @@ class SpotsCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Spots $spots
      *
      * As an administrator I want to view the spots module.
      */
     public function testScenarioViewSpotsModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Spots $spots
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the spots module for testing');
 

--- a/tests/acceptance/modules/Surveys/SurveysCest.php
+++ b/tests/acceptance/modules/Surveys/SurveysCest.php
@@ -30,14 +30,12 @@ class SurveysCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Surveys $surveys
      *
      * As an administrator I want to view the surveys module.
      */
     public function testScenarioViewSurveysModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Surveys $surveys
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the surveys module for testing');
 

--- a/tests/acceptance/modules/TargetLists/TargetListsCest.php
+++ b/tests/acceptance/modules/TargetLists/TargetListsCest.php
@@ -30,14 +30,12 @@ class TargetListsCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\TargetList $targetList
      *
      * As an administrator I want to view the targets module.
      */
     public function testScenarioViewTargetsModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\TargetList $targetList
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the targets module for testing');
 

--- a/tests/acceptance/modules/Targets/TargetsCest.php
+++ b/tests/acceptance/modules/Targets/TargetsCest.php
@@ -30,14 +30,12 @@ class TargetsCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Targets $targets
      *
      * As an administrator I want to view the targets module.
      */
     public function testScenarioViewTargetsModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Targets $targets
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the targets module for testing');
 

--- a/tests/acceptance/modules/Tasks/TasksCest.php
+++ b/tests/acceptance/modules/Tasks/TasksCest.php
@@ -30,14 +30,12 @@ class TasksCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Tasks $tasks
      *
      * As an administrator I want to view the tasks module.
      */
     public function testScenarioViewTasksModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Tasks $tasks
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the tasks module for testing');
 

--- a/tests/acceptance/modules/jjwg_Address_Cache/jjwg_Address_CacheCest.php
+++ b/tests/acceptance/modules/jjwg_Address_Cache/jjwg_Address_CacheCest.php
@@ -30,14 +30,12 @@ class jjwg_Address_CacheCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\MapsAddressCache $mapsAddressCache
      *
      * As an administrator I want to view the mapsAddressCache module.
      */
     public function testScenarioViewMapsAddressCacheModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\MapsAddressCache $mapsAddressCache
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the mapsAddressCache module for testing');
 

--- a/tests/acceptance/modules/jjwg_Areas/jjwg_AreasCest.php
+++ b/tests/acceptance/modules/jjwg_Areas/jjwg_AreasCest.php
@@ -30,14 +30,12 @@ class jjwg_AreasCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\MapsAreas $mapsAreas
      *
      * As an administrator I want to view the mapsAreas module.
      */
     public function testScenarioViewMapsAreasModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\MapsAreas $mapsAreas
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the mapsAreas module for testing');
         

--- a/tests/acceptance/modules/jjwg_Maps/jjwg_MapsCest.php
+++ b/tests/acceptance/modules/jjwg_Maps/jjwg_MapsCest.php
@@ -30,14 +30,12 @@ class jjwg_MapsCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Maps $maps
      *
      * As an administrator I want to view the maps module.
      */
     public function testScenarioViewMapsModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Maps $maps
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the maps module for testing');
 

--- a/tests/acceptance/modules/jjwg_Markers/jjwg_MarkersCest.php
+++ b/tests/acceptance/modules/jjwg_Markers/jjwg_MarkersCest.php
@@ -30,14 +30,12 @@ class jjwg_MarkersCest
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\MapsMarkers $mapsMarkers
      *
      * As an administrator I want to view the mapsMarkers module.
      */
     public function testScenarioViewMapsMarkersModule(
         \AcceptanceTester $I,
-        \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\MapsMarkers $mapsMarkers
+        \Step\Acceptance\ListView $listView
     ) {
         $I->wantTo('View the mapsMarkers module for testing');
 


### PR DESCRIPTION
## Description
A lot of these files only had methods like `gotoContacts`, which were removed in #7479 

This shouldn't be merged until after the #7477 PR is merged. It's built off that branch to prevent merge conflicts when the webdriverhelper changes are merged.

## Motivation and Context
This continues to clean up a lot of dead test code.

## How To Test This
Make sure Travis continues to pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
