### PR TITLE
Replace the createAccount method

### DIFF
--- a/tests/_support/Step/Acceptance/Accounts.php
+++ b/tests/_support/Step/Acceptance/Accounts.php
@@ -7,41 +7,24 @@ class Accounts extends \AcceptanceTester
     /**
      * Create an account
      *
-     * @param $name
+     * @param string $name
+     * @return string Account ID
      */
     public function createAccount($name)
     {
-        $I = new EditView($this->getScenario());
-        $DetailView = new DetailView($this->getScenario());
-        $Sidebar = new SideBar($this->getScenario());
-        $faker = $this->getFaker();
+        global $db;
+        $id = create_guid();
+        $accountType = 'Customer';
 
-        $I->see('Create Account', '.actionmenulink');
-        $Sidebar->clickSideBarAction('Create');
-        $I->waitForEditViewVisible();
-        $I->fillField('#name', $name);
-        $I->fillField('#phone_office', $faker->phoneNumber());
-        $I->fillField('#website', $faker->url());
-        $I->fillField('#phone_fax', $faker->phoneNumber());
-        $I->fillField('#Accounts0emailAddress0', $faker->email());
-        $I->fillField('#billing_address_street', $faker->streetAddress());
-        $I->fillField('#billing_address_city', $faker->city());
-        $I->fillField('#billing_address_state', $faker->city());
-        $I->fillField('#billing_address_postalcode', $faker->postcode());
-        $I->fillField('#billing_address_country', $faker->country());
-        $I->fillField('#description', $faker->text());
-        $I->fillField('#annual_revenue', $faker->randomDigit());
-        $I->fillField('#employees', $faker->randomDigit());
+        $query = "INSERT INTO accounts (id, name, account_type, date_entered) VALUES ('?', '?', '?', '?')";
 
-        $I->checkOption('#shipping_checkbox');
-        $I->selectOption('#account_type', 'Analyst');
-        $I->selectOption('#industry', 'Apparel');
+        $db->pQuery($query, array(
+            $id,
+            $name,
+            $accountType,
+            date('Y-m-d H:i:s')
+        ));
 
-        $I->seeElement('#assigned_user_name');
-        $I->seeElement('#parent_name');
-        $I->seeElement('#campaign_name');
-
-        $I->clickSaveButton();
-        $DetailView->waitForDetailViewVisible();
+        return $id;
     }
 }

--- a/tests/acceptance/_bootstrap.php
+++ b/tests/acceptance/_bootstrap.php
@@ -1,2 +1,13 @@
 <?php
 // Here you can initialize variables that will be available to your tests
+
+/* bootstrap composer's autoloader */
+require_once __DIR__ . '/../../vendor/autoload.php';
+global $sugar_config, $db;
+
+require_once __DIR__ . '/../../include/database/DBManagerFactory.php';
+
+require_once __DIR__ . '/../../include/utils.php';
+require_once __DIR__ .'/../../include/modules.php';
+require_once __DIR__ .'/../../include/entryPoint.php';
+$db = DBManagerFactory::getInstance();

--- a/tests/acceptance/modules/Accounts/AccountsCest.php
+++ b/tests/acceptance/modules/Accounts/AccountsCest.php
@@ -53,7 +53,8 @@ class AccountsCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\ListView $listView
-     * @param \Step\Acceptance\Accounts $accounts
+     * @param \Step\Acceptance\EditView $editView
+     * @param \Step\Acceptance\SideBar $sideBar
      *
      * As administrative user I want to create a report with the reports module so that I can test
      * the standard fields.
@@ -62,10 +63,10 @@ class AccountsCest
         \AcceptanceTester $I,
         \Step\Acceptance\DetailView $detailView,
         \Step\Acceptance\ListView $listView,
-        \Step\Acceptance\Accounts $accounts
+        \Step\Acceptance\EditView $editView,
+        \Step\Acceptance\SideBar $sideBar
     ) {
         $I->wantTo('Create an Account');
-
 
         // Navigate to accounts list-view
         $I->loginAsAdmin();
@@ -74,7 +75,35 @@ class AccountsCest
 
         // Create account
         $this->fakeData->seed($this->fakeDataSeed);
-        $accounts->createAccount('Test_'. $this->fakeData->company());
+        $faker = $I->getFaker();
+
+        $I->see('Create Account', '.actionmenulink');
+        $sideBar->clickSideBarAction('Create');
+        $editView->waitForEditViewVisible();
+        $I->fillField('#name', 'Test_' . $this->fakeData->company());
+        $I->fillField('#phone_office', $faker->phoneNumber());
+        $I->fillField('#website', $faker->url());
+        $I->fillField('#phone_fax', $faker->phoneNumber());
+        $I->fillField('#Accounts0emailAddress0', $faker->email());
+        $I->fillField('#billing_address_street', $faker->streetAddress());
+        $I->fillField('#billing_address_city', $faker->city());
+        $I->fillField('#billing_address_state', $faker->city());
+        $I->fillField('#billing_address_postalcode', $faker->postcode());
+        $I->fillField('#billing_address_country', $faker->country());
+        $I->fillField('#description', $faker->text());
+        $I->fillField('#annual_revenue', $faker->randomDigit());
+        $I->fillField('#employees', $faker->randomDigit());
+
+        $I->checkOption('#shipping_checkbox');
+        $I->selectOption('#account_type', 'Analyst');
+        $I->selectOption('#industry', 'Apparel');
+
+        $I->seeElement('#assigned_user_name');
+        $I->seeElement('#parent_name');
+        $I->seeElement('#campaign_name');
+
+        $editView->clickSaveButton();
+        $detailView->waitForDetailViewVisible();
 
         // Delete account
         $detailView->clickActionMenuItem('Delete');
@@ -122,7 +151,7 @@ class AccountsCest
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\Accounts $accounts
     ) {
-        $I->wantTo('Create an Account');
+        $I->wantTo('Create a child Account');
 
         // Navigate to accounts list-view
         $I->loginAsAdmin();
@@ -132,10 +161,13 @@ class AccountsCest
         // Create account
         $this->fakeData->seed($this->fakeDataSeed);
         $parentAccountName = 'Test_' . $this->fakeData->company();
-        $accounts->createAccount($parentAccountName);
+        $accountId = $accounts->createAccount($parentAccountName);
+
+        $I->visitPage('Accounts', 'DetailView', $accountId);
+        $detailView->waitForDetailViewVisible();
 
         // Click on Member Organizations subpanel
-        $I->click(['id' => 'subpanel_title_accounts']);
+        $I->click('#subpanel_title_accounts');
         $I->waitForElementVisible('#member_accounts_create_button');
 
         // Add child account

--- a/tests/acceptance/modules/Users/UsersCest.php
+++ b/tests/acceptance/modules/Users/UsersCest.php
@@ -85,7 +85,10 @@ class UsersCest
 
         // Create account
         $this->fakeData->seed($this->fakeDataSeed);
-        $accounts->createAccount('Test_'. $this->fakeData->company());
+        $accountId = $accounts->createAccount('Test_'. $this->fakeData->company());
+
+        $I->visitPage('Accounts', 'DetailView', $accountId);
+        $DetailView->waitForDetailViewVisible();
 
         // View the Subpanels Hint
         $I->see('Leads (0)', '//*[@id="subpanel_title_leads"]/div/div');


### PR DESCRIPTION
## Description
It now uses a database call instead of inputting values via a form.

This is based on how it's done in the API tests. It should make the tests faster.

## Motivation and Context
See #7484.

The contents of the `createAccount` method were moved to the AccountsCest file, where the accounts are created as part of a test. That's the only place this should be used.

## How To Test This
Make sure the tests continue to pass :)

Also, when this PR is merged it'll need a bit of work to be merged into hotfix, see https://github.com/salesagility/SuiteCRM/commit/30d2076bf0be6bde71814130719ccd3d4078d3b2. I'm pretty sure you can just take the changes I have here and apply them to AccountsTester.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.