### PR TITLE
Fixed #7267 - Database Failure after upgrading to Version 7.11.4

### DIFF
--- a/modules/Meetings/metadata/subpanels/ForHistory.php
+++ b/modules/Meetings/metadata/subpanels/ForHistory.php
@@ -111,12 +111,6 @@ $subpanel_layout = array(
             'vname' => 'LBL_LIST_DATE_ENTERED',
             'width' => '10%',
         ),
-           'date_end'=>array(
-            'vname' => 'LBL_LIST_DUE_DATE',
-            'width' => '10%',
-            'alias' => 'date_due',
-            'sort_by' => 'date_due'
-        ),
         'assigned_user_name' => array(
             'name' => 'assigned_user_name',
             'vname' => 'LBL_LIST_ASSIGNED_TO_NAME',

--- a/modules/Meetings/metadata/subpanels/ForHistory.php
+++ b/modules/Meetings/metadata/subpanels/ForHistory.php
@@ -111,6 +111,10 @@ $subpanel_layout = array(
             'vname' => 'LBL_LIST_DATE_ENTERED',
             'width' => '10%',
         ),
+        'date_due'=>array(
+            'vname' => 'LBL_LIST_DUE_DATE',
+            'width' => '10%',
+        ),
         'assigned_user_name' => array(
             'name' => 'assigned_user_name',
             'vname' => 'LBL_LIST_ASSIGNED_TO_NAME',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixed a database error with the history subpanel.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #7267 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create a lead.
2. Add a note to the history subpanel.
3. Add a task to the activities subpanel.
4. Edit the task and save. Upon redirection, you should be taken back to the lead detail-view and the due date of the task should be visible with no database errors.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->