### PR TITLE
 Fixed #6935 - Cookie path is not respected if globally set

### DIFF
--- a/include/MVC/SugarApplication.php
+++ b/include/MVC/SugarApplication.php
@@ -790,7 +790,7 @@ class SugarApplication
     $name,
         $value,
         $expire = 0,
-        $path = '/',
+        $path = null,
         $domain = null,
         $secure = false,
         $httponly = true

--- a/include/MVC/SugarApplication.php
+++ b/include/MVC/SugarApplication.php
@@ -785,9 +785,16 @@ class SugarApplication
     /**
      * Wrapper for the PHP setcookie() function, to handle cases where headers have
      * already been sent
+     * @param $name
+     * @param $value
+     * @param int $expire
+     * @param null $path
+     * @param null $domain
+     * @param bool $secure
+     * @param bool $httponly
      */
     public static function setCookie(
-    $name,
+        $name,
         $value,
         $expire = 0,
         $path = null,
@@ -795,10 +802,10 @@ class SugarApplication
         $secure = false,
         $httponly = true
     ) {
-        if(isSSL()){
-	        $secure = true;
+        if (isSSL()) {
+            $secure = true;
         }
-        if (is_null($domain)) {
+        if ($domain === null) {
             if (isset($_SERVER["HTTP_HOST"])) {
                 $domain = $_SERVER["HTTP_HOST"];
             } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixed an issue where the session path would be set to "/" and ignore changes made to session.cookie_path.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #6935

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Install suitecrm inside a folder (/alpha)
2. Add the following to .htaccess: ```php_value session.cookie_path /alpha```
3. Login and check path for cookies

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->