### PR TITLE
WIP: Fix flaky tests by adding default wait time to waitForText.

### DIFF
--- a/tests/_support/Step/Acceptance/ModuleBuilder.php
+++ b/tests/_support/Step/Acceptance/ModuleBuilder.php
@@ -126,7 +126,7 @@ class ModuleBuilder extends Administration
     {
         $I = $this;
         $I->waitForElementVisible('#sugarMsgWindow_mask');
-        $I->waitForText('This operation is completed successfully', null, '#sugarMsgWindow_c');
+        $I->waitForText('This operation is completed successfully', 10, '#sugarMsgWindow_c');
         $I->click('.container-close');
     }
 

--- a/tests/_support/Step/Acceptance/ModuleBuilder.php
+++ b/tests/_support/Step/Acceptance/ModuleBuilder.php
@@ -125,8 +125,9 @@ class ModuleBuilder extends Administration
     public function closePopupSuccess()
     {
         $I = $this;
-        # Wait the modal to hide itself.
-        $I->waitForElementNotVisible('#sugarMsgWindow_mask');
+        $I->waitForText('This operation is completed successfully', 10, '#sugarMsgWindow_c');
+        $I->waitForElementVisible('a.container-close');
+        $I->click('a.container-close');
     }
 
     /**

--- a/tests/_support/Step/Acceptance/ModuleBuilder.php
+++ b/tests/_support/Step/Acceptance/ModuleBuilder.php
@@ -125,10 +125,8 @@ class ModuleBuilder extends Administration
     public function closePopupSuccess()
     {
         $I = $this;
-        $I->waitForElementVisible('#sugarMsgWindow_mask');
-        $I->waitForText('This operation is completed successfully', 10, '#sugarMsgWindow_c');
-        $I->waitForElementVisible('.container-close');
-        $I->click('.container-close');
+        # Wait the modal to hide itself.
+        $I->waitForElementNotVisible('#sugarMsgWindow_mask');
     }
 
     /**

--- a/tests/_support/Step/Acceptance/ModuleBuilder.php
+++ b/tests/_support/Step/Acceptance/ModuleBuilder.php
@@ -127,6 +127,7 @@ class ModuleBuilder extends Administration
         $I = $this;
         $I->waitForElementVisible('#sugarMsgWindow_mask');
         $I->waitForText('This operation is completed successfully', 10, '#sugarMsgWindow_c');
+        $I->waitForElementVisible('.container-close');
         $I->click('.container-close');
     }
 


### PR DESCRIPTION
## Description
This prevents the method from failing when the text takes a few seconds to load. I thought setting the `timeout` argument to `null` would make it fallback to the default value, but apparently that isn't what happens, so it wasn't waiting at all before failing.

## Motivation and Context
It was causing flaky failures occasionally, e.g. https://travis-ci.org/salesagility/SuiteCRM/jobs/555959272

```
1) CompanyModuleCest: Create a company module for testing
 Test  tests/acceptance/Core/CompanyModuleCest.php:testScenarioCreateCompanyModule
                                                                                                                                         
  [Facebook\WebDriver\Exception\TimeOutException] Waited for 0 secs but text 'This operation is completed successfully' still not found  
                                                                                                                                         
Scenario Steps:
 34. $I->waitForText("This operation is completed ...",null,"#sugarMsgWindow_c") at tests/_support/Step/Acceptance/ModuleBuilder.php:129
 33. $I->waitForElementVisible("#sugarMsgWindow_mask") at tests/_support/Step/Acceptance/ModuleBuilder.php:128
 32. $I->click("Save") at tests/_support/Step/Acceptance/ModuleBuilder.php:70
 31. $I->wait(1) at tests/_support/Step/Acceptance/ModuleBuilder.php:69
 30. $I->click("#type_company") at tests/_support/Step/Acceptance/ModuleBuilder.php:53
 29. $I->checkOption("[name=importable]") at tests/_support/Step/Acceptance/ModuleBuilder.php:45
```

## How To Test This
Make sure Travis passes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.