### PR TITLE
Cleanup files created by acceptance tests between test runs

### DIFF
--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -18,4 +18,56 @@ class Acceptance extends \Codeception\Module
         }
         return true;
     }
+
+    public function _beforeSuite()
+    {
+        $directories = array(
+            "custom/modulebuilder/builds/CompanyTestModule",
+            "custom/modulebuilder/packages/CompanyTestModule",
+            "modules/Test_CompanyTestModule"
+        );
+        
+        foreach ($directories as $_index => $directory) {
+            if (is_dir($directory)) {
+                $this->getModule('Filesystem')->deleteDir($directory);
+            }
+        }
+
+        $files = array(
+            "custom/application/Ext/Include/modules.ext.php",
+            "custom/Extension/application/Ext/Include/CompanyTestModule.php"
+        );
+
+        foreach ($files as $_index => $file) {
+            if (file_exists($file)) {
+                unlink($file);
+            }
+        }
+    }
+
+    public function _afterSuite()
+    {
+        $directories = array(
+            "custom/modulebuilder/builds/CompanyTestModule/",
+            "custom/modulebuilder/packages/CompanyTestModule/",
+            "modules/Test_CompanyTestModule/"
+        );
+
+        foreach ($directories as $_index => $directory) {
+            if (is_dir($directory)) {
+                $this->getModule('Filesystem')->deleteDir($directory);
+            }
+        }
+
+        $files = array(
+            "custom/application/Ext/Include/modules.ext.php",
+            "custom/Extension/application/Ext/Include/CompanyTestModule.php"
+        );
+
+        foreach ($files as $_index => $file) {
+            if (file_exists($file)) {
+                unlink($file);
+            }
+        }
+    }
 }

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -21,36 +21,29 @@ class Acceptance extends \Codeception\Module
 
     public function _beforeSuite()
     {
-        $directories = array(
-            "custom/modulebuilder/builds/CompanyTestModule",
-            "custom/modulebuilder/packages/CompanyTestModule",
-            "modules/Test_CompanyTestModule"
-        );
-        
-        foreach ($directories as $_index => $directory) {
-            if (is_dir($directory)) {
-                $this->getModule('Filesystem')->deleteDir($directory);
-            }
-        }
-
-        $files = array(
-            "custom/application/Ext/Include/modules.ext.php",
-            "custom/Extension/application/Ext/Include/CompanyTestModule.php"
-        );
-
-        foreach ($files as $_index => $file) {
-            if (file_exists($file)) {
-                unlink($file);
-            }
-        }
+        $this->deleteModuleFiles('CompanyTestModule');
     }
 
     public function _afterSuite()
     {
+        $this->deleteModuleFiles('CompanyTestModule');
+    }
+
+    /**
+     * Deletes module files and directories created by the module builder.
+     * This allows the acceptance tests to be re-run.
+     * @param string $module
+     */
+    private function deleteModuleFiles($module) {
         $directories = array(
-            "custom/modulebuilder/builds/CompanyTestModule/",
-            "custom/modulebuilder/packages/CompanyTestModule/",
-            "modules/Test_CompanyTestModule/"
+            "custom/modulebuilder/builds/{$module}",
+            "custom/modulebuilder/packages/{$module}",
+            "modules/Test_{$module}"
+        );
+        
+        $files = array(
+            "custom/application/Ext/Include/modules.ext.php",
+            "custom/Extension/application/Ext/Include/{$module}.php"
         );
 
         foreach ($directories as $_index => $directory) {
@@ -58,11 +51,6 @@ class Acceptance extends \Codeception\Module
                 $this->getModule('Filesystem')->deleteDir($directory);
             }
         }
-
-        $files = array(
-            "custom/application/Ext/Include/modules.ext.php",
-            "custom/Extension/application/Ext/Include/CompanyTestModule.php"
-        );
 
         foreach ($files as $_index => $file) {
             if (file_exists($file)) {

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -19,14 +19,35 @@ class Acceptance extends \Codeception\Module
         return true;
     }
 
-    public function _beforeSuite()
+    // Clean up any files left behind by module builder tests.
+    // This needs to be run both before _and_ after to handle the case where
+    // the test run is cancelled or fails and the afterSuite() hook isn't run.
+    public function _beforeSuite($settings = array())
     {
-        $this->deleteModuleFiles('CompanyTestModule');
+        $this->deleteModulesHelper();
     }
 
+    // Clean up any files left behind by module builder tests.
     public function _afterSuite()
     {
-        $this->deleteModuleFiles('CompanyTestModule');
+        $this->deleteModulesHelper();
+    }
+
+    // Clean up any files left behind by module builder tests.
+    private function deleteModulesHelper() {
+        $modules = array(
+            'BasicTestModule',
+            'CompanyTestModule',
+            'FileTestModule',
+            'IssueTestModule',
+            'PersonTestModule',
+            'SaleTestModule',
+            'TestModuleFields'
+        );
+        
+        foreach ($modules as $module) {
+            $this->deleteModuleFiles($module);
+        }
     }
 
     /**


### PR DESCRIPTION
## Description
Fixes #7419! Now the acceptance tests can be run as many times as you want, without needing to worry about the files that are left behind by previous test runs.

This doesn't take very long, so it shouldn't add any noticeable runtime to the acceptance suite.

Unfortunately, there are still two files modified by the acceptance tests, which I didn't fix: `Api/Core/Config/ApiConfig.php` and `custom/modules/unified_search_modules_display.php`. The former is modified to include an `OAUTH2_ENCRYPTION_KEY` (can we make that an environment variable or something?) and the latter is just some spacing changes (should I just commit the changed version of this file so it doesn't get changed every time we run the tests?).

## Motivation and Context

This allows me to run the acceptance tests locally without worrying about the modules being left behind by a previous test run. We could also ignore the relevant directories if we want to, to prevent `git status` from returning ~130 files while the test suite is still running.

## How To Test This
Clone the repository locally, follow the automated testing instructions (latest docs are [here](https://github.com/salesagility/SuiteDocs/pull/300)), and run the acceptance tests locally to verify that the files are deleted before and after the tests are run. Make sure you can re-run the acceptance tests.

You might want to use something like `./vendor/bin/codecept run acceptance tests/acceptance/Core/CompanyModuleCest.php -vvv -d --env custom` (assuming you set up the custom.yml env) to run just some of the acceptance tests, instead of all of them.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.