### PR TITLE
Fix for issue #7537: Contract Renewall reminder Calls not shown in Calendar

### DIFF
--- a/modules/AOS_Contracts/AOS_Contracts.php
+++ b/modules/AOS_Contracts/AOS_Contracts.php
@@ -133,6 +133,9 @@ class AOS_Contracts extends AOS_Contracts_sugar
             $call->deleted = 0;
             $call->save();
             $this->call_id = $call->id;
+            $relate_values = array('user_id'=>$call->assigned_user_id,'call_id'=>$call->id);
+            $data_values = array('accept_status'=>'none');
+            $call->set_relationship($call->rel_users_table, $relate_values, true, true, $data_values);
         }
     }
 


### PR DESCRIPTION
Added code to Call reminder, to put entry into calls_users relation, so Reminder Call is visible in Calendar.

<!--- Provide a general summary of your changes in the Title above -->
New Call have to have entry in calls_users table.

## Description
<!--- Describe your changes in detail -->
After saving a call, relations table for this call is populated.

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fix for issue #7537
Renewal Remainder Calls are now visible in Calendar, after Contract creation.

## How To Test This
Create New Contract With renewal date.
Check Calendar for the Reneal date to see if the call is displayed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
