### PR TITLE
SugarWidgetSubPanelEmailLink: Fix missing opt-in ticks after inline editing

### DIFF
--- a/include/ListView/ListViewDisplay.php
+++ b/include/ListView/ListViewDisplay.php
@@ -488,13 +488,7 @@ class ListViewDisplay
         }
 
 
-        $userPref = $GLOBALS['current_user']->getPreference('email_link_type');
-        $defaultPref = $GLOBALS['sugar_config']['email_default_client'];
-        if ($userPref != '') {
-            $client = $userPref;
-        } else {
-            $client = $defaultPref;
-        }
+        $client = $GLOBALS['current_user']->getEmailClient();
 
         if ($client === 'sugar') {
             require_once 'modules/Emails/EmailUI.php';

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelEmailLink.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelEmailLink.php
@@ -54,7 +54,6 @@ class SugarWidgetSubPanelEmailLink extends SugarWidgetField
     public function displayList(&$layout_def)
     {
         global $current_user;
-        global $sugar_config;
         global $focus;
 
         if (isset($layout_def['varname'])) {
@@ -65,13 +64,7 @@ class SugarWidgetSubPanelEmailLink extends SugarWidgetField
         }
         $value = $layout_def['fields'][$key];
 
-        $userPref = $current_user->getPreference('email_link_type');
-        $defaultPref = $sugar_config['email_default_client'];
-        if ($userPref != '') {
-            $client = $userPref;
-        } else {
-            $client = $defaultPref;
-        }
+        $client = $current_user->getEmailClient();
 
         if ($client == 'sugar') {
             require_once('modules/Emails/EmailUI.php');

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelEmailLink.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelEmailLink.php
@@ -56,33 +56,19 @@ class SugarWidgetSubPanelEmailLink extends SugarWidgetField
         global $current_user;
         global $focus;
 
-        if (isset($layout_def['varname'])) {
-            $key = strtoupper($layout_def['varname']);
-        } else {
-            $key = $this->_get_column_alias($layout_def);
-            $key = strtoupper($key);
+        require_once('modules/Emails/EmailUI.php');
+        $emailUi = new EmailUI();
+        if ($focus !== null) {
+            return $emailUi->populateComposeViewFields($focus);
         }
-        $value = $layout_def['fields'][$key];
-
-        $client = $current_user->getEmailClient();
-
-        if ($client == 'sugar') {
-            require_once('modules/Emails/EmailUI.php');
-            $emailUi = new EmailUI();
-            if ($focus !== null) {
-                return $emailUi->populateComposeViewFields($focus);
-            }
-            if (!empty($layout_def['module']) && !empty($layout_def['fields']) && !empty($layout_def['fields']['ID'])) {
-                $bean = BeanFactory::getBean($layout_def['module'], $layout_def['fields']['ID']);
-                if (!empty($bean)) {
-                    return $emailUi->populateComposeViewFields($bean);
-                }
-            }
-            if ($current_user !== null) {
-                return $emailUi->populateComposeViewFields($current_user);
+        if (!empty($layout_def['module']) && !empty($layout_def['fields']) && !empty($layout_def['fields']['ID'])) {
+            $bean = BeanFactory::getBean($layout_def['module'], $layout_def['fields']['ID']);
+            if (!empty($bean)) {
+                return $emailUi->populateComposeViewFields($bean);
             }
         }
-
-        return '<a href="mailto:' . $value . '" >' . $value . '</a>';
+        if ($current_user !== null) {
+            return $emailUi->populateComposeViewFields($current_user);
+        }
     }
 }

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelTopComposeEmailButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelTopComposeEmailButton.php
@@ -61,18 +61,13 @@ class SugarWidgetSubPanelTopComposeEmailButton extends SugarWidgetSubPanelTopBut
             return $temp;
         }
 
-        global $app_strings, $current_user, $sugar_config;
+        global $app_strings, $current_user;
         $title = $app_strings['LBL_COMPOSE_EMAIL_BUTTON_TITLE'];
         $value = $app_strings['LBL_COMPOSE_EMAIL_BUTTON_LABEL'];
 
         //martin Bug 19660
-        $userPref = $current_user->getPreference('email_link_type');
-        $defaultPref = $sugar_config['email_default_client'];
-        if ($userPref != '') {
-            $client = $userPref;
-        } else {
-            $client = $defaultPref;
-        }
+        $client = $current_user->getEmailClient();
+
         /** @var Person|Company|Opportunity $bean */
         $bean = $defines['focus'];
 


### PR DESCRIPTION
## Description

**Note for reviewers: Both commits just remove unneeded code. The indentation changes make it look otherwise..**

The first commit replaces some code with the equivalent getEmailClient().

The second commit:

SugarWidgetSubPanelEmailLink uses a simple mailto link for the non-sugar client
case, but since #6486 EmailUI can create links for external email clients and also include
opt-in related ticks.

Remove the fallback case and let EmailUI handle it.

When inline editing an email field and then pressing enter the then shown link will now
include opt-in ticks when the external email client is used.

## Motivation and Context

Inline editing removes opt-in ticks while it shouldn't.

## How To Test This

* View a lead
* Inline edit the email
* Press enter
* The opt-in ticks should still be there

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.