### PR TITLE
Fix for issue: #7558 Contract Reminder Call get wrong parent_id

### DIFF
--- a/modules/AOS_Contracts/AOS_Contracts.php
+++ b/modules/AOS_Contracts/AOS_Contracts.php
@@ -104,6 +104,9 @@ class AOS_Contracts extends AOS_Contracts_sugar
      */
     public function createLink()
     {
+        LoggerManager::getLogger()->deprecated('AOS_Contracts->createLink is deprecated and will be 
+        removed in a future release');
+
         require_once('modules/Calls/Call.php');
         $call = new call();
 

--- a/modules/AOS_Contracts/AOS_Contracts.php
+++ b/modules/AOS_Contracts/AOS_Contracts.php
@@ -72,12 +72,14 @@ class AOS_Contracts extends AOS_Contracts_sugar
         self::__construct();
     }
 
+    /**
+     * @param bool $check_notify
+     * @return string
+     */
     public function save($check_notify = false)
     {
-        if (empty($this->id) || (isset($_POST['duplicateSave']) && $_POST['duplicateSave'] == 'true')) {
-            unset($_POST['group_id']);
-            unset($_POST['product_id']);
-            unset($_POST['service_id']);
+        if (empty($this->id) || (isset($_POST['duplicateSave']) && $_POST['duplicateSave'] === 'true')) {
+            unset($_POST['group_id'], $_POST['product_id'], $_POST['service_id']);
         }
 
         require_once('modules/AOS_Products_Quotes/AOS_Utils.php');
@@ -95,6 +97,30 @@ class AOS_Contracts extends AOS_Contracts_sugar
         }
 
         return $return_id;
+    }
+
+    /**
+     * @deprecated
+     */
+    public function createLink()
+    {
+        require_once('modules/Calls/Call.php');
+        $call = new call();
+
+        if ($this->renewal_reminder_date != 0) {
+            $call->id = $this->call_id;
+
+            if (!isset($this->contract_account_id)) {
+                LoggerManager::getLogger()->warn('Contract Account ID not defined for AOS Contracts / create link.');
+                $contractAccountId = null;
+            } else {
+                $contractAccountId = $this->contract_account_id;
+            }
+            $call->parent_id = $contractAccountId;
+            $call->parent_type = 'Accounts';
+            $call->reminder_time = 60;
+            $call->save();
+        }
     }
 
     public function mark_deleted($id)

--- a/modules/AOS_Contracts/AOS_Contracts.php
+++ b/modules/AOS_Contracts/AOS_Contracts.php
@@ -80,10 +80,6 @@ class AOS_Contracts extends AOS_Contracts_sugar
             unset($_POST['service_id']);
         }
 
-        if (isset($_POST['renewal_reminder_date']) && !empty($_POST['renewal_reminder_date'])) {
-            $this->createReminder();
-        }
-
         require_once('modules/AOS_Products_Quotes/AOS_Utils.php');
 
         perform_aos_save($this);
@@ -95,8 +91,9 @@ class AOS_Contracts extends AOS_Contracts_sugar
         $productQuoteGroup->save_groups($_POST, $this, 'group_');
 
         if (isset($_POST['renewal_reminder_date']) && !empty($_POST['renewal_reminder_date'])) {
-            $this->createLink();
+            $this->createReminder();
         }
+
         return $return_id;
     }
 
@@ -133,27 +130,6 @@ class AOS_Contracts extends AOS_Contracts_sugar
             $call->deleted = 0;
             $call->save();
             $this->call_id = $call->id;
-        }
-    }
-
-    public function createLink()
-    {
-        require_once('modules/Calls/Call.php');
-        $call = new call();
-
-        if ($this->renewal_reminder_date != 0) {
-            $call->id = $this->call_id;
-
-            if (!isset($this->contract_account_id)) {
-                LoggerManager::getLogger()->warn('Contract Account ID not defined for AOS Contracts / create link.');
-                $contractAccountId = null;
-            } else {
-                $contractAccountId = $this->contract_account_id;
-            }
-            $call->parent_id = $contractAccountId;
-            $call->parent_type = 'Accounts';
-            $call->reminder_time = 60;
-            $call->save();
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When Contract is created coresponding Reminder Call get AccountId as parent_id.
Wher Contract is edited, coresponding Reminder Call get ContractId as parent_id 

## Description
Relocated call 
  $this->createReminder(); 
below 
  $return_id = parent::save($check_notify);
since createReminder needs id of Contract to determine parent_id.

Also removed call to $this->createLink(); and removed function createLink, since it creates wrong parent for Call.


<!--- Describe your changes in detail -->
Issue: #7558

## Motivation and Context
Contract generated Reminder Calls should have consistent parent_id on creation and subsequent edit/saves.
parent_id should be Contract_id, as explained in the issue #7558

## How To Test This
- Create Contract with Reminder Date
- Check generated Reminder Call
- Call should have Contract as parent_it (related to)

- Edit Contract
- Save Contract
- Check generated Reminder Call
- Call should still have Contract as parent_id


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->