### PR TITLE
Add a get_current_language() helper function

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -3295,11 +3295,8 @@ class SugarBean
             $locale->translateCharsetMIME(trim($notify_name), 'UTF-8', $OBCharset)
         );
 
-        if (empty($_SESSION['authenticated_user_language'])) {
-            $current_language = $sugar_config['default_language'];
-        } else {
-            $current_language = $_SESSION['authenticated_user_language'];
-        }
+
+        $current_language = get_current_language();
         $xtpl = new XTemplate(get_notify_template_file($current_language));
         if ($this->module_dir == "Cases") {
             //we should use Case, you can refer to the en_us.notify_template.html.

--- a/include/MVC/SugarApplication.php
+++ b/include/MVC/SugarApplication.php
@@ -345,11 +345,7 @@ class SugarApplication
      */
     public static function preLoadLanguages()
     {
-        if (!empty($_SESSION['authenticated_user_language'])) {
-            $GLOBALS['current_language'] = $_SESSION['authenticated_user_language'];
-        } else {
-            $GLOBALS['current_language'] = $GLOBALS['sugar_config']['default_language'];
-        }
+        $GLOBALS['current_language'] = get_current_language();
         $GLOBALS['log']->debug('current_language is: ' . $GLOBALS['current_language']);
         //set module and application string arrays based upon selected language
         $GLOBALS['app_strings'] = return_application_language($GLOBALS['current_language']);
@@ -361,11 +357,7 @@ class SugarApplication
      */
     public function loadLanguages()
     {
-        if (!empty($_SESSION['authenticated_user_language'])) {
-            $GLOBALS['current_language'] = $_SESSION['authenticated_user_language'];
-        } else {
-            $GLOBALS['current_language'] = $GLOBALS['sugar_config']['default_language'];
-        }
+        $GLOBALS['current_language'] = get_current_language();
         $GLOBALS['log']->debug('current_language is: ' . $GLOBALS['current_language']);
         //set module and application string arrays based upon selected language
         $GLOBALS['app_strings'] = return_application_language($GLOBALS['current_language']);

--- a/include/utils.php
+++ b/include/utils.php
@@ -657,6 +657,22 @@ function get_language_display($key)
     return $sugar_config['languages'][$key];
 }
 
+/**
+ * Returns the currently active language string.
+ *
+ * @return string
+ */
+function get_current_language()
+{
+    global $sugar_config;
+
+    if (!empty($_SESSION['authenticated_user_language'])) {
+        return $_SESSION['authenticated_user_language'];
+    } else {
+        return $sugar_config['default_language'];
+    }
+}
+
 function get_assigned_user_name($assigned_user_id, $is_group = '')
 {
     static $saved_user_list = null;

--- a/modules/Activities/EmailReminder.php
+++ b/modules/Activities/EmailReminder.php
@@ -47,6 +47,7 @@ require_once("modules/Calls/Call.php");
 require_once("modules/Users/User.php");
 require_once("modules/Contacts/Contact.php");
 require_once("modules/Leads/Lead.php");
+require_once("include/utils.php");
 
 /**
  * Class for sending email reminders of meetings and call to invitees
@@ -129,11 +130,7 @@ class EmailReminder
      */
     public function sendReminders(SugarBean $bean, Administration $admin, $recipients)
     {
-        if (empty($_SESSION['authenticated_user_language'])) {
-            $current_language = $GLOBALS['sugar_config']['default_language'];
-        } else {
-            $current_language = $_SESSION['authenticated_user_language'];
-        }
+        $current_language = get_current_language();
 
         if (!empty($bean->created_by)) {
             $user_id = $bean->created_by;

--- a/modules/Emails/EmailUI.php
+++ b/modules/Emails/EmailUI.php
@@ -42,6 +42,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
+require_once("include/utils.php");
 require_once("include/ytree/Tree.php");
 require_once("include/ytree/ExtNode.php");
 require_once("include/SugarFolders/SugarFolders.php");
@@ -952,7 +953,7 @@ HTML;
             $this->smarty->assign("app_strings", $app_strings);
             $this->smarty->assign(
                 "contact_strings",
-                return_module_language($_SESSION['authenticated_user_language'], 'Contacts')
+                return_module_language(get_current_language(), 'Contacts')
             );
             $this->smarty->assign("contact", $contactMeta);
 

--- a/modules/Home/QuickSearch.php
+++ b/modules/Home/QuickSearch.php
@@ -41,6 +41,7 @@
 
 require_once('include/SugarObjects/templates/person/Person.php');
 require_once('include/MVC/SugarModule.php');
+require_once('include/utils.php');
 
 /**
  * quicksearchQuery class, handles AJAX calls from quicksearch.js
@@ -286,11 +287,7 @@ class quicksearchQuery
 
                     // get fields to match enum vals
                     if (empty($app_list_strings)) {
-                        if (isset($_SESSION['authenticated_user_language']) && $_SESSION['authenticated_user_language'] != '') {
-                            $current_language = $_SESSION['authenticated_user_language'];
-                        } else {
-                            $current_language = $sugar_config['default_language'];
-                        }
+                        $current_language = get_current_language();
                         $app_list_strings = return_app_list_strings_language($current_language);
                     }
 

--- a/modules/Home/sitemap.php
+++ b/modules/Home/sitemap.php
@@ -41,15 +41,12 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
+require_once("include/utils.php");
+
 $sm = sm_build_array();
 $sm_smarty = new Sugar_Smarty();
 
-global $sugar_config;
-if (isset($_SESSION['authenticated_user_language']) && $_SESSION['authenticated_user_language'] != '') {
-    $current_language = $_SESSION['authenticated_user_language'];
-} else {
-    $current_language = $sugar_config['default_language'];
-}
+$current_language = get_current_language();
 
 $mod_strings = return_module_language($current_language, 'Home');
 $sm_smarty->assign('CLOSE', isset($mod_strings['LBL_CLOSE_SITEMAP']) ? $mod_strings['LBL_CLOSE_SITEMAP'] : '');
@@ -87,7 +84,7 @@ function sm_build_array()
 
 
     include("include/modules.php");
-    global $sugar_config,$mod_strings;
+    global $mod_strings;
 
 
     // Need to set up mod_strings when we iterate through module menus.
@@ -95,11 +92,9 @@ function sm_build_array()
     if (!empty($mod_strings)) {
         $orig_modstrings = $mod_strings;
     }
-    if (isset($_SESSION['authenticated_user_language']) && $_SESSION['authenticated_user_language'] != '') {
-        $current_language = $_SESSION['authenticated_user_language'];
-    } else {
-        $current_language = $sugar_config['default_language'];
-    }
+
+    $current_language = get_current_language();
+
     $exclude= array();		// in case you want to exclude any.
     $mstr_array = array();
 

--- a/modules/Users/authentication/EmailAuthenticate/EmailAuthenticateUser.php
+++ b/modules/Users/authentication/EmailAuthenticate/EmailAuthenticateUser.php
@@ -129,11 +129,6 @@ class EmailAuthenticateUser extends SugarAuthenticateUser
         $notify_mail->CharSet = $sugar_config['default_charset'];
         $notify_mail->AddAddress(((!empty($row['email1']))?$row['email1']: $row['email2']), $locale->translateCharsetMIME(trim($row['first_name'] . ' ' . $row['last_name']), 'UTF-8', $OBCharset));
 
-        if (empty($_SESSION['authenticated_user_language'])) {
-            $current_language = $sugar_config['default_language'];
-        } else {
-            $current_language = $_SESSION['authenticated_user_language'];
-        }
         $notify_mail->Subject = 'Sugar Token';
         $notify_mail->Body = 'Your sugar session authentication token  is: ' . $password;
         $notify_mail->setMailerForSystem();

--- a/service/JsonRPCServer/JsonRPCServer.php
+++ b/service/JsonRPCServer/JsonRPCServer.php
@@ -45,6 +45,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
 
 require_once __DIR__ . '/../../soap/SoapHelperFunctions.php';
 require_once __DIR__ . '/../../include/json_config.php';
+require_once __DIR__ . '/../../include/utils.php';
 require_once __DIR__ . '/JsonRPCServerUtils.php';
 require_once __DIR__ . '/JsonRPCServerCalls.php';
 
@@ -99,11 +100,7 @@ class JsonRPCServer
         session_start();
         $log->debug('JSON_SERVER:session started');
 
-        if (isset($_SESSION['authenticated_user_language']) && $_SESSION['authenticated_user_language'] !== '') {
-            $current_language = $_SESSION['authenticated_user_language'];
-        } else {
-            $current_language = $sugar_config['default_language'];
-        }
+        $current_language = get_current_language();
 
         $log->debug('JSON_SERVER: current_language:' . $current_language);
 

--- a/service/JsonRPCServer/JsonRPCServerCalls.php
+++ b/service/JsonRPCServer/JsonRPCServerCalls.php
@@ -44,6 +44,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
 
 require_once __DIR__ . '/../../soap/SoapHelperFunctions.php';
 require_once __DIR__ . '/../../include/json_config.php';
+require_once __DIR__ . '/../../include/utils.php';
 require_once __DIR__ . '/JsonRPCServerUtils.php';
 
 /**
@@ -174,11 +175,7 @@ class JsonRPCServerCalls
 
                     // get fields to match enum vals
                     if (empty($app_list_strings)) {
-                        if (isset($_SESSION['authenticated_user_language']) && $_SESSION['authenticated_user_language'] !== '') {
-                            $current_language = $_SESSION['authenticated_user_language'];
-                        } else {
-                            $current_language = $sugar_config['default_language'];
-                        }
+                        $current_language = get_current_language();
                         $app_list_strings = return_app_list_strings_language($current_language);
                     }
 

--- a/tests/unit/phpunit/include/UtilsTest.php
+++ b/tests/unit/phpunit/include/UtilsTest.php
@@ -93,4 +93,29 @@ class UtilsTest extends StateCheckerPHPUnitTestCaseAbstract
         $this->assertEquals(array('foo'), unencodeMultienum('^foo^'));
         $this->assertEquals(array('foo', 'bar'), unencodeMultienum('^foo^,^bar^'));
     }
+
+    public function testget_languages()
+    {
+        $this->assertEquals(get_languages(), ['en_us' => 'English (US)']);
+        $this->assertEquals(get_all_languages(), ['en_us' => 'English (US)']);
+        $this->assertEquals(get_language_display('en_us'), 'English (US)');
+    }
+
+    public function testget_current_language()
+    {
+        global $sugar_config;
+        $state = new StateSaver();
+        $state->pushGlobals();
+
+        $_SESSION['authenticated_user_language'] = 'foo';
+        $this->assertEquals(get_current_language(), 'foo');
+        $this->assertEquals(get_current_language(), 'foo');
+
+        $sugar_config['default_language'] = 'bar';
+        $this->assertEquals(get_current_language(), 'foo');
+        unset($_SESSION['authenticated_user_language']);
+        $this->assertEquals(get_current_language(), 'bar');
+
+        $state->popGlobals();
+    }
 }

--- a/vCard.php
+++ b/vCard.php
@@ -43,13 +43,10 @@
 
 
 require_once('include/vCard.php');
+require_once('include/utils.php');
 
-if (isset($_SESSION['authenticated_user_language']) && $_SESSION['authenticated_user_language'] != '') {
-    $current_language = $_SESSION['authenticated_user_language'];
-} else {
-    $current_language = $sugar_config['default_language'];
-}
 
+$current_language = get_current_language();
 //set module and application string arrays based upon selected language
 $app_strings = return_application_language($current_language);
 $app_list_strings = return_app_list_strings_language($current_language);


### PR DESCRIPTION
## Description

This can be used instead of accessing the global "current_language" variable.

Replace various accesses to the "authenticated_user_language" session var
with a call to get_current_language().

Adds some basic unit tests.

## Motivation and Context

@gymad suggested not accessing the global "current_language" in another PR, so I looked into providing a function for this instead and found lots of duplicated code that could be replaced with it.

## How To Test This

Run the unit tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.