### PR TITLE
Add wait to HomeCest so it won't flake.

### DIFF
--- a/tests/acceptance/modules/Home/HomeCest.php
+++ b/tests/acceptance/modules/Home/HomeCest.php
@@ -46,6 +46,10 @@ class HomeCest
         $dashboard->waitForDashboardVisible();
         $detailView->clickActionMenuItem('Add Dashlets');
         $I->waitForElementVisible('#chartCategory');
+        # TODO: Replace with waitForElementClickable
+        # This wait is necessary right now because the chartCategory button isn't
+        # necessarily clickable immediately, which can cause flaky failures.
+        $I->wait(1);
         $I->click('#chartCategory');
         $I->waitForText('All Opportunities By Lead Source By Outcome');
         $I->click('All Opportunities By Lead Source By Outcome');


### PR DESCRIPTION
## Description
This wait is necessary right now because the chartCategory button isn't necessarily clickable immediately, which can cause flaky failures.

I previously tried fixing it with #7473, but that didn't fix the problem and it was pretty much just a guess since I didn't think I could reproduce the failures locally. This time, I ran the test repeatedly locally and was able to reproduce it somewhere around 1 in every 5 or so test runs.

With this change, I've run it 30 times now and I haven't seen it fail, so I'm fairly certain this fixes the problem.

You can see my description of the flaky test here: https://github.com/salesagility/SuiteCRM/issues/7272#issuecomment-505589148

## Motivation and Context
Solves a source of test flakiness that was really annoying me, since I kept hitting it on my PRs. I'd prefer to not use `wait()`s at all, but I don't really have a choice until we upgrade to a newer version of Codeception.

## How To Test This
Make sure Travis passes. Optionally, you can also run this test locally a few times to make sure it doesn't fail:

`./vendor/bin/codecept run acceptance tests/acceptance/modules/Home/HomeCest.php --env custom`

See the [automated testing](https://docs.suitecrm.com/developer/automatedtesting/) docs for setting the test suite up locally.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.