### PR TITLE
FIX issue #7567: Missing Contracts from selection of Related to: field

### DIFF
--- a/include/language/en_us.lang.php
+++ b/include/language/en_us.lang.php
@@ -447,6 +447,11 @@ $app_list_strings = array(
 
         'Tasks' => 'Task',
 
+        'AOS_Contracts' => 'Contract',
+        'AOS_Invoices' => 'Invoice',
+        'AOS_Quotes' => 'Quote',
+        'AOS_Products' => 'Product',
+
     ),
 
     'record_type_display_notes' => array(
@@ -465,6 +470,11 @@ $app_list_strings = array(
 
         'Meetings' => 'Meeting',
         'Calls' => 'Call',
+
+        'AOS_Contracts' => 'Contract',
+        'AOS_Invoices' => 'Invoice',
+        'AOS_Quotes' => 'Quote',
+        'AOS_Products' => 'Product',
     ),
 
     'parent_type_display' => array(
@@ -481,6 +491,11 @@ $app_list_strings = array(
         'ProjectTask' => 'Project Task',
 
         'Prospects' => 'Target',
+        
+        'AOS_Contracts' => 'Contract',
+        'AOS_Invoices' => 'Invoice',
+        'AOS_Quotes' => 'Quote',
+        'AOS_Products' => 'Product',        
 
     ),
     'parent_line_items' => array(


### PR DESCRIPTION
Added AOS modules in record_tpye_* drop downs. It is usefull, that at least Calls can have Contract/Quote/Invoice as parent.

<!--- Provide a general summary of your changes in the Title above -->
Added selection of AOS_ modules as related to: fields in en_US.lang.php

## Description
<!--- Describe your changes in detail -->
Added selection of AOS_ modules as related to: fields in en_US.lang.php

## Motivation and Context
To be able to select Contracts, etc in related to field in Activities (Calls, Meetings, ...)

## How To Test This
Crete Call. Select Contract as related to: field

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->