### PR TITLE
Fixed #4881 - Detail view of no imported email is different as imported + missing time unit + attachments

### DIFF
--- a/modules/Emails/metadata/detailviewdefs.php
+++ b/modules/Emails/metadata/detailviewdefs.php
@@ -141,15 +141,21 @@ $viewdefs[$module_name]['DetailView'] = array(
             array(
                 'parent_name'
             ),
-            array(
-                'date_entered' => array(
+            [
+                'date_entered' => [
                     'name' => 'date_entered',
+                    'customCode' => '{$fields.date_entered.value} {$APP.LBL_BY} {$fields.created_by_name.value}',
                     'label' => 'LBL_DATE_ENTERED',
-                )
-            ),
-            array(
+                ]
+            ],
+            'date_sent_received' => [
+                'name' => 'date_sent_received',
+                'vname' => 'date_sent_received',
+                'label' => 'LBL_DATE_SENT_RECEIVED',
+            ],
+            [
                 'category_id',
-            ),
+            ],
         )
     )
 );

--- a/modules/Emails/metadata/nonimporteddetailviewdefs.php
+++ b/modules/Emails/metadata/nonimporteddetailviewdefs.php
@@ -121,9 +121,10 @@ $viewdefs[$module_name]['DetailView'] = array(
                 ),
             ),
             array(
-                'date_entered' => array(
-                    'name' => 'date_entered',
-                    'label' => 'LBL_DATE_ENTERED',
+                'date_sent_received' => array(
+                    'name' => 'date_sent_received',
+                    'customCode' => '{$fields.date_entered.value} {$APP.LBL_BY} {$fields.created_by_name.value}',
+                    'label' => 'LBL_DATE_SENT_RECEIVED',
                 )
             )
         )

--- a/modules/Emails/metadata/nonimporteddetailviewdefs.php
+++ b/modules/Emails/metadata/nonimporteddetailviewdefs.php
@@ -120,13 +120,13 @@ $viewdefs[$module_name]['DetailView'] = array(
                     'label' => 'LBL_BODY'
                 ),
             ),
-            array(
-                'date_sent_received' => array(
+            [
+                'date_sent_received' => [
                     'name' => 'date_sent_received',
-                    'customCode' => '{$fields.date_entered.value} {$APP.LBL_BY} {$fields.created_by_name.value}',
+                    'customCode' => '{$fields.date_entered.value}',
                     'label' => 'LBL_DATE_SENT_RECEIVED',
-                )
-            )
+                ]
+            ]
         )
     )
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Unified the imported and non-imported email detail-views:

- Added Date Sent/Received to non-imported and imported emails.
- Fixed the date_entered on imported emails.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #6973 
Issue reference: #4881 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Check the detail-view of imported and non-imported emails.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->