### PR TITLE
export: Update export_excel_compatible to work with all Excel versions

### DIFF
--- a/export.php
+++ b/export.php
@@ -47,7 +47,6 @@ ini_set('zlib.output_compression', 'Off');
 ob_start();
 require_once('include/export_utils.php');
 global $sugar_config;
-global $locale;
 global $current_user;
 global $app_list_strings;
 
@@ -74,28 +73,12 @@ if (!empty($app_list_strings['moduleList'][$_REQUEST['module']])) {
     $filename = $app_list_strings['moduleList'][$_REQUEST['module']];
 }
 
-//strip away any blank spaces
-$filename = str_replace(' ', '', $filename);
-
-$transContent = $GLOBALS['locale']->translateCharset($content, 'UTF-8', $GLOBALS['locale']->getExportCharset());
-
 if (!empty($_REQUEST['members'])) {
     $filename .= '_'.'members';
 }
 ///////////////////////////////////////////////////////////////////////////////
 ////	BUILD THE EXPORT FILE
-ob_clean();
-header("Pragma: cache");
-header("Content-type: application/octet-stream; charset=".$GLOBALS['locale']->getExportCharset());
-header("Content-Disposition: attachment; filename={$filename}.csv");
-header("Content-transfer-encoding: binary");
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: " . TimeDate::httpTime());
-header("Cache-Control: post-check=0, pre-check=0", false);
-if (!empty($sugar_config['export_excel_compatible'])) {
-    $transContent=chr(255) . chr(254) . mb_convert_encoding($transContent, 'UTF-16LE', 'UTF-8');
-}
-header("Content-Length: ".mb_strlen($transContent, '8bit'));
-print $transContent;
 
+ob_clean();
+printCSV($content, $filename);
 sugar_cleanup(true);

--- a/include/Localization/Localization.php
+++ b/include/Localization/Localization.php
@@ -403,6 +403,26 @@ class Localization
     }
 
     /**
+     * Prefixes the input with a BOM.
+     *
+     * @param string $string The string to add a BOM to
+     * @param string $fromCharset The charset of the input string
+     * @return string The input string including a BOM
+     * @throws UnexpectedValueException in case the encoding isn't supported
+     */
+    public function addBOM($string, $fromCharset) {
+        $charset  = $this->normalizeCharset($fromCharset);
+        if ($charset === 'utf8') {
+            return "\xef\xbb\xbf" . $string;
+        } else if ($charset === 'utf16le') {
+            return "\xff\xfe" . $string;
+        } else if ($charset === 'utf16be') {
+            return "\xfe\xff" . $string;
+        }
+        throw new UnexpectedValueException('Encoding not supported: ' . $fromCharset);
+    }
+
+    /**
      * translates a character set from one to another, and the into MIME-header friendly format
      */
     public function translateCharsetMIME($string, $fromCharset, $toCharset='UTF-8', $encoding="Q")

--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -1157,22 +1157,8 @@ class AOR_Report extends Basic
             $csv = substr($csv, 0, strlen($csv) - strlen($delimiter));
         }
 
-        $csv = $GLOBALS['locale']->translateCharset($csv, 'UTF-8', $GLOBALS['locale']->getExportCharset());
-
         ob_clean();
-        header("Pragma: cache");
-        header("Content-type: text/comma-separated-values; charset=" . $GLOBALS['locale']->getExportCharset());
-        header("Content-Disposition: attachment; filename=\"{$this->name}.csv\"");
-        header("Content-transfer-encoding: binary");
-        header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-        header("Last-Modified: " . TimeDate::httpTime());
-        header("Cache-Control: post-check=0, pre-check=0", false);
-        header("Content-Length: " . mb_strlen($csv, '8bit'));
-        if (!empty($sugar_config['export_excel_compatible'])) {
-            $csv = chr(255) . chr(254) . mb_convert_encoding($csv, 'UTF-16LE', 'UTF-8');
-        }
-        print $csv;
-
+        printCSV($csv, $this->name);
         sugar_cleanup(true);
     }
 

--- a/tests/unit/phpunit/include/Localization/LocalizationTest.php
+++ b/tests/unit/phpunit/include/Localization/LocalizationTest.php
@@ -1,0 +1,20 @@
+<?php
+
+require_once ('include/Localization/Localization.php');
+
+class LocalizationTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
+{
+    public function testaddBOM()
+    {
+        $local = new Localization();
+        $utf8 = 'foo';
+        $this->assertEquals("\xef\xbb\xbf" . 'foo', $local->addBOM($utf8, 'UTF-8'));
+        $utf16le = $local->translateCharset($utf8, 'UTF-8', 'UTF-16LE');
+        $this->assertEquals("\xFF\xFE" . $utf16le, $local->addBOM($utf16le, 'UTF-16LE'));
+        $utf16be = $local->translateCharset($utf8, 'UTF-16LE', 'UTF-16BE');
+        $this->assertEquals("\xFE\xFF" . $utf16be, $local->addBOM($utf16be, 'UTF-16BE'));
+
+        $this->setExpectedException('UnexpectedValueException');
+        $local->addBOM('foobar', 'ASCII');
+    }
+}


### PR DESCRIPTION
## Description

Excel on Windows/macOS when simply opening a CSV file will try to guess the
CSV dialect (encoding, delimiter, etc) and just go with the first guess.
It's still possible to do an explicit import with Excel where you can select the
dialect, but that's not very obvious.

The most common wrong guess is that mostly ASCII utf-8 will get detected as latin-1.

I've tested various encodings with Excel (2019) and codepoints from latin-1:

* utf-8: win/macOS use latin-1
* utf-8+bom: win/macOS correctly use utf-8
* utf-16le: win uses utf-16le, macOS garbled text
* utf-16le+bom: win/macOS fail to detect CSV and load it as one text block

thus utf-8+bom is the preferred mode.

This patch makes the "export_excel_compatible" mode use utf-8+bom for the CSV encoding.

In addition this removes the hardcoded delimiter in export_excel_compatible mode, because excel
uses the Windows user list separator for this and there is no way of knowing it (except in javascript maybe)
and so we better leave this setting up to the user.

## Motivation and Context

I'd like to have exported CSV files work as is in Excel on Windows and macOS (and LibreOffice, but that just works anyway)

## How To Test This

* Set export_excel_compatible to true
* Export a report or a list selection and open it in Excel

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
