### PR TITLE
FIXED #7209 - Inline Edit alert Even if I dont make a change.

### DIFF
--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -323,7 +323,7 @@ $(document).on('click', function (e) {
                     date_compare = true;
                 }
             } else {
-                output_value_compare = $(output_value).text();
+                output_value_compare = output_value;
             }
             if (user_value != output_value_compare) {
                 message_field = message_field != 'undefined' ? message_field : '';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When you edit inline a fields, click outside the field you get an alert. This is cool and good, but even if I dont make any change to the fields I get the alert.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://github.com/salesagility/SuiteCRM/issues/7209

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Inline edit a field.
2. Click outside the field.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->