### PR TITLE
Remove lastView variables from tests.

### DIFF
--- a/tests/acceptance/Core/BasicModuleCest.php
+++ b/tests/acceptance/Core/BasicModuleCest.php
@@ -5,12 +5,6 @@ use Faker\Generator;
 class BasicModuleCest
 {
     /**
-     * @var string $lastView helps the test skip some repeated tests in order to make the test framework run faster at the
-     * potential cost of being accurate and reliable
-     */
-    protected $lastView;
-
-    /**
      * @var Generator $fakeData
      */
     protected $fakeData;
@@ -64,7 +58,6 @@ class BasicModuleCest
         );
 
         $repair->clickQuickRepairAndRebuild();
-        $this->lastView = 'ModuleBuilder';
     }
 
     /**
@@ -88,7 +81,6 @@ class BasicModuleCest
         $navigationBar->clickAllMenuItem(\Page\BasicModule::$NAME);
 
         $listView->waitForListViewVisible();
-        $this->lastView = 'ListView';
     }
 
     /**
@@ -125,7 +117,6 @@ class BasicModuleCest
         $editView->fillField('#description', $this->fakeData->paragraph);
         $editView->clickSaveButton();
         $detailView->waitForDetailViewVisible();
-        $this->lastView = 'DetailView';
     }
 
     /**
@@ -160,7 +151,6 @@ class BasicModuleCest
         $this->fakeData->seed($this->fakeDataSeed);
         $listView->clickNameLink($this->fakeData->name);
         $detailView->waitForDetailViewVisible();
-        $this->lastView = 'DetailView';
     }
 
     /**
@@ -204,7 +194,6 @@ class BasicModuleCest
         $editView->click('Save');
 
         $detailView->waitForDetailViewVisible();
-        $this->lastView = 'DetailView';
     }
 
     /**
@@ -255,7 +244,6 @@ class BasicModuleCest
         $detailView->acceptPopup();
 
         $listView->waitForListViewVisible();
-        $this->lastView = 'ListView';
     }
 
     /**
@@ -295,6 +283,5 @@ class BasicModuleCest
         $detailView->acceptPopup();
 
         $listView->waitForListViewVisible();
-        $this->lastView = 'ListView';
     }
 }

--- a/tests/acceptance/Core/CompanyModuleCest.php
+++ b/tests/acceptance/Core/CompanyModuleCest.php
@@ -5,12 +5,6 @@ use Faker\Generator;
 class CompanyModuleCest
 {
     /**
-     * @var string $lastView helps the test skip some repeated tests in order to make the test framework run faster at the
-     * potential cost of being accurate and reliable
-     */
-    protected $lastView;
-
-    /**
      * @var Generator $fakeData
      */
     protected $fakeData;
@@ -63,8 +57,6 @@ class CompanyModuleCest
             \Page\CompanyModule::$NAME,
             \SuiteCRM\Enumerator\SugarObjectType::company
         );
-
-        $this->lastView = 'ModuleBuilder';
     }
 
     /**
@@ -88,7 +80,6 @@ class CompanyModuleCest
         $navigationBar->clickAllMenuItem(\Page\CompanyModule::$NAME);
 
         $listView->waitForListViewVisible();
-        $this->lastView = 'ListView';
     }
 
     /**
@@ -141,7 +132,6 @@ class CompanyModuleCest
         $editView->fillField('#description', $this->fakeData->paragraph);
         $editView->clickSaveButton();
         $detailView->waitForDetailViewVisible();
-        $this->lastView = 'DetailView';
     }
 
     /**
@@ -178,7 +168,6 @@ class CompanyModuleCest
         $listView->clickNameLink($this->fakeData->company);
 
         $detailView->waitForDetailViewVisible();
-        $this->lastView = 'DetailView';
     }
 
     /**
@@ -223,7 +212,6 @@ class CompanyModuleCest
         $editView->click('Save');
 
         $detailView->waitForDetailViewVisible();
-        $this->lastView = 'DetailView';
     }
 
     /**
@@ -275,7 +263,6 @@ class CompanyModuleCest
         $detailView->acceptPopup();
 
         $listView->waitForListViewVisible();
-        $this->lastView = 'ListView';
     }
 
     /**
@@ -317,6 +304,5 @@ class CompanyModuleCest
         $detailView->acceptPopup();
 
         $listView->waitForListViewVisible();
-        $this->lastView = 'ListView';
     }
 }

--- a/tests/acceptance/Core/FileModuleCest.php
+++ b/tests/acceptance/Core/FileModuleCest.php
@@ -5,12 +5,6 @@ use Faker\Generator;
 class FileModuleCest
 {
     /**
-     * @var string $lastView helps the test skip some repeated tests in order to make the test framework run faster at the
-     * potential cost of being accurate and reliable
-     */
-    protected $lastView;
-
-    /**
      * @var Generator $fakeData
      */
     protected $fakeData;
@@ -61,8 +55,6 @@ class FileModuleCest
             \Page\FileModule::$NAME,
             \SuiteCRM\Enumerator\SugarObjectType::file
         );
-
-        $this->lastView = 'ModuleBuilder';
     }
 
     /**
@@ -85,7 +77,6 @@ class FileModuleCest
         $navigationBar->clickAllMenuItem(\Page\FileModule::$NAME);
 
         $listView->waitForListViewVisible();
-        $this->lastView = 'ListView';
     }
 
     /**
@@ -128,7 +119,6 @@ class FileModuleCest
         // TODO: other fields
         $editView->clickSaveButton();
         $detailview->waitForDetailViewVisible();
-        $this->lastView = 'DetailView';
         $detailview->see($fileName, '#uploadfile');
         
         $I->deleteFile($fileDir.$fileName);
@@ -167,7 +157,6 @@ class FileModuleCest
         $this->fakeData->seed($this->fakeDataSeed);
         $listView->clickNameLink($this->fakeData->lastName . '.test.txt');
         $detailView->waitForDetailViewVisible();
-        $this->lastView = 'DetailView';
     }
 
     /**
@@ -209,7 +198,6 @@ class FileModuleCest
         $editView->click('Save');
 
         $detailView->waitForDetailViewVisible();
-        $this->lastView = 'DetailView';
     }
 
     /**
@@ -259,7 +247,6 @@ class FileModuleCest
         $detailView->acceptPopup();
 
         $listView->waitForListViewVisible();
-        $this->lastView = 'ListView';
     }
 
     /**
@@ -297,6 +284,5 @@ class FileModuleCest
         $detailView->acceptPopup();
 
         $listView->waitForListViewVisible();
-        $this->lastView = 'ListView';
     }
 }

--- a/tests/acceptance/Core/IssueModuleCest.php
+++ b/tests/acceptance/Core/IssueModuleCest.php
@@ -4,13 +4,6 @@ use Faker\Generator;
 
 class IssueModuleCest
 {
-
-    /**
-     * @var string $lastView helps the test skip some repeated tests in order to make the test framework run faster at the
-     * potential cost of being accurate and reliable
-     */
-    protected $lastView;
-
     /**
      * @var Generator $fakeData
      */
@@ -61,8 +54,6 @@ class IssueModuleCest
             \Page\IssueModule::$NAME,
             \SuiteCRM\Enumerator\SugarObjectType::issue
         );
-
-        $this->lastView = 'ModuleBuilder';
     }
 
     /**
@@ -85,7 +76,6 @@ class IssueModuleCest
         $navigationBar->clickAllMenuItem(\Page\IssueModule::$NAME);
 
         $listView->waitForListViewVisible();
-        $this->lastView = 'ListView';
     }
 
     /**
@@ -122,7 +112,6 @@ class IssueModuleCest
         $editView->fillField('#description', $this->fakeData->paragraph);
         $editView->clickSaveButton();
         $detailView->waitForDetailViewVisible();
-        $this->lastView = 'DetailView';
     }
 
     /**
@@ -156,7 +145,6 @@ class IssueModuleCest
         $this->fakeData->seed($this->fakeDataSeed);
         $listView->clickNameLink($this->fakeData->name);
         $detailView->waitForDetailViewVisible();
-        $this->lastView = 'DetailView';
     }
 
     /**
@@ -199,7 +187,6 @@ class IssueModuleCest
         $editView->click('Save');
 
         $detailView->waitForDetailViewVisible();
-        $this->lastView = 'DetailView';
     }
 
     /**
@@ -249,7 +236,6 @@ class IssueModuleCest
         $detailView->acceptPopup();
 
         $listView->waitForListViewVisible();
-        $this->lastView = 'ListView';
     }
 
     /**
@@ -288,6 +274,5 @@ class IssueModuleCest
         $detailView->acceptPopup();
 
         $listView->waitForListViewVisible();
-        $this->lastView = 'ListView';
     }
 }

--- a/tests/acceptance/Core/ModuleBuilderFieldsCest.php
+++ b/tests/acceptance/Core/ModuleBuilderFieldsCest.php
@@ -9,12 +9,6 @@ use Faker\Generator;
 class ModuleBuilderFieldsCest
 {
     /**
-     * @var string $lastView helps the test skip some repeated tests in order to make the test framework run faster at the
-     * potential cost of being accurate and reliable
-     */
-    protected $lastView;
-
-    /**
      * @var Generator $fakeData
      */
     protected $fakeData;
@@ -65,8 +59,6 @@ class ModuleBuilderFieldsCest
             \Page\ModuleFields::$NAME,
             \SuiteCRM\Enumerator\SugarObjectType::basic
         );
-
-        $this->lastView = 'ModuleBuilder';
     }
 
     /**

--- a/tests/acceptance/Core/PersonModuleCest.php
+++ b/tests/acceptance/Core/PersonModuleCest.php
@@ -6,12 +6,6 @@ use JeroenDesloovere\VCard\VCard;
 class PersonModuleCest
 {
     /**
-     * @var string $lastView helps the test skip some repeated tests in order to make the test framework run faster at the
-     * potential cost of being accurate and reliable
-     */
-    protected $lastView;
-
-    /**
      * @var Generator $fakeData
      */
     protected $fakeData;
@@ -62,8 +56,6 @@ class PersonModuleCest
             \Page\PersonModule::$NAME,
             \SuiteCRM\Enumerator\SugarObjectType::person
         );
-
-        $this->lastView = 'ModuleBuilder';
     }
 
     /**
@@ -87,7 +79,6 @@ class PersonModuleCest
         $navigationBar->clickAllMenuItem(\Page\PersonModule::$NAME);
 
         $listView->waitForListViewVisible();
-        $this->lastView = 'ListView';
     }
 
     /**
@@ -149,7 +140,6 @@ class PersonModuleCest
         $editView->clickSaveButton();
 
         $detailView->waitForDetailViewVisible();
-        $this->lastView = 'DetailView';
     }
 
     /**
@@ -190,7 +180,6 @@ class PersonModuleCest
         $this->fakeData->seed($this->fakeDataSeed);
         $listView->clickNameLink($name);
         $detailView->waitForDetailViewVisible();
-        $this->lastView = 'DetailView';
     }
 
     /**
@@ -241,7 +230,6 @@ class PersonModuleCest
         $editView->click('Save');
 
         $detailView->waitForDetailViewVisible();
-        $this->lastView = "DetailView";
     }
 
     /**
@@ -344,7 +332,6 @@ class PersonModuleCest
         $detailView->acceptPopup();
 
         $listView->waitForListViewVisible();
-        $this->lastView = 'ListView';
     }
 
     /**
@@ -407,7 +394,6 @@ class PersonModuleCest
         $I->click('#import_vcard_button', '.import-vcard');
 
         $detailView->waitForDetailViewVisible();
-        $this->lastView = ' DetailView';
         $detailView->see($firstname.' '.$lastname, '.module-title-text');
 
         // Delete Record
@@ -415,7 +401,6 @@ class PersonModuleCest
         $detailView->acceptPopup();
 
         $listView->waitForListViewVisible();
-        $this->lastView = 'ListView';
 
         $I->deleteFile($fileDir.$fileName);
     }

--- a/tests/acceptance/modules/AOW_Workflow/AOW_WorkflowCest.php
+++ b/tests/acceptance/modules/AOW_Workflow/AOW_WorkflowCest.php
@@ -130,6 +130,5 @@ class AOW_WorkflowCest
     //     $detailView->acceptPopup();
     //
     //     $listView->waitForListViewVisible();
-    //     $this->lastView = 'ListView';
     // }
 }


### PR DESCRIPTION
## Description
These were made unnecessary by #7417, and I hadn't gotten around to cleaning them up until now. They were used to do certain things depending on the previous test that was run, but this introduced non-determinism into the tests and caused them to flake, so removing these shouldn't impact anything. I doubt this'll cause any problems for the hotfix merge, but it might be worth keeping in mind just in case any tests had a `lastView` declaration added between 7.10 and 7.11.

## Motivation and Context
It's dead code.

## How To Test This
Make sure Travis passes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.