### PR TITLE
Shuffle the codeception tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ before_script:
 script:
   # Run the wizard installer
   - echo "using install wizard"
-  - ./vendor/bin/codecept run install --env travis-ci-hub -f --ext DotReporter
+  - ./vendor/bin/codecept run install --env travis-ci-hub --ext DotReporter
   - ./build/push_output.sh
 
   # Run the unit tests
@@ -95,10 +95,10 @@ script:
   - sudo chmod 600 Api/V8/OAuth2/p*.key
   # - sudo chown www-data:www-data Api/V8/OAuth2/p*.key
   # Run API functional tests
-  - ./vendor/bin/codecept run tests/api/V8/ -f --ext DotReporter
+  - ./vendor/bin/codecept run tests/api/V8/ --ext DotReporter
   # RUN Basic Acceptance test
   - echo "\$sugar_config['imap_test'] = true;" >> config_override.php
-  - ./vendor/bin/codecept run acceptance --env travis-ci-hub -f --ext DotReporter
+  - ./vendor/bin/codecept run acceptance --env travis-ci-hub --ext DotReporter
 
 after_script:
   - ./build/push_output.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ before_script:
 script:
   # Run the wizard installer
   - echo "using install wizard"
-  - ./vendor/bin/codecept run install --env travis-ci-hub --ext DotReporter
+  - ./vendor/bin/codecept run install --env travis-ci-hub -f --ext DotReporter
   - ./build/push_output.sh
 
   # Run the unit tests
@@ -95,10 +95,10 @@ script:
   - sudo chmod 600 Api/V8/OAuth2/p*.key
   # - sudo chown www-data:www-data Api/V8/OAuth2/p*.key
   # Run API functional tests
-  - ./vendor/bin/codecept run tests/api/V8/ --ext DotReporter
+  - ./vendor/bin/codecept run tests/api/V8/ -f --ext DotReporter
   # RUN Basic Acceptance test
   - echo "\$sugar_config['imap_test'] = true;" >> config_override.php
-  - ./vendor/bin/codecept run acceptance --env travis-ci-hub --ext DotReporter
+  - ./vendor/bin/codecept run acceptance --env travis-ci-hub -f
 
 after_script:
   - ./build/push_output.sh

--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -9,6 +9,7 @@ settings:
   bootstrap: _bootstrap.php
   colors: true
   memory_limit: 16000M
+  shuffle: true
 extensions:
   enabled:
     - Codeception\Extension\RunFailed

--- a/tests/acceptance/Core/BasicModuleCest.php
+++ b/tests/acceptance/Core/BasicModuleCest.php
@@ -65,6 +65,8 @@ class BasicModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      *
+     * @depends testScenarioCreateBasicModule
+     * 
      * As administrative user I want to view my basic test module so that I can see if it has been
      * deployed correctly.
      */
@@ -89,6 +91,8 @@ class BasicModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\EditView $editView
      *
+     * @depends testScenarioCreateBasicModule
+     * 
      * As administrative user I want to create a record with my basic test module so that I can test
      * the standard fields.
      */
@@ -124,6 +128,8 @@ class BasicModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
+     * 
+     * @depends testScenarioCreateRecord
      *
      * As administrative user I want to view the record by selecting it in the list view
      */
@@ -160,6 +166,8 @@ class BasicModuleCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
      *
+     * @depends testScenarioCreateRecord
+     * 
      * As administrative user I want to edit the record by selecting it in the detail view
      */
     public function testScenarioEditRecordFromDetailView(
@@ -203,6 +211,8 @@ class BasicModuleCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
      *
+     * @depends testScenarioCreateRecord
+     * 
      * As administrative user I want to duplicate the record
      */
     public function testScenarioDuplicateRecordFromDetailView(
@@ -252,6 +262,11 @@ class BasicModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      *
+     * @depends testScenarioCreateRecord
+     * @depends testScenarioViewRecordFromListView
+     * @depends testScenarioEditRecordFromDetailView
+     * @depends testScenarioDuplicateRecordFromDetailView
+     * 
      * As administrative user I want to delete the record by selecting it in the detail view
      */
     public function testScenarioDeleteRecordFromDetailView(

--- a/tests/acceptance/Core/CompanyModuleCest.php
+++ b/tests/acceptance/Core/CompanyModuleCest.php
@@ -64,6 +64,8 @@ class CompanyModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      *
+     * @depends testScenarioCreateCompanyModule
+     * 
      * As administrative user I want to view my company test module so that I can see if it has been
      * deployed correctly.
      */
@@ -88,6 +90,8 @@ class CompanyModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\EditView $editView
      * @param \Step\Acceptance\DetailView $detailView
+     * 
+     * @depends testScenarioCreateCompanyModule
      *
      * As administrative user I want to create a record with my company test module so that I can test
      * the standard fields.
@@ -140,6 +144,8 @@ class CompanyModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      *
+     * @depends testScenarioCreateRecord
+     * 
      * As administrative user I want to view the record by selecting it in the list view
      */
     public function testScenarioViewRecordFromListView(
@@ -177,6 +183,8 @@ class CompanyModuleCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
      *
+     * @depends testScenarioCreateRecord
+     * 
      * As administrative user I want to edit the record by selecting it in the detail view
      */
     public function testScenarioEditRecordFromDetailView(
@@ -221,6 +229,8 @@ class CompanyModuleCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
      *
+     * @depends testScenarioCreateRecord
+     * 
      * As administrative user I want to duplicate the record
      */
     public function testScenarioDuplicateRecordFromDetailView(
@@ -270,6 +280,11 @@ class CompanyModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      *
+     * @depends testScenarioCreateRecord
+     * @depends testScenarioViewRecordFromListView
+     * @depends testScenarioEditRecordFromDetailView
+     * @depends testScenarioDuplicateRecordFromDetailView
+     * 
      * As administrative user I want to delete the record by selecting it in the detail view
      */
     public function testScenarioDeleteRecordFromDetailView(

--- a/tests/acceptance/Core/FileModuleCest.php
+++ b/tests/acceptance/Core/FileModuleCest.php
@@ -62,6 +62,8 @@ class FileModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      *
+     * @depends testScenarioCreateFileModule
+     * 
      * As administrative user I want to view my file test module so that I can see if it has been
      * deployed correctly.
      */
@@ -85,6 +87,8 @@ class FileModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailview
      * @param \Step\Acceptance\EditView $editView
+     * 
+     * @depends testScenarioCreateFileModule
      *
      * As administrative user I want to create a record with my file test module so that I can test
      * the standard fields.
@@ -130,6 +134,8 @@ class FileModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      *
+     * @depends testScenarioCreateRecord
+     *
      * As administrative user I want to view the record by selecting it in the list view
      */
     public function testScenarioViewRecordFromListView(
@@ -165,7 +171,9 @@ class FileModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
-     *
+     * 
+     * @depends testScenarioCreateRecord
+     * 
      * As administrative user I want to edit the record by selecting it in the detail view
      */
     public function testScenarioEditRecordFromDetailView(
@@ -207,6 +215,8 @@ class FileModuleCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
      *
+     * @depends testScenarioCreateRecord
+     * 
      * As administrative user I want to duplicate the record
      */
     public function testScenarioDuplicateRecordFromDetailView(
@@ -254,7 +264,12 @@ class FileModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
-     *
+     * 
+     * @depends testScenarioCreateRecord
+     * @depends testScenarioViewRecordFromListView
+     * @depends testScenarioEditRecordFromDetailView
+     * @depends testScenarioDuplicateRecordFromDetailView
+     * 
      * As administrative user I want to delete the record by selecting it in the detail view
      */
     public function testScenarioDeleteRecordFromDetailView(

--- a/tests/acceptance/Core/IssueModuleCest.php
+++ b/tests/acceptance/Core/IssueModuleCest.php
@@ -61,6 +61,8 @@ class IssueModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      *
+     * @depends testScenarioCreateIssueModule
+     * 
      * As administrative user I want to view my issue test module so that I can see if it has been
      * deployed correctly.
      */
@@ -84,6 +86,8 @@ class IssueModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\EditView $editView
      * @param \Step\Acceptance\DetailView $detailView
+     * 
+     * @depends testScenarioCreateIssueModule
      *
      * As administrative user I want to create a record with my issue test module so that I can test
      * the standard fields.
@@ -119,6 +123,8 @@ class IssueModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
+     * 
+     * @depends testScenarioCreateRecord
      *
      * As administrative user I want to view the record by selecting it in the list view
      */
@@ -153,6 +159,8 @@ class IssueModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
+     * 
+     * @depends testScenarioCreateRecord
      *
      * As administrative user I want to edit the record by selecting it in the detail view
      */
@@ -196,6 +204,8 @@ class IssueModuleCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
      *
+     * @depends testScenarioCreateRecord
+     * 
      * As administrative user I want to duplicate the record
      */
     public function testScenarioDuplicateRecordFromDetailView(
@@ -243,6 +253,11 @@ class IssueModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
+     * 
+     * @depends testScenarioCreateRecord
+     * @depends testScenarioViewRecordFromListView
+     * @depends testScenarioEditRecordFromDetailView
+     * @depends testScenarioDuplicateRecordFromDetailView
      *
      * As administrative user I want to delete the record by selecting it in the detail view
      */

--- a/tests/acceptance/Core/ModuleBuilderFieldsCest.php
+++ b/tests/acceptance/Core/ModuleBuilderFieldsCest.php
@@ -37,7 +37,6 @@ class ModuleBuilderFieldsCest
     {
     }
 
-    // Tests
     /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\ModuleBuilder $moduleBuilder
@@ -64,6 +63,9 @@ class ModuleBuilderFieldsCest
     /**
      * @param AcceptanceTester $I
      * @param \Step\Acceptance\ModuleBuilder $moduleBuilder
+     * 
+     * @depends testScenarioCreateFieldsModule
+     * 
      * As an administrator I want to add a relate field to the basic module so that I can test relating records to the
      * accounts module
      */
@@ -140,11 +142,12 @@ class ModuleBuilderFieldsCest
         $moduleBuilder->closePopupSuccess();
     }
 
-
-
     /**
      * @param AcceptanceTester $I
      * @param \Step\Acceptance\ModuleBuilder $moduleBuilder
+     * 
+     * @depends testScenarioAddRelateField
+     * 
      * As an administrator I want to add a html field to the basic module so that I can test relating records to the
      * accounts module
      */
@@ -225,6 +228,8 @@ class ModuleBuilderFieldsCest
      * @param AcceptanceTester $I
      * @param \Step\Acceptance\ModuleBuilder $moduleBuilder
      * @param \Step\Acceptance\Repair $repair
+     * 
+     * @depends testScenarioAddHtmlField
      *
      * As an administrator I want to test deploying a module
      */
@@ -251,6 +256,8 @@ class ModuleBuilderFieldsCest
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\Accounts $accounts
      *
+     * @depends testScenarioDeployModule
+     * 
      * As an administrator I want to test relating to the accounts module
      */
     public function testScenarioRelateToAccounts(

--- a/tests/acceptance/Core/PersonModuleCest.php
+++ b/tests/acceptance/Core/PersonModuleCest.php
@@ -63,6 +63,8 @@ class PersonModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      *
+     * @depends testScenarioCreatePersonModule
+     * 
      * As administrative user I want to view my person test module so that I can see if it has been
      * deployed correctly.
      */
@@ -87,6 +89,8 @@ class PersonModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
+     * 
+     * @depends testScenarioCreatePersonModule
      *
      * As administrative user I want to create a record with my person test module so that I can test
      * the standard fields.
@@ -147,6 +151,8 @@ class PersonModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
+     * 
+     * @depends testScenarioCreateRecord
      *
      * As administrative user I want to view the record by selecting it in the list view
      */
@@ -188,6 +194,8 @@ class PersonModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
+     * 
+     * @depends testScenarioCreateRecord
      *
      * As administrative user I want to edit the record by selecting it in the detail view
      */
@@ -238,6 +246,8 @@ class PersonModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
+     * 
+     * @depends testScenarioCreateRecord
      *
      * As administrative user I want to duplicate the record
      */
@@ -293,6 +303,11 @@ class PersonModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
+     * 
+     * @depends testScenarioCreateRecord
+     * @depends testScenarioViewRecordFromListView
+     * @depends testScenarioEditRecordFromDetailView
+     * @depends testScenarioDuplicateRecordFromDetailView
      *
      * As administrative user I want to delete the record by selecting it in the detail view
      */
@@ -335,18 +350,18 @@ class PersonModuleCest
     }
 
     /**
-    /**
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
+     * 
+     * @depends testScenarioCreateRecord
      *
      * As administrative user I want to delete the record by selecting it in the detail view
      */
     public function testScenarioImportVCardFromDetailView(
         \AcceptanceTester $I,
         \Step\Acceptance\NavigationBar $navigationBar,
-        \Step\Acceptance\SideBar $sideBar,
         \Step\Acceptance\ListView $listView,
         \Step\Acceptance\DetailView $detailView
     ) {

--- a/tests/acceptance/Core/SaleModuleCest.php
+++ b/tests/acceptance/Core/SaleModuleCest.php
@@ -62,6 +62,8 @@ class SaleModuleCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
+     * 
+     * @depends testScenarioCreateSaleModule
      *
      * As administrative user I want to view my sale test module so that I can see if it has been
      * deployed correctly.
@@ -86,6 +88,8 @@ class SaleModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
+     * 
+     * @depends testScenarioCreateSaleModule
      *
      * As administrative user I want to create a record with my sale test module so that I can test
      * the standard fields.
@@ -127,6 +131,8 @@ class SaleModuleCest
      * @param \AcceptanceTester $I
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
+     * 
+     * @depends testScenarioCreateRecord
      *
      * As administrative user I want to view the record by selecting it in the list view
      */
@@ -160,6 +166,8 @@ class SaleModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
+     * 
+     * @depends testScenarioCreateRecord
      *
      * As administrative user I want to edit the record by selecting it in the detail view
      */
@@ -203,6 +211,8 @@ class SaleModuleCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
      * @param \Step\Acceptance\EditView $editView
+     * 
+     * @depends testScenarioCreateRecord
      *
      * As administrative user I want to duplicate the record
      */
@@ -252,6 +262,11 @@ class SaleModuleCest
      * @param \Step\Acceptance\NavigationBar $navigationBar
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\DetailView $detailView
+     * 
+     * @depends testScenarioCreateRecord
+     * @depends testScenarioViewRecordFromListView
+     * @depends testScenarioEditRecordFromDetailView
+     * @depends testScenarioDuplicateRecordFromDetailView
      *
      * As administrative user I want to delete the record by selecting it in the detail view
      */

--- a/tests/acceptance/modules/Accounts/AccountsCest.php
+++ b/tests/acceptance/modules/Accounts/AccountsCest.php
@@ -142,6 +142,15 @@ class AccountsCest
         $I->see('InlineAccountNameEdit');
     }
 
+    /**
+     * @param \AcceptanceTester $I
+     * @param \Step\Acceptance\DetailView $detailView
+     * @param \Step\Acceptance\EditView $editView
+     * @param \Step\Acceptance\ListView $listView
+     * @param \Step\Acceptance\Accounts $accounts
+     *
+     * As an admin user I want to create a child account.
+     */
     public function testScenarioCreateAccountChild(
         \AcceptanceTester $I,
         \Step\Acceptance\DetailView $detailView,

--- a/tests/acceptance/modules/Accounts/AccountsCest.php
+++ b/tests/acceptance/modules/Accounts/AccountsCest.php
@@ -114,7 +114,7 @@ class AccountsCest
      * @param \Step\Acceptance\ListView $listView
      * @param \Step\Acceptance\Accounts $accounts
      *
-     * As administrative user I want to inline edit a field on the list-view
+     * As an admin user I want to inline edit a field on the list-view
      */
     public function testScenarioInlineEditListView(
         \AcceptanceTester $I,


### PR DESCRIPTION
## Description

![image](https://user-images.githubusercontent.com/2977353/61561776-007db780-aa2d-11e9-84f2-f61c8ad3badb.png)

Testing to see if we can fix #7022 right now :) I'm guessing there are tests that are implicitly dependent on one another (I know that's true of PHPUnit, so I haven't enabled it for PHPUnit yet).

## Motivation and Context
This may introduce new flakiness – which is not ideal – but it helps prevent tests that are dependent on state created by other tests, which causes fragile tests. See #7022 for a fuller description of the problems this can solve.

## How To Test This
See if Travis passes!

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.