### PR TITLE
Fixed #7599 - Unwanted email generated in case creation & update

### DIFF
--- a/modules/AOP_Case_Updates/CaseUpdatesHook.php
+++ b/modules/AOP_Case_Updates/CaseUpdatesHook.php
@@ -66,7 +66,7 @@ class CaseUpdatesHook
         foreach ($_FILES['case_update_file'] as $key => $vals) {
             foreach ($vals as $index => $val) {
                 if (!array_key_exists('case_update_file' . $index, $_FILES)) {
-                    $_FILES['case_update_file' . $index] = array();
+                    $_FILES['case_update_file' . $index] = [];
                     ++$count;
                 }
                 $_FILES['case_update_file' . $index][$key] = $val;
@@ -458,12 +458,12 @@ class CaseUpdatesHook
     {
         global $app_strings, $sugar_config;
         //Order of beans seems to matter here so we place contact first.
-        $beans = array(
+        $beans = [
             'Contacts' => $contact->id,
-            'Cases'    => $bean->id,
-            'Users'    => $bean->assigned_user_id,
-        );
-        $ret = array();
+            'Cases' => $bean->id,
+            'Users' => $bean->assigned_user_id,
+        ];
+        $ret = [];
         $ret['subject'] = from_html(aop_parse_template($template->subject, $beans));
         $ret['body'] = from_html(
             $app_strings['LBL_AOP_EMAIL_REPLY_DELIMITER'] . aop_parse_template(
@@ -498,7 +498,7 @@ class CaseUpdatesHook
     {
         global $sugar_config;
         if (!array_key_exists('aop', $sugar_config)) {
-            return array();
+            return [];
         }
 
         return $sugar_config['aop'];
@@ -616,17 +616,20 @@ class CaseUpdatesHook
         if ($module === 'Import') {
             //Don't send email on import
             LoggerManager::getLogger()->warn("Don't send email on import");
+
             return;
         }
         if (!isAOPEnabled()) {
             LoggerManager::getLogger()->warn("Don't send email if AOP enabled");
+
             return;
         }
         if ($caseUpdate->internal) {
             LoggerManager::getLogger()->warn("Don't send email if case update is internal");
+
             return;
         }
-        $signature = array();
+        $signature = [];
         $addDelimiter = true;
         $aop_config = $sugar_config['aop'];
         if ($caseUpdate->assigned_user_id) {
@@ -637,7 +640,7 @@ class CaseUpdatesHook
             if ($email_template->id) {
                 foreach ($caseUpdate->getContacts() as $contact) {
                     $GLOBALS['log']->info('AOPCaseUpdates: Calling send email');
-                    $emails = array();
+                    $emails = [];
                     $emails[] = $contact->emailAddress->getPrimaryAddress($contact);
                     $caseUpdate->sendEmail(
                         $emails,
@@ -655,8 +658,8 @@ class CaseUpdatesHook
                 $email_template = $email_template->retrieve($aop_config['user_email_template_id']);
             }
             $addDelimiter = false;
-            if ($emails && $email_template) {
-                $GLOBALS['log']->info('AOPCaseUpdates: Calling send email');
+            if ($emails && $email_template->id) {
+                LoggerManager::getLogger()->info('AOPCaseUpdates: Calling send email');
                 $caseUpdate->sendEmail(
                     $emails,
                     $email_template,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Prevents a blank email being sent by AOP when 'User Email Template' is set to 'None'.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #7599 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Set all AOP template choice dropdowns to 'None'
2. Process an inbound email

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->