### PR TITLE
WIP: Fix the inline edit cancel dialog showing up repeatedly.

### DIFF
--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -273,7 +273,19 @@ function clickedawayclose(field,id,module, type){
     clickListenerActive = true;
 }
 
-$(document).on('click', function (e) {
+/*
+ * Disable any existing click listeners before registering this listener.
+ * This is done to prevent the listener from being registered more than
+ * once across page views.
+ */
+$(document).off().on('click', warnOnLeavingActiveField);
+
+/**
+ * Display a confirmation dialog if the user clicks outside of a field that's actively being edited.
+ * 
+ * @param {Event} e - the click event 
+ */
+function warnOnLeavingActiveField(e) {
     if (clickListenerActive) {
         var field = ie_field;
         var id = ie_id;
@@ -342,7 +354,7 @@ $(document).on('click', function (e) {
             }
         }
     }
-});
+};
 
 /**
  * Depending on what type of field we are editing the parts of the field may differ and need different jquery to pickup the values


### PR DESCRIPTION
## Description
Fix #7432.

This is done by disabling the listener before registering it initially, which removes any listeners that may have existed in a previous page view.

## How To Test This
Try to reproduce this issue, make it sure doesn't occur:

- Go to a Lead detailview page (or any detailview page should work, really).
- Hard reload.
- If you edit a field now and try to click out, the 'cancel' dialog will only show up once.
- Click the next or previous buttons to navigate to a new Lead.
- If you edit a field and try to click out now, and then hit cancel on the dialog it'll show up twice.

With this change it should no longer show up more than once.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.