### PR TITLE
Avoid adding quotes on already quoted parameters.

### DIFF
--- a/include/utils.php
+++ b/include/utils.php
@@ -3989,7 +3989,7 @@ function string_format($format, $args, $escape = true)
             $args[$i] = implode("','", $values);
         }
 
-        $result = str_replace('{'.$i.'}', "'" . $args[$i] . "'", $result);
+        $result = str_replace('{'.$i.'}', $db->quote($args[$i]), $result);
     }
 
     return $result;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix #6996
Avoid adding quotes on already quoted parameters by using already existing `quote` method instead of concatenating quotes with php dot operator.

## Description
Improve the way values are quoted when replacing parameters in `SELECT` clauses, for only adding quotes if needed.
Fixes #6996 
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
See #6996

## How To Test This
1. Browse ListView of any module that uses "My favorites" filter, for example: Projects.
2. Set "My Favorites" checkbox to checked.
3. Click Search button.
4. The query should be generated properly without throwing errors.
   
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->