### PR TITLE
Fix for issue:  #7634 Task subpanels/for activites fix

### DIFF
--- a/modules/Tasks/metadata/subpanels/ForActivities.php
+++ b/modules/Tasks/metadata/subpanels/ForActivities.php
@@ -76,8 +76,8 @@ $subpanel_layout = array(
         'date_due' => array(
             'vname' => 'LBL_LIST_DUE_DATE',
             'width' => '10%',
-            'alias' => 'date_end',
-            'sort_by' => 'date_end',
+            'alias' => 'date_due',
+            'sort_by' => 'date_due',
         ),
         'assigned_user_name' => array(
             'name' => 'assigned_user_name',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
PR solves problem with wrong table field in subpanel definition (defined date_end instead date_due).

## Description
Fixed definition on table column definition for subpanels.

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
#7634 Oportunities with assigned tasks not displayed

<!--- Why is this change required? What problem does it solve? -->
Fix issue which render Opportunities lists unusable.

<!--- Please describe in detail how to test your changes. -->
Attach task to Opportunity and list should still work.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->