### PR TITLE
Fixed #7622 - Make the code:coverage Robo command work outside of CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
       if: type IN (pull_request) OR branch in (master, develop, hotfix)
       php: "7.0"
       dist: xenial
-      script: ./vendor/bin/codecept run install --env travis-ci-hub -f --ext DotReporter; echo "\$sugar_config['state_checker']['test_state_check_mode'] = 1;" >> config_override.php  ; ./vendor/bin/robo code:coverage; cat codeception.yml; bash <(curl -s https://codecov.io/bash) -f tests/_output/coverage.xml
+      script: ./vendor/bin/codecept run install --env travis-ci-hub -f --ext DotReporter; echo "\$sugar_config['state_checker']['test_state_check_mode'] = 1;" >> config_override.php  ; ./vendor/bin/robo code:coverage --ci; cat codeception.yml; bash <(curl -s https://codecov.io/bash) -f tests/_output/coverage.xml
 
 services:
   - mysql

--- a/lib/Robo/Plugin/Commands/CodeCoverageCommands.php
+++ b/lib/Robo/Plugin/Commands/CodeCoverageCommands.php
@@ -37,6 +37,7 @@
  * reasonably feasible for technical reasons, the Appropriate Legal Notices must
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
+
 namespace SuiteCRM\Robo\Plugin\Commands;
 
 use SuiteCRM\Utility\OperatingSystem;
@@ -51,7 +52,7 @@ class CodeCoverageCommands extends \Robo\Tasks
 
     /**
      * Runs code coverage
-     * @param array $opts
+     * @param array $opts optional command line argument if using a continuous integration environment
      * @throws RuntimeException
      */
     public function codeCoverage($opts = ['ci' => false])
@@ -63,7 +64,7 @@ class CodeCoverageCommands extends \Robo\Tasks
             if ($this->isEnvironmentTravisCI()) {
                 $range = $this->getCommitRangeForTravisCi();
             } else {
-                throw new \RuntimeException('unable to detect continuous integration environment');
+                throw new \RuntimeException('Unable to detect continuous integration environment');
             }
         }
 
@@ -96,6 +97,7 @@ class CodeCoverageCommands extends \Robo\Tasks
     private function generateCodeCoverageFile()
     {
         $this->_exec($this->getCodeCoverageCommand());
+        $this->say('Code coverage xml outputted to ./tests/_output/coverage.xml');
     }
 
     /**
@@ -121,6 +123,7 @@ class CodeCoverageCommands extends \Robo\Tasks
         $command =
             $os->toOsPath('./vendor/bin/phpunit')
             . ' --configuration ./tests/phpunit.xml.dist --coverage-clover ./tests/_output/coverage.xml ./tests/unit/phpunit';
+
         return $command;
     }
 }

--- a/lib/Robo/Plugin/Commands/CodeCoverageCommands.php
+++ b/lib/Robo/Plugin/Commands/CodeCoverageCommands.php
@@ -52,8 +52,8 @@ class CodeCoverageCommands extends \Robo\Tasks
 
     /**
      * Runs code coverage
-     * @param array $opts optional command line argument if using a continuous integration environment
-     * @throws RuntimeException
+     * @param array $opts
+     * @option bool $ci Should be set to true if using a Continuous Integration environment.
      */
     public function codeCoverage($opts = ['ci' => false])
     {

--- a/lib/Robo/Plugin/Commands/CodeCoverageCommands.php
+++ b/lib/Robo/Plugin/Commands/CodeCoverageCommands.php
@@ -50,18 +50,21 @@ class CodeCoverageCommands extends \Robo\Tasks
     use RoboTrait;
 
     /**
-     * Runs code coverage for travis ci
+     * Runs code coverage
+     * @param array $opts
      * @throws RuntimeException
      */
-    public function codeCoverage()
+    public function codeCoverage($opts = ['ci' => false])
     {
         $this->say('Code Coverage');
 
         // Get environment
-        if ($this->isEnvironmentTravisCI()) {
-            $range = $this->getCommitRangeForTravisCi();
-        } else {
-            throw new \RuntimeException('unable to detect continuous integration environment');
+        if ($opts['ci'] === true) {
+            if ($this->isEnvironmentTravisCI()) {
+                $range = $this->getCommitRangeForTravisCi();
+            } else {
+                throw new \RuntimeException('unable to detect continuous integration environment');
+            }
         }
 
         $this->disableStateChecker();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Removes an unncessary limitation of the robo code coverage command so that it now allows a non-ci envionment get code coverage.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #7622 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Check Travis.
2. Run ```./vendor/bin/robo code:coverage``` and retrieve code covage info.
3. Run ```./vendor/bin/robo code:coverage --ci``` and it should fail with no ci detected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->