### PR TITLE
Add diagnostics task

### DIFF
--- a/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
+++ b/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
@@ -39,13 +39,26 @@
  */
 namespace SuiteCRM\Robo\Plugin\Commands;
 
+use Robo\Task\Base\loadTasks;
 use SuiteCRM\Utility\OperatingSystem;
 use SuiteCRM\Utility\Paths;
+use DBManagerFactory;
 
 class DiagnosticsCommands extends \Robo\Tasks
 {
+    use loadTasks;
     use \SuiteCRM\Robo\Traits\RoboTrait;
+    use \SuiteCRM\Robo\Traits\CliRunnerTrait;
 
+    /**
+     * @var DBManager
+     */
+    protected $db;
+
+    public function __construct() {
+        $this->bootstrap();
+        $this->db = DBManagerFactory::getInstance();
+    }
     /**
      * Print diagnostic information about SuiteCRM.
      * Useful for reporting issues.
@@ -118,7 +131,7 @@ class DiagnosticsCommands extends \Robo\Tasks
      * @return String
      */
     protected function getSuiteCrmVersion() {
-        require_once('suitecrm_version.php');
+        global $suitecrm_version;
         return $suitecrm_version;
     }
 
@@ -158,7 +171,18 @@ class DiagnosticsCommands extends \Robo\Tasks
      * @return String
      */
     protected function getDatabaseVersion() {
-        return 'Not implemented.';
+        $dbInfo = $this->db->getDbInfo();
+        // Determine the database adapter based on the keys that exist in
+        // the array returned by getDbInfo().
+        if (array_key_exists("MySQLi Server Info", $dbInfo)) {
+            return "MySQL {$dbInfo["MySQLi Server Info"]}";
+        } else if (array_key_exists("MySQL Server Info", $dbInfo)) {
+            return "MySQL {$dbInfo["MySQL Server Info"]}";
+        } else if (array_key_exists("version", $dbInfo)) {
+            return "MSSQL {$dbInfo["version"]}";
+        } else {
+            return 'Unable to determine the database';
+        }
     }
 
     /**

--- a/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
+++ b/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
@@ -53,21 +53,38 @@ class DiagnosticsCommands extends \Robo\Tasks
 
         $this->io()->section('Versions');
 
-        $versionsList = [];
+        $versionList = [];
         $listing = [];
 
-        $versionsList["Operating System"] = $this->getOperatingSystem();
-        $versionsList["SuiteCRM"] = $this->getSuiteCrmVersion();
-        $versionsList["PHP"] = $this->getPhpVersion();
-        $versionsList["Composer"] = $this->getComposerVersion();
-        $versionsList["Apache"] = $this->getApacheVersion();
-        $versionsList["Database"] = $this->getDatabaseVersion();
+        $versionList["Operating System"] = $this->getOperatingSystem();
+        $versionList["SuiteCRM"] = $this->getSuiteCrmVersion();
+        $versionList["PHP"] = $this->getPhpVersion();
+        $versionList["Composer"] = $this->getComposerVersion();
+        $versionList["Apache"] = $this->getApacheVersion();
+        $versionList["Database"] = $this->getDatabaseVersion();
 
-        foreach ($versionsList as $key => $value) {
+        foreach ($versionList as $key => $value) {
             $listing[] = "{$key}: {$value}";
         }
-        
+
         $this->io()->listing($listing);
+
+        $this->io()->section('PHP/SuiteCRM Files');
+
+        $fileList = [];
+
+        $fileList["SuiteCRM Directory"] = $this->getSuiteCrmDirectory();
+        $fileList["SuiteCRM Config"] = $this->getSuiteCrmConfig();
+        $fileList["SuiteCRM Log"] = $this->getSuiteCrmLog();
+        $fileList["PHP INI"] = $this->getPhpIniFile();
+        $fileList["PHP Errors"] = $this->getPhpErrorsFile();
+        $fileList["PHP Binary"] = $this->getPhpBinary();
+
+        foreach ($fileList as $key => $value) {
+            $fileListing[] = "{$key}: {$value}";
+        }
+
+        $this->io()->listing($fileListing);
 
         $this->say('Diagnostics Complete');
     }
@@ -133,6 +150,54 @@ class DiagnosticsCommands extends \Robo\Tasks
      * @return String
      */
     protected function getDatabaseVersion() {
+        return 'Not implemented.';
+    }
+
+    /**
+     * Returns the path for the root of the SuiteCRM instance.
+     * @return String
+     */
+    protected function getSuiteCrmDirectory() {
+        return 'Not implemented.';
+    }
+    
+    /**
+     * Returns the path for the SuiteCRM config.php.
+     * @return String
+     */
+    protected function getSuiteCrmConfig() {
+        return 'Not implemented.';
+    }
+    
+    /**
+     * Returns the path for the suitecrm.log.
+     * @return String
+     */
+    protected function getSuiteCrmLog() {
+        return 'Not implemented.';
+    }
+    
+    /**
+     * Returns the path for the php.ini.
+     * @return String
+     */
+    protected function getPhpIniFile() {
+        return 'Not implemented.';
+    }
+    
+    /**
+     * Returns the path for the PHP errors.log.
+     * @return String
+     */
+    protected function getPhpErrorsFile() {
+        return 'Not implemented.';
+    }
+    
+    /**
+     * Returns the path for the PHP binary.
+     * @return String
+     */
+    protected function getPhpBinary() {
         return 'Not implemented.';
     }
 }

--- a/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
+++ b/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
@@ -189,7 +189,7 @@ class DiagnosticsCommands extends \Robo\Tasks
      * @return String
      */
     protected function getPhpIniFile() {
-        return 'Not implemented.';
+        return php_ini_loaded_file();
     }
     
     /**
@@ -197,7 +197,14 @@ class DiagnosticsCommands extends \Robo\Tasks
      * @return String
      */
     protected function getPhpErrorsFile() {
-        return 'Not implemented.';
+        // If the directory starts with `.` it's relative to the base path.
+        // Otherwise, just print whatever it returns.
+        $errorDir = pathinfo(ini_get('error_log'), PATHINFO_DIRNAME);
+        if (substr($errorDir, 0, strlen('.')) === '.') {
+            return $this->getBasePath() . DIRECTORY_SEPARATOR . ini_get('error_log');
+        } else {
+            return ini_get('error_log');
+        }
     }
     
     /**

--- a/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
+++ b/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
@@ -57,9 +57,14 @@ class DiagnosticsCommands extends \Robo\Tasks
         $listing = [];
 
         $versionsList["Operating System"] = $this->getOperatingSystem();
+        $versionsList["SuiteCRM"] = $this->getSuiteCrmVersion();
+        $versionsList["PHP"] = $this->getPhpVersion();
+        $versionsList["Composer"] = $this->getComposerVersion();
+        $versionsList["Apache"] = $this->getApacheVersion();
+        $versionsList["Database"] = $this->getDatabaseVersion();
 
         foreach ($versionsList as $key => $value) {
-          $listing[] = "{$key}: {$value}";
+            $listing[] = "{$key}: {$value}";
         }
         
         $this->io()->listing($listing);
@@ -88,5 +93,45 @@ class DiagnosticsCommands extends \Robo\Tasks
         } else {
             return 'Unable to detect operating system';
         }
+    }
+
+    /**
+     * Returns the current SuiteCRM version.
+     * @return String
+     */
+    protected function getSuiteCrmVersion() {
+        return 'Not implemented.';
+    }
+
+    /**
+     * Returns the current PHP version.
+     * @return String
+     */
+    protected function getPhpVersion() {
+        return phpversion();
+    }
+
+    /**
+     * Returns the current Composer version.
+     * @return String
+     */
+    protected function getComposerVersion() {
+        return 'Not implemented.';
+    }
+
+    /**
+     * Returns the current Apache version.
+     * @return String
+     */
+    protected function getApacheVersion() {
+        return 'Not implemented.';
+    }
+
+    /**
+     * Returns the current database type and version.
+     * @return String
+     */
+    protected function getDatabaseVersion() {
+        return 'Not implemented.';
     }
 }

--- a/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
+++ b/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
@@ -48,6 +48,7 @@ class DiagnosticsCommands extends \Robo\Tasks
 
     /**
      * Print diagnostic information about SuiteCRM.
+     * Useful for reporting issues.
      */
     public function diagnostics() {
         $this->io()->title('SuiteCRM Diagnostics');

--- a/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
+++ b/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
@@ -105,6 +105,7 @@ class DiagnosticsCommands extends \Robo\Tasks
 
     /**
      * Returns the current PHP version.
+     * TODO: Make sure this returns the PHP version of the CRM and not the PHP CLI version.
      * @return String
      */
     protected function getPhpVersion() {

--- a/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
+++ b/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
@@ -137,6 +137,7 @@ class DiagnosticsCommands extends \Robo\Tasks
      */
     protected function getComposerVersion() {
         // Take a string like 'Composer version 1.8.6 2019-06-11 15:03:05' and get the version string from it.
+        // TODO: This won't work for pre-release/beta versions.
         $composerVersionString = exec('composer --version');
         $re = '/Composer version (\d+\.\d+\.\d+)/';
         preg_match($re, $composerVersionString, $matches);

--- a/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
+++ b/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ *
+ * SugarCRM Community Edition is a customer relationship management program developed by
+ * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2019 SalesAgility Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License version 3 as published by the
+ * Free Software Foundation with the addition of the following permission added
+ * to Section 15 as permitted in Section 7(a): FOR ANY PART OF THE COVERED WORK
+ * IN WHICH THE COPYRIGHT IS OWNED BY SUGARCRM, SUGARCRM DISCLAIMS THE WARRANTY
+ * OF NON INFRINGEMENT OF THIRD PARTY RIGHTS.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program; if not, see http://www.gnu.org/licenses or write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ *
+ * You can contact SugarCRM, Inc. headquarters at 10050 North Wolfe Road,
+ * SW2-130, Cupertino, CA 95014, USA. or at email address contact@sugarcrm.com.
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "Powered by
+ * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
+namespace SuiteCRM\Robo\Plugin\Commands;
+
+use SuiteCRM\Utility\OperatingSystem;
+
+class DiagnosticsCommands extends \Robo\Tasks
+{
+    use \SuiteCRM\Robo\Traits\RoboTrait;
+
+    /**
+     * Print diagnostic information about SuiteCRM.
+     */
+    public function diagnostics() {
+        $this->io()->title('SuiteCRM Diagnostics');
+
+        $this->io()->section('Versions');
+
+        $versionsList = [];
+        $listing = [];
+
+        $versionsList["Operating System"] = $this->getOperatingSystem();
+
+        foreach ($versionsList as $key => $value) {
+          $listing[] = "{$key}: {$value}";
+        }
+        
+        $this->io()->listing($listing);
+
+        $this->say('Diagnostics Complete');
+    }
+
+    /**
+     * Returns the current operating system.
+     * @return String
+     */
+    protected function getOperatingSystem() {
+        $os = new OperatingSystem();
+        if ($os->isOsWindows()) {
+            return 'Windows';
+        } elseif ($os->isOsLinux()) {
+            return 'Linux';
+        } elseif ($os->isOsMacOSX()) {
+            return 'macOS';
+        } elseif ($os->isOsBSD()) {
+            return 'BSD';
+        } elseif ($os->isOsSolaris()) {
+            return 'Solaris';
+        } elseif ($os->isOsUnknown()) {
+            return 'Unknown operating system';
+        } else {
+            return 'Unable to detect operating system';
+        }
+    }
+}

--- a/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
+++ b/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
@@ -136,7 +136,12 @@ class DiagnosticsCommands extends \Robo\Tasks
      * @return String
      */
     protected function getComposerVersion() {
-        return 'Not implemented.';
+        // Take a string like 'Composer version 1.8.6 2019-06-11 15:03:05' and get the version string from it.
+        $composerVersionString = exec('composer --version');
+        $re = '/Composer version (\d+\.\d+\.\d+)/';
+        preg_match($re, $composerVersionString, $matches);
+
+        return $matches[1];
     }
 
     /**

--- a/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
+++ b/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
@@ -40,6 +40,7 @@
 namespace SuiteCRM\Robo\Plugin\Commands;
 
 use SuiteCRM\Utility\OperatingSystem;
+use SuiteCRM\Utility\Paths;
 
 class DiagnosticsCommands extends \Robo\Tasks
 {
@@ -54,7 +55,6 @@ class DiagnosticsCommands extends \Robo\Tasks
         $this->io()->section('Versions');
 
         $versionList = [];
-        $listing = [];
 
         $versionList["Operating System"] = $this->getOperatingSystem();
         $versionList["SuiteCRM"] = $this->getSuiteCrmVersion();
@@ -64,10 +64,10 @@ class DiagnosticsCommands extends \Robo\Tasks
         $versionList["Database"] = $this->getDatabaseVersion();
 
         foreach ($versionList as $key => $value) {
-            $listing[] = "{$key}: {$value}";
+            $versionListing[] = "{$key}: {$value}";
         }
 
-        $this->io()->listing($listing);
+        $this->io()->listing($versionListing);
 
         $this->io()->section('PHP/SuiteCRM Files');
 
@@ -117,7 +117,8 @@ class DiagnosticsCommands extends \Robo\Tasks
      * @return String
      */
     protected function getSuiteCrmVersion() {
-        return 'Not implemented.';
+        require_once('suitecrm_version.php');
+        return $suitecrm_version;
     }
 
     /**
@@ -158,15 +159,16 @@ class DiagnosticsCommands extends \Robo\Tasks
      * @return String
      */
     protected function getSuiteCrmDirectory() {
-        return 'Not implemented.';
+        return $this->getBasePath();
     }
     
     /**
      * Returns the path for the SuiteCRM config.php.
+     * TODO: Is it possible to set the config file to be somewhere else?
      * @return String
      */
     protected function getSuiteCrmConfig() {
-        return 'Not implemented.';
+        return $this->getBasePath() . DIRECTORY_SEPARATOR . 'config.php';
     }
     
     /**
@@ -174,7 +176,12 @@ class DiagnosticsCommands extends \Robo\Tasks
      * @return String
      */
     protected function getSuiteCrmLog() {
-        return 'Not implemented.';
+        global $sugar_config;
+        if ($sugar_config['log_dir'] === '.') {
+            return $this->getBasePath() . DIRECTORY_SEPARATOR . $sugar_config['log_file'];
+        } else {
+            return $this->getBasePath() . DIRECTORY_SEPARATOR . $sugar_config['log_dir'] . $sugar_config['log_file'];
+        }
     }
     
     /**
@@ -199,5 +206,15 @@ class DiagnosticsCommands extends \Robo\Tasks
      */
     protected function getPhpBinary() {
         return 'Not implemented.';
+    }
+
+    /**
+     * Returns the absolute path of the CRM root directory.
+     * @return String
+     */
+    protected function getBasePath() {
+        $os = new OperatingSystem();
+        $paths = new Paths();
+        return $os->toOsPath($paths->getProjectPath());
     }
 }

--- a/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
+++ b/lib/Robo/Plugin/Commands/DiagnosticsCommands.php
@@ -212,7 +212,7 @@ class DiagnosticsCommands extends \Robo\Tasks
      * @return String
      */
     protected function getPhpBinary() {
-        return 'Not implemented.';
+        return PHP_BINARY;
     }
 
     /**


### PR DESCRIPTION
## Description
Add the Robo task described in #7631.

## Motivation and Context
We want to have an easy way to get info about the current CRM instance via the command line. 

## How To Test This
Use `./vendor/bin/robo diagnostics` and see that it outputs the right information.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

## TODO

- Return the Apache version as part of the task.
- Make sure it's getting accurate data for the web process rather than the CLI process.
- Also add a diagnostics task that gets the information for the CLI PHP configuration?
- Fixup the commit history.
- Make a short version with just the information we'd want to include in a bug report / forum post?