### PR TITLE
Fix icons not rendering properly in Alerts.

### DIFF
--- a/modules/Alerts/templates/default.tpl
+++ b/modules/Alerts/templates/default.tpl
@@ -22,7 +22,8 @@
         <a class="alert-link text-{if $result->type != null}{$result->type}{else}info{/if}" href="index.php?module=Alerts&action=redirect&record={$result->id}">
         {/if}
             {if $result->target_module != null }
-                <img src="index.php?entryPoint=getImage&imageName={$result->target_module}.gif"/>
+                {* Pluralize the module name if necessary. *}
+                <span class="suitepicon suitepicon-module-{$result->target_module|lower|replace:'_':'-'}{if substr($result->target_module, -1) !== 's'}s{/if}"></span>
                 <strong class="text-{if $result->type != null}{$result->type}{else}info{/if}">{$result->target_module}</strong>
             {else}
                 <strong class="text-{if $result->type != null}{$result->type}{else}info{/if}">Alert</strong>

--- a/modules/Alerts/templates/default.tpl
+++ b/modules/Alerts/templates/default.tpl
@@ -22,7 +22,7 @@
         <a class="alert-link text-{if $result->type != null}{$result->type}{else}info{/if}" href="index.php?module=Alerts&action=redirect&record={$result->id}">
         {/if}
             {if $result->target_module != null }
-                <img src="index.php?entryPoint=getImage&imageName={$result->target_module}s.gif"/>
+                <img src="index.php?entryPoint=getImage&imageName={$result->target_module}.gif"/>
                 <strong class="text-{if $result->type != null}{$result->type}{else}info{/if}">{$result->target_module}</strong>
             {else}
                 <strong class="text-{if $result->type != null}{$result->type}{else}info{/if}">Alert</strong>


### PR DESCRIPTION
## Description
Previously, any modules that were plural (most of them) were getting an `s` appended to their names in order to load the image for that module, leading to the CRM trying to load images like `Leadss.gif`, which does not exist. This only applies the `s` when the module name isn't already plural (this is done by just checking if the module name ends with an `s`, which isn't perfect but better than before). This also changes the icons from `.gif` files to html tags that render the icon font, since most other static image icons have been replaced already by #5273 and #5457.

Fixes #6264 (which should not be closed)

Before:

![image](https://user-images.githubusercontent.com/2977353/62149246-82d16b80-b2b8-11e9-92c9-34fada7341e3.png)

Now it looks like this:

<img width="172" alt="Screen Shot 2019-07-30 at 10 54 14 AM" src="https://user-images.githubusercontent.com/2977353/62149205-6cc3ab00-b2b8-11e9-8381-4310e44c5711.png">

## Motivation and Context
Icons weren't loading.

~~Ideally, this would be fixed by replacing the gif with a `span` using the new icon font, as I mentioned in my comment on #6264, but I'd prefer to just fix this quickly for now and do that at a later time.~~ This now replaces the gif icons with the `span` tag icon font icons. :) 

## How To Test This
1. Log in as someone with notifications, or generate notifications for your own user account somehow.
2. Open the notifications dropdown.
3. See that the icon next to the notification text is visible and loads. Leads and Calls are both good example notifications.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.