### PR TITLE
Format InlineEditing.js with prettier.

### DIFF
--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -41,8 +41,9 @@ buildEditField();
 
 //Global Variables.
 
-var inlineEditSaveButtonImg = "themes/"+SUGAR.themes.theme_name+"/images/inline_edit_save_icon.svg";
-if($("#inline_edit_icon").length) {
+var inlineEditSaveButtonImg = "themes/" + SUGAR.themes.theme_name + "/images/inline_edit_save_icon.svg";
+
+if ($("#inline_edit_icon").length) {
     var inlineEditIcon = $("#inline_edit_icon")[0].outerHTML;
 } else {
     var inlineEditIcon = "";
@@ -51,22 +52,20 @@ if($("#inline_edit_icon").length) {
 var view = action_sugar_grp1;
 var currentModule = module_sugar_grp1;
 
-
 var clicks = 0;
 timer = null;
 
-function buildEditField(){
-    $(".inlineEdit a").click(function (e) {
-
-        if(e.which !== undefined && e.which === 2){
+function buildEditField() {
+    $(".inlineEdit a").click(function(e) {
+        if (e.which !== undefined && e.which === 2) {
             return;
         }
 
-        if(this.id != "inlineEditSaveButton") {
+        if (this.id != "inlineEditSaveButton") {
             var linkUrl = $(this).attr("href");
             var linkTarget = $(this).attr("target");
 
-            if (typeof clicks == 'undefined') {
+            if (typeof clicks == "undefined") {
                 clicks = 0;
             }
 
@@ -75,7 +74,7 @@ function buildEditField(){
                 clicks++;
             }
 
-            if(e.ctrlKey && clicks == 1){
+            if (e.ctrlKey && clicks == 1) {
                 return;
             }
 
@@ -87,78 +86,86 @@ function buildEditField(){
                 return false;
             }
             if (clicks == 1) {
-
-                timer = setTimeout(function () {
+                timer = setTimeout(function() {
                     // if reaches end of timeout without another click follow link
-                    if (linkTarget)
+                    if (linkTarget) {
                         window.open(linkUrl, linkTarget);
-                    else
+                    } else {
                         window.location.href = linkUrl;
-                    clicks = 0;             //after action performed, reset counter
-
+                    }
+                    clicks = 0; //after action performed, reset counter
                 }, 500);
-
             } else {
-
-                clearTimeout(timer);    //prevent single-click action
+                clearTimeout(timer); //prevent single-click action
                 clicks = 0;
-
             }
         }
     });
 
-
     var onInlineEditDblClick = function(elem, e) {
-
         var _this = elem;
         e.preventDefault();
         // depending on what view you are using will find the id,module,type of field, and field name from the view
 
-        if(view == "view_GanttChart" )
+        if (view == "view_GanttChart") {
             view = "DetailView";
+        }
 
-        if(view == "DetailView"){
-            var field = $(_this).attr( "field" );
-            var type = $(_this).attr( "type" );
+        if (view == "DetailView") {
+            var field = $(_this).attr("field");
+            var type = $(_this).attr("type");
 
-            if(currentModule){
+            if (currentModule) {
                 var module = currentModule;
-            }else{
+            } else {
                 var module = module_sugar_grp1;
             }
 
-            var id = $("input[name=record]").attr( "value" );
-        }else{
-            var field = $(_this).attr( "field" );
-            var type = $(_this).attr( "type" );
+            var id = $("input[name=record]").attr("value");
+        } else {
+            var field = $(_this).attr("field");
+            var type = $(_this).attr("type");
             var module = $("#displayMassUpdate input[name=module]").val();
-            var id = $(_this).closest('tr').find('[type=checkbox]').attr( "value" );
+            var id = $(_this)
+                .closest("tr")
+                .find("[type=checkbox]")
+                .attr("value");
         }
 
-        if ($('[field="'+field+'"]').attr('class').indexOf('fix-inlineEdit-textarea') > 0) {
-            $('[field="'+field+'"]').removeClass('fix-inlineEdit-textarea');
+        if (
+            $('[field="' + field + '"]')
+                .attr("class")
+                .indexOf("fix-inlineEdit-textarea") > 0
+        ) {
+            $('[field="' + field + '"]').removeClass("fix-inlineEdit-textarea");
         }
 
         //If we find all the required variables to do inline editing.
-        if(field && id && module){
-
+        if (field && id && module) {
             //Do ajax call to retrieve the validation for the field.
-            var validation = getValidationRules(field,module,id);
+            var validation = getValidationRules(field, module, id);
             //Do ajax call to retrieve the html elements of the field.
-            var html = loadFieldHTML(field,module,id);
+            var html = loadFieldHTML(field, module, id);
 
             //If we have the field html append it to the div we clicked.
-            if(html){
-                $(_this).html(validation + "<form name='EditView' id='EditView'><div id='inline_edit_field'>" + html + "</div><a id='inlineEditSaveButton'></a></form>");
-                $("#inlineEditSaveButton").html('<span class="suitepicon suitepicon-action-confirm"></span>');
+            if (html) {
+                $(_this).html(
+                    validation +
+                        "<form name='EditView' id='EditView'><div id='inline_edit_field'>" +
+                        html +
+                        "</div><a id='inlineEditSaveButton'></a></form>"
+                );
+                $("#inlineEditSaveButton").html(
+                    '<span class="suitepicon suitepicon-action-confirm"></span>'
+                );
                 //If the field is a relate field we will need to retrieve the extra js required to make the field work.
-                if(type == "relate" || type == "parent") {
+                if (type == "relate" || type == "parent") {
                     var relate_js = getRelateFieldJS(field, module, id);
                     $(_this).append(relate_js);
                     SUGAR.util.evalScript($(_this).html());
                     // Issue 2344 and 2499 changes - Dump existing QSProcessedFieldsArray to enable multiple QS on multiple rows.
-                    var fieldToCheck = 'EditView_' + field + '_display';
-                    if(fieldToCheck in QSProcessedFieldsArray) {
+                    var fieldToCheck = "EditView_" + field + "_display";
+                    if (fieldToCheck in QSProcessedFieldsArray) {
                         delete QSProcessedFieldsArray[fieldToCheck];
                     }
                     //Needs to be called to enable quicksearch/typeahead functionality on the field.
@@ -170,34 +177,33 @@ function buildEditField(){
 
                 //Put the cursor in the field if possible.
                 $("#" + field).focus();
-                if(type == "name" || type == "text") {
+                if (type == "name" || type == "text") {
                     // move focus to end of text (multiply by 2 to make absolute certain its end as some browsers count carriage return as more than 1 character)
                     var strLength = $("#" + field).val().length * 2;
                     $("#" + field)[0].setSelectionRange(strLength, strLength);
                 }
 
                 //We can only edit one field at a time currently so turn off the on dblclick event
-                $(".inlineEdit").off('click');
-                $(".inlineEdit").off('dblclick');
+                $(".inlineEdit").off("click");
+                $(".inlineEdit").off("dblclick");
 
                 //Call the click away function to handle if the user has clicked off the field, if they have it will close the form.
-                clickedawayclose(field,id,module, type);
+                clickedawayclose(field, id, module, type);
 
                 //Make sure the data is valid and save the details to the bean.
-                validateFormAndSave(field,id,module,type);
-
+                validateFormAndSave(field, id, module, type);
             }
         }
     };
 
     var touchtime = 0;
     $(".inlineEdit").dblclick(function(e) {
-        if(touchtime == 0) {
+        if (touchtime == 0) {
             //set first click
             touchtime = new Date().getTime();
         } else {
             //compare first click to this click and see if they occurred within double click threshold
-            if (((new Date().getTime()) - touchtime) < 800) {
+            if (new Date().getTime() - touchtime < 800) {
                 //double click occurred
                 //alert("double clicked");
                 touchtime = 0;
@@ -209,10 +215,9 @@ function buildEditField(){
         }
     });
 
-    $(".inlineEdit").dblclick(function (e) {
+    $(".inlineEdit").dblclick(function(e) {
         onInlineEditDblClick(this, e);
     });
-
 }
 
 /**
@@ -222,28 +227,29 @@ function buildEditField(){
  * @param module - the module we are editing
  * @param type - the type of the field we are editing.
  */
-function validateFormAndSave(field,id,module,type){
-
-    $("#inlineEditSaveButton").on('click', function () {
+function validateFormAndSave(field, id, module, type) {
+    $("#inlineEditSaveButton").on("click", function() {
         var valid_form = check_form("EditView");
-        if(valid_form){
-            handleSave(field, id, module, type)
+        if (valid_form) {
+            handleSave(field, id, module, type);
             clickListenerActive = false;
-            $('[field="'+field+'"]').addClass('fix-inlineEdit-textarea');
-        }else{
-            $('[field="'+field+'"]').removeClass('fix-inlineEdit-textarea');
-            return false
-        };
+            $('[field="' + field + '"]').addClass("fix-inlineEdit-textarea");
+        } else {
+            $('[field="' + field + '"]').removeClass("fix-inlineEdit-textarea");
+            return false;
+        }
     });
     // also want to save on enter/return being pressed
     $(document).keypress(function(e) {
-
         if (e.which == 13 && !e.shiftKey) {
             e.preventDefault();
             $("#inlineEditSaveButton").click();
         }
     });
 }
+
+var ie_field, ie_id, ie_module, ie_type, ie_message_field;
+var clickListenerActive = false;
 
 /**
  * Checks if any of the parent elemenets of the current element have the class inlineEditActive this means they are within
@@ -252,17 +258,16 @@ function validateFormAndSave(field,id,module,type){
  * @param id - the id of the record we are editing
  * @param module - the module we are editing
  */
-
-var ie_field, ie_id, ie_module, ie_type, ie_message_field;
-var clickListenerActive = false;
-
-function clickedawayclose(field,id,module, type){
+function clickedawayclose(field, id, module, type) {
     // Fix for issue #373 get name from system field name.
-    message_field = 'LBL_' + field.toUpperCase();
+    message_field = "LBL_" + field.toUpperCase();
     message_field = SUGAR.language.get(module, message_field);
     // Fix for issue #373 remove ':'
-    var last_charachter = message_field.substring(message_field.length, message_field.length - 1);
-    if (':'.toUpperCase() === last_charachter.toUpperCase()) {
+    var last_character = message_field.substring(
+        message_field.length,
+        message_field.length - 1
+    );
+    if (":".toUpperCase() === last_character.toUpperCase()) {
         message_field = message_field.substring(0, message_field.length - 1);
     }
     ie_field = field;
@@ -273,7 +278,7 @@ function clickedawayclose(field,id,module, type){
     clickListenerActive = true;
 }
 
-$(document).on('click', function (e) {
+$(document).on("click", function(e) {
     if (clickListenerActive) {
         var field = ie_field;
         var id = ie_id;
@@ -281,7 +286,12 @@ $(document).on('click', function (e) {
         var type = ie_type;
         var message_field = ie_message_field;
 
-        if (!$(e.target).parents().is(".inlineEditActive, .cal_panel") && !$(e.target).hasClass("inlineEditActive")) {
+        if (
+            !$(e.target)
+                .parents()
+                .is(".inlineEditActive, .cal_panel") &&
+            !$(e.target).hasClass("inlineEditActive")
+        ) {
             var output_value = loadFieldHTMLValue(field, id, module);
 
             // Resolve issues with telephone number throwing exception.
@@ -300,12 +310,12 @@ $(document).on('click', function (e) {
 
             // Return user value to empty string for comparison if undefined at this stage (empty field check fix)
             if (typeof user_value === "undefined") {
-                user_value = '';
+                user_value = "";
             }
 
             // QS Fields have '_display' in their field names. An additional check for the this field name pattern.
             if (outputValueParse != user_value && output_value != user_value) {
-                var fieldName = field + '_display';
+                var fieldName = field + "_display";
                 var replacementUserValue = $("#" + fieldName).val();
 
                 // Parsing empty text returns undefined, if the string returns anything other than undefined, replace
@@ -316,8 +326,12 @@ $(document).on('click', function (e) {
             }
 
             var date_compare = false;
-            var output_value_compare = '';
-            if (type == 'datetimecombo' || type == 'datetime' || type == 'date') {
+            var output_value_compare = "";
+            if (
+                type == "datetimecombo" ||
+                type == "datetime" ||
+                type == "date"
+            ) {
                 if (output_value == user_value) {
                     output_value_compare = user_value;
                     date_compare = true;
@@ -326,8 +340,14 @@ $(document).on('click', function (e) {
                 output_value_compare = output_value;
             }
             if (user_value != output_value_compare) {
-                message_field = message_field != 'undefined' ? message_field : '';
-                var r = confirm(SUGAR.language.translate('app_strings', 'LBL_CONFIRM_CANCEL_INLINE_EDITING') + ' ' + message_field);
+                message_field =
+                    message_field != "undefined" ? message_field : "";
+                var r = confirm(
+                    SUGAR.language.translate(
+                        "app_strings",
+                        "LBL_CONFIRM_CANCEL_INLINE_EDITING"
+                    ) + " " + message_field
+                );
                 if (r == true) {
                     var output = setValueClose(output_value);
                     clickListenerActive = false;
@@ -337,7 +357,9 @@ $(document).on('click', function (e) {
                 }
             } else {
                 // user hasn't changed value so can close field without warning them first
-                var output = date_compare ? setValueClose(user_value) : setValueClose(output_value);
+                var output = date_compare
+                    ? setValueClose(user_value)
+                    : setValueClose(output_value);
                 clickListenerActive = false;
             }
         }
@@ -353,71 +375,78 @@ $(document).on('click', function (e) {
  * @param type - the type of the field we are editing.
  * @returns {*}
  */
-
-function getInputValue(field,type){
-
-    if($('#'+ field).length > 0 && type){
-
-        switch(type) {
-            case 'relate':
-            case 'phone':
-            case 'name':
-            case 'varchar':
-                if($('#'+ field).val().length > 0) {
-                    return $('#'+ field).val();
+function getInputValue(field, type) {
+    if ($("#" + field).length > 0 && type) {
+        switch (type) {
+            case "relate":
+            case "phone":
+            case "name":
+            case "varchar":
+                if ($("#" + field).val().length > 0) {
+                    return $("#" + field).val();
                 }
                 break;
-            case 'enum':
-                if($('#'+ field + ' :selected').text().length > 0){
-                    return $('#'+ field + ' :selected').val();
+            case "enum":
+                if ($("#" + field + " :selected").text().length > 0) {
+                    return $("#" + field + " :selected").val();
                 }
                 break;
-            case 'datetime':
-            case 'datetimecombo':
-                if($('#'+ field + '_date').val().length > 0){var date = $('#'+ field + '_date').val();}
-                else var date = 00;
-                if($('#'+ field + '_hours :selected').text().length > 0){var hours = $('#'+ field + '_hours :selected').text();}
-                else var hours = 00;
-                if($('#'+ field + '_minutes :selected').text().length > 0){var minutes = $('#'+ field + '_minutes :selected').text();}
-                else var minutes = 00;
-                if($('#'+ field + '_meridiem :selected').text().length > 0){var meridiem = $('#'+ field + '_meridiem :selected').text();}
-                else var meridiem = "";
-                return date + " " + hours +":"+ minutes + meridiem;
+            case "datetime":
+            case "datetimecombo":
+                if ($("#" + field + "_date").val().length > 0) {
+                    var date = $("#" + field + "_date").val();
+                } else {
+                    var date = 00;
+                }
+                if ($("#" + field + "_hours :selected").text().length > 0) {
+                    var hours = $("#" + field + "_hours :selected").text();
+                } else {
+                    var hours = 00;
+                }
+                if ($("#" + field + "_minutes :selected").text().length > 0) {
+                    var minutes = $("#" + field + "_minutes :selected").text();
+                } else {
+                    var minutes = 00;
+                }
+                if ($("#" + field + "_meridiem :selected").text().length > 0) {
+                    var meridiem = $("#" + field + "_meridiem :selected").text();
+                } else {
+                    var meridiem = "";
+                }
+                return date + " " + hours + ":" + minutes + meridiem;
                 break;
-            case 'date':
+            case "date":
                 //if($('#'+ field + ' :selected').text().length > 0){
-                if($('#'+ field).val().length > 0){
-                    return $('#'+ field).val();
+                if ($("#" + field).val().length > 0) {
+                    return $("#" + field).val();
                 }
                 break;
-            case 'multienum':
-                if($('#'+ field + ' :selected').text().length > 0){
-                    return $('select#'+field).val();
+            case "multienum":
+                if ($("#" + field + " :selected").text().length > 0) {
+                    return $("select#" + field).val();
                 }
                 break;
-            case 'bool':
-                if($('#'+ field).is(':checked')){
+            case "bool":
+                if ($("#" + field).is(":checked")) {
                     return "on";
-                }else{
+                } else {
                     return "off";
                 }
                 break;
-            case 'radioenum':
-                if($('input[name='+field+']:checked').val()){
-                    return $('input[name='+field+']:checked').val();
+            case "radioenum":
+                if ($("input[name=" + field + "]:checked").val()) {
+                    return $("input[name=" + field + "]:checked").val();
                 }
                 break;
             default:
-                if($('#'+ field).val().length > 0) {
-                    return $('#'+ field).val();
+                if ($("#" + field).val().length > 0) {
+                    return $("#" + field).val();
                 }
         }
-    } else if(type == "parent" && $('#parent_id').val().length > 0) {
-        return $('#parent_id').val();
+    } else if (type == "parent" && $("#parent_id").val().length > 0) {
+        return $("#parent_id").val();
     }
-
 }
-
 
 /**
  * Handles the submit of the form.
@@ -430,21 +459,20 @@ function getInputValue(field,type){
  * @param module - the module we are editing
  * @param type - the type of the field we are editing.
  */
-
-function handleSave(field,id,module,type){
-    var value = getInputValue(field,type);
+function handleSave(field, id, module, type) {
+    var value = getInputValue(field, type);
     var parent_type = "";
 
-    if(typeof value === "undefined"){
+    if (typeof value === "undefined") {
         var value = "";
     }
 
-    if(type == "parent") {
-        parent_type = $('#parent_type').val();
+    if (type == "parent") {
+        parent_type = $("#parent_type").val();
     }
-    var output_value = saveFieldHTML(field,module,id,value, parent_type);
+    var output_value = saveFieldHTML(field, module, id, value, parent_type);
     // If the field type is email, we don't want to handle linebreaks in the output.
-    if (field === 'email1') {
+    if (field === "email1") {
         setValueClose(output_value, false);
     } else {
         setValueClose(output_value);
@@ -457,18 +485,25 @@ function handleSave(field,id,module,type){
  * @param value
  * @param replaceLinebreaks Whether or not to replace linebreaks in the value with <br> elements.
  */
-
 function setValueClose(value, replaceLinebreaks = true) {
-    $.get('themes/'+SUGAR.themes.theme_name+'/images/inline_edit_icon.svg', function(data) {
-        // Fix for #3136 - replace new line characters with <br /> for html on close.
-        if (replaceLinebreaks) {
-            value = value.replace(/(?:\r\n|\r|\n)/g, '<br />');
-        }
+    $.get(
+        "themes/" + SUGAR.themes.theme_name + "/images/inline_edit_icon.svg",
+        function(data) {
+            // Fix for #3136 - replace new line characters with <br /> for html on close.
+            if (replaceLinebreaks) {
+                value = value.replace(/(?:\r\n|\r|\n)/g, "<br />");
+            }
 
-        $(".inlineEditActive").html("");
-        $(".inlineEditActive").html(value + '<div class="inlineEditIcon">' + inlineEditIcon + '</div>');
-        $(".inlineEditActive").removeClass("inlineEditActive");
-    });
+            $(".inlineEditActive").html("");
+            $(".inlineEditActive").html(
+                value +
+                    '<div class="inlineEditIcon">' +
+                    inlineEditIcon +
+                    "</div>"
+            );
+            $(".inlineEditActive").removeClass("inlineEditActive");
+        }
+    );
 
     buildEditField();
 }
@@ -483,25 +518,21 @@ function setValueClose(value, replaceLinebreaks = true) {
  * @param value
  * @returns {*}
  */
-
-function saveFieldHTML(field,module,id,value, parent_type) {
-    $.ajaxSetup({"async": false});
-    var result = $.getJSON('index.php',
-        {
-            'module': 'Home',
-            'action': 'saveHTMLField',
-            'field': field,
-            'current_module': module,
-            'id': id,
-            'value': value,
-            'view' : view,
-            'parent_type': parent_type,
-            'to_pdf': true
-        }
-    );
-    $.ajaxSetup({"async": true});
-    return(result.responseText);
-
+function saveFieldHTML(field, module, id, value, parent_type) {
+    $.ajaxSetup({ async: false });
+    var result = $.getJSON("index.php", {
+        module: "Home",
+        action: "saveHTMLField",
+        field: field,
+        current_module: module,
+        id: id,
+        value: value,
+        view: view,
+        parent_type: parent_type,
+        to_pdf: true
+    });
+    $.ajaxSetup({ async: true });
+    return result.responseText;
 }
 
 /**
@@ -514,33 +545,27 @@ function saveFieldHTML(field,module,id,value, parent_type) {
  * @param value
  * @returns {*}
  */
-
 function loadFieldHTML(field, module, id) {
-    $.ajaxSetup({"async": false});
-    var result = $.getJSON('index.php',
-        {
-            'module': 'Home',
-            'action': 'getEditFieldHTML',
-            'field': field,
-            'current_module': module,
-            'id': id,
-            'view': view,
-            'to_pdf': true
-        }
-    );
-    $.ajaxSetup({"async": true});
-    if(result.responseText){
+    $.ajaxSetup({ async: false });
+    var result = $.getJSON("index.php", {
+        module: "Home",
+        action: "getEditFieldHTML",
+        field: field,
+        current_module: module,
+        id: id,
+        view: view,
+        to_pdf: true
+    });
+    $.ajaxSetup({ async: true });
+    if (result.responseText) {
         try {
-            return (JSON.parse(result.responseText));
-        } catch(e) {
+            return JSON.parse(result.responseText);
+        } catch (e) {
             return false;
         }
-
-    }else{
+    } else {
         return false;
     }
-
-
 }
 
 /**
@@ -552,23 +577,20 @@ function loadFieldHTML(field, module, id) {
  * @param id
  * @returns {*}
  */
-
 function loadFieldHTMLValue(field, id, module) {
-    $.ajaxSetup({"async": false});
-    var result = $.getJSON('index.php',
-        {
-            'module': 'Home',
-            'action': 'getDisplayValue',
-            'field': field,
-            'current_module': module,
-            'view': view,
-            'id': id,
-            'to_pdf': true
-        }
-    );
-    $.ajaxSetup({"async": true});
+    $.ajaxSetup({ async: false });
+    var result = $.getJSON("index.php", {
+        module: "Home",
+        action: "getDisplayValue",
+        field: field,
+        current_module: module,
+        view: view,
+        id: id,
+        to_pdf: true
+    });
+    $.ajaxSetup({ async: true });
 
-    return (result.responseText);
+    return result.responseText;
 }
 
 /**
@@ -580,29 +602,33 @@ function loadFieldHTMLValue(field, id, module) {
  * @param id
  * @returns {*}
  */
-
 function getValidationRules(field, module, id) {
-    $.ajaxSetup({"async": false});
-    var result = $.getJSON('index.php',
-        {
-            'module': 'Home',
-            'action': 'getValidationRules',
-            'field': field,
-            'current_module': module,
-            'id': id,
-            'to_pdf': true
-        }
-    );
-    $.ajaxSetup({"async": true});
+    $.ajaxSetup({ async: false });
+    var result = $.getJSON("index.php", {
+        module: "Home",
+        action: "getValidationRules",
+        field: field,
+        current_module: module,
+        id: id,
+        to_pdf: true
+    });
+    $.ajaxSetup({ async: true });
 
     try {
         var validation = JSON.parse(result.responseText);
-    } catch(e) {
-        alert(SUGAR.language.translate('app_strings', 'LBL_LOADING_ERROR_INLINE_EDITING'));
+    } catch (e) {
+        alert(
+            SUGAR.language.translate(
+                "app_strings",
+                "LBL_LOADING_ERROR_INLINE_EDITING"
+            )
+        );
         return false;
     }
 
-    return "<script type='text/javascript'>addToValidate('EditView', \"" + field + "\", \"" + validation['type'] + "\", " + validation['required'] + ",\"" + validation['label'] + "\");</script>";
+    return (
+        "<script type='text/javascript'>addToValidate('EditView', \"" + field + '", "' + validation["type"] + '", ' + validation["required"] + ',"' + validation["label"] + '");</script>'
+    );
 }
 
 /**
@@ -614,20 +640,17 @@ function getValidationRules(field, module, id) {
  * @param id
  * @returns {*}
  */
-
 function getRelateFieldJS(field, module, id) {
-    $.ajaxSetup({"async": false});
-    var result = $.getJSON('index.php',
-        {
-            'module': 'Home',
-            'action': 'getRelateFieldJS',
-            'field': field,
-            'current_module': module,
-            'id': id,
-            'to_pdf': true
-        }
-    );
-    $.ajaxSetup({"async": true});
+    $.ajaxSetup({ async: false });
+    var result = $.getJSON("index.php", {
+        module: "Home",
+        action: "getRelateFieldJS",
+        field: field,
+        current_module: module,
+        id: id,
+        to_pdf: true
+    });
+    $.ajaxSetup({ async: true });
 
     SUGAR.util.evalScript(result.responseText);
 


### PR DESCRIPTION
## Description
This uses [prettier](https://prettier.io) and some minor manual tweaking to improve the readability/consistency of `InlineEditing.js`.

## Motivation and Context
The JavaScript file was inconsistent and pretty messy, I wanted to fix that.

It doesn't seem like there's a minified version of InlineEditing.js in the repo? Please correct me if I'm wrong, the minification/concatenation in the admin panel didn't seem to change any relevant files.

## How To Test This
Make sure inline editing still works, see that the tests pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Code cleanup.

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.