### PR TITLE
Add a proper return type to getUserRoleNames()

### DIFF
--- a/modules/ACLRoles/ACLRole.php
+++ b/modules/ACLRoles/ACLRole.php
@@ -139,7 +139,7 @@ class ACLRole extends SugarBean
      * returns a list of Role names for a given user id
      *
      * @param GUID $user_id
-     * @return a list of ACLRole Names
+     * @return array a list of ACLRole Names
      */
     public function getUserRoleNames($user_id)
     {


### PR DESCRIPTION
## Description
This was causing my editor to highlight uses of getUserRoleNames as an error when it was used as an array.

## How To Test This
Doesn't really need tests, just review the change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.