### PR TITLE
Fix a selector for Inline Editing

### DIFF
--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -184,7 +184,7 @@ function buildEditField() {
                 }
 
                 //We can only edit one field at a time currently so turn off the on dblclick event
-                $(".inlineEdit").off("click");
+                $(".inlineEdit a").off("click");
                 $(".inlineEdit").off("dblclick");
 
                 //Call the click away function to handle if the user has clicked off the field, if they have it will close the form.


### PR DESCRIPTION
## Description
As far as I can tell, there's no click listener registered for `.inlineEdit`, but there is one for `.inlineEdit a`.

This changes the listener toggle to use that instead of a selector that doesn't have such a listener.

## Motivation and Context
The code was leaving behind click listeners that it failed to disable.

## How To Test This
Make sure inline editing continues to work and that tests pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.