### PR TITLE
Fixed #2928 Fixed #341 - clear Zend OPcache when writing files

### DIFF
--- a/include/SugarCache/SugarCache.php
+++ b/include/SugarCache/SugarCache.php
@@ -152,6 +152,12 @@ class SugarCache
         if (function_exists('apc_delete_file') && ini_get('apc.stat') == 0) {
             apc_delete_file($file);
         }
+
+        // Zend OPcache
+        if (function_exists('opcache_invalidate'))
+        {
+            opcache_invalidate($file, true);
+        }
     }
 }
 

--- a/include/utils/file_utils.php
+++ b/include/utils/file_utils.php
@@ -126,13 +126,7 @@ function write_array_to_file($the_name, $the_array, $the_file, $mode="w", $heade
                     var_export_helper($the_array) .
                     ";";
 
-    $result = sugar_file_put_contents($the_file, $the_string, LOCK_EX) !== false;
-
-    if (function_exists('opcache_invalidate')) {
-        opcache_invalidate($the_file, true);
-    }
-
-    return $result;
+    return sugar_file_put_contents($the_file, $the_string, LOCK_EX) !== false;
 }
 
 function write_encoded_file($soap_result, $write_to_dir, $write_to_file="")

--- a/include/utils/sugar_file_utils.php
+++ b/include/utils/sugar_file_utils.php
@@ -42,6 +42,8 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
+require_once(__DIR__.'/../SugarCache/SugarCache.php');
+
 /**
  * sugar_mkdir
  * Call this function instead of mkdir to apply pre-configured permission
@@ -157,7 +159,10 @@ function sugar_file_put_contents($filename, $data, $flags = null, $context = nul
         return false;
     }
 
-    return file_put_contents($filename, $data, $flags, $context);
+    $result = file_put_contents($filename, $data, $flags, $context);
+    SugarCache::cleanFile($filename);
+
+    return $result;
 }
 
 /**


### PR DESCRIPTION
This pull request is a copy of the existing pull request for the hotfix branch:
#6518

OPcache causes some issues when writing .php files which are read shortly after: in this case the cached version of the file is read instead of the newly written file.

## Description
This change improves OPcache handling by

- reverting pull request 8833fae
- using the SugarCache object, which already has an implementation for APC for removing specific files from the cache and implementing OPcache cache refreshing in SugarCache::cleanFile

The refresh of the file cache of OPcache is implemented in a more central place: sugar_file_put_contents, as all write actions of SuiteCRM are processed by this method.

## Motivation and Context
This change solves multiple problems concerning OPcache with SuiteCRM, especially editing layouts in Studio.

## How To Test This
Please see issue #2928

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->