### PR TITLE
Fixed #7712 - case insensitive detection of header X-CampTrackID

### DIFF
--- a/modules/Campaigns/ProcessBouncedEmails.php
+++ b/modules/Campaigns/ProcessBouncedEmails.php
@@ -213,8 +213,8 @@ function checkBouncedEmailForIdentifier($email_description)
     $identifiers = array();
     $found = false;
     //Check if the identifier is present in the header.
-    if (preg_match('/X-CampTrackID: [a-z0-9\-]*/', $email_description, $matches)) {
-        $identifiers = preg_split('/X-CampTrackID: /', $matches[0], -1, PREG_SPLIT_NO_EMPTY);
+    if (preg_match('/X-CampTrackID: [a-z0-9\-]*/i', $email_description, $matches)) {
+        $identifiers = preg_split('/X-CampTrackID: /i', $matches[0], -1, PREG_SPLIT_NO_EMPTY);
         $found = true;
         $GLOBALS['log']->debug("Found campaign identifier in header of email");
     } elseif (preg_match('/index.php\?entryPoint=removeme&identifier=[a-z0-9\-]*/', $email_description, $matches)) {


### PR DESCRIPTION
Make sure the scan for the header is case insensitive to make it more robust. Some SMTP services convert "X-CampTrackID" to lowercase, making it "x-camptrackid".

## Description
SuiteCRM identifies the bounce either by the opt-out link or the e-mail header. In case an email is bounced and the contents of the email are in base64 format, SuiteCRM checks this header.
Some SMTP Services like outlook.com convert headers to lowercase. In this case, "x-camptrackid" is not identified accordingly.

## Motivation and Context
This change adds robustness for SMTP services that change the case of email headers.

## How To Test This
See https://github.com/salesagility/SuiteCRM/issues/7712

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->