### PR TITLE
Make "robo test" commands fail if tests fail

### DIFF
--- a/lib/Robo/Plugin/Commands/TestRunCommands.php
+++ b/lib/Robo/Plugin/Commands/TestRunCommands.php
@@ -67,7 +67,7 @@ class TestRunCommands extends \Robo\Tasks
         $command .= ' -f';
       }
       
-      $this->_exec($command);
+      return $this->_exec($command);
     }
 
     /**
@@ -95,7 +95,7 @@ class TestRunCommands extends \Robo\Tasks
         $command .= ' -f';
       }
       
-      $this->_exec($command);
+      return $this->_exec($command);
     }
 
     /**
@@ -123,7 +123,7 @@ class TestRunCommands extends \Robo\Tasks
         $command .= ' -f';
       }
       
-      $this->_exec($command);
+      return $this->_exec($command);
     }
 
     /**
@@ -151,6 +151,6 @@ class TestRunCommands extends \Robo\Tasks
         $command .= ' --stop-on-error --stop-on-failure';
       }
 
-      $this->_exec($command);
+      return $this->_exec($command);
     }
 }


### PR DESCRIPTION
## Description

The robo command always quit with a 0 return status which makes it not usable
in a CI environment.

Fordward the comman result to make the robo command fail when tests fail.

## Motivation and Context

I'd like to run the tests in CI

## How To Test This

* `./vendor/bin/robo test:unit`
* It should return != 0 in case test fail

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.