### PR TITLE
EmailMarketing: Add security groups support

### DIFF
--- a/modules/EmailMarketing/vardefs.php
+++ b/modules/EmailMarketing/vardefs.php
@@ -251,3 +251,8 @@ $dictionary['EmailMarketing'] = array(
     ),
   ),
 );
+
+if (!class_exists('VardefManager')) {
+    require_once('include/SugarObjects/VardefManager.php');
+}
+VardefManager::createVardef('EmailMarketing', 'EmailMarketing', ['security_groups']);

--- a/tests/unit/phpunit/modules/SecurityGroups/SecurityGroupTest.php
+++ b/tests/unit/phpunit/modules/SecurityGroups/SecurityGroupTest.php
@@ -369,6 +369,7 @@ class SecurityGroupTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
             'FP_Event_Locations',
             'Tasks',
             'jjwg_Markers',
+            'EmailMarketing',
             'EmailTemplates',
             'Campaigns',
             'jjwg_Areas',


### PR DESCRIPTION
## Description

When a user of a security group creates a marketing entry then no
other user in the same group can see/edit it.

This adds the security group relation so that new records are associated with
the right group and other users in the same group can access the marketing email
record.

## Motivation and Context

See above

## How To Test This

* Two users in the same security group
* Create a newsletter with one, and create a marketing entry (just follow the wizard)
* Log in with the other user
* When viewing the campaign the marketing entry should be visible in the subpanel

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.