### PR TITLE
FIX #7781 - Now we can compile SuiteP only one color_scheme

### DIFF
--- a/lib/Robo/Plugin/Commands/BuildCommands.php
+++ b/lib/Robo/Plugin/Commands/BuildCommands.php
@@ -60,7 +60,7 @@ class BuildCommands extends \Robo\Tasks
     public function buildSuiteP(array $opts = ['color_scheme' => ''])
     {
         $this->say('Compile SuiteP Theme (SASS)');
-        if (empty($this->$opts['color_scheme'])) {
+        if (empty($opts['color_scheme'])) {
             /** Look for Subthemes in the SuiteP theme Dir **/
             $std = 'themes/SuiteP/css/';
             $this->locateSubTheme($std);
@@ -71,18 +71,17 @@ class BuildCommands extends \Robo\Tasks
             $this->locateSubTheme($ctd);
 
             return;
-
         }
 
-        if (is_array($this->$opts['color_scheme'])) {
-            foreach ($this->$opts['color_scheme'] as $colorScheme) {
+        if (is_array($opts['color_scheme'])) {
+            foreach ($opts['color_scheme'] as $colorScheme) {
                 $this->buildSuitePColorScheme($colorScheme);
             }
 
             return;
         }
 
-        $this->buildSuitePColorScheme($this->$opts['color_scheme']);
+        $this->buildSuitePColorScheme($opts['color_scheme']);
         $this->say('Compile SuiteP Theme (SASS) Complete');
     }
 

--- a/lib/Robo/Plugin/Commands/BuildCommands.php
+++ b/lib/Robo/Plugin/Commands/BuildCommands.php
@@ -54,13 +54,13 @@ class BuildCommands extends \Robo\Tasks
     /**
      * Build SuiteP theme
      * @param array $opts optional command line arguments
-     * color_scheme - set which color scheme you wish to build
+     * color-scheme - set which color scheme you wish to build
      * @throws \RuntimeException
      */
     public function buildSuiteP(array $opts = ['color-scheme' => ''])
     {
         $this->say('Compile SuiteP Theme (SASS)');
-        if (empty($opts['color_scheme'])) {
+        if (empty($opts['color-scheme'])) {
             /** Look for Subthemes in the SuiteP theme Dir **/
             $std = 'themes/SuiteP/css/';
             $this->locateSubTheme($std);
@@ -73,15 +73,15 @@ class BuildCommands extends \Robo\Tasks
             return;
         }
 
-        if (is_array($opts['color_scheme'])) {
-            foreach ($opts['color_scheme'] as $colorScheme) {
+        if (is_array($opts['color-scheme'])) {
+            foreach ($opts['color-scheme'] as $colorScheme) {
                 $this->buildSuitePColorScheme($colorScheme);
             }
 
             return;
         }
 
-        $this->buildSuitePColorScheme($opts['color_scheme']);
+        $this->buildSuitePColorScheme($opts['color-scheme']);
         $this->say('Compile SuiteP Theme (SASS) Complete');
     }
 

--- a/lib/Robo/Plugin/Commands/BuildCommands.php
+++ b/lib/Robo/Plugin/Commands/BuildCommands.php
@@ -57,7 +57,7 @@ class BuildCommands extends \Robo\Tasks
      * color_scheme - set which color scheme you wish to build
      * @throws \RuntimeException
      */
-    public function buildSuiteP(array $opts = ['color_scheme' => ''])
+    public function buildSuiteP(array $opts = ['color-scheme' => ''])
     {
         $this->say('Compile SuiteP Theme (SASS)');
         if (empty($opts['color_scheme'])) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

Read #7781

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Read #7781

## How To Test This
<!--- Please describe in detail how to test your changes. -->

Run:

```bash
$ ./vendor/bin/robo build:suite-p --color_scheme Dawn 
```
And verify that only Dawn color_scheme is compiled
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->