### PR TITLE
Fixed #7779 - PHP Fatal error in modules/Connectors

### DIFF
--- a/modules/Connectors/connectors/sources/ext/rest/twitter/config.php
+++ b/modules/Connectors/connectors/sources/ext/rest/twitter/config.php
@@ -1,5 +1,6 @@
 <?php
 /***CONNECTOR SOURCE***/
+$config = [];
 $config['name'] = 'Twitter';
 $config['properties']['consumer_key'] = '';
 $config['properties']['consumer_secret'] = '';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
modules/Connectors/connectors/sources/ext/rest/twitter/config.php produces PHP Fatal error: 
```Uncaught Error: Cannot use string offset as an array when hitting CRM home.```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Simply initialise the config array before assignments.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Check for PHP fatals on the homepage.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->