### PR TITLE
Support custom email options

### DIFF
--- a/include/SugarEmailAddress/templates/forEditView.tpl
+++ b/include/SugarEmailAddress/templates/forEditView.tpl
@@ -129,6 +129,13 @@ var emailAddressWidgetLoaded = false;
                                                 </div>
 					</div>
                 {/if}
+
+                                {foreach from=$customOptionsArr item=option}
+                                    <div class="col-xs-3 col-sm-2 col-md-2 col-lg-2 text-center email-address-option">
+                                        <label class="text-sm col-xs-12">{$app_strings[$option.label]}</label>
+                                        <div><input type="checkbox" name="" title="{$app_strings[$option.label]}" id={$option.id} class={$option.id} value="" enabled="true"></div>
+                                </div>
+                                {/foreach}
 			</div>
 		</div>
 
@@ -141,6 +148,7 @@ var eaw = SUGAR.EmailAddressWidget.instances.{$module}{$index} = new SUGAR.Email
 eaw.emailView = '{$emailView}';
 eaw.emailIsRequired = "{$required}";
 eaw.tabIndex = '{$tabindex}';
+eaw.customOptions = {$customOptions};
 var addDefaultAddress = '{$addDefaultAddress}';
 var prefillEmailAddress = '{$prefillEmailAddresses}';
 var prefillData = {$prefillData};

--- a/jssource/src_files/include/SugarEmailAddress/SugarEmailAddress.js
+++ b/jssource/src_files/include/SugarEmailAddress/SugarEmailAddress.js
@@ -65,6 +65,7 @@
     emailView: "",
     emailIsRequired: false,
     tabIndex: -1,
+    customOptions: {},
 
     isIE: function () {
       var ua = window.navigator.userAgent;
@@ -89,7 +90,8 @@
           o[i].opt_out,
           o[i].invalid_email,
           o[i].email_address_id,
-          o[i].confirm_opt_in
+          o[i].confirm_opt_in,
+          o[i]
         );
       }
     },//prefillEmailAddresses
@@ -113,6 +115,13 @@
             if (invalidEl) {
               invalidEl.checked = email['invalid_email'] == 1 ? true : false;
             }
+
+	    _eaw.customOptions.forEach(function(option) {
+                var el = $('#' + this.module + this.id + 'emailAddress' + option.vname + 'Flag' + targetNumber);
+                if (el) {
+                    el.checked = email[option.name] == 1 ? true : false;
+                }
+            });
           }
         }
         //Set the verified flag to true
@@ -219,7 +228,7 @@
       return false;
     },//freezeEvent
 
-    addEmailAddress: function (tableId, address, primaryFlag, replyToFlag, optOutFlag, invalidFlag, emailId, optInFlag) {
+    addEmailAddress: function (tableId, address, primaryFlag, replyToFlag, optOutFlag, invalidFlag, emailId, optInFlag, data) {
       _eaw = this;
 
       if (_eaw.addInProgress) {
@@ -355,6 +364,22 @@
         optInCheckbox.prop("checked", (optInFlag == 'opt-in' || optInFlag == 'confirmed-opt-in'));
       }
 
+      _eaw.customOptions.forEach(function(option) {
+          var checkbox = lineContainer.find('input#' + option.id);
+          if (checkbox.length == 1) {
+              checkbox.attr('name', this.module + _eaw.id + 'emailAddress' + option.vname + 'Flag[]');
+              checkbox.attr('id', this.module + _eaw.id + 'emailAddress' + option.vname + 'Flag' + _eaw.totalEmailAddresses);
+              checkbox.attr('value', this.module + _eaw.id + 'emailAddress' + _eaw.totalEmailAddresses);
+              checkbox.attr('tabindex', tabIndexCount);
+              checkbox.attr('enabled', "true");
+              checkbox.eaw = _eaw;
+ 
+              if(data.hasOwnProperty(option.name)) {
+                  checkbox.prop("checked", (data[option.name] == '1')); 
+              }
+          }
+      });
+
       // Verified flag
       var verifiedField = lineContainer.find('input#verified-flag');
       verifiedField.attr('name', this.module + _eaw.id + 'emailAddressVerifiedFlag');
@@ -459,6 +484,12 @@
           $(value).find('input.email-address-opted-in-flag').first().prop('name', module + id + "emailAddressOptInFlag[]");
           $(value).find('input.email-address-opted-in-flag').first().prop('id', module + id + "emailAddressOptInFlag" + counter);
           $(value).find('input.email-address-opted-in-flag').first().prop('value', module + id + 'emailAddress' + counter);
+
+          _eaw.customOptions.forEach(function(option) {
+              $(value).find('input.' + option.id).first().prop('name', module + id + "emailAddress" + option.vname + "Flag[]");
+              $(value).find('input.' + option.id).first().prop('id', module + id + "emailAddress" + option.vname + "Flag" + counter);
+              $(value).find('input.' + option.id).first().prop('value', module + id + 'emailAddress' + counter);
+          });
 
           // remove button
           $(value).find('.email-address-remove-button').first().prop('name', counter);


### PR DESCRIPTION
This feature allow business to add custom email options other than Primary, Opted Out and Invalid

## Description
The configuration is:
(1) Create a file custom/metadata/email_addressesMetaData.php. Example:

require_once('metadata/email_addressesMetaData.php');
$dictionary['EmailAddress']['fields']['billing'] = array(
      'name'    => 'billing',
      'type'    => 'bool',
      'default' => 0,
      'vname'   => 'billing',
      'custom_option' => true,
      'label' => 'LBL_EMAIL_BILLING',
);

(2) Add the language. For example in custom/include/language/en_us.lang.php

<?php
$app_strings['LBL_EMAIL_BILLING']='Billing';

Database rebuild is required to add custom options in email_addresses table. In addition JS compressed files rebuild is required.

## Motivation and Context
Some business require additional attributes about the people or account email addresses. For example, whether this email address is used for billing purposes.  

## How To Test This
Add a custom option. Rebuild database and JS compressed file. Edit people or account. Add an email address. Check/uncheck the custom option. Save

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

