### PR TITLE
ShowDuplicates: Only show accessible duplicates

### DIFF
--- a/include/SugarObjects/forms/PersonFormBase.php
+++ b/include/SugarObjects/forms/PersonFormBase.php
@@ -240,7 +240,15 @@ abstract class PersonFormBase extends FormBase
             }
         } //if
 
-        return !empty($rows) ? $rows : null;
+        $can_view = [];
+        foreach ($rows as $row) {
+            $bean = BeanFactory::getBean($this->moduleName, $row['id']);
+            if ($bean->ACLAccess('view')) {
+                $can_view[] = $row;
+            }
+        }
+
+        return !empty($can_view) ? $can_view : null;
     }
 
 

--- a/modules/Accounts/AccountFormBase.php
+++ b/modules/Accounts/AccountFormBase.php
@@ -86,22 +86,24 @@ class AccountFormBase
             $query .=   ' ('. $temp_query . ' ) ';
         }
 
+        $rows = array();
         if (!empty($query)) {
-            $rows = array();
             $db = DBManagerFactory::getInstance();
             $result = $db->query($query);
-            $i=-1;
             while (($row=$db->fetchByAssoc($result)) != null) {
-                $i++;
-                $rows[$i] = $row;
+                $rows[] = $row;
             }
-            if ($i==-1) {
-                return null;
-            }
-
-            return $rows;
         }
-        return null;
+
+        $can_view = [];
+        foreach ($rows as $row) {
+            $bean = BeanFactory::getBean('Accounts', $row['id']);
+            if ($bean->ACLAccess('view')) {
+                $can_view[] = $row;
+            }
+        }
+
+        return !empty($can_view) ? $can_view : null;
     }
 
 

--- a/modules/Leads/views/view.convertlead.php
+++ b/modules/Leads/views/view.convertlead.php
@@ -950,7 +950,9 @@ class ViewConvertLead extends SugarView
             while ($row = $lead->db->fetchByAssoc($result)) {
                 $contact = new Contact();
                 $contact->retrieve($row['id']);
-                $dupes[$row['id']] = $contact->name;
+                if ($contact->ACLAccess('view')) {
+                    $dupes[$row['id']] = $contact->name;
+                }
             }
             if (!empty($dupes)) {
                 foreach ($dupes as $id => $name) {

--- a/modules/Opportunities/OpportunityFormBase.php
+++ b/modules/Opportunities/OpportunityFormBase.php
@@ -59,22 +59,24 @@ class OpportunityFormBase
             $query .= getLikeForEachWord('name', $_POST[$prefix.'name']);
         }
 
+        $rows = array();
         if (!empty($query)) {
-            $rows = array();
             $db = DBManagerFactory::getInstance();
             $result = $db->query($query.')');
-            $i=-1;
             while (($row=$db->fetchByAssoc($result)) != null) {
-                $i++;
-                $rows[$i] = $row;
+                $rows[] = $row;
             }
-            if ($i==-1) {
-                return null;
-            }
-        
-            return $rows;
         }
-        return null;
+
+        $can_view = [];
+        foreach ($rows as $row) {
+            $bean = BeanFactory::getBean('Opportunities', $row['id']);
+            if ($bean->ACLAccess('view')) {
+                $can_view[] = $row;
+            }
+        }
+
+        return !empty($can_view) ? $can_view : null;
     }
 
 

--- a/modules/Prospects/ProspectFormBase.php
+++ b/modules/Prospects/ProspectFormBase.php
@@ -82,19 +82,24 @@ class ProspectFormBase
             }
         }
 
+        $rows = array();
         if (!empty($query)) {
-            $rows = array();
-        
             $db = DBManagerFactory::getInstance();
             $result = $db->query($query.');');
             while ($row = $db->fetchByAssoc($result)) {
                 $rows[] = $row;
             }
-            if (count($rows) > 0) {
-                return $rows;
+        }
+
+        $can_view = [];
+        foreach ($rows as $row) {
+            $bean = BeanFactory::getBean('Prospects', $row['id']);
+            if ($bean->ACLAccess('view')) {
+                $can_view[] = $row;
             }
         }
-        return null;
+
+        return !empty($can_view) ? $can_view : null;
     }
 
 


### PR DESCRIPTION
## Description

In case a user tries to create a new lead/account etc it shows duplicates
from other security groups to which the user doesn't have access to.

This adds checks to the various checkForDuplicates() implementations to
only return duplicates which the user can view.

## Motivation and Context

Users shouldn't see things to which they don't have the rights.

## How To Test This

* Create a lead as user A (security group X)
* Create a lead with the same name as user B (security group Y)
* There should be a duplicate page when creating the second lead.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.