### PR TITLE
Robo: Add a --filter option to tests:unit for filtering tests

### DIFF
--- a/lib/Robo/Plugin/Commands/TestRunCommands.php
+++ b/lib/Robo/Plugin/Commands/TestRunCommands.php
@@ -39,6 +39,8 @@
  */
 namespace SuiteCRM\Robo\Plugin\Commands;
 
+use Symfony\Component\Console\Input\InputOption;
+
 class TestRunCommands extends \Robo\Tasks
 {
     use \SuiteCRM\Robo\Traits\RoboTrait;
@@ -137,9 +139,10 @@ class TestRunCommands extends \Robo\Tasks
      * @usage tests:unit
      * @usage tests:unit ./tests/unit/phpunit/modules/Favorites/FavoritesTest.php
      * @usage tests:unit ./tests/unit/phpunit/modules/
+     * @usage tests:unit --filter testdeleteFavorite ./tests/unit/phpunit/modules/Favorites/FavoritesTest.php
      * @usage tests:unit --debug ./tests/unit/phpunit/modules/Favorites/FavoritesTest.php
      */
-    public function TestsUnit($fileOrDirectory = './tests/unit/phpunit', $opts = ['debug' => false, 'fail-fast' => false]) {
+    public function TestsUnit($fileOrDirectory = './tests/unit/phpunit', $opts = ['debug' => false, 'fail-fast' => false, 'filter' => InputOption::VALUE_REQUIRED]) {
       $this->say('Running PHPUnit Unit Test Suite.');
 
       $command = "./vendor/bin/phpunit --colors --configuration ./tests/phpunit.xml.dist {$fileOrDirectory}";
@@ -149,6 +152,9 @@ class TestRunCommands extends \Robo\Tasks
       }
       if ($opts['fail-fast']) {
         $command .= ' --stop-on-error --stop-on-failure';
+      }
+      if ($opts['filter']) {
+          $command .= ' --filter ' . $opts['filter'];
       }
 
       return $this->_exec($command);


### PR DESCRIPTION
## Description

This allows one to run only one specific test method of a test class, which is
helpful when you implement a new test or want to investigate a specific failing one.

The --filter option is passed as is to phpunit, see https://phpunit.readthedocs.io/en/latest/textui.html
for details.

## How To Test This

* ``./vendor/bin/robo tests:unit --filter testdeleteFavorite ./tests/unit/phpunit/modules/Favorites/FavoritesTest.php``

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.