### PR TITLE
Fix a sql query bug for quote purchase subpanel

### DIFF
--- a/modules/AOS_Products/AOS_Products.php
+++ b/modules/AOS_Products/AOS_Products.php
@@ -114,7 +114,7 @@ class AOS_Products extends AOS_Products_sugar
 				JOIN aos_quotes ON aos_quotes.id = aos_products_quotes.parent_id AND aos_quotes.stage = 'Closed Accepted' AND aos_quotes.deleted = 0
 				JOIN accounts ON accounts.id = aos_quotes.billing_account_id -- AND accounts.deleted = 0
 
-				GROUP BY accounts.id
+				GROUP BY aos_quotes.id
 			) AS aos_quotes
 
 		";


### PR DESCRIPTION
Fix database failure in quote purchases subpanel

## Description
Fix database failure in quote purchases subpanel

## Motivation and Context
The quote purchases subpanel expansion lead to a database failure 

MySQL error 1055: Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'suitecrm.aos_quotes.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by

## How To Test This
Create a product. Create a quote that include the product as a line item. Select an account. Save the quote. Go to the product page and expand the Purchases subpanel

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

