### PR TITLE
Save email addresses before saving company/person

### DIFF
--- a/include/SugarObjects/templates/company/Company.php
+++ b/include/SugarObjects/templates/company/Company.php
@@ -85,8 +85,13 @@ class Company extends Basic
         $this->add_address_streets('billing_address_street');
         $this->add_address_streets('shipping_address_street');
         $ori_in_workflow = empty($this->in_workflow) ? false : true;
-        $this->emailAddress->handleLegacySave($this);
-        $record_id = parent::save($check_notify);
+	$this->emailAddress->handleLegacySave($this);
+
+        if (empty($this->id)) {
+	    $this->id = create_guid();
+            $this->new_with_id = true;
+	}
+
         $override_email = array();
         if (!empty($this->email1_set_in_workflow)) {
             $override_email['emailAddress0'] = $this->email1_set_in_workflow;
@@ -111,6 +116,7 @@ class Company extends Basic
             );
         }
 
+	$record_id = parent::save($check_notify);
         return $record_id;
     }
 

--- a/include/SugarObjects/templates/person/Person.php
+++ b/include/SugarObjects/templates/person/Person.php
@@ -188,10 +188,15 @@ class Person extends Basic
         $this->add_address_streets('primary_address_street');
         $this->add_address_streets('alt_address_street');
         $ori_in_workflow = empty($this->in_workflow) ? false : true;
-        $this->emailAddress->handleLegacySave($this);
+	$this->emailAddress->handleLegacySave($this);
+
+        if (empty($this->id)) {
+            $this->id = create_guid();
+            $this->new_with_id = true;
+        }
+
         // bug #39188 - store emails state before workflow make any changes
         $this->emailAddress->stash($this->id, $this->module_dir);
-        parent::save($check_notify);
         $override_email = array();
         if (!empty($this->email1_set_in_workflow)) {
             $override_email['emailAddress0'] = $this->email1_set_in_workflow;
@@ -216,6 +221,7 @@ class Person extends Basic
             );
         }
 
+	parent::save($check_notify);
         return $this->id;
     }
 


### PR DESCRIPTION
Save email addresses before saving company/person

## Description
Save email addresses before saving company/person

## Motivation and Context
I found that the company/person updated email addresses are not available when company/person after_save logic hook was called. This is an issue if the after_save logic hook expect latest company/person email addresses.

## How To Test This
Create a after_save logic hook for accounts. In the after_save logic hook print out the email addresses:

$emails = $bean->get_linked_beans('email_addresses', 'EmailAddresses');
foreach($emails as $email) {
    // print $email
}

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
