### PR TITLE
Removing an item from subpanel should only require the item edit access right

### DIFF
--- a/include/ListView/ListViewSubPanel.php
+++ b/include/ListView/ListViewSubPanel.php
@@ -380,13 +380,11 @@ if (!defined('sugarEntry') || !sugarEntry) {
                  * $field_acl['DetailView'] = $aItem->ACLAccess('DetailView');
                  * $field_acl['ListView'] = $aItem->ACLAccess('ListView');
                  * $field_acl['EditView'] = $aItem->ACLAccess('EditView');
-                 * $field_acl['Delete'] = $aItem->ACLAccess('Delete');
                  */
                 //pass is_owner, in_group...vars defined above
                 $field_acl['DetailView'] = $aItem->ACLAccess('DetailView', $aclaccess_is_owner, $aclaccess_in_group);
                 $field_acl['ListView'] = $aItem->ACLAccess('ListView', $aclaccess_is_owner, $aclaccess_in_group);
                 $field_acl['EditView'] = $aItem->ACLAccess('EditView', $aclaccess_is_owner, $aclaccess_in_group);
-                $field_acl['Delete'] = $aItem->ACLAccess('Delete', $aclaccess_is_owner, $aclaccess_in_group);
                 /* END - SECURITY GROUPS */
                 foreach ($thepanel->get_list_fields() as $field_name => $list_field) {
                     //add linked field attribute to the array.
@@ -490,7 +488,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
                                         $widget_contents[$aVal][$field_name] = '&nbsp;';
                                     }
                                 } elseif (preg_match("/button/i", $list_field['name'])) {
-                                    if ((($list_field['name'] === 'edit_button' && $field_acl['EditView']) || ($list_field['name'] === 'close_button' && $field_acl['EditView']) || ($list_field['name'] === 'remove_button' && $field_acl['Delete'])) && '' != ($_content = $layout_manager->widgetDisplay($list_field))) {
+                                    if ((($list_field['name'] === 'edit_button' && $field_acl['EditView']) || ($list_field['name'] === 'close_button' && $field_acl['EditView']) || ($list_field['name'] === 'remove_button' && $field_acl['EditView'])) && '' != ($_content = $layout_manager->widgetDisplay($list_field))) {
                                         $button_contents[$aVal][] = $_content;
                                         unset($_content);
                                     } else {


### PR DESCRIPTION
Removing an item from subpanel should only require the item edit access right

## Description
Removing an item from subpanel should only require the item edit access right

## Motivation and Context
Currently the code look for Delete access right in order to remove an item from subpanel. This should not be needed. We are not removing the item. We are just removing the item relationship with another item - in other words - editing it.

## How To Test This
Create a lead with another login. Login as another user. Create an account.  Add relationship between the account and the lead. With the change, the user with edit right to the lead should be able to remove the lead from Account Lead subpanel

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

