### PR TITLE
InboundEmailTest: Make tests independent to make them work with the state checker

### DIFF
--- a/tests/unit/phpunit/modules/InboundEmail/InboundEmailTest.php
+++ b/tests/unit/phpunit/modules/InboundEmail/InboundEmailTest.php
@@ -4,22 +4,26 @@ include_once __DIR__ . '/../../../../../include/Imap/ImapHandlerFakeData.php';
 include_once __DIR__ . '/../../../../../include/Imap/ImapHandlerFake.php';
 require_once __DIR__ . '/../../../../../modules/InboundEmail/InboundEmail.php';
 
+/**
+ * Like tempfile() but takes a mode
+ *
+ * @param $mode
+ * @return bool|resource
+ */
+function tempFileWithMode($mode)
+{
+    $path = tempnam(sys_get_temp_dir(), '');
+    $file = fopen($path, $mode);
+    register_shutdown_function(function() use($path) {
+        if (file_exists($path)) {
+            unlink($path);
+        }
+    });
+    return $file;
+}
+
 class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 {
-    public static $class_state = null;
-
-    public static function setUpBeforeClass()
-    {
-        // FIXME: The tests here depend on the email_cache table staying around and the right test order.
-        // Until that is fixed (run with RUN_PER_TESTS to see the problem) we at least restore after the class is done.
-        self::$class_state = new SuiteCRM\StateSaver();
-        self::$class_state->pushTable('email_cache');
-    }
-
-    public static function tearDownAfterClass()
-    {
-        self::$class_state->popTable('email_cache');
-    }
 
     protected function storeStateAll()
     {
@@ -32,6 +36,8 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $state->pushTable('folders');
         $state->pushTable('folders_subscriptions');
         $state->pushTable('config');
+        $state->pushTable('email_cache');
+        $state->pushFile('config.php');
         $state->pushGlobals();
         
         return $state;
@@ -41,6 +47,7 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
     {
         // clean up
         $state->popGlobals();
+        $state->popFile('config.php');
         $state->popTable('config');
         $state->popTable('folders_subscriptions');
         $state->popTable('folders');
@@ -48,6 +55,7 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $state->popTable('inbound_email');
         $state->popTable('inbound_email_autoreply');
         $state->popTable('inbound_email_cache_ts');
+        $state->popTable('email_cache');
     }
 
 
@@ -78,7 +86,7 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $fake->add('setTimeout', [3, 60], [true]);
         $fake->add('getErrors', null, [false]);
         $fake->add('getConnection', null, [function () {
-            return fopen('fakeImapResource', 'wb+');
+            return tempFileWithMode('wb+');
         }]);
         $fake->add('close', null, [null]);
         $fake->add('ping', null, [true]);
@@ -104,7 +112,7 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $fake->add('setTimeout', [3, 60], [true]);
         $fake->add('getErrors', null, [false]);
         $fake->add('getConnection', null, [function () {
-            return fopen('fakeImapResource', 'wb+');
+            return tempFileWithMode('wb+');
         }]);
         $fake->add('close', null, [null]);
         $fake->add('ping', null, [true]);
@@ -129,7 +137,7 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $fake->add('setTimeout', [3, 60], [true]);
         $fake->add('getErrors', null, [false]);
         $fake->add('getConnection', null, [function () {
-            return fopen('fakeImapResource', 'wb+');
+            return tempFileWithMode('wb+');
         }]);
         $fake->add('close', null, [null]);
         $fake->add('ping', null, [true]);
@@ -153,7 +161,7 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $fake->add('setTimeout', [3, 60], [true]);
         $fake->add('getErrors', null, [false]);
         $fake->add('getConnection', null, [function () {
-            return fopen('fakeImapResource', 'wb+');
+            return tempFileWithMode('wb+');
         }]);
         $fake->add('close', null, [null]);
         $fake->add('ping', null, [true]);
@@ -181,12 +189,12 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $fake->add('setTimeout', [2, 15], [true]);
         $fake->add('setTimeout', [3, 15], [true]);
         $fake->add('open', ["{:/service=/ssl/tls/validate-cert/secure}", null, null, 0, 0, []], [function () {
-            return fopen('fakeImapResource', 'wb+');
+            return tempFileWithMode('wb+');
         }]);
         $fake->add('getLastError', null, ['Too many login failures']);
         $fake->add('getAlerts', null, [null]);
         $fake->add('getConnection', null, [function () {
-            return fopen('fakeImapResource', 'wb+');
+            return tempFileWithMode('wb+');
         }]);
         $fake->add('getMailboxes', ['{:/service=/ssl/tls/validate-cert/secure}', '*'], [[]]);
         $fake->add('close', null, [null]);
@@ -213,7 +221,7 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $fake->add('setTimeout', [3, 60], [true]);
         $fake->add('getErrors', null, [false]);
         $fake->add('getConnection', null, [function () {
-            return fopen('fakeImapResource', 'wb+');
+            return tempFileWithMode('wb+');
         }]);
         $fake->add('getMailboxes', ['{:/service=/notls/novalidate-cert/secure}', '*'], [[]]);
         $fake->add('ping', null, [true]);
@@ -252,12 +260,12 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $fake->add('setTimeout', [3, 60], [true]);
         $fake->add('getErrors', null, [false]);
         $fake->add('open', ["{:/service=/notls/novalidate-cert/secure}", null, null, 0, 0, []], [function () {
-            return fopen('fakeImapResource', 'wb+');
+            return tempFileWithMode('wb+');
         }]);
         $fake->add('getLastError', null, ["SECURITY PROBLEM: insecure server advertised AUTH=PLAIN"]);
         $fake->add('getAlerts', null, [false]);
         $fake->add('getConnection', null, [function () {
-            return fopen('fakeImapResource', 'wb+');
+            return tempFileWithMode('wb+');
         }]);
         $fake->add('getMailboxes', ['{:/service=/notls/novalidate-cert/secure}', '*'], [[]]);
         $fake->add('close', null, [null]);
@@ -290,12 +298,12 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $fake->add('setTimeout', [3, 60], [true]);
         $fake->add('getErrors', null, [false]);
         $fake->add('open', ["{:/service=/notls/novalidate-cert/secure}", null, null, 0, 0, []], [function () {
-            return fopen('fakeImapResource', 'wb+');
+            return tempFileWithMode('wb+');
         }]);
         $fake->add('getLastError', null, ['Too many login failures']);
         $fake->add('getAlerts', null, [false]);
         $fake->add('getConnection', null, [function () {
-            return fopen('fakeImapResource', 'wb+');
+            return tempFileWithMode('wb+');
         }]);
         $fake->add('getMailboxes', ['{:/service=/notls/novalidate-cert/secure}', '*'], [[]]);
         $fake->add('close', null, [null]);
@@ -338,12 +346,12 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $fake->add('setTimeout', [3, 60], [true]);
         $fake->add('getErrors', null, [false]);
         $fake->add('open', ["{:/service=/notls/novalidate-cert/secure}", null, null, 0, 0, []], [function () {
-            return fopen('fakeImapResource', 'wb+');
+            return tempFileWithMode('wb+');
         }]);
         $fake->add('getLastError', null, [false]);
         $fake->add('getAlerts', null, [false]);
         $fake->add('getConnection', null, [function () {
-            return fopen('fakeImapResource', 'wb+');
+            return tempFileWithMode('wb+');
         }]);
         $fake->add('getMailboxes', ['{:/service=/notls/novalidate-cert/secure}', '*'], [[]]);
         $fake->add('close', null, [null]);
@@ -386,12 +394,12 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $fake->add('setTimeout', [3, 60], [true]);
         $fake->add('getErrors', null, [false]);
         $fake->add('open', ["{:/service=/ssl/tls/validate-cert/secure}", null, null, 0, 0, []], [function () {
-            return fopen('fakeImapResource', 'wb+');
+            return tempFileWithMode('wb+');
         }]);
         $fake->add('getLastError', null, [false]);
         $fake->add('getAlerts', null, [false]);
         $fake->add('getConnection', null, [function () {
-            return fopen('fakeImapResource', 'wb+');
+            return tempFileWithMode('wb+');
         }]);
         $fake->add('getMailboxes', ['{:/service=/ssl/tls/validate-cert/secure}', '*'], [[]]);
         $fake->add('close', null, [null]);
@@ -960,15 +968,7 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $this->restoreStateAll($state);
     }
 
-    public function testsetCacheValue()
-    {
-        // save state
-        
-        $state = $this->storeStateAll();
-        
-        // test
-        
-        
+    private function setDummyCacheValue() {
         $inboundEmail = new InboundEmail();
 
         $inboundEmail->id = 1;
@@ -990,6 +990,15 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         //execute the method to populate email cache
         $inboundEmail->setCacheValue('INBOX', $inserts);
         $inboundEmail->setCacheValue('INBOX.Trash', $inserts);
+        return $inboundEmail;
+    }
+
+    public function testsetCacheValue()
+    {
+        // save state
+
+        $state = $this->storeStateAll();
+        $inboundEmail = $this->setDummyCacheValue();
 
         //retrieve back to verify the records created
         $result = $inboundEmail->getCacheValue('INBOX');
@@ -1071,8 +1080,7 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $state = $this->storeStateAll();
         
         // test
-        
-        
+
         $inboundEmail = new InboundEmail();
 
         //test without a valid id
@@ -1080,7 +1088,7 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $this->assertEquals(false, $result);
 
         //test with a valid id set
-        $inboundEmail->id = 1;
+        $inboundEmail = $this->setDummyCacheValue();
         $result = $inboundEmail->validCacheExists('');
         $this->assertEquals(true, $result);
         
@@ -1122,9 +1130,7 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         // test
         
         
-        $inboundEmail = new InboundEmail();
-
-        $inboundEmail->id = 1;
+        $inboundEmail = $this->setDummyCacheValue();
 
         //test with invalid mailbox
         $result = $inboundEmail->getCacheUnreadCount('OUTBOX');
@@ -1148,9 +1154,7 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         // test
         
         
-        $inboundEmail = new InboundEmail();
-
-        $inboundEmail->id = 1;
+        $inboundEmail = $this->setDummyCacheValue();
 
         //test with invalid mailbox
         $result = $inboundEmail->getCacheCount('OUTBOX');
@@ -1172,11 +1176,10 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $state = $this->storeStateAll();
         
         // test
-        
-        
-        $inboundEmail = new InboundEmail();
 
-        $inboundEmail->id = 1;
+
+        $inboundEmail = $this->setDummyCacheValue();
+
 
         //test with invalid mailbox
         $result = $inboundEmail->getCacheUnread('OUTBOX');
@@ -1198,11 +1201,9 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $state = $this->storeStateAll();
         
         // test
-        
-        
-        $inboundEmail = new InboundEmail();
 
-        $inboundEmail->id = 1;
+
+        $inboundEmail = $this->setDummyCacheValue();
 
         //execute the method to populate answered field
         $inboundEmail->mark_answered(1, 'pop3');
@@ -1226,9 +1227,7 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         // test
         
         
-        $inboundEmail = new InboundEmail();
-
-        $inboundEmail->id = 1;
+        $inboundEmail = $this->setDummyCacheValue();
 
         $result = $inboundEmail->pop3_shiftCache(array('1' => '1'), array('1'));
 
@@ -1252,9 +1251,9 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         // test
         
         
-        $inboundEmail = new InboundEmail();
+        $inboundEmail = $this->setDummyCacheValue();
 
-        $inboundEmail->id = 1;
+        $inboundEmail->pop3_shiftCache(array('1' => '1'), array('1'));
 
         //test with invalid msgNo
         $result = $inboundEmail->getUIDLForMessage('2');
@@ -1304,9 +1303,8 @@ class InboundEmailTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         // test
         
         
-        $inboundEmail = new InboundEmail();
-
-        $inboundEmail->id = 1;
+        $inboundEmail = $this->setDummyCacheValue();
+        $inboundEmail->pop3_shiftCache(array('1' => '1'), array('1'));
 
         $result = $inboundEmail->pop3_getCacheUidls();
 


### PR DESCRIPTION
## Description

The test methods in InboundEmailTest depended on the test order to run correctly and
failed if the state checker was run per test instead of per class.

This patch makes the tests not depend on each other and restores the state so that the state checker
is happy.

* Move some imap cache setup in a setDummyCacheValue() method
* Use a temp file instead of creating a "fakeImapResource" file in the source dir
* Save/Restore more things between tests

See #7480

## Motivation and Context

* Run the tests outside of travis-ci

## How To Test This

* Run the test suite with `StateCheckerConfig::RUN_PER_TESTS`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

