### PR TITLE
FIX #7828 - Robo tasks for common actions that are performed in Repair Administration module

### DIFF
--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -5,7 +5,7 @@
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
  *
  * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
- * Copyright (C) 2011 - 2018 SalesAgility Ltd.
+ * Copyright (C) 2011 - 2019 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -90,7 +90,7 @@ class RepairCommands extends \Robo\Tasks
         $total = count($queries);
 
         if (!$opts['no-execute']) {
-            $this->say("Database synchronized with vardefs!");
+            $this->say('Database synchronized with vardefs!');
             $this->say("Executed queries: {$total}");
             return;
         }

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -113,7 +113,7 @@ class RepairCommands extends \Robo\Tasks
      * show-output - Set if you want to see the rebuildExtensions() output.
      * @throws \RuntimeException
      */
-    public function repairRebuildExtensions(array $opts = ['show-output' => 'no'])
+    public function repairRebuildExtensions(array $opts = ['show-output' => false])
     {
         $this->say("Rebuilding Extensions...");
         require_once 'modules/Administration/QuickRepairAndRebuild.php';

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -137,13 +137,13 @@ class RepairCommands extends \Robo\Tasks
 
         $_REQUEST['silent'] = 'no';
 
-        if ($opts['show-output'] === 'yes') {
+        if ($opts['show-output']) {
             unset($_REQUEST['silent']);
         }
 
         require_once 'modules/Administration/RebuildRelationship.php';
 
-        if ($opts['show-output'] === 'yes') {
+        if ($opts['show-output']) {
             echo "\n";
         }
         $this->say("Relationships rebuilt!");

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -66,8 +66,8 @@ class RepairCommands extends \Robo\Tasks
         $db = \DBManagerFactory::getInstance();
         $queries = [];
         \VardefManager::clearVardef();
-
         $execute = false;
+
         if ($opts['execute'] === 'yes') {
             $execute = true;
         }
@@ -92,17 +92,16 @@ class RepairCommands extends \Robo\Tasks
             }
         }
 
+        $total = count($queries);
+
         if ($execute) {
-            $total = count($queries);
             $this->say("Database synchronized with vardefs!");
             $this->say("Executed queries: {$total}");
             return;
         }
 
-        $this->say("You need to execute the following queries in order to get database synchronized with vardefs");
-        foreach ($queries as $query) {
-            print_r($query);
-        }
+        $this->say("Execute the following queries {$total} in order to get database synchronized with vardefs");
+        array_map('print_r', $queries);
     }
 
 

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -77,7 +77,7 @@ class RepairCommands extends \Robo\Tasks
             $GLOBALS['reload_vardefs'] = true;
             $focus = new $bean_name();
 
-            if (isset($focus->disable_vardefs) && $focus->disable_vardefs == false && isset($focus->module_dir)) {
+            if (isset($focus->disable_vardefs) && $focus->disable_vardefs === false && isset($focus->module_dir)) {
                 include 'modules/'.$focus->module_dir.'/vardefs.php';
                 $sql = $db->repairTable($focus, !$opts['no-execute']);
 

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -136,7 +136,7 @@ class RepairCommands extends \Robo\Tasks
 
 
     /**
-     * Rebuild Extensions - This Robo task executes rebuildExtensions()
+     * Rebuilds relationships defined in modules/**/vardefs.php.
      * @param array $opts optional command line arguments
      * @option bool $show-output - Set if you want to see the RebuildRelationships output.
      * @throws \RuntimeException

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -136,7 +136,7 @@ class RepairCommands extends \Robo\Tasks
 
 
     /**
-     * Rebuilds relationships defined in modules/**/vardefs.php.
+     * Rebuilds relationships defined in modules/MODULE/vardefs.php.
      * @param array $opts optional command line arguments
      * @option bool $show-output - Set if you want to see the RebuildRelationships output.
      * @throws \RuntimeException

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -60,7 +60,7 @@ class RepairCommands extends \Robo\Tasks
      * @option bool $execute - Set if you want the command to execute SQL at the end of the repair, true by default.
      * @throws \RuntimeException
      */
-    public function repairDatabase(array $opts = ['execute' => 'yes'])
+    public function repairDatabase(array $opts = ['execute' => true])
     {
         global  $beanFiles;
         $this->say('Repairing database...');

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -156,6 +156,6 @@ class RepairCommands extends \Robo\Tasks
         if ($opts['show-output'] === 'yes') {
             echo "\n";
         }
-        $this->say("Relationships rebuilded!");
+        $this->say("Relationships rebuilt!");
     }
 }

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -111,7 +111,7 @@ class RepairCommands extends \Robo\Tasks
     public function repairRebuildExtensions(array $opts = ['show-output' => false])
     {
         $this->say("Rebuilding Extensions...");
-        require_once 'modules/Administration/QuickRepairAndRebuild.php';
+        require_once __DIR__ . '/../../../../modules/Administration/QuickRepairAndRebuild.php';
         global $current_user;
         $current_user->is_admin = '1';
         $tool = new \RepairAndClear();

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -136,7 +136,7 @@ class RepairCommands extends \Robo\Tasks
     /**
      * Rebuild Extensions - This Robo task executes rebuildExtensions()
      * @param array $opts optional command line arguments
-     * show-output - Set if you want to see the RebuildRelationship output.
+     * @option bool $show-output - Set if you want to see the RebuildRelationships output.
      * @throws \RuntimeException
      */
     public function repairRebuildRelationships(array $opts = ['show-output' => 'no'])

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -101,4 +101,28 @@ class RepairCommands extends \Robo\Tasks
             $this->say("Executed queries: {$total}");
         }
     }
+
+
+
+    /**
+     * Rebuild Extensions - This Robo task executes rebuildExtensions()
+     * @throws \RuntimeException
+     */
+    public function repairRebuildExtensions(array $opts = ['show-output' => 'no'])
+    {
+        $this->say("Rebuilding Extensions...");
+        require_once 'modules/Administration/QuickRepairAndRebuild.php';
+        global $current_user;
+        $current_user->is_admin = '1';
+
+        $show_output = false;
+        if ($opts['show-output'] === 'yes') {
+            $show_output = true;
+        }
+
+        $tool = new \RepairAndClear();
+        $tool->show_output = $show_output;
+        $tool->rebuildExtensions();
+        $this->say("Extensions rebuilded!");
+    }
 }

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -131,7 +131,7 @@ class RepairCommands extends \Robo\Tasks
         if ($opts['show-output'] === 'yes') {
             echo "\n";
         }
-        $this->say("Extensions rebuilded!");
+        $this->say("Extensions rebuilt!");
     }
 
 

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -40,6 +40,12 @@
 
 namespace SuiteCRM\Robo\Plugin\Commands;
 
+use DBManagerFactory;
+use RepairAndClear;
+use Robo\Tasks as RoboTasks;
+use RuntimeException;
+use VardefManager;
+
 /**
  * Class RepairCommands
  *
@@ -49,9 +55,7 @@ namespace SuiteCRM\Robo\Plugin\Commands;
  * @license  GNU GPLv3
  * @link     RepairCommands
  */
-
-
-class RepairCommands extends \Robo\Tasks
+class RepairCommands extends RoboTasks
 {
     /**
      * Synchronize database tables with vardefs.
@@ -64,9 +68,9 @@ class RepairCommands extends \Robo\Tasks
     {
         global $beanFiles;
         $this->say('Repairing database...');
-        $db = \DBManagerFactory::getInstance();
+        $db = DBManagerFactory::getInstance();
         $queries = [];
-        \VardefManager::clearVardef();
+        VardefManager::clearVardef();
 
         foreach ($beanFiles as $bean_name => $file) {
             if (!file_exists($file)) {
@@ -114,7 +118,7 @@ class RepairCommands extends \Robo\Tasks
         require_once __DIR__ . '/../../../../modules/Administration/QuickRepairAndRebuild.php';
         global $current_user;
         $current_user->is_admin = '1';
-        $tool = new \RepairAndClear();
+        $tool = new RepairAndClear();
         $tool->show_output = $opts['show-output'];
         $tool->rebuildExtensions();
 

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -92,15 +92,16 @@ class RepairCommands extends \Robo\Tasks
             }
         }
 
-        if (!$execute) {
-            $this->say("You need to execute the following queries in order to get database synchronized with vardefs");
-            foreach ($queries as $query) {
-                print_r($query);
-            }
-        } else {
+        if ($execute) {
             $total = count($queries);
             $this->say("Database synchronized with vardefs!");
             $this->say("Executed queries: {$total}");
+            return;
+        }
+
+        $this->say("You need to execute the following queries in order to get database synchronized with vardefs");
+        foreach ($queries as $query) {
+            print_r($query);
         }
     }
 

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -54,7 +54,8 @@ namespace SuiteCRM\Robo\Plugin\Commands;
 class RepairCommands extends \Robo\Tasks
 {
     /**
-     * Repair database - Synchronize database with vardefs
+     * Synchronize database tables with vardefs.
+     *
      * @param array $opts optional command line arguments
      * execute - Set if you want that the command executes the SQL or not.
      * @throws \RuntimeException

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -62,7 +62,7 @@ class RepairCommands extends \Robo\Tasks
      */
     public function repairDatabase(array $opts = ['execute' => true])
     {
-        global  $beanFiles;
+        global $beanFiles;
         $this->say('Repairing database...');
         $db = \DBManagerFactory::getInstance();
         $queries = [];

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -57,7 +57,7 @@ class RepairCommands extends \Robo\Tasks
      * Synchronize database tables with vardefs.
      *
      * @param array $opts optional command line arguments
-     * execute - Set if you want that the command executes the SQL or not.
+     * @option bool $execute - Set if you want the command to execute SQL at the end of the repair, true by default.
      * @throws \RuntimeException
      */
     public function repairDatabase(array $opts = ['execute' => 'yes'])

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -110,7 +110,7 @@ class RepairCommands extends \Robo\Tasks
      * This Robo task rebuilds the CRM extension files found in custom/Extension.
      * 
      * @param array $opts optional command line arguments
-     * show-output - Set if you want to see the rebuildExtensions() output.
+     * @option bool $show-output - Set if you want to see the rebuildExtensions() output.
      * @throws \RuntimeException
      */
     public function repairRebuildExtensions(array $opts = ['show-output' => false])

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -114,16 +114,11 @@ class RepairCommands extends \Robo\Tasks
         require_once 'modules/Administration/QuickRepairAndRebuild.php';
         global $current_user;
         $current_user->is_admin = '1';
-
-        $show_output = false;
-        if ($opts['show-output'] === 'yes') {
-            $show_output = true;
-        }
-
         $tool = new \RepairAndClear();
-        $tool->show_output = $show_output;
+        $tool->show_output = $opts['show-output'];
         $tool->rebuildExtensions();
-        if ($opts['show-output'] === 'yes') {
+
+        if ($opts['show-output']) {
             echo "\n";
         }
         $this->say("Extensions rebuilt!");

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ *
+ * SugarCRM Community Edition is a customer relationship management program developed by
+ * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2018 SalesAgility Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License version 3 as published by the
+ * Free Software Foundation with the addition of the following permission added
+ * to Section 15 as permitted in Section 7(a): FOR ANY PART OF THE COVERED WORK
+ * IN WHICH THE COPYRIGHT IS OWNED BY SUGARCRM, SUGARCRM DISCLAIMS THE WARRANTY
+ * OF NON INFRINGEMENT OF THIRD PARTY RIGHTS.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program; if not, see http://www.gnu.org/licenses or write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ *
+ * You can contact SugarCRM, Inc. headquarters at 10050 North Wolfe Road,
+ * SW2-130, Cupertino, CA 95014, USA. or at email address contact@sugarcrm.com.
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "Powered by
+ * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
+
+namespace SuiteCRM\Robo\Plugin\Commands;
+
+use SuiteCRM\Utility\OperatingSystem;
+use SuiteCRM\Robo\Traits\RoboTrait;
+use Robo\Task\Base\loadTasks;
+
+class RepairCommands extends \Robo\Tasks
+{
+    use loadTasks;
+    use RoboTrait;
+
+    /**
+     * Repair database - Synchronize database with vardefs
+     * @param array $opts optional command line arguments
+     * execute - Set if you want that the command executes the SQL or not.
+     * @throws \RuntimeException
+     */
+    public function repairDatabase(array $opts = ['execute' => 'yes'])
+    {
+        global  $beanFiles;
+        $this->say('Repairing database...');
+        $db = \DBManagerFactory::getInstance();
+        $queries = [];
+        \VardefManager::clearVardef();
+
+        $execute = false;
+        if ($opts['execute'] === 'yes') {
+            $execute = true;
+        }
+
+        foreach ($beanFiles as $bean_name => $file) {
+            require_once $file;
+
+            if (! file_exists($file)) {
+                continue;
+            }
+
+            $GLOBALS['reload_vardefs'] = true;
+            $focus = new $bean_name();
+
+            if (isset($focus->disable_vardefs) && $focus->disable_vardefs == false) {
+                if (isset($focus->module_dir)) {
+                    include 'modules/'.$focus->module_dir.'/vardefs.php';
+                    $sql = $db->repairTable($focus, $execute);
+
+                    if (!empty($sql)) {
+                        $queries[] = $sql;
+                    }
+                }
+            }
+        }
+
+        if (!$execute) {
+            $this->say("You need to execute the following queries in order to get database synchronized with vardefs");
+            foreach ($queries as $query) {
+                print_r($query);
+            }
+        } else {
+            $total = count($queries);
+            $this->say("Database synchronized with vardefs!");
+            $this->say("Executed queries: {$total}");
+        }
+    }
+}

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -75,21 +75,19 @@ class RepairCommands extends \Robo\Tasks
         foreach ($beanFiles as $bean_name => $file) {
             require_once $file;
 
-            if (! file_exists($file)) {
+            if (!file_exists($file)) {
                 continue;
             }
 
             $GLOBALS['reload_vardefs'] = true;
             $focus = new $bean_name();
 
-            if (isset($focus->disable_vardefs) && $focus->disable_vardefs == false) {
-                if (isset($focus->module_dir)) {
-                    include 'modules/'.$focus->module_dir.'/vardefs.php';
-                    $sql = $db->repairTable($focus, $execute);
+            if (isset($focus->disable_vardefs) && $focus->disable_vardefs == false && isset($focus->module_dir)) {
+                include 'modules/'.$focus->module_dir.'/vardefs.php';
+                $sql = $db->repairTable($focus, $execute);
 
-                    if (!empty($sql)) {
-                        $queries[] = $sql;
-                    }
+                if (!empty($sql)) {
+                    $queries[] = $sql;
                 }
             }
         }
@@ -146,10 +144,10 @@ class RepairCommands extends \Robo\Tasks
     {
         $this->say("Rebuilding Relationships...");
 
+        $_REQUEST['silent'] = 'no';
+
         if ($opts['show-output'] === 'yes') {
             unset($_REQUEST['silent']);
-        } else {
-            $_REQUEST['silent'] = 'no';
         }
 
         require_once 'modules/Administration/RebuildRelationship.php';

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -69,7 +69,7 @@ class RepairCommands extends \Robo\Tasks
         \VardefManager::clearVardef();
         $execute = false;
 
-        if ($opts['execute'] === 'yes') {
+        if ($opts['execute']) {
             $execute = true;
         }
 

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -125,6 +125,34 @@ class RepairCommands extends \Robo\Tasks
         $tool = new \RepairAndClear();
         $tool->show_output = $show_output;
         $tool->rebuildExtensions();
+        if ($opts['show-output'] === 'yes') {
+            echo "\n";
+        }
         $this->say("Extensions rebuilded!");
+    }
+
+
+    /**
+     * Rebuild Extensions - This Robo task executes rebuildExtensions()
+     * @param array $opts optional command line arguments
+     * show-output - Set if you want to see the RebuildRelationship output.
+     * @throws \RuntimeException
+     */
+    public function repairRebuildRelationships(array $opts = ['show-output' => 'no'])
+    {
+        $this->say("Rebuilding Relationships...");
+
+        $_REQUEST['silent'] = 'no';
+
+        if ($opts['show-output'] === 'yes') {
+            $_REQUEST['silent'] = 'yes';
+        }
+
+        require_once 'modules/Administration/RebuildRelationship.php';
+
+        if ($opts['show-output'] === 'yes') {
+            echo "\n";
+        }
+        $this->say("Relationships rebuilded!");
     }
 }

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -141,7 +141,7 @@ class RepairCommands extends \Robo\Tasks
             unset($_REQUEST['silent']);
         }
 
-        require_once 'modules/Administration/RebuildRelationship.php';
+        require_once __DIR__ . '/../../../../modules/Administration/RebuildRelationship.php';
 
         if ($opts['show-output']) {
             echo "\n";

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -40,10 +40,6 @@
 
 namespace SuiteCRM\Robo\Plugin\Commands;
 
-use SuiteCRM\Utility\OperatingSystem;
-use SuiteCRM\Robo\Traits\RoboTrait;
-use Robo\Task\Base\loadTasks;
-
 /**
  * Class RepairCommands
  *
@@ -57,9 +53,6 @@ use Robo\Task\Base\loadTasks;
 
 class RepairCommands extends \Robo\Tasks
 {
-    use loadTasks;
-    use RoboTrait;
-
     /**
      * Repair database - Synchronize database with vardefs
      * @param array $opts optional command line arguments

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -73,12 +73,11 @@ class RepairCommands extends \Robo\Tasks
         }
 
         foreach ($beanFiles as $bean_name => $file) {
-            require_once $file;
-
             if (!file_exists($file)) {
                 continue;
             }
 
+            require_once $file;
             $GLOBALS['reload_vardefs'] = true;
             $focus = new $bean_name();
 

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -103,7 +103,7 @@ class RepairCommands extends \Robo\Tasks
 
     /**
      * This Robo task rebuilds the CRM extension files found in custom/Extension.
-     * 
+     *
      * @param array $opts optional command line arguments
      * @option bool $show-output - Set if you want to see the rebuildExtensions() output.
      * @throws \RuntimeException

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -106,7 +106,8 @@ class RepairCommands extends \Robo\Tasks
 
 
     /**
-     * Rebuild Extensions - This Robo task executes rebuildExtensions()
+     * This Robo task rebuilds the CRM extension files found in custom/Extension.
+     * 
      * @param array $opts optional command line arguments
      * show-output - Set if you want to see the rebuildExtensions() output.
      * @throws \RuntimeException

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -106,6 +106,8 @@ class RepairCommands extends \Robo\Tasks
 
     /**
      * Rebuild Extensions - This Robo task executes rebuildExtensions()
+     * @param array $opts optional command line arguments
+     * show-output - Set if you want to see the rebuildExtensions() output.
      * @throws \RuntimeException
      */
     public function repairRebuildExtensions(array $opts = ['show-output' => 'no'])

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -44,6 +44,17 @@ use SuiteCRM\Utility\OperatingSystem;
 use SuiteCRM\Robo\Traits\RoboTrait;
 use Robo\Task\Base\loadTasks;
 
+/**
+ * Class RepairCommands
+ *
+ * @category RoboTasks
+ * @package  SuiteCRM\Robo\Plugin\Commands
+ * @author   Jose C. Massón <jose AT gcoop DOT coop>
+ * @license  GNU GPLv3
+ * @link     RepairCommands
+ */
+
+
 class RepairCommands extends \Robo\Tasks
 {
     use loadTasks;

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -146,10 +146,10 @@ class RepairCommands extends \Robo\Tasks
     {
         $this->say("Rebuilding Relationships...");
 
-        $_REQUEST['silent'] = 'no';
-
         if ($opts['show-output'] === 'yes') {
-            $_REQUEST['silent'] = 'yes';
+            unset($_REQUEST['silent']);
+        } else {
+            $_REQUEST['silent'] = 'no';
         }
 
         require_once 'modules/Administration/RebuildRelationship.php';

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -133,7 +133,7 @@ class RepairCommands extends \Robo\Tasks
      */
     public function repairRebuildRelationships(array $opts = ['show-output' => false])
     {
-        $this->say("Rebuilding Relationships...");
+        $this->say('Rebuilding Relationships...');
 
         $_REQUEST['silent'] = 'no';
 

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -57,21 +57,16 @@ class RepairCommands extends \Robo\Tasks
      * Synchronize database tables with vardefs.
      *
      * @param array $opts optional command line arguments
-     * @option bool $execute - Set if you want the command to execute SQL at the end of the repair, true by default.
+     * @option bool $no-execute - Set if you do not want the command to execute SQL at the end of the repair.
      * @throws \RuntimeException
      */
-    public function repairDatabase(array $opts = ['execute' => true])
+    public function repairDatabase(array $opts = ['no-execute' => false])
     {
         global $beanFiles;
         $this->say('Repairing database...');
         $db = \DBManagerFactory::getInstance();
         $queries = [];
         \VardefManager::clearVardef();
-        $execute = false;
-
-        if ($opts['execute']) {
-            $execute = true;
-        }
 
         foreach ($beanFiles as $bean_name => $file) {
             if (!file_exists($file)) {
@@ -84,7 +79,7 @@ class RepairCommands extends \Robo\Tasks
 
             if (isset($focus->disable_vardefs) && $focus->disable_vardefs == false && isset($focus->module_dir)) {
                 include 'modules/'.$focus->module_dir.'/vardefs.php';
-                $sql = $db->repairTable($focus, $execute);
+                $sql = $db->repairTable($focus, !$opts['no-execute']);
 
                 if (!empty($sql)) {
                     $queries[] = $sql;
@@ -94,7 +89,7 @@ class RepairCommands extends \Robo\Tasks
 
         $total = count($queries);
 
-        if ($execute) {
+        if (!$opts['no-execute']) {
             $this->say("Database synchronized with vardefs!");
             $this->say("Executed queries: {$total}");
             return;

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -146,6 +146,6 @@ class RepairCommands extends \Robo\Tasks
         if ($opts['show-output']) {
             echo "\n";
         }
-        $this->say("Relationships rebuilt!");
+        $this->say('Relationships rebuilt!');
     }
 }

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -141,7 +141,7 @@ class RepairCommands extends \Robo\Tasks
      * @option bool $show-output - Set if you want to see the RebuildRelationships output.
      * @throws \RuntimeException
      */
-    public function repairRebuildRelationships(array $opts = ['show-output' => 'no'])
+    public function repairRebuildRelationships(array $opts = ['show-output' => false])
     {
         $this->say("Rebuilding Relationships...");
 

--- a/lib/Robo/Plugin/Commands/RepairCommands.php
+++ b/lib/Robo/Plugin/Commands/RepairCommands.php
@@ -121,7 +121,7 @@ class RepairCommands extends \Robo\Tasks
         if ($opts['show-output']) {
             echo "\n";
         }
-        $this->say("Extensions rebuilt!");
+        $this->say('Extensions rebuilt!');
     }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

This PR fixes #7828 
Sometimes it is very useful to perform some actions in SuiteCRM through the command line.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

With the passage of time we have been adding habitual tasks to an immense Makefile. But since SuiteCRM has RoboTask, we can migrate those tasks to RoboTask.
The tasks that we add in this PR, are the first ones that we have migrated from our Makefile to Robo.

We added 3 tasks:


### Repair database

This task synchronize database with vardefs

```bash
$ ./vendor/bin/robo repair:database  
➜  Repairing database...
➜  Database synchronized with vardefs!
➜  Executed queries: 3
```

You can use the argument no-execute to not execute and show the queries in stdout

```bash
$ ./vendor/bin/robo repair:database --no-execute                                                                  
➜  Repairing database...
➜  Execute the following queries 3 in order to get database synchronized with vardefs
/* Table : users */
/*COLUMNS*/
/* INDEXES */
/*INDEX MISMATCH WITH DATABASE - idx_user_name -  ROW <name> idx_user_name <type> index <fields>[0] => 'user_name'  [1] => 'is_group'  [2] => 'status'  [3] => 'last_name'  [4] => 'first_name'  [5] => 'id'  */
/* VARDEF - idx_user_name -  ROW<name> idx_user_name <type> index <fields>[0] => 'user_name'  [1] => 'is_group'  [2] => 'status'  [3] => 'last_name (30)'  [4] => 'first_name (30)'  [5] => 'id'  */
ALTER TABLE users   DROP INDEX idx_user_name,  ADD INDEX idx_user_name (user_name,is_group,status,last_name (30),first_name (30),id)
/* Table : users */
/*COLUMNS*/
/* INDEXES */
/*INDEX MISMATCH WITH DATABASE - idx_user_name -  ROW <name> idx_user_name <type> index <fields>[0] => 'user_name'  [1] => 'is_group'  [2] => 'status'  [3] => 'last_name'  [4] => 'first_name'  [5] => 'id'  */
/* VARDEF - idx_user_name -  ROW<name> idx_user_name <type> index <fields>[0] => 'user_name'  [1] => 'is_group'  [2] => 'status'  [3] => 'last_name (30)'  [4] => 'first_name (30)'  [5] => 'id'  */
ALTER TABLE users   DROP INDEX idx_user_name,  ADD INDEX idx_user_name (user_name,is_group,status,last_name (30),first_name (30),id)
/* Table : users */
/*COLUMNS*/
/* INDEXES */
/*INDEX MISMATCH WITH DATABASE - idx_user_name -  ROW <name> idx_user_name <type> index <fields>[0] => 'user_name'  [1] => 'is_group'  [2] => 'status'  [3] => 'last_name'  [4] => 'first_name'  [5] => 'id'  */
/* VARDEF - idx_user_name -  ROW<name> idx_user_name <type> index <fields>[0] => 'user_name'  [1] => 'is_group'  [2] => 'status'  [3] => 'last_name (30)'  [4] => 'first_name (30)'  [5] => 'id'  */
ALTER TABLE users   DROP INDEX idx_user_name,  ADD INDEX idx_user_name (user_name,is_group,status,last_name (30),first_name (30),id)
```


### Rebuild Extensions

```bash
$  ./vendor/bin/robo repair:rebuild-extensions                                                                     ✭
➜  Rebuilding Extensions...
➜  Extensions rebuilt! 
```

You can use the argument show-output to see what the task is rebuilding


```bash
$  ./vendor/bin/robo repair:rebuild-extensions --show-output                                              
➜  Rebuilding Extensions...
LBL_MI_REBUILDING Include...<br>LBL_MI_REBUILDING Language...en_us<br>LBL_MI_REBUILDING ActionViewMap...<br>LBL_MI_REBUILDING ActionFileMap...<br>LBL_MI_REBUILDING ActionReMap...<br>LBL_MI_REBUILDING Administration...<br>LBL_MI_REBUILDING EntryPointRegistry...<br>LBL_MI_REBUILDING Extensions...<br>LBL_MI_REBUILDING FileAccessControlMap...<br>LBL_MI_REBUILDING Layoutdefs...<br>LBL_MI_REBUILDING GlobalLinks...<br>LBL_MI_REBUILDING LogicHooks...<br>LBL_MI_REBUILDING Menus...<br>LBL_MI_REBUILDING Include...<br>LBL_MI_REBUILDING ScheduledTasks...<br>LBL_MI_REBUILDING UserPage...<br>LBL_MI_REBUILDING Utils...<br>LBL_MI_REBUILDING Vardefs...<br>LBL_MI_REBUILDING JSGroupings...<br>LBL_MI_REBUILDING Actions...<br>LBL_MI_REBUILDING DC Actions...<br>LBL_MI_REBUILDING RelationshipsLBL_MI_REBUILDING TableDictionary...<br>
➜  Extensions rebuilt!
```


### Rebuild Relationships

```bash
$  ./vendor/bin/robo repair:rebuild-relationships                                                                  ✭
➜  Rebuilding Relationships...
➜  Relationships rebuilt!
```

You can use the argument --show-output

```bash
$  ./vendor/bin/robo repair:rebuild-relationships --show-output                                           
➜  Rebuilding Relationships...
acl_actions...<br>acl_roles...<br>relationships...<br>leads...<br>cases...<br>bugs...<br>users...<br>campaign_log...<br>project...<br>project_task...<br>campaigns...<br>prospect_lists...<br>prospects...<br>email_marketing...<br>campaign_trkrs...<br>releases...<br>emailman...<br>schedulers...<br>job_queue...<br>contacts...<br>accounts...<br>opportunities...<br>email_templates...<br>notes...<br>calls...<br>emails...<br>meetings...<br>tasks...<br>users...<br>users...<br>currencies...<br>tracker...<br>import_maps...<br>users_last_import...<br>config...<br>upgrade_history...<br>vcals...<br>alerts...<br>roles...<br>documents...<br>document_revisions...<br>fields_meta_data...<br>inbound_email...<br>saved_search...<br>user_preferences...<br>...<br>email_addresses...<br>emails_text...<br>spots...<br>aobh_businesshours...<br>sugarfeed...<br>eapm...<br>oauth_consumer...<br>oauth_tokens...<br>am_projecttemplates...<br>am_tasktemplates...<br>favorites...<br>aok_knowledge_base_categories...<br>aok_knowledgebase...<br>reminders...<br>reminders_invitees...<br>fp_events...<br>fp_event_locations...<br>aod_indexevent...<br>aod_index...<br>aop_case_events...<br>aop_case_updates...<br>aor_reports...<br>aor_fields...<br>aor_charts...<br>aor_conditions...<br>aor_scheduled_reports...<br>aos_contracts...<br>aos_invoices...<br>aos_pdf_templates...<br>aos_product_categories...<br>aos_products...<br>aos_products_quotes...<br>aos_line_item_groups...<br>aos_quotes...<br>aow_actions...<br>aow_workflow...<br>aow_processed...<br>aow_conditions...<br>jjwg_maps...<br>jjwg_markers...<br>jjwg_areas...<br>jjwg_address_cache...<br>calls_reschedule...<br>securitygroups...<br>outbound_email...<br>templatesectionline...<br>oauth2tokens...<br>oauth2clients...<br>surveyresponses...<br>surveys...<br>surveyquestionresponses...<br>surveyquestions...<br>surveyquestionoptions...<br>accounts_bugs...<br>accounts_cases...<br>accounts_contacts...<br>accounts_opportunities...<br>calls_contacts...<br>calls_users...<br>calls_leads...<br>cases_bugs...<br>contacts_bugs...<br>contacts_cases...<br>contacts_users...<br>custom_fields...<br>email_addresses...<br>EmailAddress...<br>emails_email_addr_rel...<br>email_addr_bean_rel...<br>emails_beans...<br>emails_text...<br>folders...<br>folders_subscriptions...<br>folders_rel...<br>meetings_contacts...<br>meetings_users...<br>meetings_leads...<br>opportunities_contacts...<br>users_feeds...<br>users_password_link...<br>prospect_list_campaigns...<br>prospect_lists_prospects...<br>roles_modules...<br>roles_users...<br>OutboundEmail...<br>AddressBook...<br>projects_bugs...<br>projects_cases...<br>projects_products...<br>projects_accounts...<br>projects_contacts...<br>projects_opportunities...<br>acl_roles_actions...<br>acl_roles_users...<br>InboundEmail_autoreply...<br>InboundEmail_cacheTimestamp...<br>email_cache...<br>email_marketing_prospect_lists...<br>UserSignature...<br>linked_documents...<br>documents_accounts...<br>documents_contacts...<br>documents_opportunities...<br>documents_cases...<br>documents_bugs...<br>oauth_nonce...<br>cron_remove_documents...<br>aok_knowledgebase_categories...<br>am_projecttemplates_project_1...<br>am_projecttemplates_contacts_1...<br>am_projecttemplates_users_1...<br>am_tasktemplates_am_projecttemplates...<br>aos_contracts_documents...<br>aos_quotes_aos_contracts...<br>aos_quotes_aos_invoices...<br>aos_quotes_project...<br>aow_processed_aow_actions...<br>fp_event_locations_fp_events_1...<br>fp_events_contacts...<br>fp_events_fp_event_delegates_1...<br>fp_events_fp_event_locations_1...<br>fp_events_leads_1...<br>fp_events_prospects_1...<br>jjwg_maps_jjwg_areas...<br>jjwg_maps_jjwg_markers...<br>project_contacts_1...<br>project_users_1...<br>securitygroups_acl_roles...<br>securitygroups_default...<br>securitygroups_records...<br>securitygroups_users...<br>surveyquestionoptions_surveyquestionresponses...<br>
➜  Relationships rebuilded!
```

## How To Test This
<!--- Please describe in detail how to test your changes. -->

Just execute the command mentioned above ;-)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->