### PR TITLE
SugarFeed: Various fixes for 7.10.19/20 regressions

### DIFF
--- a/modules/SugarFeed/Dashlets/SugarFeedDashlet/SugarFeedDashlet.php
+++ b/modules/SugarFeed/Dashlets/SugarFeedDashlet/SugarFeedDashlet.php
@@ -660,8 +660,8 @@ enableQS(false);
     public function getPostForm()
     {
         global $current_user;
-        
-        if (!empty($this->selectedCategories) && !in_array('User Feed', $this->categories, true)) {
+
+        if (!empty($this->selectedCategories) && !key_exists('UserFeed', $this->categories)) {
             // The user feed system isn't enabled, don't let them post notes
             return '';
         }

--- a/modules/SugarFeed/Dashlets/SugarFeedDashlet/SugarFeedDashlet.php
+++ b/modules/SugarFeed/Dashlets/SugarFeedDashlet/SugarFeedDashlet.php
@@ -267,6 +267,7 @@ class SugarFeedDashlet extends DashletGeneric
             $all_modules = array_merge($regular_modules,$owner_modules);
             if(!is_admin($GLOBALS['current_user']) && count($all_modules) > 0)
             {
+                $securitygroup_where = '';
                 $first = true;
                 foreach($all_modules as $module)
                 {

--- a/modules/SugarFeed/SugarFeed.php
+++ b/modules/SugarFeed/SugarFeed.php
@@ -463,32 +463,16 @@ class SugarFeed extends Basic
         foreach ($replies['list'] as $reply) {
             // Setup the delete link
             $delete = '';
-
-            if (!isset($data['CREATED_BY'])) {
-                LoggerManager::getLogger()->warn('SugarFeed fetchReplies: Undefined index: $data[CREATED_BY]');
-                $dataCreateBy = null;
-            } else {
-                $dataCreateBy = $data['CREATED_BY'];
-            }
-
-            if (is_admin($GLOBALS['current_user']) || $dataCreateBy == $GLOBALS['current_user']->id) {
+            if (is_admin($GLOBALS['current_user']) || $reply->created_by == $GLOBALS['current_user']->id) {
                 $delete = '<a id="sugarFieldDeleteLink'.$reply->id.'" href="#" onclick=\'SugarFeed.deleteFeed("'. $reply->id . '", "{this.id}"); return false;\'>'. $GLOBALS['app_strings']['LBL_DELETE_BUTTON_LABEL'].'</a>';
             }
 
+            $user = BeanFactory::getBean('Users', $reply->created_by);
             $image_url = 'include/images/default_user_feed_picture.png';
-            if (isset($reply->created_by)) {
-                $user = loadBean('Users');
-                $user->retrieve($reply->created_by);
-
-                if (!isset($user->picture)) {
-                    LoggerManager::getLogger()->warn('SugarFeed fetchReplies: Undefined property: User::$picture');
-                    $userPicture = null;
-                } else {
-                    $userPicture = $user->picture;
-                }
-
-                $image_url = 'index.php?entryPoint=download&id=' . $userPicture . '&type=SugarFieldImage&isTempFile=1&isProfile=1';
+            if (!empty($user) && !empty($user->picture)) {
+                $image_url = 'index.php?entryPoint=download&id=' . $user->picture . '&type=SugarFieldImage&isTempFile=1&isProfile=1';
             }
+
             $replyHTML .= '<div style="float: left; margin-right: 3px; width: 50px; height: 50px;"><!--not_in_theme!--><img src="'.$image_url.'" style="max-width: 50px; max-height: 50px;"></div> ';
             $replyHTML .= str_replace("{this.CREATED_BY}", get_assigned_user_name($reply->created_by), html_entity_decode($reply->name)).'<br>';
             $replyHTML .= '<div class="byLineBox"><span class="byLineLeft">'. $this->getTimeLapse($reply->date_entered) . '&nbsp;</span><div class="byLineRight">  &nbsp;' .$delete. '</div></div><div class="clear"></div>';

--- a/modules/SugarFeed/SugarFeed.php
+++ b/modules/SugarFeed/SugarFeed.php
@@ -388,6 +388,13 @@ class SugarFeed extends Basic
         $data = parent::get_list_view_data();
         $delete = '';
 
+        if (!isset($data['CREATED_BY'])) {
+            LoggerManager::getLogger()->warn('SugarFeed fetchReplies: Undefined index: $data[CREATED_BY]');
+            $dataCreateBy = null;
+        } else {
+            $dataCreateBy = $data['CREATED_BY'];
+        }
+
         if (!isset($data['DESCRIPTION'])) {
             LoggerManager::getLogger()->warn('SugarFeed get_list_view_data: Undefined index: DESCRIPTION ');
             $dataDescription = null;
@@ -421,6 +428,10 @@ class SugarFeed extends Basic
             $dataId = null;
         } else {
             $dataId = $data['ID'];
+        }
+
+        if (is_admin($GLOBALS['current_user']) || $dataCreateBy == $GLOBALS['current_user']->id) {
+            $delete = ' | <a id="sugarFieldDeleteLink'.$dataId.'" href="#" onclick=\'SugarFeed.deleteFeed("'. $dataId . '", "{this.id}"); return false;\'>'. $GLOBALS['app_strings']['LBL_DELETE_BUTTON_LABEL'].'</a>';
         }
 
         $data['NAME'] .= $this->getTimeLapse($dataDateEntered) . '&nbsp;</span><div class="byLineRight"><a id="sugarFeedReplyLink'.$dataId.'" href="#" onclick=\'SugarFeed.buildReplyForm("'.$dataId.'", "{this.id}", this); return false;\'>'.$GLOBALS['app_strings']['LBL_EMAIL_REPLY'].'</a>' .$delete. '</div></div>';


### PR DESCRIPTION
## Description

See the commits for details:

* Fixes creating feed entries for non-english users
* Fix php error log spam
* Fix delete links not being shown for feed entries and replies

## Motivation and Context

* Make things work like in 7.10.18

## How To Test This

* As a non-english user try to create a feed entry
* Create a feed entry and try to delete it again
* Create a reply to an entry of a different user and try to delete it again

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.