### PR TITLE
Workflow: Properly delete records which are marked as deleted

### DIFF
--- a/modules/AOW_Actions/actions/actionCreateRecord.php
+++ b/modules/AOW_Actions/actions/actionCreateRecord.php
@@ -380,7 +380,20 @@ class actionCreateRecord extends actionBase
         $record->process_save_dates =false;
         $record->new_with_id = false;
 
+        /* Since we only work on non-deleted records this means the delete field
+         * was set during this action.
+         * Complete the deletion process by calling mark_deleted() after save() */
+        $was_deleted = false;
+        if ($record->deleted) {
+            $record->deleted = 0;
+            $was_deleted = true;
+        }
+
         $record->save($check_notify);
+
+        if ($was_deleted) {
+            $record->mark_deleted($record->id);
+        }
 
         $record->processed = $bean_processed;
     }


### PR DESCRIPTION
## Description

There is currently no action for deleting a record, only for modifying one.

The only way atm is to set the "deleted" field during the workflow action which
seems to work but leaves tangling relations in the DB and not all code handles that
properly, leading to weird errors/states and a bloated DB

Improves the current way by checking if the delete field was set during the action
and properly delete the record after the action is done, including relations etc.

## Motivation and Context

Searching for how to delete with a workflow leads to descriptions pointing to set the deleted field, but that's not working right currently.

## How To Test This

* Delete a record with a workflow, all relations should be marked as deleted as well.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.