### PR TITLE
Fixed #7838 - 'Undefined index: docType' PHP notice

### DIFF
--- a/download.php
+++ b/download.php
@@ -238,10 +238,10 @@ if ((!isset($_REQUEST['isProfile']) && empty($_REQUEST['id'])) || empty($_REQUES
             }
         } else {
             header('Content-type: ' . $mime_type);
-            if ($_REQUEST['preview'] === "yes") {
-                header("Content-Disposition: inline; filename=\"".$name."\";");
+            if (isset($_REQUEST['preview']) && $_REQUEST['preview'] === 'yes') {
+                header('Content-Disposition: inline; filename="' . $name . '";');
             } else {
-                header("Content-Disposition: attachment; filename=\"" . $name . "\";");
+                header('Content-Disposition: attachment; filename="' . $name . '";');
             }
         }
         // disable content type sniffing in MSIE

--- a/include/SugarFields/Fields/File/SugarFieldFile.php
+++ b/include/SugarFields/Fields/File/SugarFieldFile.php
@@ -155,7 +155,8 @@ class SugarFieldFile extends SugarFieldBase
 
         if ($move) {
             $upload_file->final_move($bean->id);
-            $upload_file->upload_doc($bean, $bean->id, $params[$prefix . $vardef['docType']], $bean->$field, $upload_file->mime_type);
+            $docType = $prefix . $vardef['docType'];
+            $upload_file->upload_doc($bean, $bean->id, isset($params[$docType]), $bean->$field, $upload_file->mime_type);
         } elseif (! empty($old_id)) {
             // It's a duplicate, I think
 

--- a/include/SugarFields/Fields/File/SugarFieldFile.php
+++ b/include/SugarFields/Fields/File/SugarFieldFile.php
@@ -155,7 +155,7 @@ class SugarFieldFile extends SugarFieldBase
 
         if ($move) {
             $upload_file->final_move($bean->id);
-            $docType = $prefix . $vardef['docType'];
+            $docType = $prefix . isset($vardef['docType']);
             $upload_file->upload_doc($bean, $bean->id, isset($params[$docType]), $bean->$field, $upload_file->mime_type);
         } elseif (! empty($old_id)) {
             // It's a duplicate, I think


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixed undefined index in document upload and download.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #7838

```
Tested in 7.10.20:
[Mon Sep  9 19:17:47 2019] PHP Notice:  Undefined index: docType in /home/jose/trabajos/SuiteCRM/include/SugarFields/Fields/File/SugarFieldFile.php on line 158
[Mon Sep  9 19:17:47 2019] PHP Stack trace:
[Mon Sep  9 19:17:47 2019] PHP   1. {main}() /home/jose/trabajos/SuiteCRM/index.php:0
[Mon Sep  9 19:17:47 2019] PHP   2. SugarApplication->execute() /home/jose/trabajos/SuiteCRM/index.php:52
[Mon Sep  9 19:17:47 2019] PHP   3. NotesController->execute() /home/jose/trabajos/SuiteCRM/include/MVC/SugarApplication.php:113
[Mon Sep  9 19:17:47 2019] PHP   4. NotesController->process() /home/jose/trabajos/SuiteCRM/include/MVC/Controller/SugarController.php:373
[Mon Sep  9 19:17:47 2019] PHP   5. NotesController->handle_action() /home/jose/trabajos/SuiteCRM/include/MVC/Controller/SugarController.php:468
[Mon Sep  9 19:17:47 2019] PHP   6. NotesController->pre_action() /home/jose/trabajos/SuiteCRM/include/MVC/Controller/SugarController.php:494
[Mon Sep  9 19:17:47 2019] PHP   7. NotesController->pre_save() /home/jose/trabajos/SuiteCRM/include/MVC/Controller/SugarController.php:508
[Mon Sep  9 19:17:47 2019] PHP   8. SugarFieldFile->save() /home/jose/trabajos/SuiteCRM/include/MVC/Controller/SugarController.php:664
```
```
Mon Sep  9 19:32:13 2019] PHP Notice:  Undefined index: preview in /home/jose/trabajos/SuiteCRM/download.php on line 241
[Mon Sep  9 19:32:13 2019] PHP Stack trace:
[Mon Sep  9 19:32:13 2019] PHP   1. {main}() /home/jose/trabajos/SuiteCRM/index.php:0
[Mon Sep  9 19:32:13 2019] PHP   2. SugarApplication->execute() /home/jose/trabajos/SuiteCRM/index.php:52
[Mon Sep  9 19:32:13 2019] PHP   3. HomeController->execute() /home/jose/trabajos/SuiteCRM/include/MVC/SugarApplication.php:113
[Mon Sep  9 19:32:13 2019] PHP   4. HomeController->process() /home/jose/trabajos/SuiteCRM/include/MVC/Controller/SugarController.php:373
[Mon Sep  9 19:32:13 2019] PHP   5. HomeController->handleEntryPoint() /home/jose/trabajos/SuiteCRM/include/MVC/Controller/SugarController.php:468
[Mon Sep  9 19:32:13 2019] PHP   6. require_once() /home/jose/trabajos/SuiteCRM/include/MVC/Controller/SugarController.php:1020
```



## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Upload a document and check for PHP notices.
2. Download the uploaded document and check for PHP notices.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->