### PR TITLE
Create custom module in custom folder

### DIFF
--- a/include/MVC/View/SugarView.php
+++ b/include/MVC/View/SugarView.php
@@ -1217,7 +1217,9 @@ EOHTML;
      */
     protected function _checkModule()
     {
-        if (!empty($this->module) && !file_exists('modules/' . $this->module)) {
+        global $beanFiles;
+
+        if (!empty($this->module) && !file_exists('modules/' . $this->module) && !file_exists($beanFiles[$this->module])) {
             $error = str_replace("[module]", "$this->module", $GLOBALS['app_strings']['ERR_CANNOT_FIND_MODULE']);
             $GLOBALS['log']->fatal($error);
             echo $error;

--- a/include/SugarObjects/templates/basic/metadata/metafiles.php
+++ b/include/SugarObjects/templates/basic/metadata/metafiles.php
@@ -40,10 +40,10 @@
 
 $module_name = '<module_name>';
 $metafiles[$module_name] = array(
-    'detailviewdefs' => 'modules/' . $module_name . '/metadata/detailviewdefs.php',
-    'editviewdefs' => 'modules/' . $module_name . '/metadata/editviewdefs.php',
-    'listviewdefs' => 'modules/' . $module_name . '/metadata/listviewdefs.php',
-    'searchdefs' => 'modules/' . $module_name . '/metadata/searchdefs.php',
-    'popupdefs' => 'modules/' . $module_name . '/metadata/popupdefs.php',
-    'searchfields' => 'modules/' . $module_name . '/metadata/SearchFields.php',
+    'detailviewdefs' => 'custom/modules/' . $module_name . '/metadata/detailviewdefs.php',
+    'editviewdefs' => 'custom/modules/' . $module_name . '/metadata/editviewdefs.php',
+    'listviewdefs' => 'custom/modules/' . $module_name . '/metadata/listviewdefs.php',
+    'searchdefs' => 'custom/modules/' . $module_name . '/metadata/searchdefs.php',
+    'popupdefs' => 'custom/modules/' . $module_name . '/metadata/popupdefs.php',
+    'searchfields' => 'custom/modules/' . $module_name . '/metadata/SearchFields.php',
 );

--- a/include/SugarObjects/templates/company/metadata/metafiles.php
+++ b/include/SugarObjects/templates/company/metadata/metafiles.php
@@ -40,10 +40,10 @@
 
 $module_name = '<module_name>';
 $metafiles[$module_name] = array(
-    'detailviewdefs' => 'modules/' . $module_name . '/metadata/detailviewdefs.php',
-    'editviewdefs' => 'modules/' . $module_name . '/metadata/editviewdefs.php',
-    'listviewdefs' => 'modules/' . $module_name . '/metadata/listviewdefs.php',
-    'searchdefs' => 'modules/' . $module_name . '/metadata/searchdefs.php',
-    'popupdefs' => 'modules/' . $module_name . '/metadata/popupdefs.php',
-    'searchfields' => 'modules/' . $module_name . '/metadata/SearchFields.php',
+    'detailviewdefs' => 'custom/modules/' . $module_name . '/metadata/detailviewdefs.php',
+    'editviewdefs' => 'custom/modules/' . $module_name . '/metadata/editviewdefs.php',
+    'listviewdefs' => 'custom/modules/' . $module_name . '/metadata/listviewdefs.php',
+    'searchdefs' => 'custom/modules/' . $module_name . '/metadata/searchdefs.php',
+    'popupdefs' => 'custom/modules/' . $module_name . '/metadata/popupdefs.php',
+    'searchfields' => 'custom/modules/' . $module_name . '/metadata/SearchFields.php',
 );

--- a/include/SugarObjects/templates/file/metadata/metafiles.php
+++ b/include/SugarObjects/templates/file/metadata/metafiles.php
@@ -44,10 +44,10 @@ if (!defined('sugarEntry') || !sugarEntry) {
 
 $module_name = '<module_name>';
 $metafiles[$module_name] = array(
-    'detailviewdefs' => 'modules/' . $module_name . '/metadata/detailviewdefs.php',
-    'editviewdefs' => 'modules/' . $module_name . '/metadata/editviewdefs.php',
-    'listviewdefs' => 'modules/' . $module_name . '/metadata/listviewdefs.php',
-    'searchdefs' => 'modules/' . $module_name . '/metadata/searchdefs.php',
-    'popupdefs' => 'modules/' . $module_name . '/metadata/popupdefs.php',
-    'searchfields' => 'modules/' . $module_name . '/metadata/SearchFields.php',
+    'detailviewdefs' => 'custom/modules/' . $module_name . '/metadata/detailviewdefs.php',
+    'editviewdefs' => 'custom/modules/' . $module_name . '/metadata/editviewdefs.php',
+    'listviewdefs' => 'custom/modules/' . $module_name . '/metadata/listviewdefs.php',
+    'searchdefs' => 'custom/modules/' . $module_name . '/metadata/searchdefs.php',
+    'popupdefs' => 'custom/modules/' . $module_name . '/metadata/popupdefs.php',
+    'searchfields' => 'custom/modules/' . $module_name . '/metadata/SearchFields.php',
 );

--- a/include/SugarObjects/templates/issue/metadata/metafiles.php
+++ b/include/SugarObjects/templates/issue/metadata/metafiles.php
@@ -40,10 +40,10 @@
 
 $module_name = '<module_name>';
 $metafiles[$module_name] = array(
-    'detailviewdefs' => 'modules/' . $module_name . '/metadata/detailviewdefs.php',
-    'editviewdefs' => 'modules/' . $module_name . '/metadata/editviewdefs.php',
-    'listviewdefs' => 'modules/' . $module_name . '/metadata/listviewdefs.php',
-    'searchdefs' => 'modules/' . $module_name . '/metadata/searchdefs.php',
-    'popupdefs' => 'modules/' . $module_name . '/metadata/popupdefs.php',
-    'searchfields' => 'modules/' . $module_name . '/metadata/SearchFields.php',
+    'detailviewdefs' => 'custom/modules/' . $module_name . '/metadata/detailviewdefs.php',
+    'editviewdefs' => 'custom/modules/' . $module_name . '/metadata/editviewdefs.php',
+    'listviewdefs' => 'custom/modules/' . $module_name . '/metadata/listviewdefs.php',
+    'searchdefs' => 'custom/modules/' . $module_name . '/metadata/searchdefs.php',
+    'popupdefs' => 'custom/modules/' . $module_name . '/metadata/popupdefs.php',
+    'searchfields' => 'custom/modules/' . $module_name . '/metadata/SearchFields.php',
 );

--- a/include/SugarObjects/templates/person/metadata/metafiles.php
+++ b/include/SugarObjects/templates/person/metadata/metafiles.php
@@ -40,10 +40,10 @@
 
 $module_name = '<module_name>';
 $metafiles[$module_name] = array(
-    'detailviewdefs' => 'modules/' . $module_name . '/metadata/detailviewdefs.php',
-    'editviewdefs' => 'modules/' . $module_name . '/metadata/editviewdefs.php',
-    'listviewdefs' => 'modules/' . $module_name . '/metadata/listviewdefs.php',
-    'searchdefs' => 'modules/' . $module_name . '/metadata/searchdefs.php',
-    'popupdefs' => 'modules/' . $module_name . '/metadata/popupdefs.php',
-    'searchfields' => 'modules/' . $module_name . '/metadata/SearchFields.php',
+    'detailviewdefs' => 'custom/modules/' . $module_name . '/metadata/detailviewdefs.php',
+    'editviewdefs' => 'custom/modules/' . $module_name . '/metadata/editviewdefs.php',
+    'listviewdefs' => 'custom/modules/' . $module_name . '/metadata/listviewdefs.php',
+    'searchdefs' => 'custom/modules/' . $module_name . '/metadata/searchdefs.php',
+    'popupdefs' => 'custom/modules/' . $module_name . '/metadata/popupdefs.php',
+    'searchfields' => 'custom/modules/' . $module_name . '/metadata/SearchFields.php',
 );

--- a/include/SugarObjects/templates/sale/metadata/metafiles.php
+++ b/include/SugarObjects/templates/sale/metadata/metafiles.php
@@ -44,11 +44,11 @@ if (!defined('sugarEntry') || !sugarEntry) {
 
 $module_name = '<module_name>';
 $metafiles[$module_name] = array(
-    'detailviewdefs' => 'modules/' . $module_name . '/metadata/detailviewdefs.php',
-    'editviewdefs' => 'modules/' . $module_name . '/metadata/editviewdefs.php',
-    'listviewdefs' => 'modules/' . $module_name . '/metadata/listviewdefs.php',
-    'searchdefs' => 'modules/' . $module_name . '/metadata/searchdefs.php',
-    'popupdefs' => 'modules/' . $module_name . '/metadata/popupdefs.php',
-    'searchfields' => 'modules/' . $module_name . '/metadata/SearchFields.php',
+    'detailviewdefs' => 'custom/modules/' . $module_name . '/metadata/detailviewdefs.php',
+    'editviewdefs' => 'custom/modules/' . $module_name . '/metadata/editviewdefs.php',
+    'listviewdefs' => 'custom/modules/' . $module_name . '/metadata/listviewdefs.php',
+    'searchdefs' => 'custom/modules/' . $module_name . '/metadata/searchdefs.php',
+    'popupdefs' => 'custom/modules/' . $module_name . '/metadata/popupdefs.php',
+    'searchfields' => 'custom/modules/' . $module_name . '/metadata/SearchFields.php',
 
 );

--- a/modules/ModuleBuilder/MB/MBModule.php
+++ b/modules/ModuleBuilder/MB/MBModule.php
@@ -80,7 +80,7 @@ class MBModule
         $this->path = $this->getModuleDir() ;
         //		$this->mbrelationship = new MBRelationship($this->name, $this->path, $this->key_name);
         $this->relationships = new UndeployedRelationships($this->path) ;
-        $this->mbvardefs = new MBVardefs($this->name, $this->path, $this->key_name) ;
+        $this->mbvardefs = new MBVardefs($this->name, $this->path . "/Ext/Vardefs", $this->key_name) ;
 
         $this->load() ;
     }
@@ -316,7 +316,7 @@ class MBModule
             $old_config_md5 = $this->config_md5 ;
             $this->saveConfig() ;
             $this->getVardefs() ;
-            $this->mbvardefs->save($this->key_name) ;
+            // $this->mbvardefs->save($this->key_name) ;
             //           $this->mbrelationship->save ( $this->key_name ) ;
             $this->relationships->save() ;
             $this->copyMetaData() ;
@@ -489,11 +489,16 @@ class MBModule
             fwrite($fp, $smarty->fetch('modules/ModuleBuilder/tpls/MBModule/Class.tpl'));
             fclose($fp);
         }
+
         //write vardefs
-        $fp = sugar_fopen($path . '/vardefs.php', 'w') ;
+        if (! file_exists($path . '/Ext/Vardefs')) {
+            mkdir_recursive($path . '/Ext/Vardefs') ;
+        }
+
+        $fp = sugar_fopen($path . '/Ext/Vardefs/vardefs.ext.php', 'w') ;
         fwrite($fp, $smarty->fetch('modules/ModuleBuilder/tpls/MBModule/vardef.tpl')) ;
         fclose($fp) ;
-        
+
         if (! file_exists($path . '/metadata')) {
             mkdir_recursive($path . '/metadata') ;
         }
@@ -523,8 +528,8 @@ class MBModule
     public function addInstallDefs(&$installDefs)
     {
         $name = $this->key_name ;
-        $installDefs [ 'copy' ] [] = array( 'from' => '<basepath>/SugarModules/modules/' . $name , 'to' => 'modules/' . $name ) ;
-        $installDefs [ 'beans' ] [] = array( 'module' => $name , 'class' => $name , 'path' => 'modules/' . $name . '/' . $name . '.php' , 'tab' => $this->config [ 'has_tab' ] ) ;
+        $installDefs [ 'copy' ] [] = array( 'from' => '<basepath>/SugarModules/modules/' . $name , 'to' => 'custom/modules/' . $name ) ;
+        $installDefs [ 'beans' ] [] = array( 'module' => $name , 'class' => $name , 'path' => 'custom/modules/' . $name . '/' . $name . '.php' , 'tab' => $this->config [ 'has_tab' ] ) ;
         $this->relationships->addInstallDefs($installDefs) ;
     }
 

--- a/modules/ModuleBuilder/MB/MBVardefs.php
+++ b/modules/ModuleBuilder/MB/MBVardefs.php
@@ -163,19 +163,21 @@ class MBVardefs
     public function save()
     {
         $header = file_get_contents('modules/ModuleBuilder/MB/header.php');
-        write_array_to_file('vardefs', $this->vardef, $this->path . '/vardefs.php', 'w', $header);
+        if (mkdir_recursive($this->path)) {
+            write_array_to_file('vardefs', $this->vardef, $this->path . '/vardefs.ext.php', 'w', $header);
+        }
     }
 
     public function build($path)
     {
         $header = file_get_contents('modules/ModuleBuilder/MB/header.php');
-        write_array_to_file('dictionary["' . $this->name . '"]', $this->getVardefs(), $path . '/vardefs.php', 'w', $header);
+	write_array_to_file('dictionary["' . $this->name . '"]', $this->getVardefs(), $this->path . '/vardefs.ext.php', 'w', $header);
     }
     public function load()
     {
         $this->vardef = array('fields'=>array(), 'relationships'=>array());
-        if (file_exists($this->path . '/vardefs.php')) {
-            include($this->path. '/vardefs.php');
+        if (file_exists($this->path . '/vardefs.ext.php')) {
+            include($this->path. '/vardefs.ext.php');
             $this->vardef = $vardefs;
         }
     }


### PR DESCRIPTION
Create custom module in custom folder

## Description
ModuleBuilder deploy custom module in custom/modules folder

## Motivation and Context
By having custom module in custom/modules folder, this make migrating to new SuiteCRM version easier and less error-prone. This is so because all files under module folder can be deleted or overwritten.

## How To Test This
Create a new package with a module in ModuleBuilder. Click deploy

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

