### PR TITLE
SuiteP: Add html data tags to allow module and field identification

### DIFF
--- a/themes/SuiteP/include/DetailView/tab_panel_content.tpl
+++ b/themes/SuiteP/include/DetailView/tab_panel_content.tpl
@@ -59,10 +59,10 @@
 
         {{if $smarty.foreach.colIteration.total > 1 && $colData.colspan != 3}}
             {*<!-- DIV column - colspan != 3 -->*}
-            <div class="col-xs-12 col-sm-6 detail-view-row-item">
+            <div class="col-xs-12 col-sm-6 detail-view-row-item" data-field="{{$colData.field.name}}">
         {{else}}
             {*<!-- DIV column - colspan = 3 -->*}
-            <div class="col-xs-12 col-sm-12 detail-view-row-item">
+            <div class="col-xs-12 col-sm-12 detail-view-row-item" data-field="{{$colData.field.name}}">
         {{/if}}
 
 

--- a/themes/SuiteP/include/EditView/tab_panel_content.tpl
+++ b/themes/SuiteP/include/EditView/tab_panel_content.tpl
@@ -7,9 +7,9 @@
                 {*column*}
                 {*<!-- COLUMN -->*}
                 {{if $smarty.foreach.colIteration.total > 1 && $colData.colspan != 3}}
-                    <div class="col-xs-12 col-sm-6 edit-view-row-item">
+                    <div class="col-xs-12 col-sm-6 edit-view-row-item" data-field="{{$colData.field.name}}">
                 {{else}}
-                    <div class="col-xs-12 col-sm-12 edit-view-row-item">
+                    <div class="col-xs-12 col-sm-12 edit-view-row-item" data-field="{{$colData.field.name}}">
                 {{/if}}
 
                 {{counter name="fieldCount" start=0 print=false assign="fieldCount"}}

--- a/themes/SuiteP/tpls/header.tpl
+++ b/themes/SuiteP/tpls/header.tpl
@@ -64,5 +64,5 @@
 <div id="bootstrap-container"
      class="{if $THEME_CONFIG.display_sidebar && $smarty.cookies.sidebartoggle|default:'' != 'collapsed'}col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2{/if} main bootstrap-container">
     <div id="content" class="content">
-        <div id="pagecontent" class=".pagecontent">
+        <div id="pagecontent" class=".pagecontent" data-module="{$MODULE_NAME}">
 {/if}


### PR DESCRIPTION
## Description
The present commit adds a "data-module" tag to the SuiteP pagecontent div and "data-field" tags in the edit and detail views. 

## Motivation and Context
The SuiteP theme does currently not allow to differentiate between different modules in the html code. This is not necessary for the standard SuiteP layout (not a bug). However, it would allow for tiny customization with css here and there. These additions allows developers to easily customize the appearance of individual views by simply adding custom css code, e.g.:
`
div#pagecontent[data-module='Accounts'] .edit-view-row-item[data-field='assigned_user_name'] .label {  
  color: red;  
}
`
## How To Test This
You can add the above css code into custom/themes/SuiteP/css/Dawn/style.css and should see the color change.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->