### PR TITLE
Fix emails being sent from 'Root User'.

### DIFF
--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -2973,11 +2973,15 @@ class Email extends Basic
         $mail = $this->setMailer($mail, '', $ieId);
 
         if (($mail->oe->type === 'system') && (!isset($sugar_config['email_allow_send_as_user']) || (!$sugar_config['email_allow_send_as_user']))) {
-            $mail->From =
-            $sender =
-            $ReplyToAddr = $mail->oe->smtp_from_addr;
+            $fromAddr = $mail->oe->smtp_from_addr;
+            $fromName = $mail->oe->smtp_from_name;
+
+            $mail->From = $fromAddr;
+            $sender = $fromAddr;
+            $ReplyToAddr = $fromAddr;
             isValidEmailAddress($mail->From);
-            $ReplyToName = $mail->oe->smtp_from_name;
+            $ReplyToName = $fromName;
+            $mail->FromName = $fromName;
         } else {
 
             // FROM ADDRESS


### PR DESCRIPTION
## Description
When emails were being sent from 'system' and the 'allow sending as user' toggle wasn't enabled, the email was being sent as 'Root User' instead of the name configured in the Email Settings.

## Motivation and Context
The fix was suggested here: https://github.com/salesagility/SuiteCRM/pull/6017#issuecomment-444086825

I essentially used the same code, but I refactored it because having multi-line assignment looks really ugly to me.

This fully fixes the issue described in #6012.

## How To Test This
1. Set up the CRM with the following:
   - Have an 'Outbound Email' configured as 'system', with a Name set (e.g. 'Custom Name').
   - In the Admin page 'Email Settings', make sure 'Users may send as themselves' is turned off.
1. Go to a Lead.
1. Click 'Compose Email' in the Activities subpanel.
1. Set the "To" address to your own email.
1. Send a test email.
1. Make sure the email you receive is listed as coming from 'Custom Name', not 'Root User'.

I feel like this should probably have a test, but I don't have any idea how I'd set one up, so for now I haven't.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.