### PR TITLE
travis-ci: Move the PHP 5.6 job to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ matrix:
     - name: "PHP 5.5 / MySQL 5.6"
       php: "5.5"
       dist: trusty
-    - name: "PHP 5.6 / MySQL 5.6"
+    - name: "PHP 5.6 / MySQL 5.7"
       php: "5.6"
-      dist: trusty
+      dist: xenial
     - name: "PHP 7.3 / MySQL 5.7"
       php: "7.3"
       dist: xenial


### PR DESCRIPTION
## Description

PHP5.x is currently failing because of #7848
This should at least make the PHP 5.6 job run again.
The xenial image doesn't have PHP 5.5, so we can't use it there.

## Motivation and Context

Have a working CI for PHP 5

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.