### PR TITLE
Fixed #6535 - Replace contact_xxx in templates also for leads/prospects/users

### DIFF
--- a/modules/EmailTemplates/EmailTemplateParser.php
+++ b/modules/EmailTemplates/EmailTemplateParser.php
@@ -174,6 +174,18 @@ class EmailTemplateParser
 
         $parts = explode($charUnderscore, ltrim($variable, $charVariable));
         list($moduleName, $attribute) = [array_shift($parts), join($charUnderscore, $parts)];
+
+        /* Leads/Prospects/Users have a special variable naming scheme.
+        $contact_xxx for leads/prospects and $contact_user_xxx for users */
+        if (strtolower($moduleName) === 'contact') {
+            if (in_array($this->module->object_name, ['Lead', 'Prospect'], true)) {
+                $moduleName = strtolower($this->module->object_name);
+            } else if ($this->module->object_name == 'User' && str_begin(strtolower($attribute), 'user_')) {
+                $attribute = explode('_', $attribute, 2)[1];
+                $moduleName = 'user';
+            }
+        }
+
         if (in_array($attribute, static::$allowedVariables, true)) {
             return $this->getNonDBVariableValue($attribute);
         }

--- a/tests/unit/phpunit/modules/EmailTemplates/EmailTemplateTest.php
+++ b/tests/unit/phpunit/modules/EmailTemplates/EmailTemplateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once 'modules/EmailTemplates/EmailTemplateParser.php';
+
 class EmailTemplateTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
 {
     public function setUp()
@@ -9,6 +11,42 @@ class EmailTemplateTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         global $current_user;
         get_sugar_config_defaults();
         $current_user = new User();
+    }
+
+    public function testEmailTemplateParser()
+    {
+        $emailTemplate = new EmailTemplate();
+        $emailTemplate->body_html = to_html('<h1>Hello $contact_name</h1>');
+        $emailTemplate->body = 'Hello $contact_name';
+        $emailTemplate->subject = 'Hello $contact_name';
+        $campaign = new Campaign();
+
+        $related = [new Lead(), new Contact(), new Prospect()];
+        foreach ($related as $bean) {
+            $bean->name = 'foobar';
+
+            $parser = new EmailTemplateParser($emailTemplate, $campaign, $bean, "", "");
+            $result = $parser->parseVariables();
+            $this->assertEquals('<h1>Hello foobar</h1>', from_html($result['body_html']));
+            $this->assertEquals('Hello foobar', $result['body']);
+            $this->assertEquals('Hello foobar', $result['subject']);
+        }
+    }
+
+    public function testEmailTemplateParserUser()
+    {
+        $emailTemplate = new EmailTemplate();
+        $emailTemplate->body = 'Hello $contact_user_full_name';
+        $campaign = new Campaign();
+
+        $bean = new User();
+        $bean->first_name = 'foo';
+        $bean->last_name = 'bar';
+        $bean->fill_in_additional_detail_fields();
+
+        $parser = new EmailTemplateParser($emailTemplate, $campaign, $bean, "", "");
+        $result = $parser->parseVariables();
+        $this->assertEquals('Hello foo bar', $result['body']);
     }
 
     public function testcreateCopyTemplate()


### PR DESCRIPTION
## Description

This was removed in #5337, reverted in #5397 and then re-removed in #5425.

The original template code does more things, but this should at least make
the basics work again and adds some tests.

Fixes #6535

## Motivation and Context

Sending emails with templates to leads

## How To Test This

* Create a campaign
* Add a lead to the test list
* Include a lead variable (like name)
* Send a test email
* The variable should be replaced

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
