### PR TITLE
Implement support for elastic search 7

### DIFF
--- a/lib/Search/ElasticSearch/defaultParams.yml
+++ b/lib/Search/ElasticSearch/defaultParams.yml
@@ -7,14 +7,13 @@ name_fields: &name_fields
   copy_to: named
   fields: *fields
 
-mappings:
-  _default_:
-    properties:
-      name:
-        properties:
-          name: *name_fields
-          first: *name_fields
-          last: *name_fields
-      named:
-        type: text
-        fields: *fields
+_default_:
+  properties:
+    name:
+      properties:
+        name: *name_fields
+        first: *name_fields
+        last: *name_fields
+    named:
+      type: text
+      fields: *fields


### PR DESCRIPTION
## Description
By rewriting defaultParams, i introduce support for elastic search > 7 ; this breaks with elastic search 5.x

## Motivation and Context
Because elastic search 5.6 is EOL, we need to update elastic search

## How To Test This
By change the connection from an elastic search 5 instance to elastic search > 7

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
