### PR TITLE
FIX #7875 - Wrong render in DateRangeInput using "Between" Option

### DIFF
--- a/include/SugarFields/Fields/Datetimecombo/RangeSearchForm.tpl
+++ b/include/SugarFields/Fields/Datetimecombo/RangeSearchForm.tpl
@@ -85,7 +85,7 @@ weekNumbers:false
 
 <div id="{$id}_between_range_div" style="{if $starting_choice=='between'}display:'';{else}display:none;{/if}">
 {assign var=date_value value={{sugarvar key='value' string=true}} }
-<input autocomplete="off" type="text" name="start_range_{$id}" id="start_range_{$id}" value='{$smarty.request.{{$id_range_start}} }' title='{{$vardef.help}}' {{$displayParams.field}} tabindex='{{$tabindex}}' size="11" class="rangeDateInput">
+<input autocomplete="off" type="text" name="start_range_{$id}" id="start_range_{$id}" value='{$smarty.request.{{$id_range_start}} }' title='{{$vardef.help}}' {{$displayParams.field}} tabindex='{{$tabindex}}' size="11" class="dateRangeInput">
 {{if !$displayParams.hiddeCalendar}}
     <button id="start_range_{$id}_trigger" type="button" onclick="return false" class="btn btn-danger"><span class="suitepicon suitepicon-module-calendar" alt="{$APP.LBL_ENTER_DATE}"></span></button>
 {{/if}}

--- a/include/SugarFields/Fields/Datetimecombo/RangeSearchForm.tpl
+++ b/include/SugarFields/Fields/Datetimecombo/RangeSearchForm.tpl
@@ -110,7 +110,9 @@ weekNumbers:false
 {assign var=date_value value={{sugarvar key='value' string=true}} }
 <input autocomplete="off" type="text" name="end_range_{$id}" id="end_range_{$id}" value='{$smarty.request.{{$id_range_end}} }' title='{{$vardef.help}}' {{$displayParams.field}} tabindex='{{$tabindex}}' size="11" class="dateRangeInput" maxlength="10">
 {{if !$displayParams.hiddeCalendar}}
-    <span class="suitepicon suitepicon-module-calendar" id="end_range_{$id}_trigger" alt="{$APP.LBL_ENTER_DATE}"></span>
+    <button id="end_range_{$id}_trigger" type="button" onclick="return false" class="btn btn-danger">
+        <span class="suitepicon suitepicon-module-calendar" alt="{$APP.LBL_ENTER_DATE}"></span>
+    </button>
 {{/if}}
 {{if $displayParams.showFormats}}
 &nbsp;(<span class="dateFormat">{$USER_DATEFORMAT}</span>)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

Read #7875

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Make SuiteCRM looks cuter ;-)

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Open a search form with a DateRange widget
2. Select Between option
3. Verify the how is rendered


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->