### PR TITLE
Fixed #6800 - Elasticsearch: Elastic index name is hardcoded

### DIFF
--- a/install/suite_install/Search.php
+++ b/install/suite_install/Search.php
@@ -73,6 +73,7 @@ function install_es()
         'host' => 'localhost',
         'user' => '',
         'pass' => '',
+        'index' => $sugar_config['unique_key']
     ];
 
     ksort($sugar_config);
@@ -123,3 +124,4 @@ function installESHooks()
         );
     }
 }
+

--- a/lib/Search/ElasticSearch/ElasticSearchEngine.php
+++ b/lib/Search/ElasticSearch/ElasticSearchEngine.php
@@ -66,7 +66,12 @@ class ElasticSearchEngine extends SearchEngine
      */
     public function __construct(Client $client = null)
     {
-        $this->client = empty($client) ? ElasticSearchClientBuilder::getClient() : $client;
+        global $sugar_config;
+        $this->client = $client === null ? ElasticSearchClientBuilder::getClient() : $client;
+
+        if (!empty($sugar_config['search']['ElasticSearch']['index'])) {
+            $this->index = $sugar_config['search']['ElasticSearch']['index'];
+        }
     }
 
     /**

--- a/tests/unit/phpunit/lib/SuiteCRM/Search/ElasticSearch/ElasticSearchEngineTest.php
+++ b/tests/unit/phpunit/lib/SuiteCRM/Search/ElasticSearch/ElasticSearchEngineTest.php
@@ -59,6 +59,8 @@ class ElasticSearchEngineTest extends \SuiteCRM\Search\SearchTestAbstract
 
     public function testCreateSearchParams1()
     {
+        global $sugar_config;
+
         $engine = new ElasticSearchEngine();
         $searchString = "hello search";
         $size = 30;
@@ -67,7 +69,7 @@ class ElasticSearchEngineTest extends \SuiteCRM\Search\SearchTestAbstract
         $query = SearchQuery::fromString($searchString, $size, $from);
 
         $expectedParams = [
-            'index' => 'main',
+            'index' => $sugar_config['unique_key'],
             'body' => [
                 'stored_fields' => [],
                 'from' => $from,
@@ -91,6 +93,8 @@ class ElasticSearchEngineTest extends \SuiteCRM\Search\SearchTestAbstract
 
     public function testCreateSearchParams2()
     {
+        global $sugar_config;
+
         $engine = new ElasticSearchEngine();
         $searchString = "test";
         $size = 30;
@@ -98,7 +102,7 @@ class ElasticSearchEngineTest extends \SuiteCRM\Search\SearchTestAbstract
         $query = SearchQuery::fromString($searchString, $size);
 
         $expectedParams = [
-            'index' => 'main',
+            'index' => $sugar_config['unique_key'],
             'body' => [
                 'stored_fields' => [],
                 'from' => 0,
@@ -140,6 +144,8 @@ class ElasticSearchEngineTest extends \SuiteCRM\Search\SearchTestAbstract
      */
     private function getMockedHits()
     {
+        global $sugar_config;
+
         $mockedResults = [
             'took' => 5,
             'timed_out' => false,
@@ -158,21 +164,21 @@ class ElasticSearchEngineTest extends \SuiteCRM\Search\SearchTestAbstract
                         [
                             0 =>
                                 [
-                                    '_index' => 'main',
+                                    '_index' => $sugar_config['unique_key'],
                                     '_type' => 'Accounts',
                                     '_id' => 'id1',
                                     '_score' => 1.0,
                                 ],
                             1 =>
                                 [
-                                    '_index' => 'main',
+                                    '_index' => $sugar_config['unique_key'],
                                     '_type' => 'Accounts',
                                     '_id' => 'id2',
                                     '_score' => 1.0,
                                 ],
                             2 =>
                                 [
-                                    '_index' => 'main',
+                                    '_index' => $sugar_config['unique_key'],
                                     '_type' => 'Contacts',
                                     '_id' => 'id3',
                                     '_score' => 0.5,
@@ -281,9 +287,11 @@ class ElasticSearchEngineTest extends \SuiteCRM\Search\SearchTestAbstract
 
     public function testGetIndex()
     {
+        global $sugar_config;
+
         $engine = new ElasticSearchEngine();
 
-        self::assertEquals('main', $engine->getIndex());
+        self::assertEquals($sugar_config['unique_key'], $engine->getIndex());
 
         $expected = 'Foo';
         $engine->setIndex($expected);

--- a/tests/unit/phpunit/lib/SuiteCRM/Search/ElasticSearch/ElasticSearchIndexerTest.php
+++ b/tests/unit/phpunit/lib/SuiteCRM/Search/ElasticSearch/ElasticSearchIndexerTest.php
@@ -170,8 +170,10 @@ class ElasticSearchIndexerTest extends SearchTestAbstract
      */
     private function getExpectedHeader()
     {
+        global $sugar_config;
+
         $expected = [
-            'index' => 'main',
+            'index' => $sugar_config['unique_key'],
             'type' => 'Contacts',
             'id' => '00000000-0000-0000-0000-000000000000',
         ];
@@ -310,6 +312,8 @@ class ElasticSearchIndexerTest extends SearchTestAbstract
 
     public function testRemoveBeans()
     {
+        global $sugar_config;
+
         $mock = m::mock('Elasticsearch\Client');
         $beans = [$this->getTestBean(), $this->getTestBean()];
 
@@ -318,8 +322,20 @@ class ElasticSearchIndexerTest extends SearchTestAbstract
                 'ignore' => [404],
             ],
             'body' => [
-                ['delete' => ['index' => 'main', 'type' => 'Contacts', 'id' => '00000000-0000-0000-0000-000000000000',]],
-                ['delete' => ['index' => 'main', 'type' => 'Contacts', 'id' => '00000000-0000-0000-0000-000000000000',]],
+                [
+                    'delete' => [
+                        'index' => $sugar_config['unique_key'],
+                        'type' => 'Contacts',
+                        'id' => '00000000-0000-0000-0000-000000000000',
+                    ]
+                ],
+                [
+                    'delete' => [
+                        'index' => $sugar_config['unique_key'],
+                        'type' => 'Contacts',
+                        'id' => '00000000-0000-0000-0000-000000000000',
+                    ]
+                ],
             ]
         ];
 
@@ -335,11 +351,13 @@ class ElasticSearchIndexerTest extends SearchTestAbstract
 
     public function testRemoveBean()
     {
+        global $sugar_config;
+
         $mock = m::mock('Elasticsearch\Client');
         $bean = $this->getTestBean();
 
         $params = [
-            'index' => 'main',
+            'index' => $sugar_config['unique_key'],
             'type' => 'Contacts',
             'id' => '00000000-0000-0000-0000-000000000000',
         ];
@@ -369,12 +387,14 @@ class ElasticSearchIndexerTest extends SearchTestAbstract
 
     public function testRemoveIndex()
     {
+        global $sugar_config;
+
         list($mockClient, $mockIndices) = $this->getMockIndices();
 
         $mockIndices
             ->shouldReceive('delete')
             ->once()
-            ->with(['index' => 'main', 'client' => ['ignore' => [404]]]);
+            ->with(['index' => $sugar_config['unique_key'], 'client' => ['ignore' => [404]]]);
 
         $indexer = new ElasticSearchIndexer($mockClient);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Set the Elasitcsearch Index key to be either a configured value or the Instance's unique key. 

This allows one Elasticsearch server to hold multiple CRM instances without collisions.

Added an additional Elasticsearch config setting so that existing instances can continue to use the 'main' index if needed (though not recommended)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently if you have multiple instances of CRM and a single Elasticsearch server, they will all share the same 'index' - like dropping all the data in a big pot. This makes a complete mess of the elastic search results. 

This PR foregoes the generic 'main' index name and uses the CRM's unique key instead. 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Spin up a CRM instance and connect to Elasticsearch. Sync records
2. Spin up a second CRM instance and connect to the same Elasticsearch server. Sync records
3. Use the following command to ensure that there are corresponding indices in ES: `http://{your-es-url}:{port}/_cat/indices`. You should see something like:
```
yellow open 7c4e625f1cc2eb9168f015bf4892d49d 2v2W_WSgSbq7VPQU7DxvUw 5 1    54   2 340.9kb 340.9kb <----- First CRM
yellow open .monitoring-alerts-6             IuAw_8RoS7qmWP10LGXMlg 1 1     1   0   6.2kb   6.2kb
yellow open .watcher-history-6-2019.09.18    vpUuN1MtRW6C4iB7P15naw 1 1  4860   0   3.8mb   3.8mb
yellow open .monitoring-es-6-2019.09.18      _1pClFoASv-aUsuJU4OI2Q 1 1 81845 396  49.6mb  49.6mb
yellow open .watcher-history-6-2019.09.17    hwWgHKAgTvCsTyYmBnLE_Q 1 1  1780   0   1.5mb   1.5mb
yellow open .watches                         K2glAI5dSL2RgE5H0-y3fQ 1 1     4   0    20kb    20kb
yellow open .triggered_watches               rQ1rKfnoQdmcyiFpQ7itaQ 1 1     0   0 295.7kb 295.7kb
yellow open 9d21e42c9e96c4278fcb5b458ff106d1 zpcNiJGTQTGByU7VelY_CQ 5 1    54   0 250.8kb 250.8kb <---- Second CRM
yellow open .monitoring-es-6-2019.09.17      oarReo1oQv-WgxuNGSJIlQ 1 1 23106 320  14.3mb  14.3mb
```
4. Create a new Account named "Foo" in each instance. Sync with ES
5. Search for that Account in each instance. The results should return the correct account with the correct ID. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This could break existing instances that are using Elasticsearch. 

They could have two options depending on their environment
1. Simply run a reindex. This would create and sync to the newly named index. (they could manually delete the 'main' index). This would be ideal for instances that have a smallish index where it is not troublsome/timeconsuming to run a full reindex.
2. Add the `index` attribute to the `search.ElasticSearch` config and set the value to `'main'`. This would instruct the system to continue using the 'main' index.


### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->