### PR TITLE
add setting for an large database, e.g. 2000000 contacts, for an faster list queue query

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -3465,7 +3465,9 @@ class SugarBean
             '',
             false,
             null,
-            $singleSelect
+            $singleSelect,
+            false,
+            'LIMIT ' . $row_offset . ', ' . $limit
         );
         return $this->process_list_query($query, $row_offset, $limit, $max, $where);
     }
@@ -3503,6 +3505,7 @@ class SugarBean
      * @param object $parentbean creating a subquery for this bean.
      * @param bool $singleSelect Optional, default false.
      * @param bool $ifListForExport
+     * @param string $limit Optional, default empty
      * @return String select query string, optionally an array value will be returned if $return_array= true.
      */
     public function create_new_list_query(
@@ -3515,7 +3518,8 @@ class SugarBean
         $return_array = false,
         $parentbean = null,
         $singleSelect = false,
-        $ifListForExport = false
+        $ifListForExport = false,
+        $limit = ''
     ) {
         $selectedFields = array();
         $secondarySelectedFields = array();
@@ -3568,7 +3572,7 @@ class SugarBean
         } else {
             $ret_array['select'] = " SELECT $distinct $this->table_name.id ";
         }
-        $ret_array['from'] = " FROM $this->table_name ";
+        $ret_array['from'] = (isset($sugar_config['large_table'][$this->table_name]) && $sugar_config['large_table'][$this->table_name] == true) ? " FROM (SELECT * FROM $this->table_name WHERE $this->table_name.deleted = 0 $limit) $this->table_name " : " FROM $this->table_name ";
         $ret_array['from_min'] = $ret_array['from'];
         $ret_array['secondary_from'] = $ret_array['from'];
         $ret_array['where'] = '';


### PR DESCRIPTION
## Description
We had a problem with our large database, that the contact list view load over 1 minute.
With this change it loads in several seconds.

## Motivation and Context
We had a problem with our large database, that the contact list view load over 1 minute.
The db query needs more than 40 seconds.

## How To Test This
Open the contact list view with over 2000000 contacts. Enable this feature via the config_override.php setting $sugar_config['large_table']['contacts'].

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.