### PR TITLE
Fixed #7552 - AOR Reports - Mysqli_query failed when execute Report as normal User

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -1494,6 +1494,7 @@ class AOR_Report extends Basic
 
     public function build_report_access_query(SugarBean $module, $alias)
     {
+        $module->table_name = $alias;
         $where = '';
         if ($module->bean_implements('ACL') && ACLController::requireOwner($module->module_dir, 'list')) {
             global $current_user;


### PR DESCRIPTION

## Description
Added missing initialization of variable used in building of SQL query.
https://github.com/salesagility/SuiteCRM/issues/7552

## Motivation and Context
Solves reports returning no records if accessed by a non system administrator

## How To Test This
Loading a report which contains linked modules ( e.g. displaying contacts in an accounts report) resulted in a failed SQL query and no records were displayed.
With this bugfix the SQL query is not failing anymore and the records will be displayed.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist

- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

