### PR TITLE
Fix 'Undefined index: leads_id' notices in AOR_Report.php

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -826,7 +826,12 @@ class AOR_Report extends Basic
                     if ($att['function'] == 'COUNT' || !empty($att['format'])) {
                         $html .= $row[$name];
                     } else {
-                        $params = array('record_id' => $row[$att['alias'] . '_id']);
+                        // Make sure the `{$module}_id` key exists on $row, to prevent PHP notices.
+                        if (isset($row[$att['alias'] . '_id'])) {
+                            $params = array('record_id' => $row[$att['alias'] . '_id']);
+                        } else {
+                            $params = [];
+                        }
                         $html .= getModuleField(
                             $att['module'],
                             $att['field'],


### PR DESCRIPTION
## Description

This prevents PHP notices like "PHP Notice:  Undefined index: leads_id" when running reports.

Fixes #7868.

## Motivation and Context
It was causing a lot of notices in our error logs.

## How To Test This
1. Be on `hotfix-7.10.x`.
2. Run a report by viewing a Report DetailView page.
   - It seems easiest to reproduce this with a report on Leads, but I'm sure it happens elsewhere too.
3. Check your PHP error logs and see that there are a bunch of errors like `PHP Notice:  Undefined index: leads_id` that reference `modules/AOR_Reports/AOR_Report.php`.
4. Switch to this branch.
5. Run the report again.
6. Check your PHP error logs again and see that the error is gone, make sure the report continues to return the same result as before.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.