### PR TITLE
Protect against illegal string offset warnings in aow_utils.

### DIFF
--- a/modules/AOW_WorkFlow/aow_utils.php
+++ b/modules/AOW_WorkFlow/aow_utils.php
@@ -528,7 +528,8 @@ function getModuleField(
             $fieldlist[$name]['options'] = $mod_strings[$fieldlist[$name]['options']];
         }
         // Bug 22730: make sure all enums have the ability to select blank as the default value.
-        if (!isset($fieldlist[$name]['options'][''])) {
+        // Make sure the enum has an 'options' array to append a new value to.
+        if (isset($fieldlist[$name]['options']) && is_array($fieldlist[$name]['options']) && !isset($fieldlist[$name]['options'][''])) {
             $fieldlist[$name]['options'][''] = '';
         }
     }


### PR DESCRIPTION
## Description

Prevents warnings like `PHP Warning:  Illegal string offset ''` by making sure the enum has an 'options' array to append a new value to in `aow_utils.php`.

Fixes #7869.

## Motivation and Context

It causes a bunch of warnings when running reports.

## How To Test This

1. Be on `hotfix-7.10.x`.
2. Create a report (probably needs to involve an enum field? I'm not entirely sure, honestly).
3. Run the report.
4. Check PHP error logs and see that there are warnings like `PHP Warning:  Illegal string offset ''`.
5. Switch to this branch.
6. Run the report again.
7. Check the error logs and see that the warning no longer shows up. Also make sure the reports continue to work fine.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.