### PR TITLE
Make internal errors with 500 HTTP header

### DIFF
--- a/include/utils.php
+++ b/include/utils.php
@@ -1790,6 +1790,7 @@ function sugar_die($error_message, $exit_code = 1)
 {
     global $focus;
     sugar_cleanup();
+    http_response_code(500);
     echo $error_message;
     throw new \Exception($error_message, $exit_code);
 }


### PR DESCRIPTION
When there are internal crashes the application exit with 200 HTTP header, which is not correct, for example, on db failure.
This PR will change the HTTP header to be 500.

## Description
Today, the HTTP header can be confused monitor systems, when the SuiteCRM application return 200 when it's not correct.

## Motivation and Context
Allow monitor systems to monitor SuiteCRM application.

## How To Test This
Before the change: turn off DB and try to use the application. You'll get 200 HTTP header.
After the change: turn off DB and try to use the application. You'll get 200 HTTP header.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->