### PR TITLE
FIX #7912 - Avoid PHP Notices in getVardefs() method

### DIFF
--- a/include/generic/SugarWidgets/SugarWidgetField.php
+++ b/include/generic/SugarWidgets/SugarWidgetField.php
@@ -229,8 +229,10 @@ class SugarWidgetField extends SugarWidget
 
     public function getVardef($layout_def)
     {
-        $myName = $layout_def['column_key'];
-        $vardef = $this->layout_manager->defs['reporter']->all_fields[$myName];
+        if (!empty($layout_def['column_key']) && !empty($this->layout_manager->defs['reporter'])) {
+            $myName = $layout_def['column_key'];
+            $vardef = $this->layout_manager->defs['reporter']->all_fields[$myName];
+        }
 
         if (!isset($vardef)) {
             // No vardef, return an empty array


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

Read #7912


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Avoid annoying PHP Notices in php log

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Define a Float field in a subpanel
2. Check for Notices in PHP log


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->