### PR TITLE
Complete previous fix when ElasticSearch disabled

### DIFF
--- a/lib/Search/ElasticSearch/ElasticSearchHooks.php
+++ b/lib/Search/ElasticSearch/ElasticSearchHooks.php
@@ -89,7 +89,9 @@ class ElasticSearchHooks
     {
         $this->action = 'remove';
 
-        $this->reIndexSafe($bean);
+        if (ElasticSearchIndexer::isEnabled() !== false) {
+            $this->reIndexSafe($bean);
+        }
     }
 
     // ~ ~ ~ ~ ~ ~


### PR DESCRIPTION
This is the same as https://github.com/salesagility/SuiteCRM/pull/7020 but for deletes.

Please see  [the Forum thread](https://suitecrm.com/suitecrm/forum/suitecrm-7-0-discussion/27476-error-data-in-log-file) for more details, but here is the exact error message:

```
Mon Sep 23 16:58:17 2019 [6672][1][FATAL] [ERROR] Failed to remove bean to index
Mon Sep 23 16:58:17 2019 [6672][1][FATAL] [ERROR] SuiteCRM\Search\Exceptions\SearchException: Elasticsearch trying to re-indexing a bean but indexer is disabled in configuration. in C:\xampp\htdocs\SuiteCRM\lib\Search\ElasticSearch\ElasticSearchHooks.php:123
Stack trace:
#0 C:\xampp\htdocs\SuiteCRM\lib\Search\ElasticSearch\ElasticSearchHooks.php(105): SuiteCRM\Search\ElasticSearch\ElasticSearchHooks->reIndex(Object(Reminder_Invitee))
#1 C:\xampp\htdocs\SuiteCRM\lib\Search\ElasticSearch\ElasticSearchHooks.php(92): SuiteCRM\Search\ElasticSearch\ElasticSearchHooks->reIndexSafe(Object(Reminder_Invitee))
#2 C:\xampp\htdocs\SuiteCRM\include\utils\LogicHook.php(272): SuiteCRM\Search\ElasticSearch\ElasticSearchHooks->beanDeleted(Object(Reminder_Invitee), 'after_delete', Array)
#3 C:\xampp\htdocs\SuiteCRM\include\utils\LogicHook.php(213): LogicHook->process_hooks(Array, 'after_delete', Array)
#4 C:\xampp\htdocs\SuiteCRM\data\SugarBean.php(3129): LogicHook->call_custom_logic('Reminders_Invit...', 'after_delete', Array)
#5 C:\xampp\htdocs\SuiteCRM\data\SugarBean.php(5269): SugarBean->call_custom_logic('after_delete', Array)
#6 C:\xampp\htdocs\SuiteCRM\modules\Reminders_Invitees\Reminder_Invitee.php(159): SugarBean->mark_deleted('ee899958-86ff-0...')
#7 C:\xampp\htdocs\SuiteCRM\modules\Reminders\Reminder.php(144): Reminder_Invitee::deleteRemindersInviteesMultiple('e72eb4fb-d975-6...')
#8 C:\xampp\htdocs\SuiteCRM\modules\Reminders\Reminder.php(96): Reminder::saveRemindersData('Meetings', 'bb06a51a-8959-c...', Array)
#9 C:\xampp\htdocs\SuiteCRM\modules\Meetings\Meeting.php(324): Reminder::saveRemindersDataJson('Meetings', 'bb06a51a-8959-c...', '[{"idx":0,"id":...')
#10 C:\xampp\htdocs\SuiteCRM\modules\Meetings\MeetingFormBase.php(397): Meeting->save(true)
#11 C:\xampp\htdocs\SuiteCRM\modules\Meetings\Save.php(55): MeetingFormBase->handleSave('', true, false)
#12 C:\xampp\htdocs\SuiteCRM\include\MVC\View\SugarView.php(834): include_once('C:\\xampp\\htdocs...')
#13 C:\xampp\htdocs\SuiteCRM\include\MVC\View\views\view.classic.php(72): SugarView->includeClassicFile('modules/Meeting...')
#14 C:\xampp\htdocs\SuiteCRM\include\MVC\View\SugarView.php(226): ViewClassic->display()
#15 C:\xampp\htdocs\SuiteCRM\include\MVC\Controller\SugarController.php(435): SugarView->process()
#16 C:\xampp\htdocs\SuiteCRM\include\MVC\Controller\SugarController.php(375): SugarController->processView()
#17 C:\xampp\htdocs\SuiteCRM\include\MVC\SugarApplication.php(113): SugarController->execute()
#18 C:\xampp\htdocs\SuiteCRM\index.php(52): SugarApplication->execute()
#19 {main}
```

I am waiting on that user to confirm that this fixes his issue, that's why I left this PR as `Draft`.

I am not sure how to test this - the user has a cron job erroring out, but I am not sure which circumstances provoke this...

SuiteCRM Version: 7.11.8
