### PR TITLE
Fix #7942 add bool to eligible fields for merging

### DIFF
--- a/modules/MergeRecords/Step3.php
+++ b/modules/MergeRecords/Step3.php
@@ -61,6 +61,7 @@ global $urlPrefix;
 global $currentModule;
 global $theme;
 global $filter_for_valid_editable_attributes;
+global $invalid_attribute_by_name;
 //filter condition for fields in vardefs that can participate in merge.
 $filter_for_valid_editable_attributes =
     array(
@@ -72,6 +73,7 @@ $filter_for_valid_editable_attributes =
          array('type'=>'text','source'=>'db'),
          array('type'=>'date','source'=>'db'),
          array('type'=>'time','source'=>'db'),
+         array('type'=>'bool','source'=>'db'),
          array('type'=>'int','source'=>'db'),
          array('type'=>'long','source'=>'db'),
          array('type'=>'double','source'=>'db'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added global variable for field check in show_field() function and add bool to eligible fields for merge
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
Checkboxes don't display on merge
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
See #7942
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->