### PR TITLE
Hotfix: Do not divide by adjustment if it equals 0

### DIFF
--- a/include/ListView/ListViewSmarty.php
+++ b/include/ListView/ListViewSmarty.php
@@ -139,10 +139,12 @@ class ListViewSmarty extends ListViewDisplay
 
         $contextMenuObjectsTypes = array();
         foreach ((array)$this->displayColumns as $name => $params) {
-            if (!isset($this->displayColumns[$name]['width'])) {
+            if (!isset($this->displayColumns[$name]['width']) || 0 === $adjustment) {
                 $this->displayColumns[$name]['width'] = 0;
+            } else {
+                $this->displayColumns[$name]['width'] = floor(((int)$this->displayColumns[$name]['width']) / $adjustment);
             }
-            $this->displayColumns[$name]['width'] = floor(((int)$this->displayColumns[$name]['width']) / $adjustment);
+
             // figure out which contextMenu objectsTypes are required
             if (!empty($params['contextMenu']['objectType'])) {
                 $contextMenuObjectsTypes[$params['contextMenu']['objectType']] = true;


### PR DESCRIPTION
## Description

These changes fix issue https://github.com/salesagility/SuiteCRM/issues/7926

The OAuth clients/tokens page has no widths defined, resulting in the totalWidth being 0, and so does the adjustment. The quickfix is to prevent dividing by the variable in such case, avoiding division by 0. When adjustment is 0, we just set the final value in displayColumn to 0.

These changes also refactor the check on adjustment with the first condition. This is probably easier to read and maintain, rather than having two separates conditions resulting to the exact same code (eg setting the value in displayColumn to 0).


## How To Test This

1. Go to the Admin panel.
2. Go to "OAuth clients and tokens".
3. You're now at the page that should have the issue.
4. Make sure you don't see the following warning:

> PHP Warning: Division by zero in /Users/connorshea/code/sites/SuiteCRM/include/ListView/ListViewSmarty.php on line 145

You may want to create a client/token and then go back to the list view, to further test the fix.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist

- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.