### PR TITLE
Fixed #7953 - Elasticsearch default size setting

### DIFF
--- a/lib/Search/SearchQuery.php
+++ b/lib/Search/SearchQuery.php
@@ -28,6 +28,8 @@ if (!defined('sugarEntry') || !sugarEntry) {
  */
 class SearchQuery implements \JsonSerializable
 {
+    const DEFAULT_SEARCH_SIZE = 10;
+
     /** @var string Search query string */
     private $query;
     /** @var int The number of results per page */
@@ -49,13 +51,10 @@ class SearchQuery implements \JsonSerializable
      * @param int         $from         Offset of the search. Used for pagination
      * @param array       $options      [optional] used for additional options by SearchEngines.
      */
-    private function __construct($searchString, $engine = null, $size = 10, $from = 0, array $options = [])
+    private function __construct($searchString, $engine = null, $size = null, $from = 0, array $options = [])
     {
         $this->query = strval($searchString);
-        $this->size = intval($size);
-        if ($this->size < 0) {
-            $this->size = 1;
-        }
+        $this->size = $size ? intval($size) : $this->getDefaultSearchSize();
         $this->from = intval($from);
         $this->options = $options;
         $this->engine = $engine !== null ? strval($engine) : null;
@@ -95,7 +94,7 @@ class SearchQuery implements \JsonSerializable
     {
         $searchQuery = self::filterArray($request, 'search-query-string', '', FILTER_SANITIZE_STRING);
         $searchQueryAlt = self::filterArray($request, 'query_string', '', FILTER_SANITIZE_STRING);
-        $searchSize = self::filterArray($request, 'search-query-size', static::getDefaultSearchSize(), FILTER_SANITIZE_NUMBER_INT);
+        $searchSize = self::filterArray($request, 'search-query-size', null, FILTER_SANITIZE_NUMBER_INT);
         $searchFrom = self::filterArray($request, 'search-query-from', 0, FILTER_SANITIZE_NUMBER_INT);
         $searchEngine = self::filterArray($request, 'search-engine', null, FILTER_SANITIZE_STRING);
 
@@ -112,26 +111,6 @@ class SearchQuery implements \JsonSerializable
         );
 
         return new self($searchQuery, $searchEngine, $searchSize, $searchFrom, $request);
-    }
-
-    /**
-     * Get the default Search size by checking the config or falling back to 10
-     *
-     * @return int
-     */
-    public static function getDefaultSearchSize()
-    {
-        global $sugar_config;
-
-        if(isset($sugar_config['search']['query_size'])){
-            return (int) $sugar_config['search']['query_size'];
-        }
-
-        if(isset($sugar_config['search']['pagination']['min'])){
-            return (int) $sugar_config['search']['pagination']['min'];
-        }
-
-        return 10;
     }
 
     /**
@@ -191,6 +170,26 @@ class SearchQuery implements \JsonSerializable
             $this->size = 1;
         }
         return (int)$this->size;
+    }
+
+    /**
+     * Get the default Search size by checking the config or falling back to Constant value
+     *
+     * @return int
+     */
+    public function getDefaultSearchSize()
+    {
+        global $sugar_config;
+
+        if(isset($sugar_config['search']['query_size'])){
+            return (int) $sugar_config['search']['query_size'];
+        }
+
+        if(isset($sugar_config['search']['pagination']['min'])){
+            return (int) $sugar_config['search']['pagination']['min'];
+        }
+
+        return static::DEFAULT_SEARCH_SIZE;
     }
 
     /**

--- a/lib/Search/SearchQuery.php
+++ b/lib/Search/SearchQuery.php
@@ -95,7 +95,7 @@ class SearchQuery implements \JsonSerializable
     {
         $searchQuery = self::filterArray($request, 'search-query-string', '', FILTER_SANITIZE_STRING);
         $searchQueryAlt = self::filterArray($request, 'query_string', '', FILTER_SANITIZE_STRING);
-        $searchSize = self::filterArray($request, 'search-query-size', 10, FILTER_SANITIZE_NUMBER_INT);
+        $searchSize = self::filterArray($request, 'search-query-size', static::getDefaultSearchSize(), FILTER_SANITIZE_NUMBER_INT);
         $searchFrom = self::filterArray($request, 'search-query-from', 0, FILTER_SANITIZE_NUMBER_INT);
         $searchEngine = self::filterArray($request, 'search-engine', null, FILTER_SANITIZE_STRING);
 
@@ -112,6 +112,26 @@ class SearchQuery implements \JsonSerializable
         );
 
         return new self($searchQuery, $searchEngine, $searchSize, $searchFrom, $request);
+    }
+
+    /**
+     * Get the default Search size by checking the config or falling back to 10
+     *
+     * @return int
+     */
+    public static function getDefaultSearchSize()
+    {
+        global $sugar_config;
+
+        if(isset($sugar_config['search']['query_size'])){
+            return (int) $sugar_config['search']['query_size'];
+        }
+
+        if(isset($sugar_config['search']['pagination']['min'])){
+            return (int) $sugar_config['search']['pagination']['min'];
+        }
+
+        return 10;
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This PR addresses #7953 
It changes the SearchQuery class to check the config before falling back to a default search size. 

This is important for situations where a CRM has a minimum pagination size greater or less than 10. 

I also took the liberty of adding a dedicated setting for the default query size. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR gives developers the ability to set and potentially raise the default Elasticsearch query size. This can be especially helpful if there are 'cluttered' results (like if you're searching for a specfic Account and for whatever reason a bunch of Notes rank higher). 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Enable Elasticsearch and Index your records
2. Perform a generic search from the Navbar - you should get 10 results
3. Add the following to your config: `$sugar_config['search']['pagination']['min'] = 5`
4. Repeat the search - you should get 5 results.
5. Add the following to your config: `$sugar_config['search']['query_size'] = 11`
6. Repeat the search - you should get 11 results

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] (maybe) My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->