### PR TITLE
Fix/silent upgrade

### DIFF
--- a/modules/UpgradeWizard/silentUpgrade_step2.php
+++ b/modules/UpgradeWizard/silentUpgrade_step2.php
@@ -475,6 +475,10 @@ if (version_compare($sugar_version, '6.5.0', '<') && function_exists('repairUpgr
     repairUpgradeHistoryTable();
 }
 
+// Run quick repair and rebuild
+$repair = new RepairAndClear();
+$repair->repairAndClearAll(['clearAll'], ['All Modules']);
+
 //TAKE OUT TRASH
 if (empty($errors)) {
     set_upgrade_progress('end', 'in_progress', 'unlinkingfiles', 'in_progress');

--- a/modules/UpgradeWizard/silentUpgrade_step2.php
+++ b/modules/UpgradeWizard/silentUpgrade_step2.php
@@ -308,17 +308,7 @@ if (isset($argv[4])) {
     exit(1);
 }
 
-$unzip_dir = sugar_cached("upgrades/temp");
-
-include "$unzip_dir/manifest.php";
-if (is_file("$unzip_dir/manifest.php")) {
-    include "{$argv[1]}/manifest.php";
-}
-
-if (isset($manifest['copy_files']['from_dir']) && $manifest['copy_files']['from_dir'] != "") {
-    $zip_from_dir = $manifest['copy_files']['from_dir'];
-}
-
+$unzip_dir = sugar_cached('upgrades/temp');
 
 $install_file = $sugar_config['upload_dir'] . '/upgrades/patch/' . basename($argv[1]);
 sugar_mkdir($sugar_config['upload_dir'] . '/upgrades/patch', 0775, true);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
Fixed an issue with the file pathing in step 2 of the silent upgrader and added R&R to the final step. This issue was preventing users from upgrading and even with a workaround would prevent them from getting to the admin panel to run a repair and rebuild.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Unzip an upgrade pack and copy the updated ```silentUpgrade_step2.php``` file in this PR to it before recompressing.
2. Move the upgrade pack into the CRM and run the following command found here: https://docs.suitecrm.com/admin/installation-guide/upgrading/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->