### PR TITLE
Replace deprecated array index accessors.

### DIFF
--- a/include/utils.php
+++ b/include/utils.php
@@ -3043,7 +3043,7 @@ function javascript_escape($str)
         } elseif (ord(substr($str, $i, 1)) == 13) {
             $new_str .= '\r';
         } else {
-            $new_str .= $str{$i};
+            $new_str .= $str[$i];
         }
     }
 
@@ -3622,7 +3622,7 @@ function mark_delete_components($sub_object_array, $run_second_level = false, $s
 function return_bytes($val)
 {
     $val = trim($val);
-    $last = strtolower($val{strlen($val) - 1});
+    $last = strtolower($val[strlen($val) - 1]);
     $val = preg_replace("/[^0-9,.]/", "", $val);
 
     switch ($last) {
@@ -3674,7 +3674,7 @@ function is_windows()
  */
 function is_writable_windows($file)
 {
-    if ($file{strlen($file) - 1} == '/') {
+    if ($file[strlen($file) - 1] == '/') {
         return is_writable_windows($file . uniqid(mt_rand()) . '.tmp');
     }
 


### PR DESCRIPTION
## Description
This replaces a deprecated means of accessing elements in an array. This is a fix to make PHP 7.4 work properly (or, more properly). See also #7974.

## Motivation and Context

PHP 7.4 deprecates accessing the index of an array with `$array{1}`, we should always use `$array[1]`.

https://wiki.php.net/rfc/deprecate_curly_braces_array_access