### PR TITLE
BeanFactory: Don't return deleted beans from the cache

### DIFF
--- a/data/BeanFactory.php
+++ b/data/BeanFactory.php
@@ -110,6 +110,9 @@ class BeanFactory
                 ++self::$hits;
                 ++self::$touched[$module][$id];
                 $bean = self::$loadedBeans[$module][$id];
+                if ($deleted && $bean->deleted) {
+                    return false;
+                }
             }
         } else {
             $bean = new $beanClass();

--- a/tests/unit/phpunit/data/SugarBeanTest.php
+++ b/tests/unit/phpunit/data/SugarBeanTest.php
@@ -48,6 +48,35 @@ class SugarBeanTest extends SuitePHPUnit_Framework_TestCase
         $object->field_defs = $this->fieldDefsStore[$key]['Contact'];
     }
 
+    public function testFactoryGetCachedDeleted()
+    {
+        $state = new SuiteCRM\StateSaver();
+        $state->pushTable('leads');
+        $state->pushTable('leads_cstm');
+        $state->pushTable('sugarfeed');
+        $state->pushTable('aod_indexevent');
+        $state->pushGlobals();
+
+        // Create a lead and cache it
+        $lead = new Lead();
+        $lead->save();
+
+        $bean = BeanFactory::getBean($lead->module_dir, $lead->id);
+        $this->assertNotEmpty($bean);
+
+        // Don't return a cached result if the bean was deleted
+        $lead->mark_deleted($lead->id);
+        $this->assertEmpty(BeanFactory::getBean($lead->module_dir, $lead->id));
+        // Unless explicitly specified
+        $this->assertNotEmpty(BeanFactory::getBean($lead->module_dir, $lead->id, [], false));
+
+        $state->popGlobals();
+        $state->popTable('aod_indexevent');
+        $state->popTable('sugarfeed');
+        $state->popTable('leads_cstm');
+        $state->popTable('leads');
+    }
+
     /**
      * @see SugarBean::__construct()
      */


### PR DESCRIPTION
## Description

In case a bean is retrieved, deleted and then fetched again the bean factory
would return it despite the bean being deleted. This means the bahviour is different
depending on whether the bean is cached or not.

Avoid this by not returning a cached bean if it is marked deleted and the delete
filter isn't disabled by the caller.

## Motivation and Context

I was writing a test and was confused why deleted beans got still returned.

## How To Test This

See the unit test.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
