### PR TITLE
AOW_WorkFlow: Delete all related beans when deleting a workflow

### DIFF
--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -148,6 +148,19 @@ class AOW_WorkFlow extends Basic
         return $return_id;
     }
 
+    public function mark_deleted($id)
+    {
+        // These are owned by the workflow, so delete them instead of just removing the link
+        $beans = $this->get_linked_beans('aow_conditions');
+        $beans = array_merge($beans, $this->get_linked_beans('aow_actions'));
+        $beans = array_merge($beans, $this->get_linked_beans('aow_processed'));
+        foreach ($beans as $bean) {
+            $bean->mark_deleted($bean->id);
+        }
+
+        parent::mark_deleted($id);
+    }
+
     public function load_flow_beans()
     {
         global $beanList, $app_list_strings;


### PR DESCRIPTION
## Description

The workflow is the sole owner of them, so they should be deleted when the workflow is.
Otherwise only the relation is deleted which means the workflow field of the related beans
is deleted and the actions, conditions stay in the DB forever.

## Motivation and Context

Deleting things should delete it from the DB.

## How To Test This

1) Create a workflow
2) Add some conditions/actions
3) Delete the workflow
4) The conditions and actions shouldn't be in the DB anymore

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.