### PR TITLE
Fix more PHP 7.4 array accessor deprecations

### DIFF
--- a/include/Localization/Localization.php
+++ b/include/Localization/Localization.php
@@ -494,7 +494,7 @@ class Localization
      * @param bool is_currency Flag to also return the currency symbol
      * @return string Formatted number
      */
-    public function getLocaleFormattedNumber($number, $currencySymbol='', $is_currency=true, $user=null)
+    public function getLocaleFormattedNumber($number, $currencySymbol = '', $is_currency = true, $user = null)
     {
         $fnum            = $number;
         $majorDigits    = '';
@@ -510,8 +510,8 @@ class Localization
             if (strlen($exNum[0]) > 3) {
                 $offset = strlen($exNum[0]) % 3;
                 if ($offset > 0) {
-                    for ($i=0; $i<$offset; $i++) {
-                        $majorDigits .= $exNum[0]{$i};
+                    for ($i = 0; $i < $offset; $i++) {
+                        $majorDigits .= $exNum[0][$i];
                     }
                 }
 
@@ -521,7 +521,7 @@ class Localization
                         $majorDigits .= $thou; // add separator
                     }
 
-                    $majorDigits .= $exNum[0]{$i};
+                    $majorDigits .= $exNum[0][$i];
                     $tic++;
                 }
             } else {
@@ -693,7 +693,7 @@ eoq;
         // parse localeNameFormat
         $formattedName = '';
         for ($i=0; $i<strlen($this->localeNameFormat); $i++) {
-            $formattedName .= array_key_exists($this->localeNameFormat{$i}, $names) ? $names[$this->localeNameFormat{$i}] : $this->localeNameFormat{$i};
+            $formattedName .= array_key_exists($this->localeNameFormat[$i], $names) ? $names[$this->localeNameFormat[$i]] : $this->localeNameFormat[$i];
         }
 
         $formattedName = trim($formattedName);

--- a/include/SugarFields/Fields/Relate/SugarFieldRelate.php
+++ b/include/SugarFields/Fields/Relate/SugarFieldRelate.php
@@ -324,9 +324,9 @@ class SugarFieldRelate extends SugarFieldBase
             }
             for ($i = 0; $i < strlen($default_locale_name_format); $i++) {
                 $new_field .= array_key_exists(
-                    $default_locale_name_format{$i},
+                    $default_locale_name_format[$i],
                     $names
-                ) ? $names[$default_locale_name_format{$i}] : $default_locale_name_format{$i};
+                ) ? $names[$default_locale_name_format[$i]] : $default_locale_name_format[$i];
             }
         } else {
             $new_field = $rawField;

--- a/include/TimeDate.php
+++ b/include/TimeDate.php
@@ -1067,7 +1067,7 @@ class TimeDate
             's' => $date->format("s")
         );
         if ($ampm) {
-            $datearr['a'] = ($ampm{0} == 'a') ? $date->format("a") : $date->format("A");
+            $datearr['a'] = ($ampm[0] == 'a') ? $date->format("a") : $date->format("A");
         }
 
         return $datearr;
@@ -2074,7 +2074,7 @@ class TimeDate
         }
 
         $menu = "<select name='" . $prefix . "meridiem' " . $attrs . ">";
-        if ($am{0} == 'a') {
+        if ($am[0] == 'a') {
             $menu .= "<option value='am'{$selected["am"]}>am";
             $menu .= "<option value='pm'{$selected["pm"]}>pm";
         } else {

--- a/jssource/minify_utils.php
+++ b/jssource/minify_utils.php
@@ -304,7 +304,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
                             //Check to see that ReadNextLine is true, if so then add the last line collected
                             //make sure the last line is either the end to a comment block, or starts with '//'
                             //else do not add as it is live code.
-                            if (!empty($newLine) && ((strpos($newLine, '*/')!== false) || ($newLine{0}.$newLine{1}== '//'))) {
+                            if (!empty($newLine) && ((strpos($newLine, '*/')!== false) || ($newLine[0].$newLine[1]== '//'))) {
                                 //add new line to license string
                                 $lic_str .=$newLine;
                             }

--- a/modules/Calendar/CalendarDisplay.php
+++ b/modules/Calendar/CalendarDisplay.php
@@ -372,7 +372,7 @@ class CalendarDisplay
 
         if ($view == 'month' || $view == 'sharedMonth') {
             for ($i=0; $i<strlen($dateFormat['date']); $i++) {
-                switch ($dateFormat['date']{$i}) {
+                switch ($dateFormat['date'][$i]) {
                     case "Y":
                         $str .= " ".$date_time->year;
                         break;
@@ -388,7 +388,7 @@ class CalendarDisplay
             $last_day = $first_day->get("+6 days");
 
             for ($i=0; $i<strlen($dateFormat['date']); $i++) {
-                switch ($dateFormat['date']{$i}) {
+                switch ($dateFormat['date'][$i]) {
                         case "Y":
                             $str .= " ".$first_day->year;
                             break;
@@ -402,7 +402,7 @@ class CalendarDisplay
             }
             $str .= " - ";
             for ($i=0; $i<strlen($dateFormat['date']); $i++) {
-                switch ($dateFormat['date']{$i}) {
+                switch ($dateFormat['date'][$i]) {
                         case "Y":
                             $str .= " ".$last_day->year;
                             break;
@@ -418,7 +418,7 @@ class CalendarDisplay
             $str .= $date_time->get_day_of_week()." ";
 
             for ($i=0; $i<strlen($dateFormat['date']); $i++) {
-                switch ($dateFormat['date']{$i}) {
+                switch ($dateFormat['date'][$i]) {
                             case "Y":
                                 $str .= " ".$date_time->year;
                                 break;
@@ -434,7 +434,7 @@ class CalendarDisplay
             $str .= $date_time->get_day_of_week()." ";
 
             for ($i=0; $i<strlen($dateFormat['date']); $i++) {
-                switch ($dateFormat['date']{$i}) {
+                switch ($dateFormat['date'][$i]) {
                         case "Y":
                             $str .= " ".$date_time->year;
                             break;
@@ -456,7 +456,7 @@ class CalendarDisplay
             $last_day = $first_day->get("+6 days");
 
             for ($i=0; $i<strlen($dateFormat['date']); $i++) {
-                switch ($dateFormat['date']{$i}) {
+                switch ($dateFormat['date'][$i]) {
                         case "Y":
                             $str .= " ".$first_day->year;
                             break;
@@ -470,7 +470,7 @@ class CalendarDisplay
             }
             $str .= " - ";
             for ($i=0; $i<strlen($dateFormat['date']); $i++) {
-                switch ($dateFormat['date']{$i}) {
+                switch ($dateFormat['date'][$i]) {
                         case "Y":
                             $str .= " ".$last_day->year;
                             break;

--- a/modules/EmailMan/EmailMan.php
+++ b/modules/EmailMan/EmailMan.php
@@ -874,7 +874,7 @@ class EmailMan extends SugarBean
 
         //make sure tracking url ends with '/' character
         $strLen = strlen($this->tracking_url);
-        if ($this->tracking_url{$strLen - 1} != '/') {
+        if ($this->tracking_url[$strLen - 1] != '/') {
             $this->tracking_url .= '/';
         }
 

--- a/modules/SugarFeed/SugarFeed.php
+++ b/modules/SugarFeed/SugarFeed.php
@@ -158,7 +158,7 @@ class SugarFeed extends Basic
             }
             $d = dir($baseDir);
             while ($file = $d->read()) {
-                if ($file{0} == '.') {
+                if ($file[0] == '.') {
                     continue;
                 }
                 if (substr($file, -4) == '.php') {
@@ -232,7 +232,7 @@ class SugarFeed extends Basic
                 if (file_exists($baseDir.$module.'/SugarFeeds/')) {
                     $dFeed = dir($baseDir.$module.'/SugarFeeds/');
                     while ($file = $dFeed->read()) {
-                        if ($file{0} == '.') {
+                        if ($file[0] == '.') {
                             continue;
                         }
                         if (substr($file, -4) == '.php') {
@@ -338,7 +338,7 @@ class SugarFeed extends Basic
             }
             $d = dir($dirName);
             while ($file = $d->read()) {
-                if ($file{0} == '.') {
+                if ($file[0] == '.') {
                     continue;
                 }
                 if (substr($file, -4) == '.php') {

--- a/modules/SugarFeed/linkHandlers/Link.php
+++ b/modules/SugarFeed/linkHandlers/Link.php
@@ -54,7 +54,7 @@ class FeedLinkHandlerLink
         $feed->link_type = $link_type;
 
         //
-        if ($link_url{0} != '.' || $link_url{0} != '/') {
+        if ($link_url[0] != '.' || $link_url[0] != '/') {
             // Automatically add http:// in front of the link_url if it doesn't already have it
             if (strncmp($link_url, 'http://', 7) != 0 && strncmp($link_url, 'https://', 8) != 0) {
                 $link_url = 'http://'.$link_url;

--- a/modules/UpgradeWizard/uw_utils.php
+++ b/modules/UpgradeWizard/uw_utils.php
@@ -2462,7 +2462,7 @@ function testThis()
     $priorPath = '';
     foreach ($files as $file) {
         $relativeFile = clean_path(str_replace(getcwd().'/test', '', $file));
-        $relativeFile = ($relativeFile{0} == '/') ? substr($relativeFile, 1, strlen($relativeFile)) : $relativeFile;
+        $relativeFile = ($relativeFile[0] == '/') ? substr($relativeFile, 1, strlen($relativeFile)) : $relativeFile;
 
         $relativePath = dirname($relativeFile);
 

--- a/modules/Users/User.php
+++ b/modules/Users/User.php
@@ -1905,12 +1905,12 @@ EOQ;
         $ret1 = '';
         $ret2 = '';
         for ($i = 0; $i < strlen($macro); $i++) {
-            if (array_key_exists($macro{$i}, $format)) {
-                $ret1 .= "<i>" . $format[$macro{$i}] . "</i>";
-                $ret2 .= "<i>" . $name[$macro{$i}] . "</i>";
+            if (array_key_exists($macro[$i], $format)) {
+                $ret1 .= "<i>" . $format[$macro[$i]] . "</i>";
+                $ret2 .= "<i>" . $name[$macro[$i]] . "</i>";
             } else {
-                $ret1 .= $macro{$i};
-                $ret2 .= $macro{$i};
+                $ret1 .= $macro[$i];
+                $ret2 .= $macro[$i];
             }
         }
 


### PR DESCRIPTION
Accessing array indices with curly braces is deprecated as of PHP 7.4, this replaces a few more uses of the old syntax.

Pretty much the same as #7976.

https://wiki.php.net/rfc/deprecate_curly_braces_array_access