### PR TITLE
Fix Activities and History Queries

### DIFF
--- a/modules/Calls/metadata/subpanels/ForActivities.php
+++ b/modules/Calls/metadata/subpanels/ForActivities.php
@@ -1,7 +1,9 @@
 <?php
+
 if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
+
 /**
  *
  * SugarCRM Community Edition is a customer relationship management program developed by
@@ -41,90 +43,79 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
-
-
-$subpanel_layout = array(
-    //Removed button because this layout def is a component of
-    //the activities sub-panel.
-    //'where' => "(calls.status=\'Planned\')",
+$subpanel_layout = [
     'where' => "(calls.status != 'Held' AND calls.status != 'Not Held')",
-    
-    
-    'list_fields' => array(
-        'object_image'=>array(
+    'list_fields' => [
+        'object_image' => [
             'vname' => 'LBL_OBJECT_IMAGE',
             'widget_class' => 'SubPanelIcon',
             'width' => '2%',
-        ),
-        'name'=>array(
-             'vname' => 'LBL_LIST_SUBJECT',
-             'widget_class' => 'SubPanelDetailViewLink',
-             'width' => '30%',
-        ),
-        'status'=>array(
-             'widget_class' => 'SubPanelActivitiesStatusField',
-             'vname' => 'LBL_LIST_STATUS',
-             'width' => '15%',
-             
-        ),
-        'contact_name'=>array(
-             'widget_class' => 'SubPanelDetailViewLink',
-             'target_record_key' => 'contact_id',
-             'target_module' => 'Contacts',
-             'module' => 'Contacts',
-             'vname' => 'LBL_LIST_CONTACT',
-             'width' => '11%',
-             'sortable'=>false,
-        ),
-            'contact_name_owner'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-            ),
-            'contact_name_mod'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-            ),
-        'contact_id'=>array(
-            'usage'=>'query_only',
-            
-        ),
-        'date_end'=>array(
+        ],
+        'name' => [
+            'vname' => 'LBL_LIST_SUBJECT',
+            'widget_class' => 'SubPanelDetailViewLink',
+            'width' => '30%',
+        ],
+        'status' => [
+            'widget_class' => 'SubPanelActivitiesStatusField',
+            'vname' => 'LBL_LIST_STATUS',
+            'width' => '15%',
+        ],
+        'contact_name' => [
+            'widget_class' => 'SubPanelDetailViewLink',
+            'target_record_key' => 'contact_id',
+            'target_module' => 'Contacts',
+            'module' => 'Contacts',
+            'vname' => 'LBL_LIST_CONTACT',
+            'width' => '11%',
+            'sortable' => false,
+        ],
+        'contact_name_owner' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'contact_name_mod' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'contact_id' => [
+            'usage' => 'query_only',
+        ],
+        'date_end' => [
             'vname' => 'LBL_LIST_DUE_DATE',
             'width' => '10%',
             'alias' => 'date_due',
-            'sort_by' => 'date_due'
-        ),
-        'assigned_user_name' => array(
+            'sort_by' => 'date_due',
+        ],
+        'assigned_user_name' => [
             'name' => 'assigned_user_name',
             'vname' => 'LBL_LIST_ASSIGNED_TO_NAME',
             'widget_class' => 'SubPanelDetailViewLink',
             'target_record_key' => 'assigned_user_id',
             'target_module' => 'Employees',
             'width' => '10%',
-        ),
-        'edit_button'=>array(
+        ],
+        'edit_button' => [
             'vname' => 'LBL_EDIT_BUTTON',
-             'widget_class' => 'SubPanelEditButton',
-             'width' => '2%',
-        ),
-        'close_button'=>array(
+            'widget_class' => 'SubPanelEditButton',
+            'width' => '2%',
+        ],
+        'close_button' => [
             'widget_class' => 'SubPanelCloseButton',
             'vname' => 'LBL_LIST_CLOSE',
             'width' => '6%',
-            'sortable'=>false,
-        ),
-        'remove_button'=>array(
-                'vname' => 'LBL_REMOVE',
-             'widget_class' => 'SubPanelRemoveButton',
-             'width' => '2%',
-        ),
-        'time_start'=>array(
-            'usage'=>'query_only',
-    
-        ),
-        'recurring_source'=>array(
-            'usage'=>'query_only',
-        ),
-                    
-    ),
-);
+            'sortable' => false,
+        ],
+        'remove_button' => [
+            'vname' => 'LBL_REMOVE',
+            'widget_class' => 'SubPanelRemoveButton',
+            'width' => '2%',
+        ],
+        'time_start' => [
+            'usage' => 'query_only',
+        ],
+        'recurring_source' => [
+            'usage' => 'query_only',
+        ],
+    ],
+];

--- a/modules/Calls/metadata/subpanels/ForHistory.php
+++ b/modules/Calls/metadata/subpanels/ForHistory.php
@@ -1,7 +1,9 @@
 <?php
+
 if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
+
 /**
  *
  * SugarCRM Community Edition is a customer relationship management program developed by
@@ -41,102 +43,96 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
-
-
-$subpanel_layout = array(
-
+$subpanel_layout = [
     'where' => "(calls.status='Held' OR calls.status='Not Held')",
-
-
-
-    'list_fields' => array(
-        'object_image'=>array(
+    'list_fields' => [
+        'object_image' => [
             'vname' => 'LBL_OBJECT_IMAGE',
             'widget_class' => 'SubPanelIcon',
             'width' => '2%',
-        ),
-        'name'=>array(
-             'vname' => 'LBL_LIST_SUBJECT',
-             'widget_class' => 'SubPanelDetailViewLink',
-             'width' => '30%',
-        ),
-        'status'=>array(
-             'widget_class' => 'SubPanelActivitiesStatusField',
-             'vname' => 'LBL_LIST_STATUS',
-             'width' => '15%',
-             'force_exists'=>true //this will create a fake field in the case a field is not defined
-        ),
-        'reply_to_status' => array(
-             'usage'				=> 'query_only',
-             'force_exists'			=> true,
-             'force_default'		=> 0,
-        ),
-        'contact_name'=>array(
-             'widget_class'			=> 'SubPanelDetailViewLink',
-             'target_record_key'	=> 'contact_id',
-             'target_module'		=> 'Contacts',
-             'module'				=> 'Contacts',
-             'vname'				=> 'LBL_LIST_CONTACT',
-             'width'				=> '11%',
-             'sortable'=>false,
-        ),
-        'contact_id'=>array(
-            'usage'=>'query_only',
-        ),
-        'contact_name_owner'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'contact_name_mod'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'parent_id'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'parent_type'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'date_modified'=>array(
+        ],
+        'name' => [
+            'vname' => 'LBL_LIST_SUBJECT',
+            'widget_class' => 'SubPanelDetailViewLink',
+            'width' => '30%',
+        ],
+        'status' => [
+            'widget_class' => 'SubPanelActivitiesStatusField',
+            'vname' => 'LBL_LIST_STATUS',
+            'width' => '15%',
+            'force_exists' => true
+        ],
+        'reply_to_status' => [
+            'usage' => 'query_only',
+            'force_exists' => true,
+            'force_default' => 0,
+        ],
+        'contact_name' => [
+            'widget_class' => 'SubPanelDetailViewLink',
+            'target_record_key' => 'contact_id',
+            'target_module' => 'Contacts',
+            'module' => 'Contacts',
+            'vname' => 'LBL_LIST_CONTACT',
+            'width' => '11%',
+            'sortable' => false,
+        ],
+        'contact_id' => [
+            'usage' => 'query_only',
+        ],
+        'contact_name_owner' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'contact_name_mod' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'parent_id' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'parent_type' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'date_modified' => [
             'vname' => 'LBL_LIST_DATE_MODIFIED',
             'width' => '10%',
-        ),
-        'date_entered'=>array(
+        ],
+        'date_entered' => [
             'vname' => 'LBL_LIST_DATE_ENTERED',
             'width' => '10%',
-        ),
-          'date_end'=>array(
+        ],
+        'date_end' => [
             'vname' => 'LBL_LIST_DUE_DATE',
             'width' => '10%',
             'alias' => 'date_due',
-            'sort_by' => 'date_due'
-        ),
-        'assigned_user_name' => array(
+            'sort_by' => 'date_due',
+        ],
+        'assigned_user_name' => [
             'name' => 'assigned_user_name',
             'vname' => 'LBL_LIST_ASSIGNED_TO_NAME',
             'widget_class' => 'SubPanelDetailViewLink',
             'target_record_key' => 'assigned_user_id',
             'target_module' => 'Employees',
             'width' => '10%',
-        ),
-        'edit_button'=>array(
+        ],
+        'edit_button' => [
             'vname' => 'LBL_EDIT_BUTTON',
-             'widget_class' => 'SubPanelEditButton',
-             'width' => '2%',
-        ),
-        'remove_button'=>array(
+            'widget_class' => 'SubPanelEditButton',
+            'width' => '2%',
+        ],
+        'remove_button' => [
             'vname' => 'LBL_REMOVE',
-             'widget_class' => 'SubPanelRemoveButton',
-             'width' => '2%',
-        ),
-        'filename'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'recurring_source'=>array(
-            'usage'=>'query_only',
-        ),
-    ),
-);
+            'widget_class' => 'SubPanelRemoveButton',
+            'width' => '2%',
+        ],
+        'filename' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'recurring_source' => [
+            'usage' => 'query_only',
+        ],
+    ],
+];

--- a/modules/Emails/metadata/subpanels/ForHistory.php
+++ b/modules/Emails/metadata/subpanels/ForHistory.php
@@ -1,7 +1,9 @@
 <?php
+
 if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
+
 /**
  *
  * SugarCRM Community Edition is a customer relationship management program developed by
@@ -41,91 +43,87 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
-
-
-$subpanel_layout = array(
-    'where'				=> "",
-
-
-    'fill_in_additional_fields'	=> true,
-    'list_fields' => array(
-        'object_image'=>array(
-            'widget_class'			=> 'SubPanelIcon',
-            'width'					=> '2%',
-        ),
-        'name' => array(
-             'vname'				=> 'LBL_LIST_SUBJECT',
-             'widget_class'			=> 'SubPanelDetailViewLink',
-             'width'				=> '30%',
-             'parent_info'          => true
-        ),
-        'status' => array(
-             'vname'				=> 'LBL_LIST_STATUS',
-             'width'				=> '15%',
-        ),
-        'reply_to_status' => array(
-             'usage'				=> 'query_only',
-             'force_exists'			=> true,
-             'force_default'		=> 0,
-        ),
-        'contact_name'=>array(
-             'widget_class'         => 'SubPanelDetailViewLink',
-             'target_record_key'    => 'contact_id',
-             'target_module'        => 'Contacts',
-             'module'               => 'Contacts',
-             'vname'                => 'LBL_LIST_CONTACT',
-             'width'                => '11%',
-             'sortable'             => false,
-             'force_exists'			=> true,
-        ),
-        'contact_id'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'contact_name_owner'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'contact_name_mod'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'parent_id'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'parent_type'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'date_modified' => array(
-            'width'					=> '10%',
-        ),
-        'date_entered'=>array(
+$subpanel_layout = [
+    'where' => '',
+    'fill_in_additional_fields' => true,
+    'list_fields' => [
+        'object_image' => [
+            'widget_class' => 'SubPanelIcon',
+            'width' => '2%',
+        ],
+        'name' => [
+            'vname' => 'LBL_LIST_SUBJECT',
+            'widget_class' => 'SubPanelDetailViewLink',
+            'width' => '30%',
+            'parent_info' => true
+        ],
+        'status' => [
+            'vname' => 'LBL_LIST_STATUS',
+            'width' => '15%',
+        ],
+        'reply_to_status' => [
+            'usage' => 'query_only',
+            'force_exists' => true,
+            'force_default' => 0,
+        ],
+        'contact_name' => [
+            'widget_class' => 'SubPanelDetailViewLink',
+            'target_record_key' => 'contact_id',
+            'target_module' => 'Contacts',
+            'module' => 'Contacts',
+            'vname' => 'LBL_LIST_CONTACT',
+            'width' => '11%',
+            'sortable' => false,
+            'force_exists' => true,
+        ],
+        'contact_id' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'contact_name_owner' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'contact_name_mod' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'parent_id' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'parent_type' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'date_modified' => [
+            'width' => '10%',
+        ],
+        'date_entered' => [
             'vname' => 'LBL_LIST_DATE_ENTERED',
             'width' => '10%',
-        ),
-        'assigned_user_name' => array(
+        ],
+        'assigned_user_name' => [
             'name' => 'assigned_user_name',
             'vname' => 'LBL_LIST_ASSIGNED_TO_NAME',
             'widget_class' => 'SubPanelDetailViewLink',
             'target_record_key' => 'assigned_user_id',
             'target_module' => 'Employees',
             'width' => '10%',
-        ),
-        'edit_button' => array(
+        ],
+        'edit_button' => [
             'vname' => 'LBL_EDIT_BUTTON',
-            'widget_class'			=> 'SubPanelEditButton',
-             'width'				=> '2%',
-        ),
-        'remove_button' => array(
+            'widget_class' => 'SubPanelEditButton',
+            'width' => '2%',
+        ],
+        'remove_button' => [
             'vname' => 'LBL_REMOVE',
-             'widget_class'			=> 'SubPanelRemoveButton',
-             'width'				=> '2%',
-        ),
-        'filename' => array(
-            'usage'					=> 'query_only',
-            'force_exists'			=> true
-        ),
-    ), // end list_fields
-);
+            'widget_class' => 'SubPanelRemoveButton',
+            'width' => '2%',
+        ],
+        'filename' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+    ],
+];

--- a/modules/Emails/metadata/subpanels/ForUnlinkedEmailHistory.php
+++ b/modules/Emails/metadata/subpanels/ForUnlinkedEmailHistory.php
@@ -1,4 +1,9 @@
 <?php
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
 /**
  *
  * SugarCRM Community Edition is a customer relationship management program developed by
@@ -38,96 +43,91 @@
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
-if (!defined('sugarEntry') || !sugarEntry) {
-    die('Not A Valid Entry Point');
-}
-
-$subpanel_layout = array(
+$subpanel_layout = [
     'where' => '',
-
-    'fill_in_additional_fields'	=> true,
-    'list_fields' => array(
-        'object_image'=>array(
+    'fill_in_additional_fields' => true,
+    'list_fields' => [
+        'object_image' => [
             'vname' => 'LBL_OBJECT_IMAGE',
-            'widget_class'			=> 'SubPanelIcon',
-            'width'					=> '2%',
-        ),
-        'name' => array(
-             'vname'				=> 'LBL_LIST_SUBJECT',
-             'widget_class'			=> 'SubPanelDetailViewLink',
-             'width'				=> '30%',
-             'parent_info'          => true,
-        ),
-        'status' => array(
-             'vname'				=> 'LBL_LIST_STATUS',
-             'width'				=> '15%',
-        ),
-        'category_id' => array(
-            'vname'				=> 'LBL_LIST_CATEGORY',
-            'width'				=> '15%',
-        ),
-        'reply_to_status' => array(
-             'usage'				=> 'query_only',
-             'force_exists'			=> true,
-        ),
-        'contact_name'=>array(
-             'widget_class'         => 'SubPanelDetailViewLink',
-             'target_record_key'    => 'contact_id',
-             'target_module'        => 'Contacts',
-             'module'               => 'Contacts',
-             'vname'                => 'LBL_LIST_CONTACT',
-             'width'                => '11%',
-             'sortable'             => false,
-             'force_exists'			=> true,
-        ),
-        'contact_id' => array(
+            'widget_class' => 'SubPanelIcon',
+            'width' => '2%',
+        ],
+        'name' => [
+            'vname' => 'LBL_LIST_SUBJECT',
+            'widget_class' => 'SubPanelDetailViewLink',
+            'width' => '30%',
+            'parent_info' => true,
+        ],
+        'status' => [
+            'vname' => 'LBL_LIST_STATUS',
+            'width' => '15%',
+        ],
+        'category_id' => [
+            'vname' => 'LBL_LIST_CATEGORY',
+            'width' => '15%',
+        ],
+        'reply_to_status' => [
             'usage' => 'query_only',
             'force_exists' => true,
-        ),
-        'contact_name_owner' => array(
+        ],
+        'contact_name' => [
+            'widget_class' => 'SubPanelDetailViewLink',
+            'target_record_key' => 'contact_id',
+            'target_module' => 'Contacts',
+            'module' => 'Contacts',
+            'vname' => 'LBL_LIST_CONTACT',
+            'width' => '11%',
+            'sortable' => false,
+            'force_exists' => true,
+        ],
+        'contact_id' => [
             'usage' => 'query_only',
             'force_exists' => true,
-        ),
-        'contact_name_mod' => array(
+        ],
+        'contact_name_owner' => [
             'usage' => 'query_only',
             'force_exists' => true,
-        ),
-        'parent_id' => array(
+        ],
+        'contact_name_mod' => [
             'usage' => 'query_only',
             'force_exists' => true,
-        ),
-        'parent_type' => array(
+        ],
+        'parent_id' => [
             'usage' => 'query_only',
             'force_exists' => true,
-        ),
-        'date_modified' => array(
+        ],
+        'parent_type' => [
+            'usage' => 'query_only',
+            'force_exists' => true,
+        ],
+        'date_modified' => [
             'vname' => 'LBL_LIST_DATE_MODIFIED',
             'width' => '10%',
-        ),
-        'date_entered' => array(
+        ],
+        'date_entered' => [
             'vname' => 'LBL_LIST_DATE_ENTERED',
             'width' => '10%',
-        ),
-        'assigned_user_name' => array(
+        ],
+        'assigned_user_name' => [
             'name' => 'assigned_user_name',
             'vname' => 'LBL_LIST_ASSIGNED_TO_NAME',
             'widget_class' => 'SubPanelDetailViewLink',
             'target_record_key' => 'assigned_user_id',
             'target_module' => 'Employees',
-        ),
-        'edit_button' => array(
+        ],
+        'edit_button' => [
             'vname' => 'LBL_EDIT_BUTTON',
             'widget_class' => 'SubPanelEditButton',
             'width' => '2%',
-        ),
-        'remove_button' => array(
+        ],
+        'remove_button' => [
             'vname' => 'LBL_REMOVE',
             'widget_class' => 'SubPanelRemoveButton',
             'width' => '2%',
-        ),
-        'filename' => array(
+        ],
+        'filename' => [
             'usage' => 'query_only',
             'force_exists' => true,
-        ),
-    ), // end list_fields
-);
+        ],
+    ],
+];

--- a/modules/Emails/subpanels/ForHistory.php
+++ b/modules/Emails/subpanels/ForHistory.php
@@ -1,7 +1,9 @@
 <?php
+
 if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
+
 /**
  *
  * SugarCRM Community Edition is a customer relationship management program developed by
@@ -41,72 +43,68 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
-
-
-$subpanel_layout = array(
-    'where'				=> "",
-    
-    
-    'fill_in_additional_fields'	=> true,
-    'list_fields' => array(
-        'object_image'=>array(
-            'widget_class'			=> 'SubPanelIcon',
-            'width'					=> '2%',
-        ),
-        'name' => array(
-             'vname'				=> 'LBL_LIST_SUBJECT',
-             'widget_class'			=> 'SubPanelDetailViewLink',
-             'width'				=> '30%',
-             'parent_info'          => true
-        ),
-        'status' => array(
-             'vname'				=> 'LBL_LIST_STATUS',
-             'width'				=> '15%',
-        ),
-        'contact_name'=>array(
-             'widget_class'         => 'SubPanelDetailViewLink',
-             'target_record_key'    => 'contact_id',
-             'target_module'        => 'Contacts',
-             'module'               => 'Contacts',
-             'vname'                => 'LBL_LIST_CONTACT',
-             'width'                => '11%',
-             'sortable'             => false,
-             'force_exists'			=> true,
-        ),
-        'contact_id'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'contact_name_owner'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'contact_name_mod'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'date_modified' => array(
-            'width'					=> '10%',
-        ),
-        'date_entered'=>array(
+$subpanel_layout = [
+    'where' => '',
+    'fill_in_additional_fields' => true,
+    'list_fields' => [
+        'object_image' => [
+            'widget_class' => 'SubPanelIcon',
+            'width' => '2%',
+        ],
+        'name' => [
+            'vname' => 'LBL_LIST_SUBJECT',
+            'widget_class' => 'SubPanelDetailViewLink',
+            'width' => '30%',
+            'parent_info' => true
+        ],
+        'status' => [
+            'vname' => 'LBL_LIST_STATUS',
+            'width' => '15%',
+        ],
+        'contact_name' => [
+            'widget_class' => 'SubPanelDetailViewLink',
+            'target_record_key' => 'contact_id',
+            'target_module' => 'Contacts',
+            'module' => 'Contacts',
+            'vname' => 'LBL_LIST_CONTACT',
+            'width' => '11%',
+            'sortable' => false,
+            'force_exists' => true,
+        ],
+        'contact_id' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'contact_name_owner' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'contact_name_mod' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'date_modified' => [
+            'width' => '10%',
+        ],
+        'date_entered' => [
             'vname' => 'LBL_LIST_DATE_ENTERED',
             'width' => '10%',
-        ),
-        'assigned_user_name' => array(
+        ],
+        'assigned_user_name' => [
             'name' => 'assigned_user_name',
             'vname' => 'LBL_LIST_ASSIGNED_TO_NAME',
-        ),
-        'edit_button' => array(
-            'widget_class'			=> 'SubPanelEditButton',
-             'width'				=> '2%',
-        ),
-        'remove_button' => array(
-             'widget_class'			=> 'SubPanelRemoveButton',
-             'width'				=> '2%',
-        ),
-        'filename' => array(
-            'usage'					=> 'query_only',
-            'force_exists'			=> true
-        ),
-    ), // end list_fields
-);
+        ],
+        'edit_button' => [
+            'widget_class' => 'SubPanelEditButton',
+            'width' => '2%',
+        ],
+        'remove_button' => [
+            'widget_class' => 'SubPanelRemoveButton',
+            'width' => '2%',
+        ],
+        'filename' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+    ],
+];

--- a/modules/Meetings/metadata/subpanels/ForActivities.php
+++ b/modules/Meetings/metadata/subpanels/ForActivities.php
@@ -1,7 +1,9 @@
 <?php
+
 if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
+
 /**
  *
  * SugarCRM Community Edition is a customer relationship management program developed by
@@ -41,89 +43,81 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
-
-
-$subpanel_layout = array(
-    //Removed button because this layout def is a component of
-    //the activities sub-panel.
-
+$subpanel_layout = [
     'where' => "(meetings.status !='Held' AND meetings.status !='Not Held')",
-    
-    
-                
-    'list_fields' => array(
-        'object_image'=>array(
+    'list_fields' => [
+        'object_image' => [
             'vname' => 'LBL_OBJECT_IMAGE',
             'widget_class' => 'SubPanelIcon',
             'width' => '2%',
-            'image2'=>'__VARIABLE',
-            'image2_ext_url_field'=>'displayed_url',
-        ),
-        'name'=>array(
-             'vname' => 'LBL_LIST_SUBJECT',
-             'widget_class' => 'SubPanelDetailViewLink',
-             'width' => '42%',
-        ),
-        'status'=>array(
-             'widget_class' => 'SubPanelActivitiesStatusField',
-             'vname' => 'LBL_LIST_STATUS',
-             'width' => '15%',
-        ),
-        'contact_name'=>array(
-             'widget_class' => 'SubPanelDetailViewLink',
-             'target_record_key' => 'contact_id',
-             'target_module' => 'Contacts',
-             'module' => 'Contacts',
-             'vname' => 'LBL_LIST_CONTACT',
-             'width' => '11%',
-             'sortable'=>false,
-        ),
-        'contact_id'=>array(
-            'usage'=>'query_only',
-    
-        ),
-        'contact_name_owner'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'contact_name_mod'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'date_end'=>array(
+            'image2' => '__VARIABLE',
+            'image2_ext_url_field' => 'displayed_url',
+        ],
+        'name' => [
+            'vname' => 'LBL_LIST_SUBJECT',
+            'widget_class' => 'SubPanelDetailViewLink',
+            'width' => '42%',
+        ],
+        'status' => [
+            'widget_class' => 'SubPanelActivitiesStatusField',
+            'vname' => 'LBL_LIST_STATUS',
+            'width' => '15%',
+        ],
+        'contact_name' => [
+            'widget_class' => 'SubPanelDetailViewLink',
+            'target_record_key' => 'contact_id',
+            'target_module' => 'Contacts',
+            'module' => 'Contacts',
+            'vname' => 'LBL_LIST_CONTACT',
+            'width' => '11%',
+            'sortable' => false,
+        ],
+        'contact_id' => [
+            'usage' => 'query_only',
+        ],
+        'contact_name_owner' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'contact_name_mod' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'date_end' => [
             'vname' => 'LBL_LIST_DUE_DATE',
             'width' => '10%',
-        ),
-        'assigned_user_name' => array(
+            'alias' => 'date_due',
+            'sort_by' => 'date_due',
+        ],
+        'assigned_user_name' => [
             'name' => 'assigned_user_name',
             'vname' => 'LBL_LIST_ASSIGNED_TO_NAME',
             'widget_class' => 'SubPanelDetailViewLink',
             'target_record_key' => 'assigned_user_id',
             'target_module' => 'Employees',
             'width' => '10%',
-        ),
-        'edit_button'=>array(
+        ],
+        'edit_button' => [
             'vname' => 'LBL_EDIT_BUTTON',
-             'widget_class' => 'SubPanelEditButton',
-             'width' => '2%',
-        ),
-        'close_button'=>array(
+            'widget_class' => 'SubPanelEditButton',
+            'width' => '2%',
+        ],
+        'close_button' => [
             'widget_class' => 'SubPanelCloseButton',
             'vname' => 'LBL_LIST_CLOSE',
-            'sortable'=>false,
+            'sortable' => false,
             'width' => '6%',
-        ),
-        'remove_button'=>array(
+        ],
+        'remove_button' => [
             'vname' => 'LBL_REMOVE',
-             'widget_class' => 'SubPanelRemoveButton',
-             'width' => '2%',
-        ),
-        'time_start'=>array(
-            'usage'=>'query_only',
-    
-        ),
-        'recurring_source'=>array(
-            'usage'=>'query_only',
-        ),
-    ),
-);
+            'widget_class' => 'SubPanelRemoveButton',
+            'width' => '2%',
+        ],
+        'time_start' => [
+            'usage' => 'query_only',
+        ],
+        'recurring_source' => [
+            'usage' => 'query_only',
+        ],
+    ],
+];

--- a/modules/Meetings/metadata/subpanels/ForHistory.php
+++ b/modules/Meetings/metadata/subpanels/ForHistory.php
@@ -1,7 +1,9 @@
 <?php
+
 if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
+
 /**
  *
  * SugarCRM Community Edition is a customer relationship management program developed by
@@ -41,104 +43,97 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
-
-
-$subpanel_layout = array(
-    //Removed button because this layout def is a component of
-    //the activities sub-panel.
-
+$subpanel_layout = [
     'where' => "(meetings.status='Held' OR meetings.status='Not Held')",
-
-
-
-    'list_fields' => array(
-        'object_image'=>array(
+    'list_fields' => [
+        'object_image' => [
             'vname' => 'LBL_OBJECT_IMAGE',
             'widget_class' => 'SubPanelIcon',
             'width' => '2%',
-            'image2'=>'attachment',
-            'image2_url_field'=>'file_url'
-        ),
-        'name'=>array(
-             'vname' => 'LBL_LIST_SUBJECT',
-             'widget_class' => 'SubPanelDetailViewLink',
-             'width' => '30%',
-        ),
-        'status'=>array(
-             'widget_class' => 'SubPanelActivitiesStatusField',
-             'vname' => 'LBL_LIST_STATUS',
-             'width' => '15%',
-        ),
-        'reply_to_status' => array(
-             'usage'				=> 'query_only',
-             'force_exists'			=> true,
-             'force_default'		=> 0,
-        ),
-        'contact_name'=>array(
-             'widget_class'			=> 'SubPanelDetailViewLink',
-             'target_record_key'	=> 'contact_id',
-             'target_module'		=> 'Contacts',
-             'module'				=> 'Contacts',
-             'vname'				=> 'LBL_LIST_CONTACT',
-             'width'				=> '11%',
-             'sortable'=>false,
-        ),
-        'contact_id'=>array(
-            'usage'=>'query_only',
-
-        ),
-        'contact_name_owner'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'contact_name_mod'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'parent_id'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'parent_type'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'date_modified'=>array(
-             'vname' => 'LBL_LIST_DATE_MODIFIED',
-             'width' => '10%',
-        ),
-        'date_entered'=>array(
+            'image2' => 'attachment',
+            'image2_url_field' => 'file_url'
+        ],
+        'name' => [
+            'vname' => 'LBL_LIST_SUBJECT',
+            'widget_class' => 'SubPanelDetailViewLink',
+            'width' => '30%',
+        ],
+        'status' => [
+            'widget_class' => 'SubPanelActivitiesStatusField',
+            'vname' => 'LBL_LIST_STATUS',
+            'width' => '15%',
+        ],
+        'reply_to_status' => [
+            'usage' => 'query_only',
+            'force_exists' => true,
+            'force_default' => 0,
+        ],
+        'contact_name' => [
+            'widget_class' => 'SubPanelDetailViewLink',
+            'target_record_key' => 'contact_id',
+            'target_module' => 'Contacts',
+            'module' => 'Contacts',
+            'vname' => 'LBL_LIST_CONTACT',
+            'width' => '11%',
+            'sortable' => false,
+        ],
+        'contact_id' => [
+            'usage' => 'query_only',
+        ],
+        'contact_name_owner' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'contact_name_mod' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'parent_id' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'parent_type' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'date_modified' => [
+            'vname' => 'LBL_LIST_DATE_MODIFIED',
+            'width' => '10%',
+        ],
+        'date_entered' => [
             'vname' => 'LBL_LIST_DATE_ENTERED',
             'width' => '10%',
-        ),
-        'date_due'=>array(
+        ],
+        'date_end' => [
             'vname' => 'LBL_LIST_DUE_DATE',
             'width' => '10%',
-        ),
-        'assigned_user_name' => array(
+            'alias' => 'date_due',
+            'sort_by' => 'date_due',
+        ],
+        'assigned_user_name' => [
             'name' => 'assigned_user_name',
             'vname' => 'LBL_LIST_ASSIGNED_TO_NAME',
             'widget_class' => 'SubPanelDetailViewLink',
             'target_record_key' => 'assigned_user_id',
             'target_module' => 'Employees',
             'width' => '10%',
-        ),
-        'edit_button'=>array(
+        ],
+        'edit_button' => [
             'vname' => 'LBL_EDIT_BUTTON',
-             'widget_class' => 'SubPanelEditButton',
-             'width' => '2%',
-        ),
-        'remove_button'=>array(
+            'widget_class' => 'SubPanelEditButton',
+            'width' => '2%',
+        ],
+        'remove_button' => [
             'vname' => 'LBL_REMOVE',
-             'widget_class' => 'SubPanelRemoveButton',
-             'width' => '2%',
-        ),
-        'filename'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'recurring_source'=>array(
-            'usage'=>'query_only',
-        ),
-    ),
-);
+            'widget_class' => 'SubPanelRemoveButton',
+            'width' => '2%',
+        ],
+        'filename' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'recurring_source' => [
+            'usage' => 'query_only',
+        ],
+    ],
+];

--- a/modules/Notes/metadata/subpanels/ForHistory.php
+++ b/modules/Notes/metadata/subpanels/ForHistory.php
@@ -1,7 +1,9 @@
 <?php
+
 if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
+
 /**
  *
  * SugarCRM Community Edition is a customer relationship management program developed by
@@ -41,102 +43,91 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
-
-
-
-$subpanel_layout = array(
-    //Removed button because this layout def is a component of
-    //the activities sub-panel.
-
+$subpanel_layout = [
     'where' => '',
-
-
-    'list_fields' => array(
-        'object_image'=>array(
+    'list_fields' => [
+        'object_image' => [
             'vname' => 'LBL_OBJECT_IMAGE',
             'widget_class' => 'SubPanelIcon',
             'width' => '2%',
-            'image2'=>'attachment',
-            'image2_url_field'=> array(
+            'image2' => 'attachment',
+            'image2_url_field' => [
                 'id_field' => 'id',
                 'filename_field' => 'filename',
-            ),
-        ),
-        'name'=>array(
-             'vname' => 'LBL_LIST_SUBJECT',
-             'widget_class' => 'SubPanelDetailViewLink',
-             'width' => '30%',
-        ),
-        'status'=>array(
-             'widget_class' => 'SubPanelActivitiesStatusField',
-             'vname' => 'LBL_LIST_STATUS',
-             'width' => '15%',
-             'force_exists'=>true //this will create a fake field in the case a field is not defined
-
-        ),
-        'reply_to_status' => array(
-             'usage'				=> 'query_only',
-             'force_exists'			=> true,
-             'force_default'		=> 0,
-        ),
-        'contact_name'=>array(
-             'widget_class'			=> 'SubPanelDetailViewLink',
-             'target_record_key'	=> 'contact_id',
-             'target_module'		=> 'Contacts',
-             'module'				=> 'Contacts',
-             'vname'				=> 'LBL_LIST_CONTACT',
-             'width'				=> '11%',
-             'sortable'=>false,
-        ),
-        'parent_id'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'parent_type'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-
-        'date_modified'=>array(
-             'vname' => 'LBL_LIST_DATE_MODIFIED',
-             'width' => '10%',
-        ),
-        'date_entered'=>array(
+            ],
+        ],
+        'name' => [
+            'vname' => 'LBL_LIST_SUBJECT',
+            'widget_class' => 'SubPanelDetailViewLink',
+            'width' => '30%',
+        ],
+        'status' => [
+            'widget_class' => 'SubPanelActivitiesStatusField',
+            'vname' => 'LBL_LIST_STATUS',
+            'width' => '15%',
+            'force_exists' => true
+        ],
+        'reply_to_status' => [
+            'usage' => 'query_only',
+            'force_exists' => true,
+            'force_default' => 0,
+        ],
+        'contact_name' => [
+            'widget_class' => 'SubPanelDetailViewLink',
+            'target_record_key' => 'contact_id',
+            'target_module' => 'Contacts',
+            'module' => 'Contacts',
+            'vname' => 'LBL_LIST_CONTACT',
+            'width' => '11%',
+            'sortable' => false,
+        ],
+        'parent_id' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'parent_type' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'date_modified' => [
+            'vname' => 'LBL_LIST_DATE_MODIFIED',
+            'width' => '10%',
+        ],
+        'date_entered' => [
             'vname' => 'LBL_LIST_DATE_ENTERED',
             'width' => '10%',
-        ),
-        'assigned_user_name' => array(
+        ],
+        'assigned_user_name' => [
             'name' => 'assigned_user_name',
             'vname' => 'LBL_LIST_ASSIGNED_TO_NAME',
             'widget_class' => 'SubPanelDetailViewLink',
             'target_record_key' => 'assigned_user_id',
             'target_module' => 'Employees',
             'width' => '10%',
-        ),
-        'assigned_user_owner' => array(
-             'force_exists'=>true, //this will create a fake field since this field is not defined
-            'usage'=>'query_only'
-        ),
-        'assigned_user_mod' => array(
-             'force_exists'=>true, //this will create a fake field since this field is not defined
-            'usage'=>'query_only'
-        ),
-        'edit_button'=>array(
+        ],
+        'assigned_user_owner' => [
+            'force_exists' => true,
+            'usage' => 'query_only'
+        ],
+        'assigned_user_mod' => [
+            'force_exists' => true,
+            'usage' => 'query_only'
+        ],
+        'edit_button' => [
             'vname' => 'LBL_EDIT_BUTTON',
-             'widget_class' => 'SubPanelEditButton',
-             'width' => '2%',
-        ),
-        'remove_button'=>array(
+            'widget_class' => 'SubPanelEditButton',
+            'width' => '2%',
+        ],
+        'remove_button' => [
             'vname' => 'LBL_REMOVE',
-             'widget_class' => 'SubPanelRemoveButton',
-             'width' => '2%',
-        ),
-        'file_url'=>array(
-            'usage'=>'query_only'
-            ),
-        'filename'=>array(
-            'usage'=>'query_only'
-            ),
-
-    ),
-);
+            'widget_class' => 'SubPanelRemoveButton',
+            'width' => '2%',
+        ],
+        'file_url' => [
+            'usage' => 'query_only'
+        ],
+        'filename' => [
+            'usage' => 'query_only'
+        ],
+    ],
+];

--- a/modules/Tasks/metadata/subpanels/ForActivities.php
+++ b/modules/Tasks/metadata/subpanels/ForActivities.php
@@ -1,7 +1,9 @@
 <?php
+
 if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
+
 /**
  *
  * SugarCRM Community Edition is a customer relationship management program developed by
@@ -41,73 +43,65 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
-
-
-$subpanel_layout = array(
-    //Removed button because this layout def is a component of
-    //the activities sub-panel.
-
+$subpanel_layout = [
     'where' => "(tasks.status != 'Completed' AND tasks.status != 'Deferred')",
-            
-    'list_fields' => array(
-        'object_image'=>array(
+    'list_fields' => [
+        'object_image' => [
             'vname' => 'LBL_OBJECT_IMAGE',
             'widget_class' => 'SubPanelIcon',
             'width' => '2%',
-        ),
-        'name'=>array(
-             'vname' => 'LBL_LIST_SUBJECT',
-             'widget_class' => 'SubPanelDetailViewLink',
-             'width' => '30%',
-        ),
-        'status'=>array(
-             'widget_class' => 'SubPanelActivitiesStatusField',
-             'vname' => 'LBL_LIST_STATUS',
-             'width' => '15%',
-        ),
-        'contact_name'=>array(
-             'widget_class' => 'SubPanelDetailViewLink',
-             'target_record_key' => 'contact_id',
-             'target_module' => 'Contacts',
-             'module' => 'Contacts',
-             'vname' => 'LBL_LIST_CONTACT',
-             'width' => '11%',
-        ),
-        'date_due' => array(
+        ],
+        'name' => [
+            'vname' => 'LBL_LIST_SUBJECT',
+            'widget_class' => 'SubPanelDetailViewLink',
+            'width' => '30%',
+        ],
+        'status' => [
+            'widget_class' => 'SubPanelActivitiesStatusField',
+            'vname' => 'LBL_LIST_STATUS',
+            'width' => '15%',
+        ],
+        'contact_name' => [
+            'widget_class' => 'SubPanelDetailViewLink',
+            'target_record_key' => 'contact_id',
+            'target_module' => 'Contacts',
+            'module' => 'Contacts',
+            'vname' => 'LBL_LIST_CONTACT',
+            'width' => '11%',
+        ],
+        'date_due' => [
             'vname' => 'LBL_LIST_DUE_DATE',
             'width' => '10%',
             'alias' => 'date_end',
             'sort_by' => 'date_end',
-        ),
-        'assigned_user_name' => array(
+        ],
+        'assigned_user_name' => [
             'name' => 'assigned_user_name',
             'vname' => 'LBL_LIST_ASSIGNED_TO_NAME',
             'widget_class' => 'SubPanelDetailViewLink',
             'target_record_key' => 'assigned_user_id',
             'target_module' => 'Employees',
             'width' => '22%',
-        ),
-        'edit_button'=>array(
+        ],
+        'edit_button' => [
             'vname' => 'LBL_EDIT_BUTTON',
-             'widget_class' => 'SubPanelEditButton',
-             'width' => '2%',
-             
-        ),
-        'close_button'=>array(
+            'widget_class' => 'SubPanelEditButton',
+            'width' => '2%',
+        ],
+        'close_button' => [
             'widget_class' => 'SubPanelCloseButton',
             'vname' => 'LBL_LIST_CLOSE',
             'width' => '6%',
-            'sortable'=>false,
-        ),
-        'remove_button'=>array(
+            'sortable' => false,
+        ],
+        'remove_button' => [
             'vname' => 'LBL_REMOVE',
-             'widget_class' => 'SubPanelRemoveButton',
-             'width' => '2%',
-        ),
-        'time_due'=>array(
-            'usage'=>'query_only',
-             'alias' => 'time_start'
-        )	,
-        
-    ),
-);
+            'widget_class' => 'SubPanelRemoveButton',
+            'width' => '2%',
+        ],
+        'time_due' => [
+            'usage' => 'query_only',
+            'alias' => 'time_start'
+        ],
+    ],
+];

--- a/modules/Tasks/metadata/subpanels/ForHistory.php
+++ b/modules/Tasks/metadata/subpanels/ForHistory.php
@@ -94,8 +94,8 @@ $subpanel_layout = [
         'date_due' => [
             'vname' => 'LBL_LIST_DUE_DATE',
             'width' => '10%',
-            'alias' => 'date_due',
-            'sort_by' => 'date_due',
+            'alias' => 'date_end',
+            'sort_by' => 'date_end',
         ],
         'assigned_user_name' => [
             'name' => 'assigned_user_name',

--- a/modules/Tasks/metadata/subpanels/ForHistory.php
+++ b/modules/Tasks/metadata/subpanels/ForHistory.php
@@ -1,7 +1,9 @@
 <?php
+
 if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
+
 /**
  *
  * SugarCRM Community Edition is a customer relationship management program developed by
@@ -41,91 +43,81 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
-
-
-$subpanel_layout = array(
-    //Removed button because this layout def is a component of
-    //the activities sub-panel.
-
+$subpanel_layout = [
     'where' => "(tasks.status='Completed' OR tasks.status='Deferred')",
-
-
-
-    'list_fields' => array(
-        'object_image'=>array(
+    'list_fields' => [
+        'object_image' => [
             'vname' => 'LBL_OBJECT_IMAGE',
             'widget_class' => 'SubPanelIcon',
             'width' => '2%',
-        ),
-        'name'=>array(
-             'vname' => 'LBL_LIST_SUBJECT',
-             'widget_class' => 'SubPanelDetailViewLink',
-             'width' => '30%',
-        ),
-        'status'=>array(
-             'widget_class' => 'SubPanelActivitiesStatusField',
-             'vname' => 'LBL_LIST_STATUS',
-             'width' => '15%',
-        ),
-        'reply_to_status' => array(
-             'usage'				=> 'query_only',
-             'force_exists'			=> true,
-             'force_default'		=> 0,
-        ),
-        'contact_name'=>array(
-             'widget_class'			=> 'SubPanelDetailViewLink',
-             'target_record_key'	=> 'contact_id',
-             'target_module'		=> 'Contacts',
-             'module'				=> 'Contacts',
-             'vname'				=> 'LBL_LIST_CONTACT',
-             'width'				=> '11%',
-        ),
-        'parent_id'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
-        'parent_type'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-        ),
+        ],
+        'name' => [
+            'vname' => 'LBL_LIST_SUBJECT',
+            'widget_class' => 'SubPanelDetailViewLink',
+            'width' => '30%',
+        ],
+        'status' => [
+            'widget_class' => 'SubPanelActivitiesStatusField',
+            'vname' => 'LBL_LIST_STATUS',
+            'width' => '15%',
+        ],
+        'reply_to_status' => [
+            'usage' => 'query_only',
+            'force_exists' => true,
+            'force_default' => 0,
+        ],
+        'contact_name' => [
+            'widget_class' => 'SubPanelDetailViewLink',
+            'target_record_key' => 'contact_id',
+            'target_module' => 'Contacts',
+            'module' => 'Contacts',
+            'vname' => 'LBL_LIST_CONTACT',
+            'width' => '11%',
+        ],
+        'parent_id' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+        'parent_type' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
 
-        'date_modified'=>array(
-             'vname' => 'LBL_LIST_DATE_MODIFIED',
-             'width' => '10%',
-        ),
-        'date_entered'=>array(
+        'date_modified' => [
+            'vname' => 'LBL_LIST_DATE_MODIFIED',
+            'width' => '10%',
+        ],
+        'date_entered' => [
             'vname' => 'LBL_LIST_DATE_ENTERED',
             'width' => '10%',
-        ),
-         'date_due'=>array(
-                'vname' => 'LBL_LIST_DUE_DATE',
-                'width' => '10%',
-                'alias' => 'date_due',
-                'sort_by' => 'date_due',
-            ),
-        'assigned_user_name' => array(
+        ],
+        'date_due' => [
+            'vname' => 'LBL_LIST_DUE_DATE',
+            'width' => '10%',
+            'alias' => 'date_due',
+            'sort_by' => 'date_due',
+        ],
+        'assigned_user_name' => [
             'name' => 'assigned_user_name',
             'vname' => 'LBL_LIST_ASSIGNED_TO_NAME',
             'widget_class' => 'SubPanelDetailViewLink',
             'target_record_key' => 'assigned_user_id',
             'target_module' => 'Employees',
             'width' => '10%',
-        ),
-        'edit_button'=>array(
+        ],
+        'edit_button' => [
             'vname' => 'LBL_EDIT_BUTTON',
-             'widget_class' => 'SubPanelEditButton',
-             'width' => '2%',
-        ),
-        'remove_button'=>array(
+            'widget_class' => 'SubPanelEditButton',
+            'width' => '2%',
+        ],
+        'remove_button' => [
             'vname' => 'LBL_REMOVE',
-             'widget_class' => 'SubPanelRemoveButton',
-             'width' => '2%',
-        ),
-        'filename'=>array(
-            'usage'=>'query_only',
-            'force_exists'=>true
-            ),
-
-
-    ),
-);
+            'widget_class' => 'SubPanelRemoveButton',
+            'width' => '2%',
+        ],
+        'filename' => [
+            'usage' => 'query_only',
+            'force_exists' => true
+        ],
+    ],
+];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

Fix aliasing for `date_end`/`date_due` fields so that the columns from each of the three modules (Calls, Meetings and Tasks) match consistently in the UNION ALL queries.



### Changes:
- Calls and Meetings should use the `date_end` field aliased to `date_due` (or whatever as long as it's consistent everywhere which has been the issue thus far).
- Task should use the `date_due` field with an inverse alias of `date_end` oddly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Inconsistency in aliases across UNION table columns caused queries to intermittently failed under certain circumstances such as having at least one of each type of history record in the subpanel etc.



## How To Test This
<!--- Please describe in detail how to test your changes. -->
- Create any record and relate at least one task, meeting and call in both the Activities and History subpanels. 
- Load the detail view of that record and it should no longer die.
- Check the suite logs and there should no longer be a failing query.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.



<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->



<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->

