### PR TITLE
Move RebuildConfig.php from using XTemplate to using Smarty.

### DIFF
--- a/modules/Administration/RebuildConfig.php
+++ b/modules/Administration/RebuildConfig.php
@@ -79,11 +79,10 @@ if (!empty($_POST['perform_rebuild']) && $config_file_ready) {
 
 /////////////////////////////////////////////////////////////////////
 // TEMPLATE ASSIGNING
-$xtpl = new XTemplate('modules/Administration/RebuildConfig.html');
-$xtpl->assign('LBL_CONFIG_CHECK', $mod_strings['LBL_CONFIG_CHECK']);
-$xtpl->assign('CONFIG_CHECK', $config_check);
-$xtpl->assign('LBL_PERFORM_REBUILD', $lbl_rebuild_config);
-$xtpl->assign('DISABLE_CONFIG_REBUILD', $disable_config_rebuild);
-$xtpl->assign('BTN_PERFORM_REBUILD', $btn_rebuild_config);
-$xtpl->parse('main');
-$xtpl->out('main');
+$smarty = new Sugar_Smarty();
+$smarty->assign('LBL_CONFIG_CHECK', $mod_strings['LBL_CONFIG_CHECK']);
+$smarty->assign('CONFIG_CHECK', $config_check);
+$smarty->assign('LBL_PERFORM_REBUILD', $lbl_rebuild_config);
+$smarty->assign('DISABLE_CONFIG_REBUILD', $disable_config_rebuild);
+$smarty->assign('BTN_PERFORM_REBUILD', $btn_rebuild_config);
+$smarty->display('modules/Administration/templates/RebuildConfig.tpl');

--- a/modules/Administration/templates/RebuildConfig.tpl
+++ b/modules/Administration/templates/RebuildConfig.tpl
@@ -1,4 +1,4 @@
-<!--
+{*
 /**
  *
  * SugarCRM Community Edition is a customer relationship management program developed by
@@ -37,26 +37,25 @@
  * reasonably feasible for technical reasons, the Appropriate Legal Notices must
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
+*}
 
--->
-<!-- BEGIN: main -->
 <p>
-<form name="RebuildConfig" method="post" action="index.php">
-<input type="hidden" name="module" value="Administration">
-<input type="hidden" name="action" value="RebuildConfig">
-<input type="hidden" name="return_module" value="Administration">
-<input type="hidden" name="return_action" value="RebuildConfig">
-<input type="hidden" name="perform_rebuild" value="true">
-<table cellspacing="{CELLSPACING}" class="other view">
-<tr>
-    <td width="20%" scope="row">{LBL_CONFIG_CHECK}</td>
-    <td>{CONFIG_CHECK}</td>
-</tr>
-<tr>
-    <td scope="row">{LBL_PERFORM_REBUILD}</td>
-    <td><input type="submit" name="button" {DISABLE_CONFIG_REBUILD} value="{BTN_PERFORM_REBUILD}"></td>
-</tr>
-</table>
-</form>
+    <form name="RebuildConfig" method="post" action="index.php">
+        <input type="hidden" name="module" value="Administration">
+        <input type="hidden" name="action" value="RebuildConfig">
+        <input type="hidden" name="return_module" value="Administration">
+        <input type="hidden" name="return_action" value="RebuildConfig">
+        <input type="hidden" name="perform_rebuild" value="true">
+
+        <table cellspacing="{$CELLSPACING}" class="other view">
+        <tr>
+            <td width="20%" scope="row">{$LBL_CONFIG_CHECK}</td>
+            <td>{$CONFIG_CHECK}</td>
+        </tr>
+        <tr>
+            <td scope="row">{$LBL_PERFORM_REBUILD}</td>
+            <td><input type="submit" name="button" {$DISABLE_CONFIG_REBUILD} value="{$BTN_PERFORM_REBUILD}"></td>
+        </tr>
+        </table>
+    </form>
 </p>
-<!-- END: main -->


### PR DESCRIPTION
## Description

This renders the RebuildConfig page using Smarty instead of XTemplate.

See also #8016.

## Motivation and Context

XTemplate is old, outdated, probably insecure, and we should really remove it from the CRM. This is a step toward that.

## How To Test This
1. Go to the Administration module.
2. Go to Repair.
3. Choose "Rebuild Config"
4. Make sure it looks and works the same as it did before this change.

## Types of changes
Technical debt :)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.