### PR TITLE
Ignore vendored library files in .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -35,3 +35,27 @@ comment:
   layout: "header, diff"
   behavior: default
   require_changes: false
+
+ignore:
+  - "include/timezone/.*"
+  - "include/SuiteGraphs/.*"
+  - "include/social/.*"
+  - "include/Smarty/.*"
+  - "include/reCaptcha/.*"
+  - "include/phpmailer/.*"
+  - "include/Pear/.*"
+  - "include/pclzip/.*"
+  - "include/nusoap/.*"
+  - "include/HTTP_WebDAV_Server/.*"
+  - "include/HTMLPurifier/.*"
+  - "include/SugarXHprof/.*"
+  - "include/ytree/.*"
+  - "include/php-sql-parser.php"
+  - "include/parsecsv.lib.php"
+  - "modules/AOS_PDF_Templates/PDF_Lib/.*"
+  - "Zend/.*"
+  - "modules/AOD_Index/Lib/.*"
+  - "modules/Users/authentication/SAML2Authenticate/lib/.*"
+  - "install/demoData.en_us.php"
+  - "include/tcpdf/.*"
+  - "modules/AOR_Charts/lib/.*"


### PR DESCRIPTION
This now matches the coverage tracking in hotfix.

Make sure this passes CI, obviously, and make sure it's valid and makes sense.

Here's the file on hotfix for comparison: https://github.com/salesagility/SuiteCRM/blob/hotfix/.codecov.yml