### PR TITLE
Fixed #7874 - Unable to use custom _head.tpl file (alternative fix)

### DIFF
--- a/include/Sugar_Smarty.php
+++ b/include/Sugar_Smarty.php
@@ -172,7 +172,6 @@ class Sugar_Smarty extends Smarty
      * @param string $_smarty_include_tpl_file
      * @param string $_smarty_include_vars
      */
-
     function _smarty_include($params)
     {
         $params['smarty_include_tpl_file'] = get_custom_file_if_exists($params['smarty_include_tpl_file']);
@@ -187,7 +186,7 @@ class Sugar_Smarty extends Smarty
     public function trigger_error($error_msg, $error_type = E_USER_WARNING)
     {
         $error_msg = htmlentities($error_msg);
-
+        
         switch ($error_type) {
             case E_USER_ERROR:
                 $GLOBALS['log']->error('Smarty: ' . $error_msg);

--- a/include/Sugar_Smarty.php
+++ b/include/Sugar_Smarty.php
@@ -168,6 +168,18 @@ class Sugar_Smarty extends Smarty
     }
 
     /**
+     * called for included templates
+     * @param string $_smarty_include_tpl_file
+     * @param string $_smarty_include_vars
+     */
+
+    function _smarty_include($params)
+    {
+        $params['smarty_include_tpl_file'] = get_custom_file_if_exists($params['smarty_include_tpl_file']);
+        parent::_smarty_include($params);
+    }
+
+    /**
      * Log smarty error out to default log location
      * @param string $error_msg
      * @param integer $error_type
@@ -175,7 +187,7 @@ class Sugar_Smarty extends Smarty
     public function trigger_error($error_msg, $error_type = E_USER_WARNING)
     {
         $error_msg = htmlentities($error_msg);
-        
+
         switch ($error_type) {
             case E_USER_ERROR:
                 $GLOBALS['log']->error('Smarty: ' . $error_msg);

--- a/themes/SuiteP/tpls/header.tpl
+++ b/themes/SuiteP/tpls/header.tpl
@@ -38,11 +38,7 @@
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 *}
-{if file_exists('custom/themes/SuiteP/tpls/_head.tpl')}
-    {include file="custom/themes/SuiteP/tpls/_head.tpl"}
-{else}
-    {include file="themes/SuiteP/tpls/_head.tpl"}
-{/if}
+{include file="themes/SuiteP/tpls/_head.tpl"}
 <body onMouseOut="closeMenus();">
 
 {if $AUTHENTICATED}


### PR DESCRIPTION
Fixed #7874 - Unable to use custom _head.tpl file

Adds lookup for custom tpls in Sugar_Smarty.php, so that any {{include file='abc'}} automatically looks for a custom version of that file in custom/abc.

As discussed in the issue #7874 this might be a more general solution to the issue.

Because PR #8028 has already been merged, this PR revokes the changes made to the header.tpl, because the modification is not required any more. 