### PR TITLE
Fixed #7128 - Remove scheme to avoid mixed content error

### DIFF
--- a/modules/jjwg_Maps/views/view.map_markers.php
+++ b/modules/jjwg_Maps/views/view.map_markers.php
@@ -737,7 +737,7 @@ function setODataTable() {
                         "mColumns": "all"
                     },
                 ],
-                "sSwfPath": "http://cdn.datatables.net/tabletools/2.2.2/swf/copy_csv_xls_pdf.swf"
+                "sSwfPath": "//cdn.datatables.net/tabletools/2.2.2/swf/copy_csv_xls_pdf.swf"
             },
             "fnDrawCallback": function(oSettings) {
                 if (typeof window.parent.resizeDataTables == 'function') {


### PR DESCRIPTION
Remove scheme to avoid mixed content error

## Description
Site served over HTTPS got a mixed content error, this change is to avoid the error.
This is a quick fix as according to https://datatables.net/extensions/tabletools/ TableTools are retired... 

## Motivation and Context
Fix #7128 for HacktoberFest

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
