### PR TITLE
Fix deprecated usages of implode

### DIFF
--- a/include/OutboundEmail/OutboundEmail.php
+++ b/include/OutboundEmail/OutboundEmail.php
@@ -521,7 +521,7 @@ class OutboundEmail
         $values = $this->getValues($cols);
 
         if ($this->new_with_id) {
-            $q = sprintf("INSERT INTO outbound_email (%s) VALUES (%s)", implode($cols, ","), implode($values, ","));
+            $q = sprintf("INSERT INTO outbound_email (%s) VALUES (%s)", implode(",", $cols), implode(",", $values));
         } else {
             $updvalues = array();
             foreach ($values as $k => $val) {

--- a/install/installConfig.php
+++ b/install/installConfig.php
@@ -569,7 +569,7 @@ EOQ3;
             foreach ($_SESSION['installation_scenarios'] as $scenario) {
                 $key = $scenario['key'];
                 $description = $scenario['description'];
-                $scenarioModuleList =  implode($scenario['modulesScenarioDisplayName'], ',');
+                $scenarioModuleList = implode(',', $scenario['modulesScenarioDisplayName']);
                 $title = $scenario['title'];
 
                 $scenarioSelection.= "<input type='checkbox' name='scenarios[]' value='$key' checked><b>$title</b>.  $description ($scenarioModuleList).<br>";

--- a/modules/AOR_Charts/AOR_Chart.php
+++ b/modules/AOR_Charts/AOR_Chart.php
@@ -266,7 +266,7 @@ class AOR_Chart extends Basic
                 $hash = md5($onelabel);
                 $colours[] = substr($hash, 0, 6);
             }
-            $this->colours = "['#" . implode($colours, "','#") . "']";
+            $this->colours = "['#" . implode("','#", $colours) . "']";
             return true;
         }
         LoggerManager::getLogger()->warn('Incorrect labels given. Using default colours in charts.');

--- a/modules/ModuleBuilder/views/view.layoutview.php
+++ b/modules/ModuleBuilder/views/view.layoutview.php
@@ -125,7 +125,7 @@ class ViewLayoutView extends SugarView
             $smarty->assign($image, SugarThemeRegistry::current()->getImage($file, '', null, null, '.gif', $file)) ;
         }
 
-        $requiredFields = implode($parser->getRequiredFields(), ',');
+        $requiredFields = implode(',', $parser->getRequiredFields());
         $slashedRequiredFields = addslashes($requiredFields);
         $buttons = array( ) ;
         $disableLayout = false;


### PR DESCRIPTION
Part of #8057. This fixes usages of `implode()` where the arguments are reversed. PHP 7.4 deprecates the ability to use `implode($parts, $glue)` in favor of only supporting `implode($glue, $parts)`.

This PR fixes a few of these deprecates uses.