### PR TITLE
Added the deprecated lowercase v8 API to codecov ignore list

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -59,5 +59,5 @@ ignore:
   - "install/demoData.en_us.php"
   - "include/tcpdf/.*"
   - "modules/AOR_Charts/lib/.*"
-  # The old v8 API is deprecated/unsupported and the CI doesn't run the tests for it.
+  # The old lowercase v8 API is deprecated/unsupported and the CI doesn't run the tests for it. The new API uses an upper-case V.
   - "lib/API/.*"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -59,4 +59,5 @@ ignore:
   - "install/demoData.en_us.php"
   - "include/tcpdf/.*"
   - "modules/AOR_Charts/lib/.*"
+  # The old v8 API is deprecated/unsupported and the CI doesn't run the tests for it.
   - "lib/API/.*"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -59,3 +59,4 @@ ignore:
   - "install/demoData.en_us.php"
   - "include/tcpdf/.*"
   - "modules/AOR_Charts/lib/.*"
+  - "lib/API/.*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
The old v8 API is deprecated and we don't run any of the tests for it in Travis anymore. 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. See Travis.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->