### PR TITLE
Remove all uses of get_magic_quotes_gpc.

### DIFF
--- a/include/utils.php
+++ b/include/utils.php
@@ -2294,22 +2294,11 @@ function clean_incoming_data()
     global $sugar_config;
     global $RAW_REQUEST;
 
-    if (get_magic_quotes_gpc()) {
-        // magic quotes screw up data, we'd have to clean up
-        $RAW_REQUEST = array_map('cleanup_slashes', $_REQUEST);
-    } else {
-        $RAW_REQUEST = $_REQUEST;
-    }
+    $RAW_REQUEST = $_REQUEST;
 
-    if (get_magic_quotes_gpc() == 1) {
-        $req = array_map('preprocess_param', $_REQUEST);
-        $post = array_map('preprocess_param', $_POST);
-        $get = array_map('preprocess_param', $_GET);
-    } else {
-        $req = array_map('securexss', $_REQUEST);
-        $post = array_map('securexss', $_POST);
-        $get = array_map('securexss', $_GET);
-    }
+    $req = array_map('securexss', $_REQUEST);
+    $post = array_map('securexss', $_POST);
+    $get = array_map('securexss', $_GET);
 
     // PHP cannot stomp out superglobals reliably
     foreach ($post as $k => $v) {
@@ -2434,10 +2423,6 @@ function securexsskey($value, $die = true)
 function preprocess_param($value)
 {
     if (is_string($value)) {
-        if (get_magic_quotes_gpc() == 1) {
-            $value = stripslashes($value);
-        }
-
         $value = securexss($value);
     } elseif (is_array($value)) {
         foreach ($value as $key => $element) {

--- a/install.php
+++ b/install.php
@@ -109,13 +109,6 @@ $timedate = TimeDate::getInstance();
 setPhpIniSettings();
 $locale = new Localization();
 
-if (get_magic_quotes_gpc() == 1) {
-    $_REQUEST = array_map("stripslashes_checkstrings", $_REQUEST);
-    $_POST = array_map("stripslashes_checkstrings", $_POST);
-    $_GET = array_map("stripslashes_checkstrings", $_GET);
-}
-
-
 $GLOBALS['log'] = LoggerManager::getLogger();
 $setup_sugar_version = $suitecrm_version;
 $install_script = true;

--- a/service/example/Rest_Proxy.php
+++ b/service/example/Rest_Proxy.php
@@ -81,9 +81,6 @@ curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
 $post_data = '';
 if (!empty($_POST)) {
     foreach ($_POST as $k=>$v) {
-        if (get_magic_quotes_gpc()) {
-            $v = stripslashes($v);
-        }
         if (!empty($post_data)) {
             $post_data .= '&';
         }


### PR DESCRIPTION
This doesn't touch the vendored HTMLPurifier, which does still use this function.

[It always returns `FALSE` since PHP 5.4](https://www.php.net/manual/en/function.get-magic-quotes-gpc.php), and 7.4 deprecates it entirely. This PR removes those branches of code that never get touched.

Part of #8057.

`get_magic_quotes_runtime` is also deprecated, but it's only used in vendored libraries, so I haven't touched them.