### PR TITLE
Fix misc PHP 7.4 deprecations

### DIFF
--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -1814,7 +1814,7 @@ class InboundEmail extends SugarBean
                 'mbox' => $mailbox,
                 'totalcount' => $total
             );
-            $GLOBALS['log']->info("INBOUNDEMAIL: $status : Downloaded " . $start + sizeof($searchResults) . "messages of $total");
+            $GLOBALS['log']->info("INBOUNDEMAIL: $status : Downloaded " . ($start + sizeof($searchResults)) . " messages of $total");
         } else {
             $GLOBALS['log']->info("INBOUNDEMAIL: no results for mailbox [ {$mailbox} ]");
             $ret = array('status' => 'done');

--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -4363,7 +4363,7 @@ class InboundEmail extends SugarBean
             $name = urldecode($name);
         }
 
-        return (isset($encoding) && strtolower($encoding) == 'utf-8') ? $name : isset($encoding) ? $GLOBALS['locale']->translateCharset(
+        return ((isset($encoding) && strtolower($encoding) == 'utf-8') ? $name : isset($encoding)) ? $GLOBALS['locale']->translateCharset(
             $name,
             $encoding,
             'UTF-8'

--- a/modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php
+++ b/modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php
@@ -401,7 +401,7 @@ class SugarAuthenticate
                 if ($_SESSION["ipaddress"] != $clientIP && empty($classCheck)) {
                     $GLOBALS['log']->fatal("IP Address mismatch: SESSION IP: {$_SESSION['ipaddress']} CLIENT IP: {$clientIP}");
                     session_destroy();
-                    die($mod_strings['ERR_IP_CHANGE'] . "<a href=\"{$sugar_config['site_url']}\">" + $mod_strings['ERR_RETURN'] + "</a>");
+                    die($mod_strings['ERR_IP_CHANGE'] . "<a href=\"{$sugar_config['site_url']}\">" . $mod_strings['ERR_RETURN'] . "</a>");
                 }
             } else {
                 $_SESSION["ipaddress"] = $clientIP;


### PR DESCRIPTION
## Description
This fixes these three deprecation warnings from PHP 7.4:

```
Deprecated: The behavior of unparenthesized expressions containing both '.' and '+'/'-' will change in PHP 8: '+'/'-' will take a higher precedence in /home/travis/build/salesagility/SuiteCRM/modules/InboundEmail/InboundEmail.php on line 1817

Deprecated: Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)` in /home/travis/build/salesagility/SuiteCRM/modules/InboundEmail/InboundEmail.php on line 4366

Deprecated: The behavior of unparenthesized expressions containing both '.' and '+'/'-' will change in PHP 8: '+'/'-' will take a higher precedence in /home/travis/build/salesagility/SuiteCRM/modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php on line 404
```

Make sure the tests pass.

I'm not 100% sure the fix for InboundEmail's ternary expression is the correct fix, so please check that especially :)

Part of #8057.