### PR TITLE
Fix a deprecated usage of join.

### DIFF
--- a/include/SubPanel/SubPanelTiles.php
+++ b/include/SubPanel/SubPanelTiles.php
@@ -381,7 +381,7 @@ class SubPanelTiles
             array_push($tab_names, $tab);
         }
 
-        $tab_names = '["' . join($tab_names, '","') . '"]';
+        $tab_names = '["' . join('","', $tab_names) . '"]';
 
         $module_sub_panels = array_map('array_keys', $module_sub_panels);
         $module_sub_panels = json_encode($module_sub_panels);


### PR DESCRIPTION
join is an alias of implode. PHP 7.4 deprecates using the delimiter as the second argument.

Part of #8057. See also #8058.
