### PR TITLE
Fix issue with labels not being saved in override lang file

### DIFF
--- a/include/SugarObjects/LanguageManager.php
+++ b/include/SugarObjects/LanguageManager.php
@@ -202,6 +202,11 @@ class LanguageManager
                     'custom/modules/'.$module.'/Ext/Language/'.$lang.'.lang.ext.php',
                  );
 
+        require_once __DIR__ . '/../../ModuleInstall/ModuleInstaller.php';
+        $mi = new ModuleInstaller();
+        $mi->modules = [($module)];
+        $mi->merge_files('Ext/Language/', $lang . '.lang.ext.php', $lang);
+
         #27023, if this module template language file was not attached , get the template from this module vardef cache file if exsits and load the template language files.
         static $createdModules;
         if (empty($createdModules[$module]) && isset($GLOBALS['beanList'][$module])) {

--- a/include/utils/file_utils.php
+++ b/include/utils/file_utils.php
@@ -129,6 +129,27 @@ function write_array_to_file($the_name, $the_array, $the_file, $mode="w", $heade
     return sugar_file_put_contents($the_file, $the_string, LOCK_EX) !== false;
 }
 
+function write_override_label_to_file($the_name, $the_array, $the_file, $mode = 'w', $header = '')
+{
+    if (!empty($header) && ($mode !== 'a' || !file_exists($the_file))) {
+        $the_string = $header;
+    } else {
+        $the_string = "<?php\n" .
+            '// created: ' . date('Y-m-d H:i:s') . "\n";
+    }
+
+    foreach ($the_array as $labelName => $labelValue) {
+        $the_string .= '$' . "{$the_name}['{$labelName}'] = '{$labelValue}';\n";
+    }
+
+    $result = sugar_file_put_contents($the_file, $the_string, LOCK_EX) !== false;
+
+    if (function_exists('opcache_invalidate')) {
+        opcache_invalidate($the_file, true);
+    }
+    return $result;
+}
+
 function write_encoded_file($soap_result, $write_to_dir, $write_to_file="")
 {
     // this function dies when encountering an error -- use with caution!

--- a/modules/ModuleBuilder/parsers/parser.label.php
+++ b/modules/ModuleBuilder/parsers/parser.label.php
@@ -197,25 +197,19 @@ class ParserLabel
      */
     public static function addLabels($language, $labels, $moduleName, $basepath = null, $forRelationshipLabel = false)
     {
-        $GLOBALS [ 'log' ]->debug("ParserLabel::addLabels($language, \$labels, $moduleName, $basepath );");
-        $GLOBALS [ 'log' ]->debug('$labels:'.print_r($labels, true));
+        $GLOBALS ['log']->debug("ParserLabel::addLabels($language, \$labels, $moduleName, $basepath );");
+        $GLOBALS ['log']->debug('$labels:' . print_r($labels, true));
 
         $deployedModule = false;
         if (null === $basepath) {
             $deployedModule = true;
-            $basepath = "custom/modules/$moduleName/language";
-            if ($forRelationshipLabel) {
-                $basepath = "custom/modules/$moduleName/Ext/Language";
-            }
+            $basepath = "custom/Extension/modules/$moduleName/Ext/Language";
             if (!is_dir($basepath)) {
                 mkdir_recursive($basepath);
             }
         }
 
-        $filename = "$basepath/$language.lang.php";
-        if ($forRelationshipLabel) {
-            $filename = "$basepath/$language.lang.ext.php";
-        }
+        $filename = "$basepath/_override_$language.lang.php";
         $dir_exists = is_dir($basepath);
 
         $mod_strings = array();


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Make label changes in studio to use:  _override_ so that the changes are saved to ext last

<!--- Describe your changes in detail -->
Save label changes in override file in new function write_override_label_to_file
After label is saved use moduleinstaller->merge_files to that lang file are generated in ext to changes take effect immediately 

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Studio field and label changes should be saved in _override_ so that studio changes are genereated in Ext last

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Make studio label changes and check they are saved to: custom/Extension/modules/{module}/Ext/Language/_override_en_us.lang.php
and then generated in: custom/modules/{module}/Ext/Language/en_us.lang.ext.php

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->