### PR TITLE
Fixed #1504 - check deleted flag on email_addresses and related bean

### DIFF
--- a/include/SugarEmailAddress/SugarEmailAddress.php
+++ b/include/SugarEmailAddress/SugarEmailAddress.php
@@ -793,7 +793,7 @@ class SugarEmailAddress extends SugarBean
         }
 
         $emailCaps = "'" . $this->db->quote(strtoupper($email)) . "'";
-        $q = "SELECT * FROM email_addr_bean_rel eabl JOIN email_addresses ea ON (ea.id = eabl.email_address_id)
+        $q = "SELECT * FROM email_addr_bean_rel eabl JOIN email_addresses ea ON (ea.id = eabl.email_address_id and ea.deleted = 0)
                 WHERE ea.email_address_caps = $emailCaps and eabl.deleted=0 ";
         $r = $this->db->query($q);
 
@@ -806,10 +806,11 @@ class SugarEmailAddress extends SugarBean
                         require_once($beanFiles[$className]);
                     }
 
-                    $bean = new $className();
-                    $bean->retrieve($a['bean_id']);
+                    $bean = BeanFactory::getBean($a['bean_module'], $a['bean_id']);
+                    if ($bean !== false) {
+                        $return[] = $bean;
+                    }
 
-                    $return[] = $bean;
                 } else {
                     $GLOBALS['log']->fatal("SUGAREMAILADDRESS: could not find valid class file for [ {$className} ]");
                 }

--- a/tests/unit/phpunit/include/SugarEmailAddress/SugarEmailAddressTest.php
+++ b/tests/unit/phpunit/include/SugarEmailAddress/SugarEmailAddressTest.php
@@ -729,6 +729,44 @@ class SugarEmailAddressTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $q = /** @lang sql */
             "DELETE FROM email_addresses WHERE id = 'test_email_{$i}'";
         $db->query($q);
+
+        // test if email address is deleted then no results
+        $i = 3;
+        $this->getBeansByEmailAddressDeletedLinksTest($db, $i, 1, 0);
+        // test if bean is deleted then no results
+        $i = 4;
+        $this->getBeansByEmailAddressDeletedLinksTest($db, $i, 0, 1);
+
+    }
+
+    private function getBeansByEmailAddressDeletedLinksTest($db, $i, $ea_deleted, $bean_deleted) {
+        // must have differing values
+        self::assertFalse($ea_deleted == $bean_deleted);
+        $q = /** @lang sql */
+            "
+          INSERT INTO email_addr_bean_rel (id, email_address_id, bean_id, bean_module, primary_address, deleted) 
+          VALUES ('test_email_bean_rel_{$i}', 'test_email_{$i}', 'test_contact_{$i}', 'Contacts', '0', '0')
+        ";
+        $db->query($q);
+        $q = /** @lang sql */
+            "INSERT INTO email_addresses (id, email_address_caps, deleted) VALUES ('test_email_{$i}', 'TEST{$i}@EMAIL.COM', $ea_deleted)";
+        $db->query($q);
+        $q = /** @lang sql */
+            "INSERT INTO contacts (id, first_name, deleted) VALUES ('test_contact_{$i}', 'Test_$i}', $bean_deleted)";
+        $db->query($q);
+
+        $results = $this->ea->getBeansByEmailAddress("test{$i}@email.com");
+        self::assertEquals(array(), $results);
+
+        $q = /** @lang sql */
+            "DELETE FROM email_addr_bean_rel WHERE id = 'test_email_bean_rel_{$i}'";
+        $db->query($q);
+        $q = /** @lang sql */
+            "DELETE FROM email_addresses WHERE id = 'test_email_{$i}'";
+        $db->query($q);
+        $q = /** @lang sql */
+            "DELETE FROM contacts WHERE id = 'test_contact_{$i}'";
+        $db->query($q);
     }
 
     /**


### PR DESCRIPTION
## Description
`getBeansByEmailAddress` now checks the deleted flag on the `email_address` and when loading the related bean the result is checked and not add it to the result list

## How To Test This
The unit test is pretty comprehensive, but basically have a contact with an email address then mark the contact as deleted, using `getBeansByEmailAddress` will now not return an empty contact in the results, the results will be an empty array

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
