### PR TITLE
Uninitialized variable

### DIFF
--- a/modules/Administration/UpgradeAccess.php
+++ b/modules/Administration/UpgradeAccess.php
@@ -98,6 +98,7 @@ RedirectMatch 403 {$ignoreCase}/+files\.md5\$
 # END SUGARCRM RESTRICTIONS
 EOQ;
 
+$oldcontents = '';
 if (file_exists($htaccess_file)) {
     $fp = fopen($htaccess_file, 'rb');
     $skip = false;


### PR DESCRIPTION
Fix notice

`[17-Oct-2019 09:54:43 America/Denver] PHP Notice: Undefined variable: oldcontents in /var/www/html/suitecrm/modules/Administration/UpgradeAccess.php on line 109`

<!--- Provide a general summary of your changes in the Title above -->

## Description
I saw this notice in the forums and inspected the code. I don't think this makes any difference expect remove the notice from the logs.

## How To Test This
Just look at the code, I guess.

