### PR TITLE
Remove all deprecated Smarty files.

### DIFF
--- a/include/Smarty/Config_File.class.php
+++ b/include/Smarty/Config_File.class.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/Smarty.class.php
+++ b/include/Smarty/Smarty.class.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/Smarty_Compiler.class.php
+++ b/include/Smarty/Smarty_Compiler.class.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.assemble_plugin_filepath.php
+++ b/include/Smarty/internals/core.assemble_plugin_filepath.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.assign_smarty_interface.php
+++ b/include/Smarty/internals/core.assign_smarty_interface.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.create_dir_structure.php
+++ b/include/Smarty/internals/core.create_dir_structure.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.display_debug_console.php
+++ b/include/Smarty/internals/core.display_debug_console.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.get_include_path.php
+++ b/include/Smarty/internals/core.get_include_path.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.get_microtime.php
+++ b/include/Smarty/internals/core.get_microtime.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.get_php_resource.php
+++ b/include/Smarty/internals/core.get_php_resource.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.is_secure.php
+++ b/include/Smarty/internals/core.is_secure.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.is_trusted.php
+++ b/include/Smarty/internals/core.is_trusted.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.load_plugins.php
+++ b/include/Smarty/internals/core.load_plugins.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.load_resource_plugin.php
+++ b/include/Smarty/internals/core.load_resource_plugin.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.process_cached_inserts.php
+++ b/include/Smarty/internals/core.process_cached_inserts.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.process_compiled_include.php
+++ b/include/Smarty/internals/core.process_compiled_include.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.read_cache_file.php
+++ b/include/Smarty/internals/core.read_cache_file.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.rm_auto.php
+++ b/include/Smarty/internals/core.rm_auto.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.rmdir.php
+++ b/include/Smarty/internals/core.rmdir.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.run_insert_handler.php
+++ b/include/Smarty/internals/core.run_insert_handler.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.smarty_include_php.php
+++ b/include/Smarty/internals/core.smarty_include_php.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.write_cache_file.php
+++ b/include/Smarty/internals/core.write_cache_file.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.write_compiled_include.php
+++ b/include/Smarty/internals/core.write_compiled_include.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.write_compiled_resource.php
+++ b/include/Smarty/internals/core.write_compiled_resource.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */

--- a/include/Smarty/internals/core.write_file.php
+++ b/include/Smarty/internals/core.write_file.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * Class for backwards compatibility only
- */


### PR DESCRIPTION
Smarty is included via Composer now (#7591, #7729), so these files can be removed. If anyone is requiring these files in their custom code, they should make sure to remove those requires.

All Smarty plugins remain as-is.