### PR TITLE
Fix for #8101 - Undo to_html() for JSON API responses

### DIFF
--- a/Api/V8/JsonApi/Helper/AttributeObjectHelper.php
+++ b/Api/V8/JsonApi/Helper/AttributeObjectHelper.php
@@ -34,8 +34,8 @@ class AttributeObjectHelper
             return is_string($value)
                 ? (\DateTime::createFromFormat('Y-m-d H:i:s', $value)
                     ? date(\DateTime::ATOM, strtotime($value))
-                    : $value)
-                : $value;
+                    : from_html($value))
+                : from_html($value);
         }, $bean->toArray());
 
         if ($fields !== null) {


### PR DESCRIPTION
## Description
See [API - characters are html encoded in response](https://github.com/salesagility/SuiteCRM/issues/8101) for an extensive report of the problem and expected result.
This fix runs the bean attributes  through the function from_html() before they are json_encoded for the dataresponse.

## Motivation and Context
See  [#8101](https://github.com/salesagility/SuiteCRM/issues/8101)

## How To Test This
See  [#8101](https://github.com/salesagility/SuiteCRM/issues/8101)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
  **Note:** Depending the API chain in your processess this change can be non-breaking or even opens up the ability to use the API
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->