### PR TITLE
Remove deprecated encrypt_password function for User.

### DIFF
--- a/modules/Users/User.php
+++ b/modules/Users/User.php
@@ -1040,22 +1040,6 @@ class User extends Person implements EmailInterface
     }
 
     /**
-     * @deprecated
-     * @param string $user_name - Must be non null and at least 2 characters
-     * @param string $username_password - Must be non null and at least 1 character.
-     * @desc Take an unencrypted username and password and return the encrypted password
-     * @return string encrypted password for storage in DB and comparison against DB password.
-     */
-    public function encrypt_password($username_password)
-    {
-        // encrypt the password.
-        $salt = substr($this->user_name, 0, 2);
-        $encrypted_password = crypt($username_password, $salt);
-
-        return $encrypted_password;
-    }
-
-    /**
      * Authenicates the user; returns true if successful
      *
      * @param string $password MD5-encoded password

--- a/tests/unit/phpunit/modules/Users/UserTest.php
+++ b/tests/unit/phpunit/modules/Users/UserTest.php
@@ -542,16 +542,6 @@ class UserTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         self::assertEquals(1, preg_match('/^one\d{0,}\@email\.com$/', $actual['email']));
     }
 
-
-    public function testencrypt_password()
-    {
-        $user = new User();
-
-        $result = $user->encrypt_password("test");
-        $this->assertTrue(isset($result));
-        $this->assertGreaterThan(0, strlen($result));
-    }
-
     public function testgetPasswordHash()
     {
         $result = User::getPasswordHash("test");
@@ -560,10 +550,8 @@ class UserTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $this->assertGreaterThan(0, strlen($result));
     }
 
-
     public function testcheckPassword()
     {
-
         //test with empty password and empty hash
         $result = User::checkPassword("", '');
         $this->assertEquals(false, $result);


### PR DESCRIPTION
## Description

It's not used anywhere else in the codebase besides the test suite, so it should be safe to remove.

Part of #7744.

## How To Test This
Make sure logging in/out works, and maybe also try changing your password to make sure it encrypts it properly? Also make sure the tests pass, obviously.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.