### PR TITLE
Remove deprecated JSON functions encodeReal() and decodeReal()

### DIFF
--- a/include/JSON.php
+++ b/include/JSON.php
@@ -94,20 +94,4 @@ class JSON
     {
         return json_decode($string, $assoc);
     }
-
-    /**
-     * @deprecated use JSON::encode() instead
-     */
-    public static function encodeReal($string)
-    {
-        return self::encode($string);
-    }
-
-    /**
-     * @deprecated use JSON::decode() instead
-     */
-    public static function decodeReal($string)
-    {
-        return self::decode($string);
-    }
 }

--- a/modules/Home/QuickSearch.php
+++ b/modules/Home/QuickSearch.php
@@ -609,7 +609,7 @@ class quicksearchQuery
     {
         $json = getJSONobj();
 
-        return $json->encodeReal($data);
+        return $json->encode($data);
     }
 
     /**


### PR DESCRIPTION
## Description

These have been deprecated for over six years now.

There was only one use of `encodeReal`, so I've replaced it.

Part of #7744.

## How To Test This
Make sure Quick Search works and that the tests continue to pass.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.