### PR TITLE
Remove deprecated getReminderTime function in CallHelper.

### DIFF
--- a/modules/Calls/CallHelper.php
+++ b/modules/Calls/CallHelper.php
@@ -68,61 +68,17 @@ function getDurationMinutesOptions($focus, $field, $value, $view)
         $focus->duration_minutes = "1";
     }
     
-    if ($view == 'EditView' || $view == 'MassUpdate' || $view == "QuickCreate"
-    ) {
+    if ($view == 'EditView' || $view == 'MassUpdate' || $view == "QuickCreate") {
         $html = '<select id="duration_minutes" ';
-        if ($view != 'MassUpdate'
-            ) {
+        if ($view != 'MassUpdate') {
             $html .= 'onchange="SugarWidgetScheduler.update_time();" ';
         }
 
-        $html .=  'name="duration_minutes">';
+        $html .= 'name="duration_minutes">';
         $html .= get_select_options_with_id($focus->minutes_values, $focus->duration_minutes);
         $html .= '</select>';
         return $html;
     }
 
     return $focus->duration_minutes;
-}
-
-/**
- * @param $focus
- * @param $field
- * @param $value
- * @param $view
- * @return string
- *
- * @deprecated 6.5.0
- */
-function getReminderTime($focus, $field, $value, $view)
-{
-    global $current_user, $app_list_strings;
-    $reminder_t = -1;
-    
-    if (!empty($_REQUEST['full_form']) && !empty($_REQUEST['reminder_time'])) {
-        $reminder_t = $_REQUEST['reminder_time'];
-    } else {
-        if (isset($focus->reminder_time)) {
-            $reminder_t = $focus->reminder_time;
-        } else {
-            if (isset($value)) {
-                $reminder_t = $value;
-            }
-        }
-    }
-
-    if ($view == 'EditView' || $view == 'MassUpdate' || $view == "SubpanelCreates" || $view == "QuickCreate"
-    ) {
-        global $app_list_strings;
-        $html = '<select id="reminder_time" name="reminder_time">';
-        $html .= get_select_options_with_id($app_list_strings['reminder_time_options'], $reminder_t);
-        $html .= '</select>';
-        return $html;
-    }
- 
-    if ($reminder_t == -1) {
-        return "";
-    }
-       
-    return translate('reminder_time_options', '', $reminder_t);
 }


### PR DESCRIPTION
## Description

This code hasn't been touched since the initial commit of SuiteCRM, and has been deprecated for that long as well. It isn't used anywhere in the codebase. This PR removes the deprecated function entirely.

## How To Test This
Make sure the tests pass and that the Calls views continue to work.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.