### PR TITLE
Remove remove_redundant_http() from Account.

### DIFF
--- a/modules/Accounts/Account.php
+++ b/modules/Accounts/Account.php
@@ -175,8 +175,6 @@ class Account extends Company implements EmailInterface
         return $this->get_linked_beans('contacts', 'Contact');
     }
 
-
-
     public function clear_account_case_relationship($account_id='', $case_id='')
     {
         if (empty($case_id)) {
@@ -186,20 +184,6 @@ class Account extends Company implements EmailInterface
         }
         $query = "UPDATE cases SET account_name = '', account_id = '' WHERE account_id = '$account_id' AND deleted = 0 " . $where;
         $this->db->query($query, true, "Error clearing account to case relationship: ");
-    }
-
-    /**
-    * This method is used to provide backward compatibility with old data that was prefixed with http://
-    * We now automatically prefix http://
-    * @deprecated.
-    */
-    public function remove_redundant_http()
-    {	/*
-        if(preg_match("@http://@", $this->website))
-        {
-            $this->website = substr($this->website, 7);
-        }
-        */
     }
 
     public function fill_in_additional_list_fields()

--- a/tests/unit/phpunit/modules/Accounts/AccountTest.php
+++ b/tests/unit/phpunit/modules/Accounts/AccountTest.php
@@ -86,19 +86,6 @@ class AccountTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $Account->clear_account_case_relationship('','');*/
     }
 
-    public function testremove_redundant_http()
-    {
-        $Account = new Account();
-
-        //this method has no implementation. so test for exceptions only.
-        try {
-            $Account->remove_redundant_http();
-            $this->assertTrue(true);
-        } catch (Exception $e) {
-            $this->fail($e->getMessage() . "\nTrace:\n" . $e->getTraceAsString());
-        }
-    }
-
     public function testfill_in_additional_list_fields()
     {
         $Account = new Account('');


### PR DESCRIPTION
## Description

This code doesn't do anything and hasn't been used for a long time.

Also removes the test for it.

Part of #7744.

## How To Test This

Make sure tests pass and Accounts views work.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.