### PR TITLE
Fixed #7241 - Some files still use the DB global variable

### DIFF
--- a/include/Dashlets/DashletGenericChart.php
+++ b/include/Dashlets/DashletGenericChart.php
@@ -379,7 +379,7 @@ abstract class DashletGenericChart extends Dashlet
     //Added as the rgraph charts do not use SugarCharts and this is where this method was previously
     public function getChartData($query)
     {
-        global $app_list_strings, $db;
+        $db = DBManagerFactory::getInstance();
         $dataSet = array();
         $result = $db->query($query);
 

--- a/include/Localization/Localization.php
+++ b/include/Localization/Localization.php
@@ -195,12 +195,11 @@ class Localization
     public function loadCurrencies()
     {
         // doing it dirty here
-        global $db;
         global $sugar_config;
-
-        if (empty($db)) {
+        if (empty($sugar_config)) {
             return array();
         }
+        $db = DBManagerFactory::getInstance();
 
         $load = sugar_cache_retrieve('currency_list');
         if (!is_array($load)) {

--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -177,7 +177,8 @@ eoq;
     public function handleMassUpdate()
     {
         require_once('include/formbase.php');
-        global $current_user, $db, $disable_date_format, $timedate, $app_list_strings;
+        global $current_user, $disable_date_format, $timedate, $app_list_strings;
+        $db = DBManagerFactory::getInstance();
 
         foreach ($_POST as $post => $value) {
             if (is_array($value)) {

--- a/include/SubPanel/SubPanelRowCounter.php
+++ b/include/SubPanel/SubPanelRowCounter.php
@@ -113,7 +113,7 @@ class SubPanelRowCounter
      */
     public function getSingleSubPanelRowCount()
     {
-        $db = DBManagerFactory::getInstance();
+        $db = \DBManagerFactory::getInstance();
 
         $query = $this->makeSubPanelRowCountQuery();
         if (!$query) {

--- a/include/SubPanel/SubPanelRowCounter.php
+++ b/include/SubPanel/SubPanelRowCounter.php
@@ -113,7 +113,7 @@ class SubPanelRowCounter
      */
     public function getSingleSubPanelRowCount()
     {
-        global $db;
+        $db = DBManagerFactory::getInstance();
 
         $query = $this->makeSubPanelRowCountQuery();
         if (!$query) {

--- a/include/social/twitter/twitterapi.php
+++ b/include/social/twitter/twitterapi.php
@@ -13,7 +13,8 @@ require_once('include/social/twitter/twitter_auth/twitteroauth/twitteroauth.php'
 require_once('modules/Connectors/connectors/sources/ext/rest/twitter/config.php');
 require_once('include/social/twitter/twitter_helper.php');
 
-global $sugar_config, $db;
+global $sugar_config;
+$db = DBManagerFactory::getInstance();
 
 /*
  * Pull in connector settings for creating the authentication between Suite and Twitter.

--- a/install/install_utils.php
+++ b/install/install_utils.php
@@ -1251,7 +1251,7 @@ function drop_table_install(&$focus)
 // Creating new tables if they don't exist.
 function create_table_if_not_exist(&$focus)
 {
-    global  $db;
+    $db = DBManagerFactory::getInstance();
     $table_created = false;
 
     // normal code follows

--- a/install/suite_install/AdvancedOpenSales.php
+++ b/install/suite_install/AdvancedOpenSales.php
@@ -28,7 +28,8 @@ function install_aos()
 
 function upgrade_aos()
 {
-    global $sugar_config, $db;
+    global $sugar_config;
+    $db = DBManagerFactory::getInstance();
     if (!isset($sugar_config['aos']['version']) || $sugar_config['aos']['version'] < 5.2) {
         $db->query("UPDATE  aos_pdf_templates SET type = 'AOS_Quotes' WHERE type = 'Quotes'");
         $db->query("UPDATE  aos_pdf_templates SET type = 'AOS_Invoices' WHERE type = 'Invoices'");

--- a/modules/AM_ProjectTemplates/controller.php
+++ b/modules/AM_ProjectTemplates/controller.php
@@ -35,7 +35,8 @@ class AM_ProjectTemplatesController extends SugarController
 
     public function action_create_project()
     {
-        global $current_user, $db, $mod_strings;
+        global $current_user, $mod_strings;
+        $db = DBManagerFactory::getInstance();
 
         $project_name = $_POST['p_name'];
         $template_id = $_POST['template_id'];
@@ -314,7 +315,7 @@ class AM_ProjectTemplatesController extends SugarController
     //Create new project task
     public function action_update_GanttChart()
     {
-        global $current_user, $db;
+        global $current_user;
 
         $task_name = $_POST['task_name'];
         $project_id = $_POST['project_id'];

--- a/modules/Administration/RepairUploadFolder.php
+++ b/modules/Administration/RepairUploadFolder.php
@@ -48,7 +48,8 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * @var SugarBean $bean
  * @var DBManager $db
  */
-global $beanList, $current_user, $db, $mod_strings;
+global $beanList, $current_user, $mod_strings;
+$db = DBManagerFactory::getInstance();
 $validBeans = array();
 if (!is_admin($current_user)) {
     sugar_die($GLOBALS['app_strings']['ERR_NOT_ADMIN']);

--- a/modules/Administration/UpgradeWizard_commit.php
+++ b/modules/Administration/UpgradeWizard_commit.php
@@ -48,7 +48,6 @@ require_once('modules/Configurator/Configurator.php');
 function UWrebuild()
 {
     global $log;
-    $db = DBManagerFactory::getInstance();
     $log->info('Deleting Relationship Cache. Relationships will automatically refresh.');
 
     echo "
@@ -101,7 +100,7 @@ function UWrebuild()
 unset($_SESSION['rebuild_relationships']);
 unset($_SESSION['rebuild_extensions']);
 
-global $log, $db;
+global $log;
 
 // process commands
 if (!isset($_REQUEST['mode']) || ($_REQUEST['mode'] == "")) {

--- a/modules/Charts/Dashlets/MyPipelineBySalesStageDashlet/MyPipelineBySalesStageDashlet.php
+++ b/modules/Charts/Dashlets/MyPipelineBySalesStageDashlet/MyPipelineBySalesStageDashlet.php
@@ -306,7 +306,8 @@ EOD;
     public function getChartData(
         $query
     ) {
-        global $app_list_strings, $db;
+        global $app_list_strings;
+        $db = DBManagerFactory::getInstance();
 
         $data = array();
         $temp_data = array();

--- a/modules/Charts/Dashlets/PipelineBySalesStageDashlet/PipelineBySalesStageDashlet.php
+++ b/modules/Charts/Dashlets/PipelineBySalesStageDashlet/PipelineBySalesStageDashlet.php
@@ -259,7 +259,8 @@ EOD;
     public function getChartData(
         $query
     ) {
-        global $app_list_strings, $db;
+        global $app_list_strings;
+        $db = DBManagerFactory::getInstance();
 
         $data = array();
         $temp_data = array();

--- a/modules/Emails/include/displayAttachmentField.php
+++ b/modules/Emails/include/displayAttachmentField.php
@@ -52,7 +52,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
  */
 function displayAttachmentField($focus, $field, $value, $view)
 {
-    global $db;
+    $db = DBManagerFactory::getInstance();
     $result = '';
     $attachments = [];
 

--- a/modules/MailMerge/Step1.php
+++ b/modules/MailMerge/Step1.php
@@ -62,7 +62,8 @@ global $app_list_strings;
 global $mod_strings;
 global $current_user;
 global  $beanList, $beanFiles;
-global $sugar_version, $sugar_config, $db;
+global $sugar_version, $sugar_config;
+$db = DBManagerFactory::getInstance();
 
 $xtpl = new XTemplate('modules/MailMerge/Step1.html');
 $xtpl->assign("MOD", $mod_strings);

--- a/modules/OAuth2Tokens/OAuth2Tokens.php
+++ b/modules/OAuth2Tokens/OAuth2Tokens.php
@@ -126,7 +126,7 @@ class OAuth2Tokens extends SugarBean
     public static function getNowDateString()
     {
         /** @var DBManager */
-        global $db;
+        $db = DBManagerFactory::getInstance();
         return $db->convert('', 'now');
     }
 }

--- a/modules/Reminders/Reminder.php
+++ b/modules/Reminders/Reminder.php
@@ -278,7 +278,6 @@ class Reminder extends Basic
      * @global ??? $current_user
      * @global ??? $timedate
      * @global ??? $app_list_strings
-     * @global ??? $db
      * @global ??? $sugar_config
      * @global ??? $app_strings
      * @param jsAlerts $alert caller jsAlerts object
@@ -287,7 +286,8 @@ class Reminder extends Basic
      */
     public static function addNotifications(jsAlerts $alert, $checkDecline = true)
     {
-        global $current_user, $timedate, $app_list_strings, $db, $sugar_config, $app_strings;
+        global $current_user, $timedate, $app_list_strings, $sugar_config, $app_strings;
+        $db = DBManagerFactory::getInstance();
 
         if (empty($current_user->id)) {
             return;

--- a/modules/SecurityGroups/MassAssign.php
+++ b/modules/SecurityGroups/MassAssign.php
@@ -7,7 +7,8 @@ if (!defined('sugarEntry') || !sugarEntry) {
 require_once('modules/SecurityGroups/SecurityGroup.php');
 
 require_once('include/formbase.php');
-global $current_user, $db;
+global $current_user;
+$db = DBManagerFactory::getInstance();
 
 
 $module = $_REQUEST['return_module'];

--- a/modules/UserPreferences/UserPreference.php
+++ b/modules/UserPreferences/UserPreference.php
@@ -256,7 +256,7 @@ class UserPreference extends SugarBean
      */
     public function getUserDateTimePreferences()
     {
-        global $sugar_config, $db, $timedate, $current_user;
+        global $sugar_config, $timedate, $current_user;
 
         $user = $this->_userFocus;
 
@@ -416,6 +416,7 @@ class UserPreference extends SugarBean
         $unset_value = false
     ) {
         global $current_user, $db;
+        $db = DBManagerFactory::getInstance();
 
         // Admin-only function; die if calling as a non-admin
         if (!is_admin($current_user)) {


### PR DESCRIPTION
Replaced references to `global $db` with `$db = DBManagerFactory::getInstance()` as per Issue #7241

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
