### PR TITLE
Update html-purifier to 4.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,12 @@
     "php": ">=5.5.9",
     "ext-curl": "*",
     "ext-gd": "*",
+    "ext-imap": "*",
     "ext-json": "*",
     "ext-openssl": "*",
     "ext-zip": "*",
     "consolidation/robo": "^1.4",
-    "ezyang/htmlpurifier": "^4.10",
+    "ezyang/htmlpurifier": "^4.12",
     "google/recaptcha": "^1.1",
     "justinrainbow/json-schema": "^5.2",
     "league/oauth2-server": "^5.1",
@@ -50,8 +51,7 @@
     "zf1/zend-loader": "^1.12",
     "zf1/zend-oauth": "^1.12",
     "zf1/zend-registry": "^1.12",
-    "zf1/zend-search-lucene": "^1.12",
-    "ext-imap": "*"
+    "zf1/zend-search-lucene": "^1.12"
   },
   "require-dev": {
     "codeception/codeception": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "437f6b21adfb535499f436f22592b68b",
+    "content-hash": "247eafac6d7878eace592e6cf8586e7d",
     "packages": [
         {
             "name": "consolidation/annotated-command",
@@ -687,16 +687,16 @@
         },
         {
             "name": "ezyang/htmlpurifier",
-            "version": "v4.11.0",
+            "version": "v4.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ezyang/htmlpurifier.git",
-                "reference": "83ab08bc1af7d808a9e0fbf024f1c24bfd73c0a7"
+                "reference": "a617e55bc62a87eec73bd456d146d134ad716f03"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/83ab08bc1af7d808a9e0fbf024f1c24bfd73c0a7",
-                "reference": "83ab08bc1af7d808a9e0fbf024f1c24bfd73c0a7",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/a617e55bc62a87eec73bd456d146d134ad716f03",
+                "reference": "a617e55bc62a87eec73bd456d146d134ad716f03",
                 "shasum": ""
             },
             "require": {
@@ -730,7 +730,7 @@
             "keywords": [
                 "html"
             ],
-            "time": "2019-07-14T18:58:38+00:00"
+            "time": "2019-10-28T03:44:26+00:00"
         },
         {
             "name": "firebase/php-jwt",
@@ -5881,10 +5881,10 @@
         "php": ">=5.5.9",
         "ext-curl": "*",
         "ext-gd": "*",
+        "ext-imap": "*",
         "ext-json": "*",
         "ext-openssl": "*",
-        "ext-zip": "*",
-        "ext-imap": "*"
+        "ext-zip": "*"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
## Description
This fixes various deprecation warnings when using HTMLPurifier with PHP 7.4.

Part of #8057.

See also #8137 and the htmlpurifier NEWS file: https://github.com/ezyang/htmlpurifier/blob/v4.12.0/NEWS.

## Motivation and Context
Deprecated code shouldn't be used :)

## How To Test This
The test suite should pretty much cover anything this'd break, feel free to also try booting the CRM to make sure it works.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.