### PR TITLE
Fix a SQL query in the ACLAction code.

### DIFF
--- a/modules/ACLActions/ACLAction.php
+++ b/modules/ACLActions/ACLAction.php
@@ -91,12 +91,12 @@ class ACLAction extends SugarBean
             foreach ($ACLActions[$type]['actions'] as $action_name => $action_def) {
                 $action = new ACLAction();
 
-                $tableNameQuoted = $db->quoted($action->table_name);
+                $tableName = $action->table_name;
                 $actionNameQuoted = $db->quoted($action_name);
                 $categoryQuoted = $db->quoted($category);
                 $typeQuoted = $db->quoted($type);
 
-                $query = "SELECT * FROM " . $tableNameQuoted .
+                $query = "SELECT * FROM " . $tableName .
                     " WHERE name = " . $actionNameQuoted .
                     " AND category = " . $categoryQuoted .
                     " AND acltype = " . $typeQuoted .
@@ -138,13 +138,13 @@ class ACLAction extends SugarBean
             foreach ($ACLActions[$type]['actions'] as $action_name => $action_def) {
                 $action = new ACLAction();
 
-                $tableNameQuoted = $db->quoted($action->table_name);
+                $tableName = $action->table_name;
                 $actionNameQuoted = $db->quoted($action_name);
                 $categoryQuoted = $db->quoted($category);
                 $typeQuoted = $db->quoted($type);
 
-                $query = "SELECT * FROM " . $tableNameQuoted .
-                    " WHERE name=" . $actionNameQuoted .
+                $query = "SELECT * FROM " . $tableName .
+                    " WHERE name = " . $actionNameQuoted .
                     " AND category = " . $categoryQuoted .
                     " AND acltype = " . $typeQuoted .
                     " AND deleted = 0";

--- a/modules/ACLActions/ACLAction.php
+++ b/modules/ACLActions/ACLAction.php
@@ -106,7 +106,7 @@ class ACLAction extends SugarBean
 
                 // Only add if an action with that name and category don't exist
                 $row = $db->fetchByAssoc($result);
-                if ($row === null) {
+                if ($row === false) {
                     $action->name = $action_name;
                     $action->category = $category;
                     $action->aclaccess = $action_def['default'];
@@ -153,7 +153,7 @@ class ACLAction extends SugarBean
 
                 // Only add if an action with that name and category don't exist
                 $row = $db->fetchByAssoc($result);
-                if ($row !== null) {
+                if ($row !== false) {
                     $action->mark_deleted($row['id']);
                 }
             }


### PR DESCRIPTION
## Description

The SQL query was causing a bunch of errors in CI and potentially was the cause of the unit tests stopping early in CI.

[`suitecrm.log`](https://www.simpleupload.co.uk/uploads/xpkv7Zsuitecrm.log) was filled with messages like this:

```
Thu Oct 24 16:04:53 2019 [7958][-none-][FATAL]  Query Failed: SELECT * FROM 'acl_actions' WHERE name = 'export' AND category = 'Leads' AND acltype = 'module' AND deleted = 0: MySQL error 1064: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ''acl_actions' WHERE name = 'export' AND category = 'Leads' AND acltype = 'module' at line 1
```

This potentially fixes #8153.

## Motivation and Context

This problem was introduced with fa1dbf3fb22666f5784e8c38286ac03b376bf66c, as far as  I can tell.

## How To Test This

Make sure CI passes. Make sure all the acl_actions SQL query errors go away.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.