### PR TITLE
tests: throw an error in case exit() is called during testing

### DIFF
--- a/include/utils.php
+++ b/include/utils.php
@@ -3292,6 +3292,22 @@ function pre_login_check()
     }
 }
 
+/**
+ * Like exit() but will throw an exception if called during tests.
+ *
+ * This is to avoid exit() stopping the test suite without us noticing.
+ *
+ * @param int|string $status
+ * @throws Exception
+ */
+function suite_exit($status = 0)
+{
+    if (defined('SUITE_PHPUNIT_RUNNER'))
+        throw new Exception("exit() called during tests with status: $status");
+    else
+        exit($status);
+}
+
 function sugar_cleanup($exit = false)
 {
     static $called = false;
@@ -3309,7 +3325,7 @@ function sugar_cleanup($exit = false)
     //added this check to avoid errors during install.
     if (empty($sugar_config['dbconfig'])) {
         if ($exit) {
-            exit;
+            suite_exit();
         }
         return;
     }
@@ -3344,7 +3360,7 @@ function sugar_cleanup($exit = false)
         $db = DBManagerFactory::getInstance();
         $db->disconnect();
         if ($exit) {
-            exit;
+            suite_exit();
         }
     }
 }


### PR DESCRIPTION
## Description

When exit() is called during tests the test suite will stop without returning an error.

To avoid that add our own exit() wrapper which throws an exception instead when
tests are running. There are many more calls to exit() in the code base, this just changes the
common path through sugar_cleanup()

## Motivation and Context

Make tests fail when they fail.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->