### PR TITLE
Updating FPEvent unit test to use correct array.

### DIFF
--- a/tests/unit/phpunit/modules/FP_events/FP_eventsTest.php
+++ b/tests/unit/phpunit/modules/FP_events/FP_eventsTest.php
@@ -28,7 +28,7 @@ class FP_eventsTest extends SuiteCRM\StateCheckerPHPUnitTestCaseAbstract
         $fpEvents = new FP_events();
 
         $fpEvents->email_templates();
-        $this->assertTrue(is_array($app_list_strings['email_templet_list']));
+        $this->assertTrue(is_array($app_list_strings['emailTemplates_type_list']));
         
         // clean up
         $state->popGlobals();


### PR DESCRIPTION
Updating FPEvent unit test to use correct array.

## Description
Fixing the unit test to use the correct array value as this no longer exists as per https://github.com/salesagility/SuiteCRM/pull/8151.

## How To Test This
Running the unit test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->