### PR TITLE
Fix a PHP warning in Meeting.php.

### DIFF
--- a/modules/Meetings/Meeting.php
+++ b/modules/Meetings/Meeting.php
@@ -234,7 +234,7 @@ class Meeting extends SugarBean
 
         // Do any external API saving
         // Clear out the old external API stuff if we have changed types
-        if (isset($this->fetched_row) && $this->fetched_row['type'] != $this->type) {
+        if (isset($this->fetched_row) && !is_bool($this->fetched_row) && $this->fetched_row['type'] != $this->type) {
             $this->join_url = '';
             $this->host_url = '';
             $this->external_id = '';


### PR DESCRIPTION
## Description
PHP 7.4 logs a warning if you attempt to access a boolean, null value, float, etc. as an array. e.g. `$booleanVariable[0]` causes a warning. This PR fixes one such case where this was happening.

Part of #8057.

## How To Test This
Make sure the tests pass and the Meetings module continues to work.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.