### PR TITLE
Fix for Issue #7305

### DIFF
--- a/modules/AOR_Scheduled_Reports/AOR_Scheduled_Reports.php
+++ b/modules/AOR_Scheduled_Reports/AOR_Scheduled_Reports.php
@@ -174,21 +174,40 @@ class AOR_Scheduled_Reports extends basic
         return $emails;
     }
 
+    /**
+     * @param DateTime $date
+     * @return bool
+     * @throws Exception
+     */
     public function shouldRun(DateTime $date)
     {
         global $timedate;
-        if (empty($date)) {
-            $date = new DateTime();
-        }
+
+        $runDate = clone $date;
+        $this->handleTimeZone($runDate);
+
         $cron = Cron\CronExpression::factory($this->schedule);
-        if (empty($this->last_run) && $cron->isDue($date)) {
+        if (empty($this->last_run) && $cron->isDue($runDate)) {
             return true;
         }
+
         $lastRun = $timedate->fromDb($this->last_run);
+        $this->handleTimeZone($lastRun);
         $next = $cron->getNextRunDate($lastRun);
-        if ($next < $date) {
-            return true;
-        }
-        return false;
+
+        return $next <= $runDate;
+    }
+
+    /**
+     * @param DateTime $date
+     */
+    protected function handleTimeZone(DateTime $date)
+    {
+        global $sugar_config;
+
+        $timezone = !empty($sugar_config['default_timezone']) ? $sugar_config['default_timezone'] : date_default_timezone_get();
+        $timezone = new DateTimeZone($timezone);
+        $offset = $timezone->getOffset($date);
+        $date->modify($offset . 'second');
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added new function to convert the next run and current time before comparison so scheduled reports execute in the timezone specified in the config with: $sugar_config['default_timezone']
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes issue #7305 with timezone not being taken into consideration when scheduled reports execute

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Set $sugar_config['default_timezone'] = 'inset php timezone' in config override
Set scheduled report to run at specified time
It should execute at the correct time 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->