### PR TITLE
Fix #8173 - Workflow actions missing in edit and detail view

### DIFF
--- a/modules/AOW_Actions/actionLines.php
+++ b/modules/AOW_Actions/actionLines.php
@@ -74,7 +74,7 @@ function display_action_lines(SugarBean $focus, $field, $value, $view)
             $html .= "<script>document.getElementById('btn_ActionLine').disabled = '';</script>";
             if ($focus->id !== '') {
                 $idQuoted = $focus->db->quoted($focus->id);
-                $sql = "SELECT id FROM aow_actions WHERE aow_workflow_id = '" . $idQuoted . "' AND deleted = 0 ORDER BY action_order ASC";
+                $sql = 'SELECT id FROM aow_actions WHERE aow_workflow_id = ' . $idQuoted . ' AND deleted = 0 ORDER BY action_order ASC';
                 $result = $focus->db->query($sql);
 
                 while ($row = $focus->db->fetchByAssoc($result)) {
@@ -91,7 +91,7 @@ function display_action_lines(SugarBean $focus, $field, $value, $view)
     } elseif ($view == 'DetailView') {
         $html .= "<table border='0' width='100%' cellpadding='0' cellspacing='0'>";
         $idQuoted = $focus->db->quoted($focus->id);
-        $sql = "SELECT id FROM aow_actions WHERE aow_workflow_id = '" . $idQuoted . "' AND deleted = 0 ORDER BY action_order ASC";
+        $sql = 'SELECT id FROM aow_actions WHERE aow_workflow_id = ' . $idQuoted . ' AND deleted = 0 ORDER BY action_order ASC';
         $result = $focus->db->query($sql);
 
         while ($row = $focus->db->fetchByAssoc($result)) {


### PR DESCRIPTION
## Description
Fix to workflow actions.

## How To Test This
Try to create or edit a workflow with actions saved. Ensure those actions persist when opening the workflow again.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->