### PR TITLE
Fixed #8178 - 7.11.9 Employee role control is lost, invalid

### DIFF
--- a/modules/ACLActions/ACLAction.php
+++ b/modules/ACLActions/ACLAction.php
@@ -359,20 +359,20 @@ class ACLAction extends SugarBean
         /* END - SECURITY GROUPS */
         while ($row = $db->fetchByAssoc($result, false)) {
             /* BEGIN - SECURITY GROUPS */
-            if ($has_user_role === false && $row['user_role'] === 1) {
+            if ($has_user_role == false && $row['user_role'] == 1) {
                 $has_user_role = true;
             }
-            if ($has_role === false && ($row['user_role'] === 1 || $row['user_role'] === 0)) {
+            if ($has_role == false && ($row['user_role'] == 1 || $row['user_role'] ==0)) {
                 $has_role = true;
             }
             //if user roles should take precedence over group roles and we have a user role
             //break when we get to processing the group roles
-            if ($has_user_role === true && $row['user_role'] === 0
+            if ($has_user_role == true && $row['user_role'] == 0
                 && isset($sugar_config['securitysuite_user_role_precedence'])
-                && $sugar_config['securitysuite_user_role_precedence'] === true) {
+                && $sugar_config['securitysuite_user_role_precedence'] == true) {
                 break;
             }
-            if ($row['user_role'] === -1 && $has_role === true) {
+            if ($row['user_role'] == -1 && $has_role == true) {
                 break; //no need for default actions when a role is assigned to the user or user's group already
             }
             /* END - SECURITY GROUPS */
@@ -476,7 +476,7 @@ class ACLAction extends SugarBean
             )) {
             return true;
         }
-        if ($action !== null && isset($action->aclaccess)) {
+        if (!is_null($action) && isset($action->aclaccess)) {
             if ($action->aclaccess == ACL_ALLOW_ALL
                 || ($is_owner && $action->aclaccess == ($access == ACL_ALLOW_OWNER || $access == ACL_ALLOW_GROUP))
                 || ($in_group && $access == ACL_ALLOW_GROUP) //need to pass if in group with access somehow
@@ -637,7 +637,7 @@ class ACLAction extends SugarBean
                     }
 
                     $categories[$cat_name][$type_name][$act_name]['accessColor'] = self::AccessColor($actionAclAccess);
-                    if ($type_name === 'module') {
+                    if ($type_name == 'module') {
                         $catModAccACL = null;
                         if (isset($categories[$cat_name]['module']['access']['aclaccess'])) {
                             $catModAccACL = $categories[$cat_name]['module']['access']['aclaccess'];
@@ -646,7 +646,7 @@ class ACLAction extends SugarBean
                         }
 
                         // Requires loose comparison
-                        if ($act_name !== 'aclaccess' && $catModAccACL == ACL_ALLOW_DISABLED) {
+                        if ($act_name != 'aclaccess' && $catModAccACL == ACL_ALLOW_DISABLED) {
                             $categories[$cat_name][$type_name][$act_name]['accessColor'] = 'darkgray';
                             $disabled[] = $cat_name;
                         }
@@ -662,7 +662,7 @@ class ACLAction extends SugarBean
                     $categories[$cat_name][$type_name][$act_name]['accessName'] = ACLAction::AccessName($actionAclAccess);
                     $categories[$cat_name][$type_name][$act_name]['accessLabel'] = ACLAction::AccessLabel($actionAclAccess);
 
-                    if ($cat_name === 'Users' && $act_name === 'admin') {
+                    if ($cat_name == 'Users' && $act_name == 'admin') {
                         $categories[$cat_name][$type_name][$act_name]['accessOptions'][ACL_ALLOW_DEFAULT] = ACLAction::AccessName(ACL_ALLOW_DEFAULT);;
                         $categories[$cat_name][$type_name][$act_name]['accessOptions'][ACL_ALLOW_DEV] = ACLAction::AccessName(ACL_ALLOW_DEV);;
                     } else {

--- a/modules/ACLActions/ACLAction.php
+++ b/modules/ACLActions/ACLAction.php
@@ -645,7 +645,8 @@ class ACLAction extends SugarBean
                             LoggerManager::getLogger()->warn('Categories / category name: [' . $cat_name . '] / module / access / aclaccess is not set for ACLAction::setupCategoriesMatrix()');
                         }
 
-                        if ($act_name !== 'aclaccess' && $catModAccACL === ACL_ALLOW_DISABLED) {
+                        // Requires loose comparison
+                        if ($act_name !== 'aclaccess' && $catModAccACL == ACL_ALLOW_DISABLED) {
                             $categories[$cat_name][$type_name][$act_name]['accessColor'] = 'darkgray';
                             $disabled[] = $cat_name;
                         }

--- a/modules/ACLActions/ACLAction.php
+++ b/modules/ACLActions/ACLAction.php
@@ -590,7 +590,7 @@ class ACLAction extends SugarBean
      * STATIC function userNeedsOwnership($user_id, $category, $action,$type='module')
      * checks if a user should have ownership to do an action
      *
-     * @param GUID $user_id
+     * @param string $user_id GUID
      * @param string $category
      * @param string $action
      * @param string $type
@@ -606,12 +606,11 @@ class ACLAction extends SugarBean
 
 
         if (!empty($_SESSION['ACL'][$user_id][$category][$type][$action])) {
-            return $_SESSION['ACL'][$user_id][$category][$type][$action]['aclaccess'] === ACL_ALLOW_OWNER;
+            // Requires loose type casting
+            return $_SESSION['ACL'][$user_id][$category][$type][$action]['aclaccess'] == ACL_ALLOW_OWNER;
         }
-
         return false;
     }
-
     /**
      *
      * static pass by ref setupCategoriesMatrix(&$categories)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Fixes an issue with ACL roles allowing users to see records they don't have ownership of.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reference: #8178 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Setup your ACL role the same as the screenshot in #8178.
2. Check that your user has the correct level of access.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->