### PR TITLE
Fix issue #8180 where font colour is the same as the search bar bg

### DIFF
--- a/themes/SuiteP/css/suitep-base/navbar.scss
+++ b/themes/SuiteP/css/suitep-base/navbar.scss
@@ -780,7 +780,7 @@
   line-height: normal;
   width: 200px;
   min-height: 40px;
-  -webkit-text-fill-color: $navbar-search-bg;
+  -webkit-text-fill-color: $navbar-search-color;
   -webkit-box-shadow: 0 0 0 1000px $navbar-search-bg inset;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change auto fill font colour to standard search font colour
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
See #8180
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
See #8180
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->