### PR TITLE
Scroll QR&R to see the 'sync with vardefs' part

### DIFF
--- a/modules/Administration/templates/RepairDatabase.tpl
+++ b/modules/Administration/templates/RepairDatabase.tpl
@@ -40,13 +40,14 @@
 
 *}
 
-<h3>{$MOD.LBL_REPAIR_DATABASE_DIFFERENCES}</h3>
+<h3 class="error" style="width:100%">{$MOD.LBL_REPAIR_DATABASE_DIFFERENCES}</h3>
 <p>{$MOD.LBL_REPAIR_DATABASE_TEXT}</p>
 <form name="RepairDatabaseForm" method="post">
 <input type="hidden" name="module" value="Administration"/>
 <input type="hidden" name="action" value="repairDatabase"/>
 <input type="hidden" name="raction" value="execute"/>
-<textarea name="sql" rows="24" cols="150" id="repairsql">{$qry_str}</textarea>
+<textarea name="sql" rows="14" cols="150" id="repairsql">{$qry_str}</textarea>
 <br/>
 <input type="button" class="button" value="{$MOD.LBL_REPAIR_DATABASE_EXECUTE}" onClick="document.RepairDatabaseForm.submit();"/> 
 <input type="button" class="button" value="{$MOD.LBL_REPAIR_DATABASE_EXPORT}" onClick="document.RepairDatabaseForm.raction.value='export'; document.RepairDatabaseForm.submit();"/>
+<script>document.getElementById('repairsql').scrollIntoView(false);</script>


### PR DESCRIPTION
So it's Friday night and I decided to do something I've been postponing for too long.

## Description
When admins run a `Quick Repair and Rebuild`, sometimes there is an important message to inform them they have a mismatch between the database and the vardefs, and it offers to run an SQL query to fix it.

## Motivation and Context
People don't see the notice unless they remember to scroll down. I waste significant time in the Forums telling people to go check this, and I must have done it a hundred times.

I chose a solution that is not very fancy, but has excellent browser compatibility.

## How To Test This
1. Run a QR&R with no vardefs unsynced, to confirm that everything works as normal, as it always did.
2. Now make a change to your vardefs, to trigger the message (to facilitate, I suggest a change below)
3. Check that the browser scrolls to show the message when the QR&R finishes.

### (a possible vardefs change for testing)

Add a file called 
`custom/Extension/modules/Accounts/Ext/Vardefs/sugarfield_test.php`

with these contents (for example, any change would do):

```php
<?php

$dictionary['Account']['fields']['filename'] = array (
     'name' => 'filename',
     'vname' => 'LBL_LESS',
     'type' => 'file',
     'dbType' => 'varchar',
     'len' => '255',
     'reportable' => true,
     'comment' => 'File name associated with the note (attachment)',
     'importable' => false,
);

$dictionary['Account']['fields']['file_mime_type'] = array(
     'name' => 'file_mime_type',
     'vname' => 'LBL_ID',
     'type' => 'varchar',
     'len' => '100',
     'comment' => 'Attachment MIME type',
     'importable' => false,
);
```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.