### PR TITLE
Add a PHPDoc comment and test to unencodeMultienum()

### DIFF
--- a/include/utils.php
+++ b/include/utils.php
@@ -4810,7 +4810,12 @@ function sugar_ucfirst($string, $charset = 'UTF-8')
 }
 
 /**
- *
+ * Given a multienum encoded as a string, convert it to an array of strings,
+ * e.g. `"^Monday^,^Tuesday^,^Wednesday^,^Thursday^"` becomes
+ * `["Monday", "Tuesday", "Wednesday", "Thursday"]`.
+ * 
+ * @param string|string[] $string The encoded multienum value. If this is already an array, the array will be returned unchanged.
+ * @return string[] An array of strings representing the multienum's values.
  */
 function unencodeMultienum($string)
 {

--- a/tests/unit/phpunit/include/UtilsTest.php
+++ b/tests/unit/phpunit/include/UtilsTest.php
@@ -86,10 +86,12 @@ class UtilsTest extends StateCheckerPHPUnitTestCaseAbstract
         $this->assertEquals('^foo^,^bar^', encodeMultienumValue(array('foo', 'bar')));
     }
 
-    public function testunencodeMultienumValue()
+    public function testunencodeMultienum()
     {
         $this->assertEquals(array('foo'), unencodeMultienum('^foo^'));
         $this->assertEquals(array('foo', 'bar'), unencodeMultienum('^foo^,^bar^'));
+        // Will return the same array if given an array.
+        $this->assertEquals(array('foo', 'bar'), unencodeMultienum(['foo', 'bar']));
     }
 
     public function testget_languages()


### PR DESCRIPTION
## Description

Title pretty much says everything.

## Motivation and Context

This function was pretty useful for something I was doing, so I figured I'd document it for others.

I see that the code also handles the case where the multienum is already an array, and will just return that. So I made the parameter type `string|string[]`. I also added a unit test for that case :)

## How To Test This
Make sure the `unencodeMultienum` function docs make sense. Make sure the tests continue to pass.

## Types of changes
Documentation :)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.