### PR TITLE
Remove the deprecated load_menu() function in utils.php

### DIFF
--- a/include/utils.php
+++ b/include/utils.php
@@ -504,26 +504,6 @@ function addCronAllowedUser($addUser)
 }
 
 /**
- * @deprecated use SugarView::getMenu() instead
- */
-function load_menu($path)
-{
-    global $module_menu;
-
-    if (file_exists($path . 'Menu.php')) {
-        require $path . 'Menu.php';
-    }
-    if (file_exists('custom/' . $path . 'Ext/Menus/menu.ext.php')) {
-        require 'custom/' . $path . 'Ext/Menus/menu.ext.php';
-    }
-    if (file_exists('custom/application/Ext/Menus/menu.ext.php')) {
-        require 'custom/application/Ext/Menus/menu.ext.php';
-    }
-
-    return $module_menu;
-}
-
-/**
  * get_notify_template_file
  * This function will return the location of the email notifications template to use.
  *


### PR DESCRIPTION
## Description

It's been deprecated since SuiteCRM's initial commit and a grep for load_menu doesn't return anything, so it doesn't seem to be used anywhere.

Part of #7744.

## How To Test This
Make sure the tests pass and the function isn't used anywhere.

## Types of changes
Technical debt
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.