### PR TITLE
Backport various PHP 7.4 fixes

### DIFF
--- a/data/Relationships/M2MRelationship.php
+++ b/data/Relationships/M2MRelationship.php
@@ -59,11 +59,19 @@ class M2MRelationship extends SugarRelationship
 
         $lhsModule = $def['lhs_module'];
         $this->lhsLinkDef = $this->getLinkedDefForModuleByRelationship($lhsModule);
-        $this->lhsLink = $this->lhsLinkDef['name'];
+        if (is_bool($this->lhsLinkDef)) {
+            $this->lhsLink = null;
+        } else {
+            $this->lhsLink = $this->lhsLinkDef['name'];
+        }
 
         $rhsModule = $def['rhs_module'];
         $this->rhsLinkDef = $this->getLinkedDefForModuleByRelationship($rhsModule);
-        $this->rhsLink = $this->rhsLinkDef['name'];
+        if (is_bool($this->rhsLinkDef)) {
+            $this->rhsLink = null;
+        } else {
+            $this->rhsLink = $this->rhsLinkDef['name'];
+        }
 
         if (isset($def['self_referencing'])) {
             $this->self_referencing = $def['self_referencing'];

--- a/data/Relationships/One2MRelationship.php
+++ b/data/Relationships/One2MRelationship.php
@@ -103,8 +103,12 @@ class One2MRelationship extends M2MRelationship
                 $this->rhsLinkDef = $this->rhsLinkDef[0];
             }
         }
-        $this->lhsLink = $this->lhsLinkDef['name'];
-        $this->rhsLink = $this->rhsLinkDef['name'];
+        if (!is_bool($this->lhsLinkDef)) {
+            $this->lhsLink = $this->lhsLinkDef['name'];
+        }
+        if (!is_bool($this->rhsLinkDef)) {
+            $this->rhsLink = $this->rhsLinkDef['name'];
+        }
     }
 
     protected function linkIsLHS($link)

--- a/include/ListView/ListViewDisplay.php
+++ b/include/ListView/ListViewDisplay.php
@@ -243,7 +243,9 @@ class ListViewDisplay
      */
     public function process($file, $data, $htmlVar)
     {
-        if (!is_array($data['data'])) {
+        if (!is_array($data)) {
+            LoggerManager::getLogger()->warn('Row data must be an array, ' . gettype($data) . ' given.');
+        } else if (is_array($data) && !is_array($data['data'])) {
             LoggerManager::getLogger()->warn('Row data must be an array, ' . gettype($data['data']) . ' given and converting to an array.');
         }
         $this->rowCount = count((array)$data['data']);

--- a/include/SearchForm/SearchForm2.php
+++ b/include/SearchForm/SearchForm2.php
@@ -615,17 +615,19 @@ class SearchForm
     {
         $this->formData = array();
         $this->fieldDefs = array();
-        foreach ((array)$this->searchdefs['layout'][$this->displayView] as $data) {
-            if (is_array($data)) {
-                //Fields may be listed but disabled so that when they are enabled, they have the correct custom display data.
-                if (isset($data['enabled']) && $data['enabled'] == false) {
-                    continue;
+        if (!is_null($this->searchdefs['layout']) && !is_null($this->searchdefs['layout'][$this->displayView])) {
+            foreach ((array)$this->searchdefs['layout'][$this->displayView] as $data) {
+                if (is_array($data)) {
+                    //Fields may be listed but disabled so that when they are enabled, they have the correct custom display data.
+                    if (isset($data['enabled']) && $data['enabled'] == false) {
+                        continue;
+                    }
+                    $data['name'] = $data['name'] . '_' . $this->parsedView;
+                    $this->formData[] = array('field' => $data);
+                    $this->fieldDefs[$data['name']] = $data;
+                } else {
+                    $this->formData[] = array('field' => array('name' => $data . '_' . $this->parsedView));
                 }
-                $data['name'] = $data['name'] . '_' . $this->parsedView;
-                $this->formData[] = array('field' => $data);
-                $this->fieldDefs[$data['name']] = $data;
-            } else {
-                $this->formData[] = array('field' => array('name' => $data . '_' . $this->parsedView));
             }
         }
 

--- a/include/SearchForm/SearchForm2.php
+++ b/include/SearchForm/SearchForm2.php
@@ -615,7 +615,7 @@ class SearchForm
     {
         $this->formData = array();
         $this->fieldDefs = array();
-        if (!is_null($this->searchdefs['layout']) && !is_null($this->searchdefs['layout'][$this->displayView])) {
+        if (!is_null($this->searchdefs) && !is_null($this->searchdefs['layout']) && !is_null($this->searchdefs['layout'][$this->displayView])) {
             foreach ((array)$this->searchdefs['layout'][$this->displayView] as $data) {
                 if (is_array($data)) {
                     //Fields may be listed but disabled so that when they are enabled, they have the correct custom display data.

--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -2831,9 +2831,11 @@ class Email extends Basic
     {
         global $current_user;
 
-        // User preferences should takee precedence over everything else
+        // User preferences should take precedence over everything else
         $emailSettings = $current_user->getPreference('emailSettings', 'Emails');
-        $alwaysSendEmailsInPlainText = $emailSettings['sendPlainText'] === '1';
+        // Protect against accessing emailSettings as an array if it's null.
+        $sendPlainText = is_null($emailSettings) ? null : $emailSettings['sendPlainText'];
+        $alwaysSendEmailsInPlainText = $sendPlainText === '1';
 
         $sendEmailsInPlainText = false;
         if (isset($_REQUEST['is_only_plain_text']) && $_REQUEST['is_only_plain_text'] === 'true') {

--- a/modules/Leads/Lead.php
+++ b/modules/Leads/Lead.php
@@ -177,7 +177,7 @@ class Lead extends Person implements EmailInterface
 
             if (!empty($result)) {
                 $row = $this->db->fetchByAssoc($result);
-                if (!is_null($row)) {
+                if (!is_null($row) && !is_bool($row)) {
                     $this->account_name = $row['name'];
                     $this->account_name_owner = $row['account_name_owner'];
                 } else {
@@ -199,8 +199,15 @@ class Lead extends Person implements EmailInterface
 
             if (!empty($result)) {
                 $row = $this->db->fetchByAssoc($result);
-                $this->opportunity_name = $row['name'];
-                $this->opportunity_name_owner = $row['opportunity_name_owner'];
+
+                if (!is_null($row) && !is_bool($row)) {
+                    $this->opportunity_name = $row['name'];
+                    $this->opportunity_name_owner = $row['opportunity_name_owner'];
+                } else {
+                    $this->opportunity_name = null;
+                    $this->opportunity_name_owner = null;
+                }
+
                 $this->opportunity_name_mod = 'Opportunities';
             }
         }
@@ -216,8 +223,14 @@ class Lead extends Person implements EmailInterface
             $result = $this->db->limitQuery($query, 0, 1, true, "Want only a single row");
             if (!empty($result)) {
                 $row= $this->db->fetchByAssoc($result);
-                $this->contact_name = $locale->getLocaleFormattedName($row['first_name'], $row['last_name']);
-                $this->contact_name_owner = $row['contact_name_owner'];
+
+                if (!is_null($row) && !is_bool($row)) {
+                    $this->contact_name = $locale->getLocaleFormattedName($row['first_name'], $row['last_name']);
+                    $this->contact_name_owner = $row['contact_name_owner'];
+                } else {
+                    $this->contact_name = null;
+                    $this->contact_name_owner = null;
+                }
                 $this->contact_name_mod = 'Contacts';
             }
         }

--- a/modules/Leads/Lead.php
+++ b/modules/Leads/Lead.php
@@ -177,8 +177,13 @@ class Lead extends Person implements EmailInterface
 
             if (!empty($result)) {
                 $row = $this->db->fetchByAssoc($result);
-                $this->account_name = $row['name'];
-                $this->account_name_owner = $row['account_name_owner'];
+                if (!is_null($row)) {
+                    $this->account_name = $row['name'];
+                    $this->account_name_owner = $row['account_name_owner'];
+                } else {
+                    $this->account_name = null;
+                    $this->account_name_owner = null;
+                }
                 $this->account_name_mod = 'Accounts';
             }
         }

--- a/modules/jjwg_Areas/jjwg_Areas.php
+++ b/modules/jjwg_Areas/jjwg_Areas.php
@@ -137,8 +137,13 @@ class jjwg_Areas extends jjwg_Areas_sugar
     {
         $loc = array();
         $loc['name'] = $this->name;
-        $loc['lng'] = $this->centroid['lng'];
-        $loc['lat'] = $this->centroid['lat'];
+        if (!is_null($this->centroid)) {
+            $loc['lng'] = $this->centroid['lng'];
+            $loc['lat'] = $this->centroid['lat'];
+        } else {
+            $loc['lng'] = null;
+            $loc['lat'] = null;
+        }
         $loc = $this->define_loc($loc);
 
         return $loc;

--- a/modules/jjwg_Maps/jjwg_Maps.php
+++ b/modules/jjwg_Maps/jjwg_Maps.php
@@ -1161,7 +1161,7 @@ class jjwg_Maps extends jjwg_Maps_sugar
 
 
         // If related account address has already been geocoded
-        if (!empty($address) && $fields['jjwg_maps_geocode_status_c'] == 'OK' &&
+        if (!empty($address) && !is_bool($fields) && $fields['jjwg_maps_geocode_status_c'] == 'OK' &&
                 !empty($fields['jjwg_maps_lat_c']) && !empty($fields['jjwg_maps_lng_c'])) {
             $aInfo = array(
                 'address' => $address,


### PR DESCRIPTION
## Description

Backporting a bunch of fixes from #7987.

Mostly related to accessing booleans, integers, or null values as arrays. This causes errors in PHP 7.4, so we need to have these fixed before PHP 7.4 is released.

Part of #8057.

## Motivation and Context

PHP 7.4 support :)

## How To Test This
Make sure the CRM still works and the tests pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.