### PR TITLE
Add tests for check_php_version.

### DIFF
--- a/include/utils.php
+++ b/include/utils.php
@@ -3173,21 +3173,29 @@ function decodeJavascriptUTF8($str)
  * Do not pass in any pararameter to default to a check against the
  * current environment's PHP version.
  *
- * @param string Version to check against, defaults to the current environment's.
- *
- * @return integer1 if version is greater than the recommended PHP version,
- * 0 if version is between minimun and recomended PHP versions,
- * -1 otherwise (less than minimum or buggy version)
+ * @param string $sys_php_version Version to check against, defaults to the current environment's.
+ * @param string $min_php_version Minimum version to check against. Defaults to the SUITECRM_PHP_MIN_VERSION constant.
+ * @param string $rec_php_version Recommended version. Defaults to the SUITECRM_PHP_REC_VERSION constant
+ * 
+ * @return integer 1 if version is greater than the recommended PHP version,
+ *   0 if version is between minimun and recomended PHP versions,
+ *   -1 otherwise (less than minimum or buggy version)
  */
-function check_php_version($sys_php_version = '')
+function check_php_version($sys_php_version = '', $min_php_version = '', $rec_php_version = '')
 {
     if ($sys_php_version === '') {
         $sys_php_version = constant('PHP_VERSION');
     }
+    if ($min_php_version === '') {
+        $min_php_version = constant('SUITECRM_PHP_MIN_VERSION');
+    }
+    if ($rec_php_version === '') {
+        $rec_php_version = constant('SUITECRM_PHP_REC_VERSION');
+    }
 
     // versions below MIN_PHP_VERSION are not accepted, so return early.
-    if (version_compare($sys_php_version, constant('SUITECRM_PHP_MIN_VERSION'), '<') === true) {
-        return - 1;
+    if (version_compare($sys_php_version, $min_php_version, '<') === true) {
+        return -1;
     }
 
     // If there are some bug ridden versions, we should include them here
@@ -3199,8 +3207,8 @@ function check_php_version($sys_php_version = '')
         }
     }
 
-    //If the checked version is between the minimum and recommended versions, return 0
-    if (version_compare($sys_php_version, constant('SUITECRM_PHP_REC_VERSION'), '<') === true) {
+    // If the checked version is between the minimum and recommended versions, return 0.
+    if (version_compare($sys_php_version, $rec_php_version, '<') === true) {
         return 0;
     }
 

--- a/tests/unit/phpunit/include/UtilsTest.php
+++ b/tests/unit/phpunit/include/UtilsTest.php
@@ -114,4 +114,27 @@ class UtilsTest extends SuitePHPUnitFrameworkTestCase
         unset($_SESSION['authenticated_user_language']);
         $this->assertEquals(get_current_language(), 'bar');
     }
+
+    public function testcheck_php_version()
+    {
+        // These are used because the tests would fail if the supported
+        // versions changed, and the constants can't be redefined. So we
+        // instead pass the min/recommended versions directly to the
+        // function.
+        $minimumVersion = '5.5.0';
+        $recommendedVersion = '7.1.0';
+
+        // Returns -1 when the version is less than the minimum version.
+        $this->assertEquals(check_php_version("5.4.0", $minimumVersion, $recommendedVersion), -1);
+
+        // Returns 0 when the version is above the minimum but below the recommended version.
+        $this->assertEquals(check_php_version("7.0.0", $minimumVersion, $recommendedVersion), 0);
+
+        // Returns 1 when the version is at or above the recommended version.
+        $this->assertEquals(check_php_version("7.1.0", $minimumVersion, $recommendedVersion), 1);
+        $this->assertEquals(check_php_version("7.2.0", $minimumVersion, $recommendedVersion), 1);
+        $this->assertEquals(check_php_version("8.0.0", $minimumVersion, $recommendedVersion), 1);
+        // Handles versions with a `-dev` suffix correctly.
+        $this->assertEquals(check_php_version("7.4.0-dev", $minimumVersion, $recommendedVersion), 1);
+    }
 }


### PR DESCRIPTION
## Description

This PR adds tests for the `check_php_version` function in utils.php.

Needed to modify the way the min/recommended versions are defined in order to make it testable, but that doesn't matter for the existing uses of the function.

## Motivation and Context

I did this because I wanted to see why the version check was failing in #7987, but this didn't really give me anything to work with. I'm still stumped as to why it's failing on 7.4.0.

## How To Test This
Make sure the tests pass.

## Types of changes
Adds some tests.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.