### PR TITLE
Update the Travis Code Coverage job.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ matrix:
       before_script: composer install
       script: composer validate
     - name: "code coverage"
-      php: "7.0"
+      php: "7.3"
       dist: xenial
-      script: ./vendor/bin/codecept run install --env travis-ci-hub -f --ext DotReporter; echo "\$sugar_config['state_checker']['test_state_check_mode'] = 1;" >> config_override.php  ; ./vendor/bin/robo code:coverage --ci; cat codeception.dist.yml; bash <(curl -s https://codecov.io/bash) -f tests/_output/coverage.xml
+      script: ./vendor/bin/codecept run install --env travis-ci-hub -f --ext DotReporter; ./vendor/bin/robo code:coverage --ci; cat codeception.dist.yml; bash <(curl -s https://codecov.io/bash) -f tests/_output/coverage.xml
 
 services:
   - mysql

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,6 @@
   },
   "require-dev": {
     "codeception/codeception": "^2.0",
-    "phpunit/phpunit": "^4.8",
     "flow/jsonpath": "^0.4",
     "fzaninotto/faker": "^1.6",
     "jeroendesloovere/vcard": "v1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3a095252af293b28824a5c3908ed9330",
+    "content-hash": "247eafac6d7878eace592e6cf8586e7d",
     "packages": [
         {
             "name": "consolidation/annotated-command",


### PR DESCRIPTION
## Description

Run it on PHP 7.3 so it completes faster and remove a reference to the state checker.

The removal of the state checker seems to have caused the tests to take quite a bit longer on older versions of PHP (not sure what that's about). It's quite fast on PHP 7.3, so this updates the coverage job to use PHP 7.3, to save time.

It also removes a duplicate instance of phpunit/phpunit from `composer.json`.

## How To Test This
Make sure the tests pass and the coverage job continues to work.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.