### PR TITLE
Clear PHP notice on Home page, improve suitecrm.log message

### DIFF
--- a/include/Dashlets/Dashlet.php
+++ b/include/Dashlets/Dashlet.php
@@ -250,8 +250,8 @@ class Dashlet
         $template->assign('REFRESH_ICON', $this->setRefreshIcon());
         $template->assign('DELETE_ICON', $this->setDeleteIcon());
         $moduleName = '';
-        if (!is_object($this->seedBean)) {
-            $GLOBALS['log']->warn('incorrect seed bean');
+        if (!isset($this->seedBean) || !is_object($this->seedBean)) {
+            $GLOBALS['log']->info('seedBean not set, or not an object, for Dashlet: ' . get_class($this));
         } else {
             $moduleName = $this->seedBean->module_name;
         }


### PR DESCRIPTION
## Description
Some Dashlets (iFrame, AOR_Reports, for example) don't define `seedBean` and produce a PHP Notice that shows on the Homepage if you have `display_errors` turned on. 

```php
PHP Notice:  Undefined property: iFrameDashlet::$seedBean in /var/www/html/include/Dashlets/Dashlet.php on line 253
PHP Stack trace:
PHP   1. {main}() /var/www/html/index.php:0
PHP   2. SugarApplication->execute() /var/www/html/index.php:52
PHP   3. HomeController->execute() /var/www/html/include/MVC/SugarApplication.php:113
PHP   4. HomeController->process() /var/www/html/include/MVC/Controller/SugarController.php:373
PHP   5. HomeController->handleEntryPoint() /var/www/html/include/MVC/Controller/SugarController.php:468
PHP   6. require_once() /var/www/html/include/MVC/Controller/SugarController.php:1020
PHP   7. iFrameDashlet->getHeader() /var/www/html/include/MySugar/retrieve_dash_page.php:282

```

While fixing this, I also improved the corresponding `suitecrm.log` message.

Before:
```
[WARN] incorrect seed bean
```

After: 
```
[INFO] seedBean not set, or not an object, for Dashlet: iFrameDashlet
```

## How To Test This
1. Add iFrame dashlet to Homepage,or AOR_Reports Dashlet
2. Check both logs, PHP and suitecrm.log

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
