### PR TITLE
Remove some old code referencing PHP 5.3.

### DIFF
--- a/include/TimeDate.php
+++ b/include/TimeDate.php
@@ -2008,13 +2008,6 @@ class TimeDate
         $result = array();
         $transitions = $tz->getTransitions($year_date->ts, $year_end->ts);
         $idx = 0;
-        if (version_compare(PHP_VERSION, '5.3.0', '<')) {
-            // <5.3.0 ignores parameters, advance manually to current year
-            $start_ts = $year_date->ts;
-            while (isset($transitions[$idx]) && $transitions[$idx]["ts"] < $start_ts) {
-                $idx++;
-            }
-        }
         // get DST start
         while (isset($transitions[$idx]) && !$transitions[$idx]["isdst"]) {
             $idx++;

--- a/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php
+++ b/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php
@@ -79,11 +79,8 @@ class LDAPAuthenticateUser extends SugarAuthenticateUser
         }
         @ldap_set_option($ldapconn, LDAP_OPT_PROTOCOL_VERSION, 3);
         @ldap_set_option($ldapconn, LDAP_OPT_REFERRALS, 0); // required for AD
-        // If constant is defined, set the timeout (PHP >= 5.3)
-        if (defined('LDAP_OPT_NETWORK_TIMEOUT')) {
-            // Network timeout, lower than PHP and DB timeouts
-            @ldap_set_option($ldapconn, LDAP_OPT_NETWORK_TIMEOUT, 60);
-        }
+        // Network timeout, lower than PHP and DB timeouts
+        @ldap_set_option($ldapconn, LDAP_OPT_NETWORK_TIMEOUT, 60);
 
         $bind_user = $this->ldap_rdn_lookup($name, $password);
         $GLOBALS['log']->debug("ldapauth.ldap_authenticate_user: ldap_rdn_lookup returned bind_user=" . $bind_user);

--- a/modules/iCals/iCal.php
+++ b/modules/iCals/iCal.php
@@ -414,31 +414,19 @@ class iCal extends vCal
         $idx = 0;
         $result = array();
 
-        if (version_compare(PHP_VERSION, '5.3.0') >= 0) {
-            $year_date = SugarDateTime::createFromFormat("Y", $year, new DateTimeZone("UTC"));
-            $year_end = clone $year_date;
-            $year_end->setDate((int) $year, 12, 31);
-            $year_end->setTime(23, 59, 59);
-            $year_date->setDate((int) $year, 1, 1);
-            $year_date->setTime(0, 0, 0);
+        $year_date = SugarDateTime::createFromFormat("Y", $year, new DateTimeZone("UTC"));
+        $year_end = clone $year_date;
+        $year_end->setDate((int) $year, 12, 31);
+        $year_end->setTime(23, 59, 59);
+        $year_date->setDate((int) $year, 1, 1);
+        $year_date->setTime(0, 0, 0);
 
-            $transitions = $tz->getTransitions($year_date->getTimestamp(), $year_end->getTimestamp());
-            foreach ($transitions as $transition) {
-                if ($transition['isdst']) {
-                    break;
-                }
-                $idx++;
+        $transitions = $tz->getTransitions($year_date->getTimestamp(), $year_end->getTimestamp());
+        foreach ($transitions as $transition) {
+            if ($transition['isdst']) {
+                break;
             }
-        } else {
-            $transitions = $tz->getTransitions();
-
-            $idx = 0;
-            foreach ($transitions as $transition) {
-                if ($transition['isdst'] && (int)substr($transition["time"], 0, 4) == (int)date("Y")) {
-                    break;
-                }
-                $idx++;
-            }
+            $idx++;
         }
 
         if (empty($transitions[$idx]["isdst"])) {


### PR DESCRIPTION
## Description
PHP 5.3 has been EOL for years, and SuiteCRM doesn't support it at all anymore, so I looked around and found a few hacks related to PHP 5.3 that shouldn't be necessary anymore.

## Motivation and Context
We don't support PHP 5.3, so this shouldn't change the actual behavior of the CRM at all.

## How To Test This
Make sure the tests pass.

## Types of changes
Cleaning up old, dead code.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.