### PR TITLE
Fix #8261, Fix #7242 - Handling of temp files during Upgrades

### DIFF
--- a/modules/UpgradeWizard/cancel.php
+++ b/modules/UpgradeWizard/cancel.php
@@ -52,7 +52,6 @@ if (isset($_SESSION['install_file']) && file_exists(isset($_SESSION['install_fil
     @unlink(isset($_SESSION['install_file']));
 }
 unlinkUWTempFiles();
-unlinkUploadFiles();
 resetUwSession();
 
 $uwMain =<<<eoq

--- a/modules/UpgradeWizard/preflight.php
+++ b/modules/UpgradeWizard/preflight.php
@@ -89,7 +89,6 @@ if (version_compare(phpversion(), '5.2.0') >=0) {
 
     //Quickcreatedefs on the basis of editviewdefs
     updateQuickCreateDefs();
-    upgradeSugarCache($_SESSION['install_file']);
 
     if ((count($errors) == 1)) { // only diffs
         logThis('file preflight check passed successfully.');

--- a/modules/UpgradeWizard/systemCheck.php
+++ b/modules/UpgradeWizard/systemCheck.php
@@ -58,7 +58,13 @@ $skipDirs = array(
     '.svn',
     '.git',
 );
-$files = uwFindAllFiles(getcwd(), array(), true, $skipDirs);
+
+$files = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator(
+        getcwd(),
+        RecursiveDirectoryIterator::SKIP_DOTS | RecursiveIteratorIterator::SELF_FIRST
+    )
+);
 
 $i=0;
 $filesOut = "
@@ -74,6 +80,10 @@ $filesOut = "
 
 $isWindows = is_windows();
 foreach ($files as $file) {
+    if (dirInArray($file, $skipDirs)) {
+        continue;
+    }
+
     if ($isWindows) {
         if (!is_writable_windows($file) && file_exists($file)) {
             logThis('WINDOWS: File ['.$file.'] not readable - saving for display');

--- a/modules/UpgradeWizard/uw_utils.php
+++ b/modules/UpgradeWizard/uw_utils.php
@@ -118,8 +118,13 @@ function commitMakeBackupFiles($rest_dir, $install_file, $unzip_dir, $zip_from_d
 
     if (file_exists($rest_dir) && is_dir($rest_dir)) {
         logThis('backing up files to be overwritten...', $path);
-        $newFiles = findAllFiles(clean_path($unzip_dir . '/' . $zip_from_dir), array());
-
+        $newFiles = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(
+                clean_path($unzip_dir . '/' . $zip_from_dir),
+                RecursiveDirectoryIterator::SKIP_DOTS | RecursiveIteratorIterator::SELF_FIRST
+            )
+        );
+	    
         // keep this around for canceling
         $_SESSION['uw_restore_dir'] = getUploadRelativeName($rest_dir);
 
@@ -187,7 +192,12 @@ function commitCopyNewFiles($unzip_dir, $zip_from_dir, $path='')
         }
     }
 
-    $newFiles = findAllFiles(clean_path($unzip_dir . '/' . $zip_from_dir), array());
+    $newFiles = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator(
+            clean_path($unzip_dir . '/' . $zip_from_dir),
+            RecursiveDirectoryIterator::SKIP_DOTS | RecursiveIteratorIterator::SELF_FIRST
+        )
+    );
     $zipPath = clean_path($unzip_dir . '/' . $zip_from_dir);
 
     // handle special do-not-overwrite conditions
@@ -525,7 +535,7 @@ function getAllCustomizedModules()
 }
 
 /**
- * Array of all Modules in the version bein upgraded
+ * Array of all Modules in the version being upgraded
  * This method returns an Array of all modules
  * @return $modules Array of modules.
  */
@@ -713,7 +723,10 @@ function deleteChance()
  */
 function upgradeUWFiles($file)
 {
+    global $base_tmp_upgrade_dir;
+
     $cacheUploadUpgradesTemp = mk_temp_dir(sugar_cached("upgrades/temp"));
+    $_SESSION['unzip_dir'] = strstr($cacheUploadUpgradesTemp, $base_tmp_upgrade_dir);
 
     unzip($file, $cacheUploadUpgradesTemp);
 
@@ -733,29 +746,26 @@ function upgradeUWFiles($file)
     }
     // upgradeWizard
     if (file_exists("$from_dir/modules/UpgradeWizard")) {
-        $allFiles[] = findAllFiles("$from_dir/modules/UpgradeWizard", $allFiles);
+        $allFiles[] = findAllFiles("$from_dir/modules/UpgradeWizard", []);
     }
     // moduleInstaller
     if (file_exists("$from_dir/ModuleInstall")) {
-        $allFiles[] = findAllFiles("$from_dir/ModuleInstall", $allFiles);
+        $allFiles[] = findAllFiles("$from_dir/ModuleInstall", []);
     }
     if (file_exists("$from_dir/include/javascript/yui")) {
-        $allFiles[] = findAllFiles("$from_dir/include/javascript/yui", $allFiles);
+        $allFiles[] = findAllFiles("$from_dir/include/javascript/yui", []);
     }
     if (file_exists("$from_dir/HandleAjaxCall.php")) {
         $allFiles[] = "$from_dir/HandleAjaxCall.php";
     }
     if (file_exists("$from_dir/include/SugarTheme")) {
-        $allFiles[] = findAllFiles("$from_dir/include/SugarTheme", $allFiles);
+        $allFiles[] = findAllFiles("$from_dir/include/SugarTheme", []);
     }
     if (file_exists("$from_dir/include/SugarCache")) {
-        $allFiles[] = findAllFiles("$from_dir/include/SugarCache", $allFiles);
+        $allFiles[] = findAllFiles("$from_dir/include/SugarCache", []);
     }
     if (file_exists("$from_dir/include/utils/external_cache.php")) {
         $allFiles[] = "$from_dir/include/utils/external_cache.php";
-    }
-    if (file_exists("$from_dir/include/upload_file.php")) {
-        $allFiles[] = "$from_dir/include/upload_file.php";
     }
     if (file_exists("$from_dir/include/file_utils.php")) {
         $allFiles[] = "$from_dir/include/file_utils.php";
@@ -2233,6 +2243,59 @@ if (!function_exists('validate_manifest')) {
     }
 }
 
+/**
+ * upgradeSugarCache
+ * @deprecated This function is unused and will be removed in a future release.
+ * change from using the older SugarCache in 6.1 and below to the new one in 6.2
+ */
+function upgradeSugarCache($file)
+{
+    global $sugar_config;
+    $cacheUploadUpgradesTemp = mk_temp_dir(sugar_cached('upgrades/temp'));
+    unzip($file, $cacheUploadUpgradesTemp);
+    if (!file_exists(clean_path("{$cacheUploadUpgradesTemp}/manifest.php"))) {
+        logThis("*** ERROR: no manifest file detected while bootstraping upgrade wizard files!");
+        return;
+    }
+    include(clean_path("{$cacheUploadUpgradesTemp}/manifest.php"));
+    $from_dir = "{$cacheUploadUpgradesTemp}/{$manifest['copy_files']['from_dir']}";
+    $allFiles = array();
+    if (file_exists("$from_dir/include/SugarCache")) {
+        $allFiles = findAllFiles("$from_dir/include/SugarCache", $allFiles);
+    }
+    if (file_exists("$from_dir/include/database")) {
+        $allFiles = findAllFiles("$from_dir/include/database", $allFiles);
+    }
+    if (file_exists("$from_dir/include/utils/external_cache.php")) {
+        $allFiles[] = "$from_dir/include/utils/external_cache.php";
+    }
+    if (file_exists("$from_dir/include/utils/sugar_file_utils.php")) {
+        $allFiles[] = "$from_dir/include/utils/sugar_file_utils.php";
+    }
+    if (file_exists("$from_dir/include/utils/sugar_file_utils.php")) {
+        $allFiles[] = "$from_dir/include/utils/sugar_file_utils.php";
+    }
+    if (file_exists("$from_dir/include/utils/autoloader.php")) {
+        $allFiles[] = "$from_dir/include/utils/autoloader.php";
+    }
+    foreach ($allFiles as $k => $file) {
+        $destFile = str_replace($from_dir . "/", "", $file);
+        if (!is_dir(dirname($destFile))) {
+            mkdir_recursive(dirname($destFile)); // make sure the directory exists
+        }
+        if (stristr($file, 'uw_main.tpl')) {
+            logThis('Skipping "' . $file . '" - file copy will during commit step.');
+        } else {
+            logThis('updating UpgradeWizard code: ' . $destFile);
+            copy_recursive($file, $destFile);
+        }
+    }
+}
+
+/**
+ * unlinkUploadFiles
+ * @deprecated This function is unused and will be removed in a future release.
+ */
 function unlinkUploadFiles()
 {
     return;
@@ -2249,41 +2312,59 @@ function unlinkUploadFiles()
 }
 
 /**
+ * Recursively deletes a directory tree.
+ *
+ * @param string $folder The directory path.
+ * @param bool $keepRootFolder Whether to keep the top-level folder.
+ *
+ * @return bool TRUE on success, otherwise FALSE.
+ */
+function deleteTree($folder, $keepRootFolder = false)
+{
+    // Handle bad arguments.
+    if (empty($folder) || !file_exists($folder)) {
+        // No such file/folder exists.
+        return true;
+    }
+
+    if (is_file($folder) || is_link($folder)) {
+        // Delete file/link.
+        return @unlink($folder);
+    }
+
+    // Delete all children.
+    $files = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($folder, RecursiveDirectoryIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+
+    foreach ($files as $fileInfo) {
+        $action = ($fileInfo->isDir() ? 'rmdir' : 'unlink');
+        if (!@$action($fileInfo->getRealPath())) {
+            // Abort due to the failure:
+            return false;
+        }
+    }
+
+    // Delete the root folder itself?
+    return (!$keepRootFolder ? @rmdir($folder) : true);
+}
+
+/**
  * deletes files created by unzipping a package
  */
 function unlinkUWTempFiles()
 {
-    global $sugar_config;
     global $path;
 
-    logThis('at unlinkUWTempFiles()');
-    $tempDir='';
-    list($upgDir, $tempDir) = getUWDirs();
+    list(/* ignore first element */, $tempDir) = getUWDirs();
+    deleteTree($tempDir, true);
 
-    if (file_exists($tempDir) && is_dir($tempDir)) {
-        $files = findAllFiles($tempDir, array(), false);
-        rsort($files);
-        foreach ($files as $file) {
-            if (!is_dir($file)) {
-                //logThis('unlinking ['.$file.']', $path);
-                @unlink($file);
-            }
-        }
-        // now do dirs
-        $files = findAllFiles($tempDir, array(), true);
-        foreach ($files as $dir) {
-            if (is_dir($dir)) {
-                //logThis('removing dir ['.$dir.']', $path);
-                @rmdir($dir);
-            }
-        }
-        $cacheFile = sugar_cached("modules/UpgradeWizard/_persistence.php");
-        if (is_file($cacheFile)) {
-            logThis("Unlinking Upgrade cache file: '_persistence.php'", $path);
-            @unlink($cacheFile);
-        }
+    $cacheFile = sugar_cached('modules/UpgradeWizard/_persistence.php');
+    if (is_file($cacheFile)) {
+        logThis("Unlinking Upgrade cache file: '_persistence.php'", $path);
+        @unlink($cacheFile);
     }
-    logThis("finished!");
 }
 
 /**
@@ -4358,58 +4439,6 @@ function add_unified_search_to_custom_modules_vardefs()
 }
 
 /**
- * change from using the older SugarCache in 6.1 and below to the new one in 6.2
- */
-function upgradeSugarCache($file)
-{
-    global $sugar_config;
-    $cacheUploadUpgradesTemp = mk_temp_dir(sugar_cached('upgrades/temp'));
-
-    unzip($file, $cacheUploadUpgradesTemp);
-
-    if (!file_exists(clean_path("{$cacheUploadUpgradesTemp}/manifest.php"))) {
-        logThis("*** ERROR: no manifest file detected while bootstraping upgrade wizard files!");
-        return;
-    }
-    include(clean_path("{$cacheUploadUpgradesTemp}/manifest.php"));
-
-
-    $from_dir = "{$cacheUploadUpgradesTemp}/{$manifest['copy_files']['from_dir']}";
-    $allFiles = array();
-    if (file_exists("$from_dir/include/SugarCache")) {
-        $allFiles = findAllFiles("$from_dir/include/SugarCache", $allFiles);
-    }
-    if (file_exists("$from_dir/include/database")) {
-        $allFiles = findAllFiles("$from_dir/include/database", $allFiles);
-    }
-    if (file_exists("$from_dir/include/utils/external_cache.php")) {
-        $allFiles[] = "$from_dir/include/utils/external_cache.php";
-    }
-    if (file_exists("$from_dir/include/utils/sugar_file_utils.php")) {
-        $allFiles[] = "$from_dir/include/utils/sugar_file_utils.php";
-    }
-    if (file_exists("$from_dir/include/utils/sugar_file_utils.php")) {
-        $allFiles[] = "$from_dir/include/utils/sugar_file_utils.php";
-    }
-    if (file_exists("$from_dir/include/utils/autoloader.php")) {
-        $allFiles[] = "$from_dir/include/utils/autoloader.php";
-    }
-
-    foreach ($allFiles as $k => $file) {
-        $destFile = str_replace($from_dir."/", "", $file);
-        if (!is_dir(dirname($destFile))) {
-            mkdir_recursive(dirname($destFile)); // make sure the directory exists
-        }
-        if (stristr($file, 'uw_main.tpl')) {
-            logThis('Skipping "'.$file.'" - file copy will during commit step.');
-        } else {
-            logThis('updating UpgradeWizard code: '.$destFile);
-            copy_recursive($file, $destFile);
-        }
-    }
-}
-
-/**
  * unlinkUpgradeFiles
  * This is a helper function to clean up
  *
@@ -4532,7 +4561,7 @@ function getUWDirs()
 }
 
 /**
- * Whether directory exists within list of directories to skip
+ * Whether directory exists within list of directories to skip, matching anywhere in path
  * @param string $dir dir to be checked
  * @param array $skipDirs list with skipped dirs
  * @return boolean
@@ -4547,6 +4576,24 @@ function whetherNeedToSkipDir($dir, $skipDirs)
     return false;
 }
 
+/**
+ * Whether directory exists within list of directories, matching only beginning of path
+ * @param string $dir dir to be checked
+ * @param array $dirsArray the list of directories to check
+ * @return boolean
+ */
+function dirInArray($dir, $dirsArray)
+{
+    $dir = clean_path($dir);
+    foreach ($dirsArray as $aDir) {
+        // Match the substring only at the beginning of the path:
+        if (strpos($dir, getcwd() . '/' . $aDir) === 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
 
 /*
  * rebuildSprites


### PR DESCRIPTION
Fixes many Upgrader problems caused by the increase of our upgrade packages size, and aggravated each time the upgrade didn't finish correctly.

## Description
See the Issue #8261 for symptoms and diagnosis tools. Also #7242.

## Future work

The functions [`uwfindAllFiles`](https://github.com/salesagility/SuiteCRM/search?q=uwFindAllFiles&unscoped_q=uwFindAllFiles) and [`findAllFiles`](https://github.com/salesagility/SuiteCRM/search?q=findAllFiles&unscoped_q=findAllFiles) should be dropped entirely, and the places that use them should be refactored so that they use Iterators and don't build huge arrays in memory before acting on the files.

Exceptions to this can be made if you're sure the place where the function is used will never have to iterate over a large set of files.

## How To Test This

**Warning**: if you just pull these changes from GitHub and then run an upgrade, the files in the package will replace these and you won't test anything. Make sure you add these files _into_ the package before starting the test upgrade. 

See the Issue's "steps to reproduce" for steps to test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
