### PR TITLE
Fix "!" in pQuery and add tests

### DIFF
--- a/include/database/DBManager.php
+++ b/include/database/DBManager.php
@@ -1933,7 +1933,11 @@ abstract class DBManager
 
         $query = $this->createPreparedQuery($stmt, $data);
 
-        return $this->query($query);
+        if ($query === false) {
+            return false;
+        } else {
+            return $this->query($query);
+        }
     }
 
     /********************** SQL FUNCTIONS ****************************/

--- a/include/database/DBManager.php
+++ b/include/database/DBManager.php
@@ -1875,6 +1875,53 @@ abstract class DBManager
     /**
      * Takes a prepared stmt index and the data to replace and creates the query and runs it.
      *
+     * @deprecated This is no longer used and will be removed in a future release.
+     * 
+     * @param  int $stmt The index of the prepared statement from preparedTokens
+     * @param  array $data The array of data to replace the tokens with.
+     * @return resource result set or false on error
+     */
+    public function executePreparedQuery($stmt, $data = array())
+    {
+        if (!empty($this->preparedTokens[$stmt])) {
+            if (!is_array($data)) {
+                $data = array($data);
+            }
+            $pTokens = $this->preparedTokens[$stmt];
+            //ensure that the number of data elements matches the number of replacement tokens
+            //we found in prepare().
+            if (count($data) != $pTokens['tokenCount']) {
+                //error the data count did not match the token count
+                return false;
+            }
+            $query = '';
+            $dataIndex = 0;
+            $tokens = $pTokens['tokens'];
+            foreach ($tokens as $val) {
+                switch ($val) {
+                    case '?':
+                        $query .= $this->quote($data[$dataIndex++]);
+                        break;
+                    case '&':
+                        $filename = $data[$dataIndex++];
+                        $query .= file_get_contents($filename);
+                        break;
+                    case '!':
+                        $query .= $data[$dataIndex++];
+                        break;
+                    default:
+                        $query .= $val;
+                        break;
+                }//switch
+            }//foreach
+            return $this->query($query);
+        }
+        return false;
+    }
+
+    /**
+     * Takes a prepared stmt index and the data to replace and creates the query and runs it.
+     *
      * @param  int $stmt The index of the prepared statement from preparedTokens
      * @param  array $data The array of data to replace the tokens with.
      * @return resource result set or false on error

--- a/include/database/DBManager.php
+++ b/include/database/DBManager.php
@@ -1875,7 +1875,7 @@ abstract class DBManager
     /**
      * Takes a prepared stmt index and the data to replace and creates the query and runs it.
      *
-     * @deprecated This is no longer used and will be removed in a future release.
+     * @deprecated This is no longer used and will be removed in a future release. See createPreparedQuery() for an alternative.
      * 
      * @param  int $stmt The index of the prepared statement from preparedTokens
      * @param  array $data The array of data to replace the tokens with.

--- a/tests/unit/phpunit/include/database/DBManagerTest.php
+++ b/tests/unit/phpunit/include/database/DBManagerTest.php
@@ -58,4 +58,21 @@ class DBManagerTest extends SuitePHPUnitFrameworkTestCase
             "SELECT foo FROM bar WHERE baz != 'foo';"
         );
     }
+
+    // Make sure createPreparedQuery returns the correct SQL query when
+    // using '\?' in the input.
+    public function testcreatePreparedQueryWithEscapedToken()
+    {
+        $db = DBManagerFactory::getInstance();
+
+        // Match baz to the input variable with a question mark appended... for some reason.
+        $sql = "SELECT foo FROM bar WHERE baz = '?\?';";
+
+        $stmt = $db->prepareQuery($sql);
+
+        $this->assertEquals(
+            $db->createPreparedQuery($stmt, ["foo"]),
+            "SELECT foo FROM bar WHERE baz = 'foo?';"
+        );
+    }
 }

--- a/tests/unit/phpunit/include/database/DBManagerTest.php
+++ b/tests/unit/phpunit/include/database/DBManagerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+use SuiteCRM\Test\SuitePHPUnitFrameworkTestCase;
+
+require_once 'include/database/DBManager.php';
+
+class DBManagerTest extends SuitePHPUnitFrameworkTestCase
+{
+    // Make sure createPreparedQuery returns the correct SQL query when given
+    // a simple query.
+    public function testcreatePreparedQueryWithSimpleQuery()
+    {
+        $db = DBManagerFactory::getInstance();
+
+        $sql = "SELECT foo FROM bar WHERE baz = '?';";
+
+        $stmt = $db->prepareQuery($sql);
+
+        $this->assertEquals(
+            $db->createPreparedQuery($stmt, ["foo"]),
+            "SELECT foo FROM bar WHERE baz = 'foo';"
+        );
+    }
+
+    // Make sure createPreparedQuery returns the correct SQL query when given
+    // a slightly more complex query.
+    public function testcreatePreparedQueryWithMoreComplexQuery()
+    {
+        $db = DBManagerFactory::getInstance();
+
+        $sql = "SELECT foo FROM bar WHERE baz = '?' AND qux = '?';";
+
+        $stmt = $db->prepareQuery($sql);
+
+        $this->assertEquals(
+            $db->createPreparedQuery($stmt, ["foo", "bar"]),
+            "SELECT foo FROM bar WHERE baz = 'foo' AND qux = 'bar';"
+        );
+    }
+
+    // Make sure createPreparedQuery returns the correct SQL query when
+    // using '!=' in the input.
+    public function testcreatePreparedQueryWithNegation()
+    {
+        $db = DBManagerFactory::getInstance();
+
+        $sql = "SELECT foo FROM bar WHERE baz != '?';";
+
+        $stmt = $db->prepareQuery($sql);
+
+        $this->assertEquals(
+            $db->createPreparedQuery($stmt, ["foo"]),
+            "SELECT foo FROM bar WHERE baz != 'foo';"
+        );
+    }
+}


### PR DESCRIPTION
## Description

Fixes #7720 and adds tests for some basic pQuery functionality, to prevent it from regressing.

## Motivation and Context
A query like `SELECT foo FROM bar WHERE baz != '?';` would have failed when passed to pQuery because the `!` isn't handled in any special way when it precedes an `=`.

`!` can be used as a token, but it shouldn't conflict with valid SQL queries.

It changes the way pQuery works, by renaming `executePreparedQuery` to `createPreparedQuery` and instead handle the execution of the queries in pQuery itself. `executePreparedQuery` was only used in the `pQuery` function. The point of this change is to make pQuery easier to test. I wanted to make sure the queries were returned by a function as strings, since the results of the queries aren't relevant to me and would just add complexity to the tests.

## How To Test This
Make sure the automated tests pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.