### PR TITLE
fix(Subpanel) - Only for the first submit quick create subpanel form set the right return_action

### DIFF
--- a/include/EditView/SubpanelQuickCreate.php
+++ b/include/EditView/SubpanelQuickCreate.php
@@ -88,7 +88,7 @@ class SubpanelQuickCreate
         $this->ev->view = $this->viewType;
         $this->ev->showVCRControl = false;
         $this->ev->ss = new Sugar_Smarty();
-        //$_REQUEST['return_action'] = 'SubPanelViewer';
+        $_REQUEST['return_action'] = 'SubPanelViewer';
 
         $class = $GLOBALS['beanList'][$module];
         $bean = new $class();


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Fix the incorrect return_action for the first quick form submit from subpanel.
Meld of the quick create form:
![image](https://user-images.githubusercontent.com/18328936/69005062-045f0f00-0925-11ea-92ba-305f6005a570.png)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I'm trying to show messages by `SugarApplication::appendSuccessMessage($message)` after creation bean from subpanel because the the return action for the first bean is set to `DetailView` ajax request fetching all the SESSION messages by `SugarApplication::getSuccessMessages()` does not display them (It OK it should not) but then when I trying to get SESSION messages the array is empty because it already fetched by ajax request. This works correct only from the second bean creation.


## How To Test This
This bug related to all CRM entities, example how to reppoduce it with Case and Bugs subpanle.

1. Create case
1. Open case and create a new bug from Case subpanle BUGS by quick create form.
> ![image](https://user-images.githubusercontent.com/18328936/69004816-d88e5a00-0921-11ea-96b2-2ec81ea14693.png)
3. Check the `$_REQUEST['return_action']` it will be `DetailView`
> ![image](https://user-images.githubusercontent.com/18328936/69004729-c3fd9200-0920-11ea-9c3e-6db845b730c4.png)
4. Create second (and addition) Bug from without page refresh by quick create form.
5. Check the `$_REQUEST['return_action']` it will be  `SubPanelViewer`
> ![image](https://user-images.githubusercontent.com/18328936/69004770-2ce50a00-0921-11ea-8de9-130f9de081ba.png)
6. after applying this fix the the return_action will be always `SubPanelViewer`


<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->