### PR TITLE
Fix ajaxStatus hidden behind navigation

### DIFF
--- a/themes/SuiteP/css/suitep-base/editview.scss
+++ b/themes/SuiteP/css/suitep-base/editview.scss
@@ -1930,15 +1930,14 @@ a.tabFormAdvLink:visited {
 
 #ajaxStatusDiv {
   position: fixed;
-  top: 7px;
+  top: 65px;
   background: $panel-bg;
   color: $danger;
   padding: 5px;
   border: 1px solid $panel-default-border;
   filter: alpha(opacity=80);
   opacity: .8;
-  z-index: 20;
-
+  z-index: 1040;
 }
 
 .detail508 tr td[scope="col"] {

--- a/themes/SuiteP/tpls/header.tpl
+++ b/themes/SuiteP/tpls/header.tpl
@@ -47,7 +47,11 @@
 
 {if $AUTHENTICATED}
     <div id="ajaxHeader">
-        {include file="themes/SuiteP/tpls/_headerModuleList.tpl"}
+        {if file_exists('custom/themes/SuiteP/tpls/_headerModuleList.tpl')}
+            {include file="custom/themes/SuiteP/tpls/_headerModuleList.tpl"}
+        {else}
+            {include file="themes/SuiteP/tpls/_headerModuleList.tpl"}
+        {/if}
     </div>
 {/if}
 {literal}


### PR DESCRIPTION
## Description
- Fix #8266 
- Check for custom `_headerModuleList.tpl` file to include in `_header.tpl` so you don't have copy both to your custom folder if you're only modifying `_headerModuleList.tpl`

## Motivation and Context
Usability improved

## How To Test This
In your browser js console run: `ajaxStatus.showStatus("Testing");` you should see the status message

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.