### PR TITLE
Fix #8295 - Fix sorting icons showing counterwise

### DIFF
--- a/include/ListView/ListViewGeneric.tpl
+++ b/include/ListView/ListViewGeneric.tpl
@@ -158,10 +158,10 @@
                                 {if $params.orderBy|default:$colHeader|lower == $pageData.ordering.orderBy}
                                     {if $pageData.ordering.sortOrder == 'ASC'}
                                         {capture assign="imageName"}arrow_down.{$arrowExt}{/capture}
-                                        <span class="suitepicon suitepicon-action-sorting-descending"></span>
+                                        <span class="suitepicon suitepicon-action-sorting-ascending"></span>
                                     {else}
                                         {capture assign="imageName"}arrow_up.{$arrowExt}{/capture}
-                                        <span class="suitepicon suitepicon-action-sorting-ascending"></span>
+                                        <span class="suitepicon suitepicon-action-sorting-descending"></span>
                                     {/if}
                                 {else}
                                     {capture assign="imageName"}arrow.{$arrowExt}{/capture}

--- a/themes/SuiteP/include/ListView/ListViewGeneric.tpl
+++ b/themes/SuiteP/include/ListView/ListViewGeneric.tpl
@@ -173,11 +173,11 @@
 								{if $pageData.ordering.sortOrder == 'ASC'}
 									{capture assign="imageName"}arrow_down.{$arrowExt}{/capture}
 									{capture assign="alt_sort"}{sugar_translate label='LBL_ALT_SORT_DESC'}{/capture}
-									<span class="suitepicon suitepicon-action-sorting-descending" title="{$alt_sort}"></span>
+									<span class="suitepicon suitepicon-action-sorting-ascending" title="{$alt_sort}"></span>
 								{else}
 									{capture assign="imageName"}arrow_up.{$arrowExt}{/capture}
 									{capture assign="alt_sort"}{sugar_translate label='LBL_ALT_SORT_ASC'}{/capture}
-									<span class="suitepicon suitepicon-action-sorting-ascending" title="{$alt_sort}"></span>
+									<span class="suitepicon suitepicon-action-sorting-descending" title="{$alt_sort}"></span>
 								{/if}
 							{else}
 								{capture assign="imageName"}arrow.{$arrowExt}{/capture}


### PR DESCRIPTION
Show correct sorting icon when sorting data in ListViews: when sorting == `ASC` use class `suitepicon-action-sorting-ascending`, else use class `suitepicon-action-sorting-descending`.

## Motivation and Context
Fixes #8295 

## How To Test This
1. Open any Listview.
2. Click search button.
3. When data shows, click to order records by some field.
4. The data is shown in the correct order. Also, hovering the sorting icons shows the correct description of the sorting (Ascendant / Descendant)
5. The sorting icon that shows highlighted is the correct one.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->