### PR TITLE
Add tests and PHPDocs for return_bytes function

### DIFF
--- a/include/utils.php
+++ b/include/utils.php
@@ -3668,7 +3668,12 @@ function mark_delete_components($sub_object_array, $run_second_level = false, $s
 }
 
 /**
- * For translating the php.ini memory values into bytes.  e.g. input value of '8M' will return 8388608.
+ * Translates php.ini memory values into bytes.
+ * For example, an input value of '8M' will return 8388608.
+ * 8M is 8 mebibytes, 1 mebibyte is 1,048,576 bytes or 2^20 bytes.
+ * 
+ * @param string $val A string like '8M'.
+ * @return integer The number of bytes represented by that string.
  */
 function return_bytes($val)
 {
@@ -3695,13 +3700,10 @@ function return_bytes($val)
  */
 function url2html($string)
 {
-    //
     $return_string = preg_replace('/(\w+:\/\/)(\S+)/', ' <a href="\\1\\2" target="_new"  style="font-weight: normal;">\\1\\2</a>', $string);
 
     return $return_string;
 }
-
-// End customization by Julian
 
 /**
  * tries to determine whether the Host machine is a Windows machine.

--- a/tests/unit/phpunit/include/UtilsTest.php
+++ b/tests/unit/phpunit/include/UtilsTest.php
@@ -154,4 +154,26 @@ class UtilsTest extends SuitePHPUnitFrameworkTestCase
         // Handles versions with a `-dev` suffix correctly.
         $this->assertEquals(check_php_version("7.4.0-dev", $minimumVersion, $recommendedVersion), 1);
     }
+
+    public function testreturn_bytes()
+    {
+        // Test bytes. If you input just '8', it'll output 8.
+        $this->assertEquals(return_bytes('8'), 8);
+
+        // Test kibibytes.
+        $this->assertEquals(return_bytes('8K'), 8192);
+        $this->assertEquals(return_bytes('8k'), 8192);
+
+        // Test mebibytes.
+        // 8M is 8 mebibytes, 1 mebibyte is 1,048,576 bytes or 2^20 bytes.
+        $this->assertEquals(return_bytes('8M'), 8388608);
+        $this->assertEquals(return_bytes('8m'), 8388608);
+
+        // Test gibibytes
+        $this->assertEquals(return_bytes('8G'), 8589934592);
+        $this->assertEquals(return_bytes('8g'), 8589934592);
+
+        // Make sure it also understands strings with whitespace.
+        $this->assertEquals(return_bytes('  8K  '), 8192);
+    }
 }


### PR DESCRIPTION
## Description
Continuing my spelunking through utils.php for functions that are unused or untested, this one has a few uses throughout the codebase so I've added tests for it.

## Motivation and Context
Test coverage :)

The values are for memory, which I guess is measured in kibi/mebi/gibibytes? I was under the impression is was kilo/mega/gigabytes, but apparently not according to this function.

Also this function should maybe be updated to include support for tibibytes ;)

## How To Test This
Make sure the tests pass.

## Types of changes
Adding tests and PHPDocs :)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.