### PR TITLE
Backport more PHP 7.4 fixes

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -1530,7 +1530,7 @@ class SugarBean
                 $GLOBALS['log']->warn('Children info is not an array');
             }
             foreach ((array)$children_info as $child_info) {
-                if ($child_info['type'] == 'parent') {
+                if (is_array($child_info) && $child_info['type'] == 'parent') {
                     if (!isset($child_info['parent_type'])) {
                         $GLOBALS['log']->fatal('"parent_type" is not set');
                     }

--- a/include/SearchForm/SearchForm2.php
+++ b/include/SearchForm/SearchForm2.php
@@ -271,8 +271,13 @@ class SearchForm
                     $this->searchdefs['templateMeta']['widths']['field'] * $resize;
             }
         }
-        $this->th->ss->assign('templateMeta', $this->searchdefs['templateMeta']);
-        $this->th->ss->assign('HAS_ADVANCED_SEARCH', !empty($this->searchdefs['layout']['advanced_search']));
+        if (is_null($this->searchdefs)) {
+            $this->th->ss->assign('templateMeta', null);
+            $this->th->ss->assign('HAS_ADVANCED_SEARCH', false);
+        } else {
+            $this->th->ss->assign('templateMeta', $this->searchdefs['templateMeta']);
+            $this->th->ss->assign('HAS_ADVANCED_SEARCH', !empty($this->searchdefs['layout']['advanced_search']));
+        }
         $this->th->ss->assign('displayType', $this->displayType);
         // return the form of the shown tab only
         if ($this->showSavedSearchesOptions) {

--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -624,7 +624,7 @@ class AOW_WorkFlow extends Basic
             }
         }
 
-        if (!isset($bean->date_entered)) {
+        if (!isset($bean->date_entered) && $bean->fetched_row !== false) {
             $bean->date_entered = $bean->fetched_row['date_entered'];
         }
 

--- a/modules/Cases/Case.php
+++ b/modules/Cases/Case.php
@@ -407,7 +407,7 @@ class aCase extends Basic
         // Get the id and the name.
         $row = $this->db->fetchByAssoc($result);
 
-        if ($row !== null) {
+        if ($row !== null && $row !== false) {
             $ret_array['account_name'] = stripslashes($row['name']);
             $ret_array['account_id'] = $row['id'];
         } else {

--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -5957,7 +5957,11 @@ class InboundEmail extends SugarBean
             $r = $this->db->query($q, true);
             $a = $this->db->fetchByAssoc($r);
 
-            return $a['id'];
+            if ($a === false) {
+                return null;
+            } else {
+                return $a['id'];
+            }
         }
 
         return false;
@@ -6150,7 +6154,7 @@ class InboundEmail extends SugarBean
         $storedOptions = unserialize(base64_decode($this->stored_options));
 
         //TODO figure out if the since date is UDT
-        if ($storedOptions['only_since']) {// POP3 does not support Unseen flags
+        if (!is_bool($storedOptions) && $storedOptions['only_since']) {// POP3 does not support Unseen flags
             if (!isset($storedOptions['only_since_last']) && !empty($storedOptions['only_since_last'])) {
                 $q = "SELECT last_run FROM schedulers WHERE job = '{$this->job_name}'";
                 $r = $this->db->query($q, true);

--- a/modules/Meetings/Meeting.php
+++ b/modules/Meetings/Meeting.php
@@ -1026,7 +1026,13 @@ function getMeetingsExternalApiDropDown($focus = null, $name = null, $value = nu
         $dictionaryMeeting = $dictionary['Meeting'];
     }
 
-    if ($dictionaryMeeting['fields']['type']['options'] != "eapm_list") {
+    // Protect against null.
+    if (
+        is_null($dictionaryMeeting)
+        || is_null($dictionaryMeeting['fields'])
+        || is_null($dictionaryMeeting['fields']['type'])
+        || $dictionaryMeeting['fields']['type']['options'] != "eapm_list"
+    ) {
         $apiList = array_merge(getMeetingTypeOptions($dictionary, $app_list_strings), $apiList);
     }
 

--- a/modules/ProjectTask/updateDependencies.php
+++ b/modules/ProjectTask/updateDependencies.php
@@ -49,7 +49,14 @@ class updateDependencies
         $Task = BeanFactory::getBean('ProjectTask');
         $tasks = $Task->get_full_list("", "project_task.project_id = '".$bean->project_id."' AND project_task.predecessors = '".$bean->project_task_id."'");
 
-        if ($bean->date_finish != $bean->fetched_row['date_finish']) { //if the end date of a current task is changed
+        // Make sure the fetched row exists.
+        if ($bean->fetched_row === false) {
+            $fetchedDateFinish = null;
+        } else {
+            $fetchedDateFinish = $bean->fetched_row['date_finish'];
+        }
+
+        if ($bean->date_finish != $fetchedDateFinish) { //if the end date of a current task is changed
 
             $diff = $this->count_days($bean->date_finish, $bean->fetched_row['date_finish']); //Gets the difference in days
 

--- a/modules/jjwg_Areas/jjwg_Areas.php
+++ b/modules/jjwg_Areas/jjwg_Areas.php
@@ -242,8 +242,13 @@ class jjwg_Areas extends jjwg_Areas_sugar
             $loc['lng'] = $marker['lng'];
         } else {
             $loc['name'] = '';
-            $loc['lat'] = $this->centroid['lat'];
-            $loc['lng'] = $this->centroid['lng'];
+            if (is_null($this->centroid)) {
+                $loc['lat'] = null;
+                $loc['lng'] = null;
+            } else {
+                $loc['lat'] = $this->centroid['lat'];
+                $loc['lng'] = $this->centroid['lng'];
+            }
         }
 
         if (empty($loc['name'])) {

--- a/modules/jjwg_Maps/jjwg_Maps.php
+++ b/modules/jjwg_Maps/jjwg_Maps.php
@@ -1112,13 +1112,18 @@ class jjwg_Maps extends jjwg_Maps_sugar
                 $GLOBALS['log']->debug(__METHOD__.' Project to Opportunity');
                 $result = $this->db->limitQuery($query, 0, 1);
                 $opportunity = $this->db->fetchByAssoc($result);
-                // Find Account - Assume only one related Account for the Opportunity
-                $query = "SELECT accounts.*, accounts_cstm.* FROM accounts LEFT JOIN accounts_cstm ON accounts.id = accounts_cstm.id_c " .
-                        " LEFT JOIN accounts_opportunities ON accounts.id = accounts_opportunities.account_id AND accounts_opportunities.deleted = 0 " .
-                        " WHERE accounts.deleted = 0 AND accounts_opportunities.opportunity_id = '" . $opportunity['id'] . "'";
-                $GLOBALS['log']->debug(__METHOD__.' Opportunity to Account');
-                $result = $this->db->limitQuery($query, 0, 1);
-                $fields = $this->db->fetchByAssoc($result);
+                if ($opportunity === false) {
+                    $result = null;
+                    $fields = null;
+                } else {
+                    // Find Account - Assume only one related Account for the Opportunity
+                    $query = "SELECT accounts.*, accounts_cstm.* FROM accounts LEFT JOIN accounts_cstm ON accounts.id = accounts_cstm.id_c " .
+                            " LEFT JOIN accounts_opportunities ON accounts.id = accounts_opportunities.account_id AND accounts_opportunities.deleted = 0 " .
+                            " WHERE accounts.deleted = 0 AND accounts_opportunities.opportunity_id = '" . $opportunity['id'] . "'";
+                    $GLOBALS['log']->debug(__METHOD__.' Opportunity to Account');
+                    $result = $this->db->limitQuery($query, 0, 1);
+                    $fields = $this->db->fetchByAssoc($result);
+                }
             }
 
             if (!empty($fields)) {
@@ -1133,8 +1138,13 @@ class jjwg_Maps extends jjwg_Maps_sugar
             $result = $this->db->limitQuery($query, 0, 1);
             $meeting = $this->db->fetchByAssoc($result);
 
-            $parent_type = $meeting['parent_type'];
-            $parent_id = $meeting['parent_id'];
+            if ($meeting === false) {
+                $parent_type = null;
+                $parent_id = null;
+            } else {
+                $parent_type = $meeting['parent_type'];
+                $parent_id = $meeting['parent_id'];
+            }
             $GLOBALS['log']->debug(__METHOD__.' Meeting $parent_type: '.$parent_type);
             $GLOBALS['log']->debug(__METHOD__.' Meeting $parent_id: '.$parent_id);
 


### PR DESCRIPTION
## Description
Backporting some fixes from #7987, this is a follow-up on #8233.

This avoids cherrypicking any changes involving `$mod_strings`, since IMO we should figure out a proper fix for that ever being `null`, rather than spending the time to figure out how to protect it from being `null` throughout the codebase.

## Motivation and Context
PHP 7.4 comes out on November 28th so we should try to be ready for it :)

## How To Test This
Make sure the tests pass and the general changes make sense.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.