### PR TITLE
 Fix #8309 - Don't add delete action button without checking ACL Access

### DIFF
--- a/include/ListView/ListViewDisplay.php
+++ b/include/ListView/ListViewDisplay.php
@@ -411,14 +411,6 @@ class ListViewDisplay
             foreach ($this->actionsMenuExtraItems as $item) {
                 $menuItems[] = $item;
             }
-
-
-            if (
-                $this->delete
-                && !$this->show_action_dropdown_as_delete
-            ) {
-                $menuItems[] = $this->buildDeleteLink($location);
-            }
         }
         $link = array(
             'class' => 'clickMenu selectActions fancymenu',


### PR DESCRIPTION
Delete action button is properly added with ACL Access checking in line 354 of the same file, then this second snippet that adds the same button with similar logic but without checking ACL Access should be removed.

## Motivation and Context
Fixes #8309 

## How To Test This
1. With a user without permissions for delete action, open a ListView.
2. Click search button.
3. When data appears, select any record using the checkboxes at the left side of the first column.
4. Delete action button is not shown.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->