### PR TITLE
Fix parameter order for asserts in unit tests.

### DIFF
--- a/tests/unit/phpunit/include/UtilsTest.php
+++ b/tests/unit/phpunit/include/UtilsTest.php
@@ -97,9 +97,9 @@ class UtilsTest extends SuitePHPUnitFrameworkTestCase
 
     public function testget_languages()
     {
-        $this->assertEquals(get_languages(), ['en_us' => 'English (US)']);
-        $this->assertEquals(get_all_languages(), ['en_us' => 'English (US)']);
-        $this->assertEquals(get_language_display('en_us'), 'English (US)');
+        $this->assertEquals(['en_us' => 'English (US)'], get_languages());
+        $this->assertEquals(['en_us' => 'English (US)'], get_all_languages());
+        $this->assertEquals('English (US)', get_language_display('en_us'));
     }
 
     public function testget_current_language()
@@ -107,13 +107,13 @@ class UtilsTest extends SuitePHPUnitFrameworkTestCase
         global $sugar_config;
 
         $_SESSION['authenticated_user_language'] = 'foo';
-        $this->assertEquals(get_current_language(), 'foo');
-        $this->assertEquals(get_current_language(), 'foo');
+        $this->assertEquals('foo', get_current_language());
+        $this->assertEquals('foo', get_current_language());
 
         $sugar_config['default_language'] = 'bar';
-        $this->assertEquals(get_current_language(), 'foo');
+        $this->assertEquals('foo', get_current_language());
         unset($_SESSION['authenticated_user_language']);
-        $this->assertEquals(get_current_language(), 'bar');
+        $this->assertEquals('bar', get_current_language());
     }
 
     public function testis_admin()
@@ -142,38 +142,38 @@ class UtilsTest extends SuitePHPUnitFrameworkTestCase
         $recommendedVersion = '7.1.0';
 
         // Returns -1 when the version is less than the minimum version.
-        $this->assertEquals(check_php_version("5.4.0", $minimumVersion, $recommendedVersion), -1);
+        $this->assertEquals(-1, check_php_version("5.4.0", $minimumVersion, $recommendedVersion));
 
         // Returns 0 when the version is above the minimum but below the recommended version.
-        $this->assertEquals(check_php_version("7.0.0", $minimumVersion, $recommendedVersion), 0);
+        $this->assertEquals(0, check_php_version("7.0.0", $minimumVersion, $recommendedVersion));
 
         // Returns 1 when the version is at or above the recommended version.
-        $this->assertEquals(check_php_version("7.1.0", $minimumVersion, $recommendedVersion), 1);
-        $this->assertEquals(check_php_version("7.2.0", $minimumVersion, $recommendedVersion), 1);
-        $this->assertEquals(check_php_version("8.0.0", $minimumVersion, $recommendedVersion), 1);
+        $this->assertEquals(1, check_php_version("7.1.0", $minimumVersion, $recommendedVersion));
+        $this->assertEquals(1, check_php_version("7.2.0", $minimumVersion, $recommendedVersion));
+        $this->assertEquals(1, check_php_version("8.0.0", $minimumVersion, $recommendedVersion));
         // Handles versions with a `-dev` suffix correctly.
-        $this->assertEquals(check_php_version("7.4.0-dev", $minimumVersion, $recommendedVersion), 1);
+        $this->assertEquals(1, check_php_version("7.4.0-dev", $minimumVersion, $recommendedVersion));
     }
 
     public function testreturn_bytes()
     {
         // Test bytes. If you input just '8', it'll output 8.
-        $this->assertEquals(return_bytes('8'), 8);
+        $this->assertEquals(8, return_bytes('8'));
 
         // Test kibibytes.
-        $this->assertEquals(return_bytes('8K'), 8192);
-        $this->assertEquals(return_bytes('8k'), 8192);
+        $this->assertEquals(8192, return_bytes('8K'));
+        $this->assertEquals(8192, return_bytes('8k'));
 
         // Test mebibytes.
         // 8M is 8 mebibytes, 1 mebibyte is 1,048,576 bytes or 2^20 bytes.
-        $this->assertEquals(return_bytes('8M'), 8388608);
-        $this->assertEquals(return_bytes('8m'), 8388608);
+        $this->assertEquals(8388608, return_bytes('8M'));
+        $this->assertEquals(8388608, return_bytes('8m'));
 
         // Test gibibytes
-        $this->assertEquals(return_bytes('8G'), 8589934592);
-        $this->assertEquals(return_bytes('8g'), 8589934592);
+        $this->assertEquals(8589934592, return_bytes('8G'));
+        $this->assertEquals(8589934592, return_bytes('8g'));
 
         // Make sure it also understands strings with whitespace.
-        $this->assertEquals(return_bytes('  8K  '), 8192);
+        $this->assertEquals(8192, return_bytes('  8K  '));
     }
 }

--- a/tests/unit/phpunit/include/utils/arrayUtilsTest.php
+++ b/tests/unit/phpunit/include/utils/arrayUtilsTest.php
@@ -12,7 +12,7 @@ class array_utilsTest extends SuitePHPUnitFrameworkTestCase
 
         $expected = "array (\n  'Key1' => 'value1',\n  'Key2' => 'value2',\n)";
         $actual = var_export_helper($tempArray);
-        $this->assertSame($actual, $expected);
+        $this->assertSame($expected, $actual);
     }
 
     public function testoverride_value_to_string()
@@ -20,7 +20,7 @@ class array_utilsTest extends SuitePHPUnitFrameworkTestCase
         //execute the method and test if it returns expected values
         $expected = "\$array_name['value_name'] = 'value';";
         $actual = override_value_to_string('array_name', 'value_name', 'value');
-        $this->assertSame($actual, $expected);
+        $this->assertSame($expected, $actual);
     }
 
     public function testadd_blank_option()
@@ -30,14 +30,14 @@ class array_utilsTest extends SuitePHPUnitFrameworkTestCase
         $expected = array('' => '', 'Key1' => 'value1', 'Key2' => 'value2');
 
         $actual = add_blank_option($tempArray);
-        $this->assertSame($actual, $expected);
+        $this->assertSame($expected, $actual);
 
         //execute the method with array having a blank key value pair. function will return the same array back without any change.
         $tempArray = array('' => '', 'Key1' => 'value1', 'Key2' => 'value2');
         $expected = array('' => '', 'Key1' => 'value1', 'Key2' => 'value2');
 
         $actual = add_blank_option($tempArray);
-        $this->assertSame($actual, $expected);
+        $this->assertSame($expected, $actual);
     }
 
     public function testoverride_value_to_string_recursive()
@@ -48,7 +48,7 @@ class array_utilsTest extends SuitePHPUnitFrameworkTestCase
         $tempArray = array('Key1' => 'value1', 'Key2' => 'value2');
         $expected = "\$tempArray=array (\n  'Key1' => 'value1',\n  'Key2' => 'value2',\n);";
         $actual = override_value_to_string_recursive('', 'tempArray', $tempArray);
-        $this->assertSame($actual, $expected);
+        $this->assertSame($expected, $actual);
 
         //with keys
         $tempArray = array();
@@ -56,7 +56,7 @@ class array_utilsTest extends SuitePHPUnitFrameworkTestCase
         $expected = "\$tempArray['key1']['key2']=array (\n  'Key1' => \n  array (\n    'Key2' => \n    array (\n      'Key3' => 'value',\n      'Key4' => 'value',\n    ),\n  ),\n);";
         $actual = override_value_to_string_recursive(array('key1', 'key2'), 'tempArray', $tempArray);
 
-        $this->assertSame($actual, $expected);
+        $this->assertSame($expected, $actual);
     }
 
     public function testoverride_recursive_helper()
@@ -67,14 +67,14 @@ class array_utilsTest extends SuitePHPUnitFrameworkTestCase
         $tempArray = array('Key1' => 'value1', 'Key2' => 'value2');
         $expected = "=array (\n  'Key1' => 'value1',\n  'Key2' => 'value2',\n);";
         $actual = override_recursive_helper('', 'tempArray', $tempArray);
-        $this->assertSame($actual, $expected);
+        $this->assertSame($expected, $actual);
 
         //with keys
         $tempArray = array();
         $tempArray['Key1']['Key2'] = array('Key3' => 'value', 'Key4' => 'value');
         $expected = "['key1']['key2']=array (\n  'Key1' => \n  array (\n    'Key2' => \n    array (\n      'Key3' => 'value',\n      'Key4' => 'value',\n    ),\n  ),\n);";
         $actual = override_recursive_helper(array('key1', 'key2'), 'tempArray', $tempArray);
-        $this->assertSame($actual, $expected);
+        $this->assertSame($expected, $actual);
     }
 
     public function testoverride_value_to_string_recursive2()
@@ -84,20 +84,20 @@ class array_utilsTest extends SuitePHPUnitFrameworkTestCase
         //null array
         $expected = null;
         $actual = override_value_to_string_recursive2('tempArray', 'key1', '', false);
-        $this->assertSame($actual, $expected);
+        $this->assertSame($expected, $actual);
 
         //simple array
         $tempArray = array('Key1' => 'value1', 'Key2' => 'value2');
         $expected = "\$['tempArray']['Key1'] = 'value1';\n$['tempArray']['Key2'] = 'value2';\n";
         $actual = override_value_to_string_recursive2('', 'tempArray', $tempArray);
-        $this->assertSame($actual, $expected);
+        $this->assertSame($expected, $actual);
 
         //complex array
         $tempArray = array();
         $tempArray['Key1']['Key2'] = array('Key3' => 'value', 'Key4' => 'value');
         $expected = "\$tempArray['key1']['Key2']['Key3'] = 'value';\n\$tempArray['key1']['Key2']['Key4'] = 'value';\n";
         $actual = override_value_to_string_recursive2('tempArray', 'key1', $tempArray['Key1']);
-        $this->assertSame($actual, $expected);
+        $this->assertSame($expected, $actual);
     }
 
     public function testobject_to_array_recursive()
@@ -108,14 +108,14 @@ class array_utilsTest extends SuitePHPUnitFrameworkTestCase
         $obj = '';
         $expected = '';
         $actual = object_to_array_recursive($obj);
-        $this->assertSame($actual, $expected);
+        $this->assertSame($expected, $actual);
 
         //test with a valid object
         $obj = new TimeDate();
         $expected = array('dbDayFormat' => 'Y-m-d', 'dbTimeFormat' => 'H:i:s', 'allow_cache' => true);
         $actual = object_to_array_recursive($obj);
 
-        $this->assertSame($actual, $expected);
+        $this->assertSame($expected, $actual);
     }
 
     public function testdeepArrayDiff()
@@ -127,35 +127,35 @@ class array_utilsTest extends SuitePHPUnitFrameworkTestCase
         $tempArray2 = array('Key1' => 'value1', 'Key2' => 'value2');
         $expected = array();
         $actual = deepArrayDiff($tempArray1, $tempArray2);
-        $this->assertSame($actual, $expected);
+        $this->assertSame($expected, $actual);
 
         //different simple arrays
         $tempArray1 = array('Key1' => 'value1', 'Key2' => 'value2');
         $tempArray2 = array('Key1' => 'value1', 'Key2' => 'value3');
         $expected = array('Key2' => 'value2');
         $actual = deepArrayDiff($tempArray1, $tempArray2);
-        $this->assertSame($actual, $expected);
+        $this->assertSame($expected, $actual);
 
         //same complex arrays
         $tempArray1 = array('Key1' => array('Key2' => 'value2', 'Key3' => 'value3'));
         $tempArray2 = array('Key1' => array('Key2' => 'value2', 'Key3' => 'value3'));
         $expected = array();
         $actual = deepArrayDiff($tempArray1, $tempArray2);
-        $this->assertSame($actual, $expected);
+        $this->assertSame($expected, $actual);
 
         //complex arrays with different root node
         $tempArray1 = array('Key1' => array('Key2' => 'value2', 'Key3' => 'value3'));
         $tempArray2 = array('Key2' => array('Key2' => 'value2', 'Key3' => 'value3'));
         $expected = array('Key1' => array('Key2' => 'value2', 'Key3' => 'value3'));
         $actual = deepArrayDiff($tempArray1, $tempArray2);
-        $this->assertSame($actual, $expected);
+        $this->assertSame($expected, $actual);
 
         //complex arrays with different child node
         $tempArray1 = array('Key1' => array('Key2' => 'value2', 'Key3' => 'value3'));
         $tempArray2 = array('Key1' => array('Key2' => 'value2', 'Key4' => 'value4'));
         $expected = array('Key1' => array('Key3' => 'value3'));
         $actual = deepArrayDiff($tempArray1, $tempArray2);
-        $this->assertSame($actual, $expected);
+        $this->assertSame($expected, $actual);
     }
 
     public function testsetDeepArrayValue()


### PR DESCRIPTION
## Description
Fix the parameter order for asserts in tests.

## Motivation and Context

The expected value is supposed to go first, followed by the actual value. This swaps them in a few places that used the wrong order.

This is important because PHPUnit depends on this when showing diffs on test failure, so it can cause the output from PHPUnit to be confusing.

See [the docs for `assertEquals`](https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertEquals).

## How To Test This
Make sure CI passes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.