### PR TITLE
Remove Schedulers cron instructions from filter pop-up

### DIFF
--- a/modules/Schedulers/views/view.list.php
+++ b/modules/Schedulers/views/view.list.php
@@ -48,6 +48,8 @@ class SchedulersViewList extends ViewList
     public function display()
     {
         parent::display();
-        $this->seed->displayCronInstructions();
+        if (!($this->options['show_all'] === false)) {
+            $this->seed->displayCronInstructions();
+        }
     }
 }


### PR DESCRIPTION
## Description
![image](https://user-images.githubusercontent.com/15945027/69742031-fe8ed800-1133-11ea-8424-6f709ab267d5.png)

## How To Test This

Try this first without the fix, to see the problem

1. Open Admin / Schedulers
1. Enter the Filters dialog pop-up
1. Click the tabs (switch from `Quick Filter` to `Advanced filter` or vice-versa) until a new request is generated into the server, producing the cron instructions inside the dialog

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
