### PR TITLE
Fix #8323 - Avoid to return a value on function that is used within href attr in anchor elements

### DIFF
--- a/include/javascript/sugar_3.js
+++ b/include/javascript/sugar_3.js
@@ -373,7 +373,7 @@ uids=new Array();for(i in ar){if(typeof(ar[i])!='function'&&ar[i]==1){uids.push(
 document.MassUpdate.uid.value=uids.join(',');if(uids.length==0)return false;return true;}
 else return false;}
 sugarListView.prototype.order_checks=function(order,orderBy,moduleString){checks=sugarListView.get_checks();document.MassUpdate.elements[moduleString].value=orderBy;document.MassUpdate.lvso.value=order;if(typeof document.MassUpdate.massupdate!='undefined'){document.MassUpdate.massupdate.value='false';}
-document.MassUpdate.action.value=document.MassUpdate.return_action.value;document.MassUpdate.return_module.value='';document.MassUpdate.return_action.value='';document.MassUpdate.submit();return!checks;}
+document.MassUpdate.action.value=document.MassUpdate.return_action.value;document.MassUpdate.return_module.value='';document.MassUpdate.return_action.value='';document.MassUpdate.submit();}
 sugarListView.prototype.save_checks=function(offset,moduleString){checks=sugarListView.get_checks();if(typeof document.MassUpdate!='undefined'){document.MassUpdate.elements[moduleString].value=offset
 if(typeof document.MassUpdate.massupdate!='undefined'){document.MassUpdate.massupdate.value='false';}
 document.MassUpdate.action.value=document.MassUpdate.return_action.value;document.MassUpdate.return_module.value='';document.MassUpdate.return_action.value='';document.MassUpdate.submit();return!checks;}

--- a/jssource/src_files/include/javascript/sugar_3.js
+++ b/jssource/src_files/include/javascript/sugar_3.js
@@ -2310,9 +2310,8 @@ sugarListView.prototype.order_checks = function (order, orderBy, moduleString) {
   document.MassUpdate.return_module.value = '';
   document.MassUpdate.return_action.value = '';
   document.MassUpdate.submit();
-
-  return !checks;
 }
+
 sugarListView.prototype.save_checks = function (offset, moduleString) {
   checks = sugarListView.get_checks();
   if (typeof document.MassUpdate != 'undefined') {


### PR DESCRIPTION
Returning a value here produces a blank page when double clicking the anchor element that calls the function (the sort actions in the listview). 
Also, the return value seems to not be used anywhere and it can be safely removed.

## Description
Fixes #8323

## Motivation and Context
See #8323

## How To Test This
1. Browse a ListView.
2. Click search button.
3. When data is shown, double click on sort action in any field.
4. Data is ordered in the correct way and no blank page is shown.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
