### PR TITLE
Campaigns: Return to the previous view when clicking "Save" in "Manage Subscriptions"

### DIFF
--- a/modules/Campaigns/Subscriptions.php
+++ b/modules/Campaigns/Subscriptions.php
@@ -96,6 +96,7 @@ if (isset($_REQUEST['record'])) {
 //if subsaction has been set, then process subscriptions
 if (isset($_REQUEST['subs_action'])) {
     manageSubscriptions($focus);
+    SugarApplication::redirect("index.php?module=" . $_REQUEST['return_module'] . "&action=" . $_REQUEST['return_action'] . "&record=" . $_REQUEST['record']);
 }
 
 //$title = $GLOBALS['app_strings']['LBL_MANAGE_SUBSCRIPTIONS_FOR'].$focus->name;


### PR DESCRIPTION
## Description

In the "Manage Subscriptions" view pressing save just reloaded the page and didn't return
the user to the previous module. The only way was to click save and then cancel which is confusing.

This changes things to make it redirect to the source module after saving.

## Motivation and Context

It should be easy to change the subscription of a lead/contact.

## How To Test This

* Go to a lead
* Action menu -> Manage Subscriptions
* Click "Save"
* You should be back at the lead

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
