### PR TITLE
Campaign Wizard: Fix the attachment box being shifted down in the template editor

### DIFF
--- a/themes/SuiteP/tpls/footer.tpl
+++ b/themes/SuiteP/tpls/footer.tpl
@@ -146,12 +146,6 @@
                 $('#content').css({
                     'min-height': height + 'px'
                 });
-
-                // uploader fix
-                $('#step1_uploader').css({
-                    position: 'relative',
-                    top: ($('#wizard').height() - 90) + 'px'
-                });
             }
         });
 


### PR DESCRIPTION
## Description

For some reason there is some JS in the footer template to move #step1_uploader, which is
only used in the campaign wizard.

This resulted in the attachment box being shifted down quite a lot. Just remove it so it's right
below the template editor again.

## How To Test This

* Create a newsletter campaign
* Got to the template step
* See the attachment box right below the template editor

![Screenshot from 2019-11-28 15-19-57](https://user-images.githubusercontent.com/991986/69813842-550f1b80-11f3-11ea-930a-899aa756aa1e.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
