### PR TITLE
Adding fix to silent upgrade's upgrade history save.

### DIFF
--- a/modules/UpgradeWizard/silentUpgrade_step1.php
+++ b/modules/UpgradeWizard/silentUpgrade_step1.php
@@ -846,7 +846,26 @@ if ($upgradeType !== constant('DCE_INSTANCE')) {
                 } else {
                     $new_upgrade->description .= ' Silent Upgrade was used to upgrade the instance.';
                 }
-                $new_upgrade->save();
+
+                // Running db insert query as bean save will throw logic hook errors due to dependencies that are not set yet
+                $customID= create_guid();
+                $new_upgrade->date_entered = $GLOBALS['timedate']->nowDb();
+
+                $customIDQuoted = $db->quoted($customID);
+                $fileNameQuoted = $db->quoted($new_upgrade->filename);
+                $md5Quoted = $db->quoted($new_upgrade->md5sum);
+                $typeQuoted = $db->quoted($new_upgrade->type);
+                $statusQuoted = $db->quoted($new_upgrade->status);
+                $versionQuoted = $db->quoted($new_upgrade->version);
+                $nameQuoted = $db->quoted($new_upgrade->name);
+                $descriptionQuoted = $db->quoted($new_upgrade->description);
+                $manifestQuoted = $db->quoted($new_upgrade->manifest);
+                $dateQuoted = $db->quoted($new_upgrade->date_entered);
+
+                $upgradeHistoryInsert = "INSERT INTO `upgrade_history` (`id`, `filename`, `md5sum`, `type`, `status`, `version`, `name`, `description`, `id_name`, `manifest`, `date_entered`, `enabled`) 
+                                                     VALUES ($customIDQuoted, $fileNameQuoted, $md5Quoted, $typeQuoted, $statusQuoted, $versionQuoted, $nameQuoted, $descriptionQuoted, NULL, $manifestQuoted, $dateQuoted, '1')";
+                $result = $db->query($upgradeHistoryInsert, true, "Error writing upgrade history");
+
                 set_upgrade_progress('commit', 'in_progress', 'upgradeHistory', 'done');
                 set_upgrade_progress('commit', 'done', 'commit', 'done');
             }

--- a/modules/UpgradeWizard/silentUpgrade_step1.php
+++ b/modules/UpgradeWizard/silentUpgrade_step1.php
@@ -848,7 +848,7 @@ if ($upgradeType !== constant('DCE_INSTANCE')) {
                 }
 
                 // Running db insert query as bean save will throw logic hook errors due to dependencies that are not set yet
-                $customID= create_guid();
+                $customID = create_guid();
                 $new_upgrade->date_entered = $GLOBALS['timedate']->nowDb();
 
                 $customIDQuoted = $db->quoted($customID);
@@ -862,7 +862,7 @@ if ($upgradeType !== constant('DCE_INSTANCE')) {
                 $manifestQuoted = $db->quoted($new_upgrade->manifest);
                 $dateQuoted = $db->quoted($new_upgrade->date_entered);
 
-                $upgradeHistoryInsert = "INSERT INTO `upgrade_history` (`id`, `filename`, `md5sum`, `type`, `status`, `version`, `name`, `description`, `id_name`, `manifest`, `date_entered`, `enabled`) 
+                $upgradeHistoryInsert = "INSERT INTO upgrade_history (id, filename, md5sum, type, status, version, name, description, id_name, manifest, date_entered, enabled) 
                                                      VALUES ($customIDQuoted, $fileNameQuoted, $md5Quoted, $typeQuoted, $statusQuoted, $versionQuoted, $nameQuoted, $descriptionQuoted, NULL, $manifestQuoted, $dateQuoted, '1')";
                 $result = $db->query($upgradeHistoryInsert, true, "Error writing upgrade history");
 


### PR DESCRIPTION
## Description

This was failing due to a dependency in a logic hook - the direct save to the DB will bypass this. A larger fix should be to split step 1 of the silent upgrade process into two seperate steps - with one being an extendable way of adding files/dependencies before the upgrade process begins at all.


## Motivation and Context
The silent upgrade process would fail during the saving of upgrade history. This will allow for the upgrade process to complete successfully.

## How To Test This
As the new silentUpgrade_step1.php file will be copied over during the actual upgrade, it would not work for the first upgrade (therefore requiring a composer update prior). However, for testing purposes this file should be copied over and then the silent upgrade process followed (add the upgrade file to the correct directory and run ./vendor/bin/robo upgrade:suite <FILENAME> upgradeLog.log . admin

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->