### PR TITLE
Deprecate _pp functions.

### DIFF
--- a/XTemplate/xtpl.php
+++ b/XTemplate/xtpl.php
@@ -152,7 +152,6 @@ function __construct ($file, $alt_include = "", $mainblock="main") {
 	$this->alternate_include_directory = $alt_include;
 	$this->mainblock=$mainblock;
 	$this->filecontents=$this->r_getfile($file);	/* read in template file */
-	//if(substr_count($file, 'backup') == 1)_ppd($this->filecontents);
 	$this->blocks=$this->maketree($this->filecontents,$mainblock);	/* preprocess some stuff */
 	//$this->scan_globals();
 }

--- a/include/GroupedTabs/GroupedTabStructure.php
+++ b/include/GroupedTabs/GroupedTabStructure.php
@@ -135,8 +135,7 @@ class GroupedTabStructure
                 }
             }
         }
-        
-//        _pp($retStruct);
+
         return $retStruct;
     }
 }

--- a/include/ListView/ListViewXTPL.php
+++ b/include/ListView/ListViewXTPL.php
@@ -157,7 +157,6 @@ class ListViewXTPL extends ListViewDisplay
     public function processPagination()
     {
         global $app_strings;
-        //_pp($this->data['pageData']);
         if (empty($this->data['pageData']['urls']['prevPage'])) {
             $startLink = SugarThemeRegistry::current()->getImage("start_off", "border='0' align='absmiddle'", null, null, '.gif', $app_strings['LNK_LIST_START'])."&nbsp;".$app_strings['LNK_LIST_START'];
             $prevLink = SugarThemeRegistry::current()->getImage("previous_off", "border='0' align='absmiddle'", null, null, '.gif', $app_strings['LNK_LIST_PREVIOUS'])."&nbsp;".$app_strings['LNK_LIST_PREVIOUS'];

--- a/include/SubPanel/SubPanelDefinitions.php
+++ b/include/SubPanel/SubPanelDefinitions.php
@@ -131,9 +131,6 @@ class aSubPanel
             } else {
                 $instancePropertiesModule = $this->_instance_properties [ 'module' ];
             }
-            if (!is_dir('modules/' . $instancePropertiesModule)) {
-                _pstack_trace();
-            }
             if (!isset($this->_instance_properties [ 'subpanel_name' ])) {
                 $GLOBALS['log']->fatal('Invalid or missing SubPanelDefinition property: subpanel_name');
                 $def_path = null;

--- a/include/generic/DeleteRelationship.php
+++ b/include/generic/DeleteRelationship.php
@@ -57,7 +57,6 @@ ARGS:
   2) $_REQUEST['return_module']; :
   3) $_REQUEST['return_action']; :
 */
-//_ppd($_REQUEST);
 
 
 require_once('include/formbase.php');

--- a/include/generic/LayoutManager.php
+++ b/include/generic/LayoutManager.php
@@ -378,7 +378,6 @@ class LayoutManager
     public function widgetQuery($widget_def, $use_default = false)
     {
         $theclass = $this->getClassFromWidgetDef($widget_def, $use_default);
-        //				_pp($theclass);
         return $theclass->query($widget_def);
     }
 

--- a/include/generic/SugarWidgets/SugarWidgetField.php
+++ b/include/generic/SugarWidgets/SugarWidgetField.php
@@ -41,11 +41,6 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
-
-
-
-
-
 class SugarWidgetField extends SugarWidget
 {
     public function __construct(&$layout_manager)
@@ -67,11 +62,9 @@ class SugarWidgetField extends SugarWidget
         self::__construct($layout_manager);
     }
 
-
     public function display($layout_def)
     {
-        //print $layout_def['start_link_wrapper']."===";
-        $context = $this->layout_manager->getAttribute('context'); //_ppd($context);
+        $context = $this->layout_manager->getAttribute('context');
         $func_name = 'display'.$context;
 
         if (!empty($context) && method_exists($this, $func_name)) {

--- a/include/generic/SugarWidgets/SugarWidgetReportField.php
+++ b/include/generic/SugarWidgets/SugarWidgetReportField.php
@@ -96,7 +96,7 @@ class SugarWidgetReportField extends SugarWidgetField
     {
         $obj = $this->getSubClass($layout_def);
 
-        $context = $this->layout_manager->getAttribute('context');//_ppd($context);
+        $context = $this->layout_manager->getAttribute('context');
         $func_name = 'display'.$context;
 
 

--- a/include/utils.php
+++ b/include/utils.php
@@ -3124,6 +3124,7 @@ function br2nl($str)
  * Private helper function for displaying the contents of a given variable.
  * This function is only intended to be used for SugarCRM internal development.
  * The ppd stands for Pre Print Die.
+ * @deprecated This function is unused and will be removed in a future release.
  */
 function _ppd($mixed)
 {
@@ -3137,6 +3138,7 @@ function _ppd($mixed)
  * @param $mixed var to print_r()
  * @param $die boolean end script flow
  * @param $displayStackTrace also show stack trace
+ * @deprecated This function is unused and will be removed in a future release.
  */
 function _ppl($mixed, $die = false, $displayStackTrace = false, $loglevel = 'fatal')
 {
@@ -3168,6 +3170,7 @@ function _ppl($mixed, $die = false, $displayStackTrace = false, $loglevel = 'fat
  * The ppf stands for Pre[formatted] Print Focus [object].
  *
  * @param object bean The focus bean
+ * @deprecated This function is unused and will be removed in a future release.
  */
 function _ppf($bean, $die = false)
 {
@@ -3177,6 +3180,7 @@ function _ppf($bean, $die = false)
  * Private helper function for displaying the contents of a given variable.
  * This function is only intended to be used for SugarCRM internal development.
  * The pp stands for Pre Print.
+ * @deprecated This function is unused and will be removed in a future release.
  */
 function _pp($mixed)
 {
@@ -3186,6 +3190,7 @@ function _pp($mixed)
  * Private helper function for displaying the contents of a given variable.
  * This function is only intended to be used for SugarCRM internal development.
  * The pp stands for Pre Print.
+ * @deprecated This function is unused and will be removed in a future release.
  */
 function _pstack_trace($mixed = null)
 {
@@ -3195,6 +3200,7 @@ function _pstack_trace($mixed = null)
  * Private helper function for displaying the contents of a given variable.
  * This function is only intended to be used for SugarCRM internal development.
  * The pp stands for Pre Print Trace.
+ * @deprecated This function is unused and will be removed in a future release.
  */
 function _ppt($mixed, $textOnly = false)
 {
@@ -3204,6 +3210,7 @@ function _ppt($mixed, $textOnly = false)
  * Private helper function for displaying the contents of a given variable.
  * This function is only intended to be used for SugarCRM internal development.
  * The pp stands for Pre Print Trace Die.
+ * @deprecated This function is unused and will be removed in a future release.
  */
 function _pptd($mixed)
 {
@@ -3212,6 +3219,7 @@ function _pptd($mixed)
 /**
  * Private helper function for decoding javascript UTF8
  * This function is only intended to be used for SugarCRM internal development.
+ * @deprecated This function is unused and will be removed in a future release.
  */
 function decodeJavascriptUTF8($str)
 {

--- a/modules/Campaigns/Campaign.php
+++ b/modules/Campaigns/Campaign.php
@@ -119,7 +119,6 @@ class Campaign extends SugarBean
         $result = $this->db->query($query);
         $user = $this->db->fetchByAssoc($result);
 
-        //_ppd($user);
         if (!empty($user)) {
             if (is_array($user)) {
                 $fullName = $locale->getLocaleFormattedName($user['first_name'], $user['last_name']);

--- a/modules/Campaigns/GenerateWebToLeadForm.php
+++ b/modules/Campaigns/GenerateWebToLeadForm.php
@@ -68,7 +68,6 @@ $web_assigned_user = '';
 $web_team_user = '';
 $web_form_footer = '';
 $regex = "/^\w+(['\.\-\+]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,})+\$/";
-//_ppd($web_required_symbol);
 
 $moduleDir = '';
 if (!empty($_REQUEST['moduleDir'])) {

--- a/modules/Campaigns/PopupCampaignRoi.php
+++ b/modules/Campaigns/PopupCampaignRoi.php
@@ -64,7 +64,6 @@ $GLOBALS['log']->info("Campaign detail view");
 
 $xtpl=new XTemplate('modules/Campaigns/PopupCampaignRoi.html');
 
-//_pp($_REQUEST['id']);
 $campaign_id=$_REQUEST['id'];
 $campaign = new Campaign();
 $opp_query1  = "select camp.name, camp.actual_cost,camp.budget,camp.expected_revenue,count(*) opp_count,SUM(opp.amount) as Revenue, SUM(camp.actual_cost) as Investment,
@@ -189,7 +188,6 @@ $chart= new campaign_charts();
 //ob_end_clean();
 
 
-//_ppd($xtpl);
 //end chart
 
 $xtpl->parse("main");

--- a/modules/Campaigns/RoiDetailView.php
+++ b/modules/Campaigns/RoiDetailView.php
@@ -136,7 +136,7 @@ $campaign_id = $focus->id;
       if (empty($opp_data1['opp_count'])) {
           $opp_data1['opp_count']=0;
       }
-      //_ppd($opp_data1);
+
      $smarty->assign("OPPORTUNITIES_WON", $opp_data1['opp_count']);
           
             $camp_query1  = "select camp.name, count(*) click_thru_link";
@@ -200,7 +200,6 @@ $campaign_id = $focus->id;
     //$cache_file_name	= $current_user->getUserPrivGuid()."_campaign_response_by_activity_type_".$dateFileNameSafe[0]."_".$dateFileNameSafe[1].".xml";
     $cache_file_name_roi	= $current_user->getUserPrivGuid()."_campaign_response_by_roi_".$dateFileNameSafe[0]."_".$dateFileNameSafe[1].".xml";
     $chart= new campaign_charts();
-    //_ppd($roi_vals);
     $smarty->assign("MY_CHART_ROI", $chart->campaign_response_roi($app_list_strings['roi_type_dom'], $app_list_strings['roi_type_dom'], $focus->id, true, true));
     //end chart
     //custom chart code

--- a/modules/Campaigns/Save.php
+++ b/modules/Campaigns/Save.php
@@ -63,13 +63,11 @@ $focus = populateFromPost('', $focus);
 //store preformatted dates for 2nd save
 $preformat_start_date = $focus->start_date;
 $preformat_end_date = $focus->end_date;
-//_ppd($preformat_end_date);
 
 $focus->save($check_notify);
 $return_id = $focus->id;
 
 $GLOBALS['log']->debug("Saved record with id of ".$return_id);
-
 
 //copy compaign targets on duplicate
 if (!empty($_REQUEST['duplicateSave']) &&  !empty($_REQUEST['duplicateId'])) {

--- a/modules/Campaigns/TrackDetailView.php
+++ b/modules/Campaigns/TrackDetailView.php
@@ -262,7 +262,7 @@ $subpanel = new SubPanelTiles($focus, 'Campaigns');
                     }
                 }//end if (isset($subpane['function_parameters'])){
             }//end foreach($subpanels as $subpane_key => $subpane){
-        }//_pp($subpanel->subpanel_definitions->layout_defs);
+        }
     }//end else
 
 $deletedCampaignLogLeadsCount = $focus->getDeletedCampaignLogLeadsCount();

--- a/modules/Charts/code/Chart_outcome_by_month.php
+++ b/modules/Charts/code/Chart_outcome_by_month.php
@@ -274,7 +274,6 @@ echo get_validate_chart_js();
             $query .= " GROUP BY sales_stage,".DBManager::convert('opportunities.date_closed', 'date_format', array("'%Y-%m'"), array("'YYYY-MM'"))."ORDER BY m";
             //Now do the db queries
             //query for opportunity data that matches $datay and $user
-            //_pp($query);
 
             $result = $opp->db->query($query, true);
             //build pipeline by sales stage data

--- a/modules/Documents/Document.php
+++ b/modules/Documents/Document.php
@@ -329,7 +329,6 @@ class Document extends File
 
         global $app_list_strings;
         if (!empty($this->status_id)) {
-            //_pp($this->status_id);
             $this->status = $app_list_strings['document_status_dom'][$this->status_id];
         }
         if (!empty($this->related_doc_id)) {

--- a/modules/DynamicFields/templates/Fields/Forms/url.php
+++ b/modules/DynamicFields/templates/Fields/Forms/url.php
@@ -61,6 +61,5 @@ function get_body(&$ss, $vardef)
     $ss->assign('TARGET_OPTIONS', get_select_options_with_id($app_list_strings['link_target_dom'], $link_target));
     $ss->assign('LINK_TARGET', $link_target);
     $ss->assign('LINK_TARGET_LABEL', $app_list_strings['link_target_dom'][$link_target]);
-    //_ppd($ss->fetch('modules/DynamicFields/templates/Fields/Forms/url.tpl'));
     return $ss->fetch('modules/DynamicFields/templates/Fields/Forms/url.tpl');
 }

--- a/modules/EmailMarketing/DetailView.php
+++ b/modules/EmailMarketing/DetailView.php
@@ -148,7 +148,7 @@ if (!empty($focus->status)) {
 }
 $emails=array();
 $mailboxes=get_campaign_mailboxes($emails);
-//_ppd($emails[$focus->inbound_email_id]);
+
 if (!empty($focus->inbound_email_id) && isset($mailboxes[$focus->inbound_email_id])) {
     $xtpl->assign("FROM_MAILBOX_NAME", $mailboxes[$focus->inbound_email_id]."&nbsp;&lt;{$emails[$focus->inbound_email_id]}&gt;");
 }

--- a/modules/EmailTemplates/EmailTemplate.php
+++ b/modules/EmailTemplates/EmailTemplate.php
@@ -465,7 +465,6 @@ class EmailTemplate extends SugarBean
                 if (strpos($field_name, "user_") === 0) {
                     $userFieldName = substr($field_name, 5);
                     $value = $user->$userFieldName;
-                //_pp($userFieldName."[{$value}]");
                 } else {
                     if (isset($focus->{$field_name})) {
                         $value = $focus->{$field_name};

--- a/modules/EmailTemplates/EmailTemplateFormBase.php
+++ b/modules/EmailTemplates/EmailTemplateFormBase.php
@@ -353,13 +353,11 @@ EOQ;
 
         ///////////////////////////////////////////////////////////////////////////
         ////	ATTACHMENTS FROM DOCUMENTS
-        $count='';
-        //_pp($_REQUEST);
-        //_ppd(count($_REQUEST['document']));
+        $count = '';
         if (!empty($_REQUEST['document'])) {
             $count = count($_REQUEST['document']);
         } else {
-            $count=10;
+            $count = 10;
         }
 
         for ($i=0; $i<$count; $i++) {

--- a/modules/Emails/EmailUI.php
+++ b/modules/Emails/EmailUI.php
@@ -1028,8 +1028,6 @@ HTML;
 
         $r = $user->db->query($union);
 
-        //_pp($union);
-
         while ($a = $user->db->fetchByAssoc($r)) {
             $c = array();
 

--- a/modules/Emails/EmailUIAjax.php
+++ b/modules/Emails/EmailUIAjax.php
@@ -1688,7 +1688,6 @@ eoq;
             if (isset($_REQUEST['contactData'])) {
                 $contacts = $json->decode(from_HTML($_REQUEST['contactData']));
                 if ($contacts) {
-                    //_ppd($contacts);
                     $email->et->setContacts($contacts);
                 }
             }

--- a/modules/Emails/Grab.php
+++ b/modules/Emails/Grab.php
@@ -49,7 +49,6 @@ global $current_user;
 $focus = new Email();
 // Get Group User IDs
 $groupUserQuery = 'SELECT name, group_id FROM inbound_email ie INNER JOIN users u ON (ie.group_id = u.id AND u.is_group = 1)';
-_pp($groupUserQuery);
 $r = $focus->db->query($groupUserQuery);
 $groupIds = '';
 while ($a = $focus->db->fetchByAssoc($r)) {
@@ -61,7 +60,6 @@ $query = 'SELECT emails.id AS id FROM emails';
 $query .= " WHERE emails.deleted = 0 AND emails.status = 'unread' AND emails.assigned_user_id IN ({$groupIds})";
 //$query .= ' LIMIT 1';
 
-//_ppd($query);
 $r2 = $focus->db->query($query);
 $count = 0;
 $a2 = $focus->db->fetchByAssoc($r2);

--- a/modules/Emails/SugarRoutingAsync.php
+++ b/modules/Emails/SugarRoutingAsync.php
@@ -102,8 +102,6 @@ switch ($_REQUEST['routingAction']) {
             );
         }
         
-        //_ppd($ret);
-        
         $out = $json->encode($ret, true);
         echo $out;
     break;

--- a/modules/Groups/Save.php
+++ b/modules/Groups/Save.php
@@ -41,9 +41,6 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
-
-
-//_ppd($_REQUEST);
 $focus = new Group();
 
 // New user

--- a/modules/Home/Dashlets/InvadersDashlet/InvadersDashlet.php
+++ b/modules/Home/Dashlets/InvadersDashlet/InvadersDashlet.php
@@ -180,7 +180,6 @@ class InvadersDashlet extends Dashlet
     {
         if (isset($_REQUEST['savedText'])) {
             $optionsArray = $this->loadOptions();
-//            _pp($_REQUEST['savedText']);
             $optionsArray['savedText'] = nl2br($_REQUEST['savedText']);
             $this->storeOptions($optionsArray);
         } else {

--- a/modules/Home/SaveSubpanelLayout.php
+++ b/modules/Home/SaveSubpanelLayout.php
@@ -41,22 +41,17 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
-
-
-
 global $current_user;
 
 if (!empty($_REQUEST['layout']) && !empty($_REQUEST['layoutModule'])) {
-//    sleep (2);
-    //  _ppd($_REQUEST['layout']);
     $subpanels = explode(',', $_REQUEST['layout']);
-    
+
     $layoutParam = $_REQUEST['layoutModule'];
-    
+
     if (!empty($_REQUEST['layoutGroup']) && $_REQUEST['layoutGroup']!= translate('LBL_TABGROUP_ALL')) {
         $layoutParam .= ':'.$_REQUEST['layoutGroup'];
     }
-    
+
     $current_user->setPreference('subpanelLayout', $subpanels, 0, $layoutParam);
 } else {
     echo 'oops';

--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -280,8 +280,6 @@ class InboundEmail extends SugarBean
         );
         $raw = $this->generateFlatArrayFromMultiDimArray($multiDImArray, $this->retrieveDelimiter());
         sort($raw);
-        //_pp(explode(",", $this->mailbox));
-        //_ppd($raw);
         $raw = $this->filterMailBoxFromRaw(explode(",", $this->mailbox), $raw);
         $this->mailbox = implode(',', $raw);
         if (!empty($this->email_password)) {
@@ -1402,7 +1400,6 @@ class InboundEmail extends SugarBean
                         $this->pop3socket,
                         1024
                     ); // 8kb max buffer - shouldn't be more than 80 chars via pop3...
-                    //_pp(trim($buf));
 
                     if (trim($buf) == '.') {
                         $GLOBALS['log']->debug("*** GOT '.'");
@@ -1562,7 +1559,6 @@ class InboundEmail extends SugarBean
                         $this->pop3socket,
                         1024
                     ); // 8kb max buffer - shouldn't be more than 80 chars via pop3...
-                    //_pp(trim($buf));
 
                     if (trim($buf) == '.') {
                         $GLOBALS['log']->debug("*** GOT '.'");
@@ -1579,7 +1575,6 @@ class InboundEmail extends SugarBean
 
             // get cached UIDLs
             $cacheUIDLs = $this->pop3_getCacheUidls();
-            //			_pp($UIDLs);_pp($cacheUIDLs);
 
             // new email cache values we should deal with
             $diff = array_diff_assoc($UIDLs, $cacheUIDLs);
@@ -4239,7 +4234,6 @@ class InboundEmail extends SugarBean
      */
     public function buildBreadCrumbs($parts, $subtype, $breadcrumb = '0')
     {
-        //_pp('buildBreadCrumbs building for '.$subtype.' with BC at '.$breadcrumb);
         // loop through available parts in the array
         foreach ($parts as $k => $part) {
             // mark passage through level
@@ -4251,15 +4245,12 @@ class InboundEmail extends SugarBean
 
             // found a multi-part/mixed 'part' - keep digging
             if ($part->type == 1 && (strtoupper($part->subtype) == 'RELATED' || strtoupper($part->subtype) == 'ALTERNATIVE' || strtoupper($part->subtype) == 'MIXED')) {
-                //_pp('in loop: going deeper with subtype: '.$part->subtype.' $k is: '.$k);
                 $thisBc = $this->buildBreadCrumbs($part->parts, $subtype, $thisBc);
 
                 return $thisBc;
             } elseif (strtolower($part->subtype) == strtolower($subtype)) { // found the subtype we want, return the breadcrumb value
-                //_pp('found '.$subtype.' bc! returning: '.$thisBc);
                 return $thisBc;
             }
-            //_pp('found '.$part->subtype.' instead');
         }
     }
 
@@ -7108,7 +7099,6 @@ class InboundEmail extends SugarBean
 
             $email->to_addrs = $meta['toaddrs'];
             $email->date_sent_received = $meta['date_start'];
-            //_ppf($email,true);
 
             $this->email = $email;
             $this->email->email2init();
@@ -7501,7 +7491,6 @@ eoq;
             $arr[$k2]->date = $timedate->fromString($arr[$k2]->date)->asDb();
             $retArr[] = $arr[$k2];
         }
-        //_pp("final count: ".count($retArr));
 
         $finalReturn = array();
         $finalReturn['retArr'] = $retArr;

--- a/modules/ModuleBuilder/parsers/parser.modifylayoutview.php
+++ b/modules/ModuleBuilder/parsers/parser.modifylayoutview.php
@@ -245,7 +245,6 @@ class ParserModifyLayoutView extends ModuleBuilderParser
                 $this->_viewdefs ['panels'] [$panelID] [$rowID] = $newRow;
             }
         }
-        //          _pp($this->_viewdefs);
     }
 
     public function _padFields()

--- a/modules/ModuleBuilder/parsers/parser.modifylistview.php
+++ b/modules/ModuleBuilder/parsers/parser.modifylistview.php
@@ -103,7 +103,6 @@ class ParserModifyListView extends ModuleBuilderParser
         );
         $this->originalListViewDefs = $loaded['viewdefs'] [$this->module_name];
         $this->_variables = $loaded['variables'];
-        //		_pp($loaded);
         $this->customFile = 'custom/modules/' . $this->module_name . '/metadata/listviewdefs.php';
         if (file_exists($this->customFile)) {
             $loaded = $this->_loadFromFile('ListView', $this->customFile, $this->module_name);

--- a/modules/Relationships/Relationship.php
+++ b/modules/Relationships/Relationship.php
@@ -209,8 +209,6 @@ class Relationship extends SugarBean
             $this->load_relationship_meta();
         }
 
-        //		_ppd($GLOBALS['relationships']);
-
         if (array_key_exists($relationship_name, $GLOBALS['relationships'])) {
             foreach ($GLOBALS['relationships'][$relationship_name] as $field=>$value) {
                 $this->$field = $value;

--- a/modules/Schedulers/Scheduler.php
+++ b/modules/Schedulers/Scheduler.php
@@ -403,7 +403,6 @@ class Scheduler extends SugarBean
                 $hrName[] = $hrs;
             }
         }
-        //_pp($hrName);
         // derive minutes
         //$currentMin = date('i');
         $minName = array();
@@ -444,7 +443,6 @@ class Scheduler extends SugarBean
                 $minName[] = $mins;
             }
         }
-        //_pp($minName);
         // prep some boundaries - these are not in GMT b/c gmt is a 24hour period, possibly bridging 2 local days
         if (empty($focus->time_from)  && empty($focus->time_to)) {
             $timeFromTs = 0;
@@ -478,7 +476,6 @@ class Scheduler extends SugarBean
             //			$dateTimeEnd = '2020-12-31 23:59:59'; // if empty, set it to something ridiculous
         }
         $timeEndTs++;
-        /*_pp('hours:'); _pp($hrName);_pp('mins:'); _pp($minName);*/
         $dateobj = $timedate->getNow();
         $nowTs = $dateobj->ts;
         $GLOBALS['log']->debug(sprintf(
@@ -488,19 +485,7 @@ class Scheduler extends SugarBean
             gmdate('Y-m-d H:i:s', $timeEndTs),
             gmdate('Y-m-d H:i:s', $timeToTs),
             $timedate->nowDb()
-            ));
-        //		_pp('currentHour: '. $currentHour);
-        //		_pp('timeStartTs: '.date('r',$timeStartTs));
-        //		_pp('timeFromTs: '.date('r',$timeFromTs));
-        //		_pp('timeEndTs: '.date('r',$timeEndTs));
-        //		_pp('timeToTs: '.date('r',$timeToTs));
-        //		_pp('mktime: '.date('r',mktime()));
-        //		_pp('timeLastRun: '.date('r',$lastRunTs));
-//
-        //		_pp('hours: ');
-        //		_pp($hrName);
-        //		_pp('mins: ');
-        //		_ppd($minName);
+        ));
         foreach ($hrName as $kHr=>$hr) {
             foreach ($minName as $kMin=>$min) {
                 $timedate->tzUser($dateobj);
@@ -514,17 +499,12 @@ class Scheduler extends SugarBean
                                 if ($tsGmt <= $timeToTs) { // start is less than the time_to
                                     $validJobTime[] = $dateobj->asDb();
                                 }
-                                //_pp('Job Time is NOT smaller that TimeTO: '.$tsGmt .'<='. $timeToTs);
                             }
-                            //_pp('Job Time is NOT smaller that DateTimeEnd: '.date('Y-m-d H:i:s',$tsGmt) .'<='. $dateTimeEnd); //_pp( $tsGmt .'<='. $timeEndTs );
                         }
                     }
-                    //_pp('Job Time is NOT bigger that TimeFrom: '.$tsGmt .'>='. $timeFromTs);
                 }
-                //_pp('Job Time is NOT Bigger than DateTimeStart: '.date('Y-m-d H:i',$tsGmt) .'>='. $dateTimeStart);
             }
         }
-        //_ppd($validJobTime);
         // need ascending order to compare oldest time to last_run
         sort($validJobTime);
         /**

--- a/modules/Users/SaveSignature.php
+++ b/modules/Users/SaveSignature.php
@@ -55,8 +55,6 @@ $us->signature_html = $_REQUEST['description'];
 if (empty($us->user_id) && isset($_REQUEST['the_user_id'])) {
     $us->user_id = $_REQUEST['the_user_id'];
 }
-//_pp($_REQUEST);
-//_pp($us);
 $us->save();
 
 $js = '

--- a/modules/Users/User.php
+++ b/modules/Users/User.php
@@ -2272,7 +2272,6 @@ EOQ;
 
         $itemail = $this->emailAddress->getPrimaryAddress($this);
         //retrieve IT Admin Email
-        //_ppd( $emailTemp->body_html);
         //retrieve email defaults
         $emailObj = new Email();
         $defaults = $emailObj->getSystemDefaultEmail();


### PR DESCRIPTION
## Description

Deprecates the following functions:
- `_ppl`
- `_ppd`
- `_ppf`
- `_pp`
- `_ppt`
- `_pptd`
- `pstack_trace`
- `decodeJavascriptUTF8`

These were all unused or only used in one or two places. I've removed all instances of these functions that I found (mostly in commented code).

## Motivation and Context
Less code means less to worry about :)

## How To Test This
Make sure the functions are unused.

## Types of changes
Technical debt.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.