### PR TITLE
Add an 'Other' category to the PR template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,7 @@
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Other (code cleanup, fixing technical debt, commenting code, etc.)
 
 ### Final checklist
 <!--- Go over all the following points and check all the boxes that apply. --->


### PR DESCRIPTION
## Description
Adds an 'Other' category for changes that don't fit in the current three.

This is a PR on `master` because I'm pretty sure it needs to be on master for the template to actually have any effect.

## Motivation and Context
I frequently open PRs that don't fit in the three categories provided, so this'd be a nice improvement to have :)

## How To Test This
Just review the change :)

## Types of changes
Other ;)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.