### PR TITLE
The edit link may be set to point to the wrong module

### DIFF
--- a/include/ListView/ListViewNoMassUpdate.tpl
+++ b/include/ListView/ListViewNoMassUpdate.tpl
@@ -96,7 +96,7 @@
 			{if !empty($quickViewLinks)}
 			<td width='1%' nowrap>
 				{if $pageData.access.edit && $pageData.bean.moduleDir != "Employees"}
-					<a title='{$editLinkString}' id="edit-{$rowData.ID}" href='index.php?action=EditView&module={$params.module|default:$pageData.bean.moduleDir}&record={$rowData[$params.id]|default:$rowData.ID}&offset={$pageData.offsets.current+$smarty.foreach.rowIteration.iteration}&stamp={$pageData.stamp}&return_module={$params.module|default:$pageData.bean.moduleDir}' title="{sugar_translate label="LBL_EDIT_INLINE"}"> <span class="suitepicon suitepicon-action-edit"></span></a>
+					<a title='{$editLinkString}' id="edit-{$rowData.ID}" href='index.php?action=EditView&module={$pageData.bean.moduleDir}&record={$rowData.ID}&offset={$pageData.offsets.current+$smarty.foreach.rowIteration.iteration}&stamp={$pageData.stamp}&return_module={$pageData.bean.moduleDir}' title="{sugar_translate label="LBL_EDIT_INLINE"}"> <span class="suitepicon suitepicon-action-edit"></span></a>
 				{/if}
 			</td>
 			{/if}

--- a/themes/SuiteP/include/ListView/ListViewNoMassUpdate.tpl
+++ b/themes/SuiteP/include/ListView/ListViewNoMassUpdate.tpl
@@ -91,7 +91,7 @@
 			{if !empty($quickViewLinks)}
 			<td width='1%' nowrap>
 				{if $pageData.access.edit && $pageData.bean.moduleDir != "Employees"}
-					<a title='{$editLinkString}' id="edit-{$rowData.ID}" href='index.php?action=EditView&module={$params.module|default:$pageData.bean.moduleDir}&record={$rowData[$params.id]|default:$rowData.ID}&offset={$pageData.offsets.current+$smarty.foreach.rowIteration.iteration}&stamp={$pageData.stamp}&return_module={$params.module|default:$pageData.bean.moduleDir}' title="{sugar_translate label="LBL_EDIT_INLINE"}"><span class="suitepicon suitepicon-action-edit"></span></a>
+					<a title='{$editLinkString}' id="edit-{$rowData.ID}" href='index.php?action=EditView&module={$pageData.bean.moduleDir}&record={$rowData[$params.id]|default:$rowData.ID}&offset={$pageData.offsets.current+$smarty.foreach.rowIteration.iteration}&stamp={$pageData.stamp}&return_module={$params.module|default:$pageData.bean.moduleDir}' title="{sugar_translate label="LBL_EDIT_INLINE"}"><span class="suitepicon suitepicon-action-edit"></span></a>
 				{/if}
 			</td>
 			{/if}

--- a/themes/SuiteP/include/ListView/ListViewNoMassUpdate.tpl
+++ b/themes/SuiteP/include/ListView/ListViewNoMassUpdate.tpl
@@ -91,7 +91,7 @@
 			{if !empty($quickViewLinks)}
 			<td width='1%' nowrap>
 				{if $pageData.access.edit && $pageData.bean.moduleDir != "Employees"}
-					<a title='{$editLinkString}' id="edit-{$rowData.ID}" href='index.php?action=EditView&module={$pageData.bean.moduleDir}&record={$rowData[$params.id]|default:$rowData.ID}&offset={$pageData.offsets.current+$smarty.foreach.rowIteration.iteration}&stamp={$pageData.stamp}&return_module={$params.module|default:$pageData.bean.moduleDir}' title="{sugar_translate label="LBL_EDIT_INLINE"}"><span class="suitepicon suitepicon-action-edit"></span></a>
+					<a title='{$editLinkString}' id="edit-{$rowData.ID}" href='index.php?action=EditView&module={$pageData.bean.moduleDir}&record={$rowData.ID}&offset={$pageData.offsets.current+$smarty.foreach.rowIteration.iteration}&stamp={$pageData.stamp}&return_module={$pageData.bean.moduleDir}' title="{sugar_translate label="LBL_EDIT_INLINE"}"><span class="suitepicon suitepicon-action-edit"></span></a>
 				{/if}
 			</td>
 			{/if}


### PR DESCRIPTION
The edit link may be set to point to the wrong module.

## Description
In the unified search view, in a list view, the module in the edit link is set to the last column field module. This may not be the intended module.

## Motivation and Context
See description

## How To Test This
Add the account name to the contact module. Move the account name column to the last column. Perform a unified search using the top right search box. Observe that the contact edit link is point to the Account module.

For example:
https://localhost/index.php?action=EditView&module=Accounts&record=ad1ca218-f595-d30b-5e0d-5a3b29826b60&offset=1&stamp=1576553463003569200&return_module=Accounts

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

