### PR TITLE
Fix BeanFactory serving incomplete cached beans for Email Templates

### DIFF
--- a/modules/EmailTemplates/EmailTemplate.php
+++ b/modules/EmailTemplates/EmailTemplate.php
@@ -804,6 +804,12 @@ class EmailTemplate extends SugarBean
     {
         foreach ($bean_arr as $bean_name => $bean_id) {
             $focus = BeanFactory::getBean($bean_name, $bean_id);
+            if ($focus && $bean_id && !$focus->fetched_row) {
+                // We do not want the cached version for a newly created bean, as some data such as date fields and
+                // auto increment fields will only be correct after a retrieve operation
+                BeanFactory::unregisterBean($focus->module_dir, $focus->id);
+                $focus = BeanFactory::getBean($bean_name, $bean_id);
+            }
 
             if ($bean_name == 'Leads' || $bean_name == 'Prospects') {
                 $bean_name = 'Contacts';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Replicates a previous fix for AOW templates: #5842

When newly created beans are saved in the BeanFactory cache, they may contain incomplete data such as dates or auto increment fields. Those fields only contain the correct data after a retrieve operation. By busting the cache and forcing a retrieve operation the template can access the correct data.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes #3468 (closed but not fixed)

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Set up an email template containing a date field for any module (example Leads)
2. Ensure your profile date settings are not YYYY-MM-DD
3. Set up either a workflow or a logic hook which fires on Lead record creation
4. Set up that workflow or logic hook to send the previous email template
5. See the parsed date is in your profile format and not YYYY-MM-DD

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->