### PR TITLE
Fix #6000 for notifications not working when using mssql

### DIFF
--- a/modules/Reminders/Reminder.php
+++ b/modules/Reminders/Reminder.php
@@ -302,9 +302,7 @@ class Reminder extends Basic
         $dateTimeMax = $timedate->getNow(true)->modify("+{$app_list_strings['reminder_max_time']} seconds")->asDb(false);
 
         $dateTimeNow = $timedate->getNow(true)->asDb(false);
-
-        $dateTimeNow = $db->convert($db->quoted($dateTimeNow), 'datetime');
-        $dateTimeMax = $db->convert($db->quoted($dateTimeMax), 'datetime');
+        
 
         // Original jsAlert used to a meeting integration.
 


### PR DESCRIPTION

## Description
Removed lines 306 and 307 in Reminders.php:
```
$dateTimeNow = $db->convert($db->quoted($dateTimeNow), 'datetime');
$dateTimeMax = $db->convert($db->quoted($dateTimeMax), 'datetime');
```

## Bug

Issue https://github.com/salesagility/SuiteCRM/issues/6000

Popup Notifications not working when using MSSQL database
Stepping through the code, the issue is cased due to the $db->convert function. Wen using a MSSQL this results in the $dateTimeMax and $dateTimeNow variables not being formatted correctly. This means the WHERE clause on line 328 is incorrect and therefore getBean fails.

Tested on version 7.11.6

## Motivation and Context
Fixes notifications 

## How To Test This
Using a MSSQL db, test popup notifications for new meetings etc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->