### PR TITLE
Handle aliases more appropriately

### DIFF
--- a/include/ListView/ListViewSubPanel.php
+++ b/include/ListView/ListViewSubPanel.php
@@ -417,9 +417,16 @@ if (!defined('sugarEntry') || !sugarEntry) {
                                 $alias_field_def['name'] = $list_field['alias'];
                                 // Add alias field def into bean to can render field in subpanel
                                 $aItem->field_defs[$list_field['alias']] = $alias_field_def;
-                                if (!isset($fields[strtoupper($list_field['alias'])]) || empty($fields[strtoupper($list_field['alias'])])) {
+
+                                $fields[strtoupper($list_field['alias'])] = !empty($aItem->{$list_field['alias']})
+                                    ? $aItem->{$list_field['alias']}
+                                    : $aItem->$field_name;
+
+                                if (($alias_field_def['dbType'] ?? '') === 'datetime') {
                                     global $timedate;
-                                    $fields[strtoupper($list_field['alias'])] = (!empty($aItem->$field_name)) ? $aItem->$field_name : $timedate->to_display_date_time($aItem->{$list_field['alias']});
+                                    $fields[strtoupper($list_field['alias'])] = $timedate->to_display_date_time(
+                                        $aItem->{$list_field['alias']}
+                                    );
                                 }
                             } else {
                                 $list_field['name'] = $field_name;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sub Panel aliases experience some weird behaviour due to bean and list view query caching.
The first value gets processed correctly, but is then cached in the BeanFactory which ultimately causes the alias to be cached by the list view query. Ultimately this leads to a check on the cache always skipping any processing for subsequent record values, resulting in the values being set straight from the DB etc. Additionally whenever the logic is fired it coverts to user date time format regardless of field type meaning aliases can only really be used on date time columns. 

### Changes 
- Bypass cache check so aliased values always set.
- Check dbType before casting values to datetime.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->