### PR TITLE
Create images directory in cache if not exists

### DIFF
--- a/modules/Configurator/UploadFileCheck.php
+++ b/modules/Configurator/UploadFileCheck.php
@@ -101,6 +101,15 @@ if (file_exists($file_name) && is_file($file_name)) {
         if (($test>20 || $test<3)&& $returnArray['forQuotes'] == 'quotes') {
             $returnArray['data']='size';
         }
+
+        if (!is_dir(sugar_cached('images'))) {
+            try {
+                sugar_mkdir(sugar_cached('images'));
+            } catch (Exception $exception) {
+                $GLOBALS['log']->fatal('Unable to create cache directory \'images\'');
+            }
+        }
+
         copy($file_name, sugar_cached('images/' . str_replace(' ', '_', $upload->get_stored_file_name())));
     }
     if (!empty($returnArray['data'])) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When uploading a logo image, the temp file gets copied to the cache/images directory so that it can be displayed in the GUI as a preview. Currently this breaks if the target directory has not already been created by other functionality, resulting in a broken image link and lang string displayed as the image source path does not exist.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to admin -> system settings.
1. Upload a logo image.
1. See the broken image link and lang string.
1. Apply fix and try again.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->