### PR TITLE
Remove 'buggy version check' from php version checker.

### DIFF
--- a/include/utils.php
+++ b/include/utils.php
@@ -3255,15 +3255,6 @@ function check_php_version($sys_php_version = '', $min_php_version = '', $rec_ph
         return -1;
     }
 
-    // If there are some bug ridden versions, we should include them here
-    // and check immediately for one of this versions
-    $bug_php_versions = array();
-    foreach ($bug_php_versions as $v) {
-        if (version_compare($sys_php_version, $v, '=') === true) {
-            return -1;
-        }
-    }
-
     // If the checked version is between the minimum and recommended versions, return 0.
     if (version_compare($sys_php_version, $rec_php_version, '<') === true) {
         return 0;


### PR DESCRIPTION
## Description
This removes a 'buggy version check' from the PHP version check function in `utils.php`. This has been a huge thorn in my side for #7987.

For some reason this breaks on PHP 7.4, and we don't actually use it for anything, so I'm just removing it.

## Motivation and Context
I genuinely have no idea why this happens, but the code is hitting this part on 7.4 for some reason and causing issues like #8419, even though the buggy versions array is _empty_. It makes no sense, but it's the only explanation I have.

I tried reproducing this locally with a PHP script but it didn't have the same problem. I have absolutely no clue why this causes problems. I've already spent far too long on this issue, all I know is that this fixes it, and that's all I really care about at the moment.

## How To Test This
Make sure the tests pass in CI.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.