### PR TITLE
Fix the email address widget in custom convert lead

### DIFF
--- a/include/SugarEmailAddress/getEmailAddressWidget.php
+++ b/include/SugarEmailAddress/getEmailAddressWidget.php
@@ -51,7 +51,7 @@ function getEmailAddressWidget($focus, $field, $value, $view, $tabindex = '0')
     $sea = new SugarEmailAddress();
     $sea->setView($view);
 
-    if ($view == 'EditView' || $view == 'QuickCreate' || $view == 'ConvertLead') {
+    if ($view == 'EditView' || $view == 'QuickCreate' || strpos($view, 'ConvertLead') !== false) {
         $module = $focus->module_dir;
         if ($view == 'ConvertLead' && $module == "Contacts") {
             $module = "Leads";


### PR DESCRIPTION
The email address widget is not displayed properly in custom convert lead view

## Description
Instead of looking for the word "ConvertLead", the email address widget should look for any view that has the word "ConvertLead" in its name.

## Motivation and Context
The email address widget is displayed properly in custom convert lead view

## How To Test This
Create a custom convert lead in custom/modules/Leads/views/view.customconvertlead.php, example: 
"""
require_once("modules/Leads/views/view.convertlead.php");
class ViewCustomConvertLead extends ViewConvertLead{}
"""

Create custom/modules/Leads/metadata/convertdefs.php. Add an email field to the Contact module and the Account module.

Try to convert a lead to opportunity.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
