### PR TITLE
Allow external javascript in the detailed view

### DIFF
--- a/include/DetailView/footer.tpl
+++ b/include/DetailView/footer.tpl
@@ -43,3 +43,14 @@
 <script>SUGAR.util.doWhen("document.getElementById('form') != null",
         function(){ldelim}SUGAR.util.buildAccessKeyLabels();{rdelim});
 </script>
+
+{{if $externalJSFile}}
+{sugar_include include=$externalJSFile}
+{{/if}}
+
+{{if isset($scriptBlocks)}}
+<!-- Begin Meta-Data Javascript -->
+{{$scriptBlocks}}
+<!-- End Meta-Data Javascript -->
+{{/if}}
+


### PR DESCRIPTION
Allow external javascript in the detailed view

## Description
Allow including external javascript in the detailed view by adding viewdefs[<module name>]['DetailView']['templateMeta']['javascript'] configuration, such as
"""
'javascript' => '{sugar_getscript file="custom/modules/Opportunities/views/test.js"}',
"""

## Motivation and Context
This allows customizing the detailed view using a javascript. This is consistent with how we currently customizing the edit view with a javascript.

## How To Test This
Add a configuration as described in the Description session. Add a javascript such as
"""
$( document ).ready(function() {
    console.log("Hello Dominic!");
});
"""
as custom/modules/Opportunities/views/test.js. Go to Opportunities detailed view

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
