### PR TITLE
PDF attachment file name issue

### DIFF
--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -3059,6 +3059,11 @@ class Email extends Basic
 
                 // strip out the "Email attachment label if exists
                 $filename = str_replace($mod_strings['LBL_EMAIL_ATTACHMENT'] . ': ', '', $filename);
+		// correct encoding to handle special characters in PDF File Name. 
+		setlocale(LC_ALL, "en_US.utf8"); 
+		$filename = iconv('UTF-8','ASCII//TRANSLIT',$filename); 
+		$filename = str_replace('_', '.', $filename);
+		
                 $file_ext = pathinfo($filename, PATHINFO_EXTENSION);
                 //is attachment in our list of bad files extensions?  If so, append .txt to file location
                 //check to see if this is a file with extension located in "badext"


### PR DESCRIPTION
File name was not correct, if it contains any digits or hyphens.

## Description
Encoding for file name was not correct as reported in the issue https://github.com/salesagility/SuiteCRM/issues/8412
The change handles the file name which has any digit or special character in name. 

## Motivation and Context
PDF File Attachment has gibberish name when attached via Email PDF function.

## How To Test This

1. Click on Sales-->Quotes
2. Select and click on a Quote
3. Click on Actions tab.
4. Click on Email PDF.
5. Send Email PDF.
In the received Email check Attachment PDF file name. 

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist

- [ x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
