### PR TITLE
Fixed #8443 - Improve LanguageManager::clearLanguageCache()

### DIFF
--- a/include/SugarObjects/LanguageManager.php
+++ b/include/SugarObjects/LanguageManager.php
@@ -147,15 +147,17 @@ class LanguageManager
         }
         //if we have a module name specified then just remove that language file
         //otherwise go through each module and clean up the language
-        if (!empty($module_dir)) {
-            foreach ($languages as $clean_lang) {
-                LanguageManager::_clearCache($module_dir, $clean_lang);
-            }
-        } else {
-            $cache_dir = sugar_cached('modules/');
-            if (file_exists($cache_dir) && $dir = @opendir($cache_dir)) {
+        $cache_dir = sugar_cached('modules/');
+        if (file_exists($cache_dir)) {
+            if (!empty($module_dir)) {
+                if (is_dir($cache_dir . $module_dir)) {
+                    foreach ($languages as $clean_lang) {
+                        LanguageManager::_clearCache($module_dir, $clean_lang);
+                    }
+                }
+            } else if ($dir = @opendir($cache_dir)) {
                 while (($entry = readdir($dir)) !== false) {
-                    if ($entry == "." || $entry == "..") {
+                    if ($entry == "." || $entry == ".." || ! is_dir($cache_dir . $entry)) {
                         continue;
                     }
                     foreach ($languages as $clean_lang) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Issue reference: #8443 

Checks if an entry is a subdirectory of 'cache/modules/' before calling LanguageManager::_clearCache().

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The function LanguageManager::clearLanguageCache() causes PHP-FPM to throw a warning
when PHP-FPM has an enabled 'open_basedir' restriction and the directory 'cache/modules/' contains files.
This occurs because above function attempts to remove e.g. 'cache/modules/unified_search_modules.php/language/en_us.lang.php' through the subfunction LanguageManager::_clearCache().

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Please see "Steps to Reproduce" in Issue #8443 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->