### PR TITLE
Fixed #8445 - Improve SugarFeed::getAllFeedModules()

### DIFF
--- a/modules/SugarFeed/SugarFeed.php
+++ b/modules/SugarFeed/SugarFeed.php
@@ -229,7 +229,7 @@ class SugarFeed extends Basic
             }
             $d = dir($baseDir);
             while ($module = $d->read()) {
-                if (file_exists($baseDir.$module.'/SugarFeeds/')) {
+                if (is_dir($baseDir.$module) && file_exists($baseDir.$module.'/SugarFeeds/')) {
                     $dFeed = dir($baseDir.$module.'/SugarFeeds/');
                     while ($file = $dFeed->read()) {
                         if ($file[0] == '.') {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Issue reference: #8445

Checks if an entry is a subdirectory of 'modules/' or 'custom/modules/' before using file_exists().

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The function SugarFeed::getAllFeedModules() causes PHP-FPM to throw a warning
when PHP-FPM has an enabled 'open_basedir' restriction and the directories 'modules/' or 'custom/modules/' contain files.
This occurs because above function attempts to access e.g. 'custom/modules/logic_hooks.php/SugarFeeds/'.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Please see "Steps to Reproduce" in Issue #8445

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
