### PR TITLE
Statically Compile EXT Files & Studio Override Precedence 

### DIFF
--- a/ModuleInstall/ExtensionManager.php
+++ b/ModuleInstall/ExtensionManager.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace SuiteCRM\ModuleInstall;
+
+use \LoggerManager;
+
+/**
+ * Class ExtensionManager
+ */
+class ExtensionManager
+{
+    /**
+     * @var array
+     */
+    protected static $moduleList = [];
+
+    /**
+     * @var
+     */
+    protected static $logger;
+
+    /**
+     * Checks if authenticated and dies if not.
+     *
+     * @return void
+     */
+    protected static function handleAuth()
+    {
+        if (!defined('sugarEntry') || !sugarEntry) {
+            die('Not A Valid Entry Point');
+        }
+    }
+
+    /**
+     * Sets the static module and extension lists.
+     *
+     * @return void
+     */
+    protected static function initialise()
+    {
+        static::$moduleList = get_module_dir_list();
+        static::$logger = LoggerManager::getLogger();
+    }
+
+    /**
+     * Compiles source files for given extension to targeted file applying any given filters.
+     *
+     * @param string $extension Name of Extension i.e. 'Language'
+     * @param string $targetFileName Name of target file
+     * @param string $filter To filter file names such as language prefixes
+     * @param bool $applicationOnly Whether or not to only compile application extensions
+     * @return void
+     */
+    public static function compileExtensionFiles(
+        $extension,
+        $targetFileName,
+        $filter = '',
+        $applicationOnly = false
+    ) {
+        static::handleAuth();
+        static::initialise();
+
+        if ($extension === 'Language' && strpos($targetFileName, $filter) !== 0) {
+            $targetFileName = $filter . $targetFileName;
+        }
+
+        if (!$applicationOnly) {
+            static::compileModuleExtensions($extension, $targetFileName, $filter);
+        }
+
+        static::compileApplicationExtensions($extension, $targetFileName, $filter);
+    }
+
+    /**
+     * @param $extension
+     * @param $targetFileName
+     * @param string $filter
+     * @return void
+     */
+    protected static function compileApplicationExtensions(
+        $extension,
+        $targetFileName,
+        $filter = ''
+    ) {
+        static::$logger->{'debug'}("Merging application files for $targetFileName in $extension");
+
+        $extensionContents = '<?php' . PHP_EOL . '// WARNING: The contents of this file are auto-generated' . PHP_EOL;
+        $extPath = "application/Ext/$extension";
+        $moduleInstall  = "custom/Extension/$extPath";
+        $shouldSave = false;
+
+        if (is_dir($moduleInstall)) {
+            $dir = dir($moduleInstall);
+
+            while ($entry = $dir->read()) {
+                if (static::shouldSkipFile($entry, $moduleInstall, $filter)) {
+                    continue;
+                }
+                $shouldSave = true;
+                $file = file_get_contents("$moduleInstall/$entry");
+                $extensionContents .= PHP_EOL . static::removePhpTagsFromString($file);
+            }
+        }
+
+        if ($shouldSave) {
+            static::saveFile($extPath, $targetFileName, $extensionContents);
+            return;
+        }
+
+        static::unlinkFile($extPath, $targetFileName);
+    }
+
+    /**
+     * @param $extension
+     * @param $targetFileName
+     * @param string $filter
+     * @return void
+     */
+    protected static function compileModuleExtensions(
+        $extension,
+        $targetFileName,
+        $filter = ''
+    ) {
+        static::$logger->{'debug'}(
+            self::class . "::compileExtensionFiles() : Merging module files in " .
+            "custom/Extension/modules/<module>/$extension to custom/modules/<module>/$extension/$targetFileName"
+        );
+
+        foreach (static::$moduleList as $module) {
+            $extensionContents = '<?php'
+                . PHP_EOL
+                . '// WARNING: The contents of this file are auto-generated'
+                . PHP_EOL;
+
+            $extPath = "modules/$module/Ext/$extension";
+            $moduleInstall  = "custom/Extension/$extPath";
+            $shouldSave = false;
+
+            if (is_dir($moduleInstall)) {
+                $dir = dir($moduleInstall);
+                $shouldSave = true;
+                $override = [];
+
+                while ($entry = $dir->read()) {
+                    if (static::shouldSkipFile($entry, $moduleInstall, $filter)) {
+                        continue;
+                    }
+
+                    if (strpos($entry, '_override') === 0) {
+                        $override[] = $entry;
+                        continue;
+                    }
+
+                    $file = file_get_contents("$moduleInstall/$entry");
+                    static::$logger->{'debug'}(
+                        self::class . "->compileExtensionFiles(): found {$moduleInstall}{$entry}"
+                    );
+
+                    $extensionContents .= PHP_EOL . static::removePhpTagsFromString($file);
+                }
+
+                foreach ($override as $entry) {
+                    $file = file_get_contents("$moduleInstall/$entry");
+                    $extensionContents .= PHP_EOL . static::removePhpTagsFromString($file);
+                }
+            }
+
+            if ($shouldSave) {
+                static::saveFile($extPath, $targetFileName, $extensionContents);
+                continue;
+            }
+
+            static::unlinkFile($extPath, $targetFileName);
+        }
+    }
+
+    /**
+     * @param string $string
+     * @return string
+     */
+    protected static function removePhpTagsFromString($string)
+    {
+        return str_replace(
+            ['<?php', '?>', '<?PHP', '<?'],
+            '',
+            $string
+        );
+    }
+
+    /**
+     * @param $entry
+     * @param $moduleInstall
+     * @param $filter
+     * @return bool
+     */
+    protected static function shouldSkipFile(
+        $entry,
+        $moduleInstall,
+        $filter
+    ) {
+        if ($entry === '.' || $entry === '..' || strtolower(substr($entry, -4)) !== '.php') {
+            return true;
+        }
+
+        if (!is_file("$moduleInstall/$entry")) {
+            return true;
+        }
+
+        if (!empty($filter) && substr_count($entry, $filter) <= 0) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $extPath
+     * @param string $targetFileName
+     * @param string $extensionContents
+     * @return void
+     */
+    protected static function saveFile(
+        $extPath,
+        $targetFileName,
+        $extensionContents
+    ) {
+        if (!file_exists("custom/$extPath")) {
+            mkdir_recursive("custom/$extPath", true);
+        }
+
+        $extensionContents .= PHP_EOL;
+
+        $out = sugar_fopen("custom/$extPath/$targetFileName", 'wb');
+        fwrite($out, $extensionContents);
+        fclose($out);
+    }
+
+    /**
+     * @param $extPath
+     * @param $targetFileName
+     * @return void
+     */
+    protected static function unlinkFile($extPath, $targetFileName)
+    {
+        if (file_exists("custom/$extPath/$targetFileName")) {
+            unlink("custom/$extPath/$targetFileName");
+        }
+    }
+}

--- a/include/SugarObjects/LanguageManager.php
+++ b/include/SugarObjects/LanguageManager.php
@@ -202,10 +202,8 @@ class LanguageManager
             'custom/modules/' . $module . '/Ext/Language/' . $lang . '.lang.ext.php',
         );
 
-        require_once __DIR__ . '/../../ModuleInstall/ModuleInstaller.php';
-        $mi = new ModuleInstaller();
-        $mi->modules = [($module)];
-        $mi->merge_files('Ext/Language/', $lang . '.lang.ext.php', $lang);
+        require_once 'ModuleInstall/ExtensionManager.php';
+        SuiteCRM\ModuleInstall\ExtensionManager::compileExtensionFiles('Language', '.lang.ext.php', $lang);
 
         #27023, if this module template language file was not attached , get the template from this module vardef cache file if exsits and load the template language files.
         static $createdModules;

--- a/include/SugarObjects/LanguageManager.php
+++ b/include/SugarObjects/LanguageManager.php
@@ -202,6 +202,11 @@ class LanguageManager
             'custom/modules/' . $module . '/Ext/Language/' . $lang . '.lang.ext.php',
         );
 
+        require_once __DIR__ . '/../../ModuleInstall/ModuleInstaller.php';
+        $mi = new ModuleInstaller();
+        $mi->modules = [($module)];
+        $mi->merge_files('Ext/Language/', $lang . '.lang.ext.php', $lang);
+
         #27023, if this module template language file was not attached , get the template from this module vardef cache file if exsits and load the template language files.
         static $createdModules;
         if (empty($createdModules[$module]) && isset($GLOBALS['beanList'][$module])) {

--- a/include/utils/file_utils.php
+++ b/include/utils/file_utils.php
@@ -116,7 +116,7 @@ function remove_file_extension($filename)
 
 function write_array_to_file($the_name, $the_array, $the_file, $mode="w", $header='')
 {
-    if (!empty($header) && ($mode != 'a' || !file_exists($the_file))) {
+    if (!empty($header) && ($mode !== 'a' || $mode !== 'ab' || !file_exists($the_file))) {
         $the_string = $header;
     } else {
         $the_string =   "<?php\n" .
@@ -127,6 +127,27 @@ function write_array_to_file($the_name, $the_array, $the_file, $mode="w", $heade
                     ";";
 
     return sugar_file_put_contents($the_file, $the_string, LOCK_EX) !== false;
+}
+
+function write_override_label_to_file($the_name, $the_array, $the_file, $mode = 'w', $header = '')
+{
+    if (!empty($header) && ($mode !== 'a' || $mode !== 'ab' || !file_exists($the_file))) {
+        $the_string = $header;
+    } else {
+        $the_string = "<?php\n" .
+            '// created: ' . date('Y-m-d H:i:s') . "\n";
+    }
+
+    foreach ($the_array as $labelName => $labelValue) {
+        $the_string .= '$' . "{$the_name}['{$labelName}'] = '{$labelValue}';\n";
+    }
+
+    $result = sugar_file_put_contents($the_file, $the_string, LOCK_EX) !== false;
+
+    if (function_exists('opcache_invalidate')) {
+        opcache_invalidate($the_file, true);
+    }
+    return $result;
 }
 
 function write_encoded_file($soap_result, $write_to_dir, $write_to_file="")

--- a/modules/ModuleBuilder/parsers/parser.label.php
+++ b/modules/ModuleBuilder/parsers/parser.label.php
@@ -61,6 +61,11 @@ class ParserLabel
     protected $moduleName;
 
     /**
+     * @var LoggerManager
+     */
+    protected static $logger;
+
+    /**
      * ParserLabel constructor.
      * @param string $moduleName
      * @param string $packageName
@@ -71,6 +76,16 @@ class ParserLabel
         if (!empty($packageName)) {
             $this->packageName = $packageName;
         }
+
+        static::setLogger();
+    }
+
+    /**
+     * @return void
+     */
+    protected static function setLogger()
+    {
+        static::$logger = LoggerManager::getLogger();
     }
 
     /**
@@ -111,7 +126,9 @@ class ParserLabel
      */
     public static function removeLabel($language, $label, $labelvalue, $moduleName, $basepath = null, $forRelationshipLabel = false)
     {
-        $GLOBALS [ 'log' ]->debug("ParserLabel::removeLabels($language, \$label, \$labelvalue, $moduleName, $basepath );");
+        static::setLogger();
+
+        static::$logger->debug("ParserLabel::removeLabels($language, \$label, \$labelvalue, $moduleName, $basepath );");
         if (is_null($basepath)) {
             $deployedModule = true;
             $basepath = "custom/modules/$moduleName/language";
@@ -119,7 +136,7 @@ class ParserLabel
                 $basepath = "custom/modules/$moduleName/Ext/Language";
             }
             if (!is_dir($basepath)) {
-                $GLOBALS ['log']->debug("$basepath is not a directory.");
+                static::$logger->debug("$basepath is not a directory.");
 
                 return false;
             }
@@ -139,12 +156,12 @@ class ParserLabel
                 // obtain $mod_strings
                 include $filename;
             } else {
-                $GLOBALS ['log']->debug("file $filename does not exist.");
+                static::$logger->debug("file $filename does not exist.");
 
                 return false;
             }
         } else {
-            $GLOBALS ['log']->debug("directory $basepath does not exist.");
+            static::$logger->debug("directory $basepath does not exist.");
 
             return false;
         }
@@ -158,11 +175,11 @@ class ParserLabel
 
         if ($changed) {
             if (!write_array_to_file('mod_strings', $mod_strings, $filename)) {
-                $GLOBALS [ 'log' ]->fatal("Could not write $filename");
+                static::$logger->fatal("Could not write $filename");
             } else {
                 // if we have a cache to worry about, then clear it now
                 if ($deployedModule) {
-                    $GLOBALS ['log']->debug('PaserLabel::addLabels: clearing language cache');
+                    static::$logger->debug('PaserLabel::addLabels: clearing language cache');
                     $cache_key = 'module_language.'.$language.$moduleName;
                     sugar_cache_clear($cache_key);
                     LanguageManager::clearLanguageCache($moduleName, $language);
@@ -184,8 +201,10 @@ class ParserLabel
      */
     public static function addLabels($language, $labels, $moduleName, $basepath = null, $forRelationshipLabel = false)
     {
-        $GLOBALS ['log']->debug("ParserLabel::addLabels($language, \$labels, $moduleName, $basepath );");
-        $GLOBALS ['log']->debug('$labels:' . print_r($labels, true));
+        static::setLogger();
+
+        static::$logger->debug("ParserLabel::addLabels($language, \$labels, $moduleName, $basepath );");
+        static::$logger->debug('$labels:' . print_r($labels, true));
 
         $deployedModule = false;
         if (null === $basepath) {
@@ -225,15 +244,15 @@ class ParserLabel
         }
 
         if ($changed) {
-            $GLOBALS [ 'log' ]->debug("ParserLabel::addLabels: writing new mod_strings to $filename");
-            $GLOBALS [ 'log' ]->debug('ParserLabel::addLabels: mod_strings='.print_r($mod_strings, true));
+            static::$logger->debug("ParserLabel::addLabels: writing new mod_strings to $filename");
+            static::$logger->debug('ParserLabel::addLabels: mod_strings='.print_r($mod_strings, true));
             if (!write_override_label_to_file('mod_strings', $mod_strings, $filename)) {
-                $GLOBALS [ 'log' ]->fatal("Could not write $filename");
+                static::$logger->fatal("Could not write $filename");
             } else {
                 // if we have a cache to worry about, then clear it now
                 if ($deployedModule) {
                     SugarCache::cleanOpcodes();
-                    $GLOBALS [ 'log' ]->debug('PaserLabel::addLabels: clearing language cache');
+                    static::$logger->debug('PaserLabel::addLabels: clearing language cache');
                     $cache_key = 'module_language.'.$language.$moduleName;
                     sugar_cache_clear($cache_key);
                     LanguageManager::clearLanguageCache($moduleName, $language);
@@ -289,8 +308,8 @@ class ParserLabel
                     fwrite($file_contents, $out, strlen($out));
                     fclose($file_contents);
                 } catch (Exception $e) {
-                    $GLOBALS ['log']->fatal("Could not write $filename");
-                    $GLOBALS ['log']->fatal('Exception '.$e->getMessage());
+                    static::$logger->fatal("Could not write $filename");
+                    static::$logger->fatal('Exception '.$e->getMessage());
                 }
 
                 //2. Overwrite custom/Extension/modules/relationships/language/{ModuleName}.php
@@ -336,8 +355,8 @@ class ParserLabel
                     fwrite($file_contents, $out, strlen($out));
                     fclose($file_contents);
                 } catch (Exception $e) {
-                    $GLOBALS ['log']->fatal("Could not write $filename");
-                    $GLOBALS ['log']->fatal('Exception '.$e->getMessage());
+                    static::$logger->fatal("Could not write $filename");
+                    static::$logger->fatal('Exception '.$e->getMessage());
                     $failed_to_write = true;
                 }
 
@@ -346,7 +365,7 @@ class ParserLabel
                         // if we have a cache to worry about, then clear it now
                         if ($deployedModule) {
                             SugarCache::cleanOpcodes();
-                            $GLOBALS ['log']->debug('PaserLabel::addLabels: clearing language cache');
+                            static::$logger->debug('PaserLabel::addLabels: clearing language cache');
                             $cache_key = 'module_language.'.$language.$moduleName;
                             sugar_cache_clear($cache_key);
                             LanguageManager::clearLanguageCache($moduleName, $language);

--- a/modules/ModuleBuilder/parsers/parser.label.php
+++ b/modules/ModuleBuilder/parsers/parser.label.php
@@ -184,25 +184,19 @@ class ParserLabel
      */
     public static function addLabels($language, $labels, $moduleName, $basepath = null, $forRelationshipLabel = false)
     {
-        $GLOBALS [ 'log' ]->debug("ParserLabel::addLabels($language, \$labels, $moduleName, $basepath );");
-        $GLOBALS [ 'log' ]->debug('$labels:'.print_r($labels, true));
+        $GLOBALS ['log']->debug("ParserLabel::addLabels($language, \$labels, $moduleName, $basepath );");
+        $GLOBALS ['log']->debug('$labels:' . print_r($labels, true));
 
         $deployedModule = false;
         if (null === $basepath) {
             $deployedModule = true;
-            $basepath = "custom/modules/$moduleName/language";
-            if ($forRelationshipLabel) {
-                $basepath = "custom/modules/$moduleName/Ext/Language";
-            }
+            $basepath = "custom/Extension/modules/$moduleName/Ext/Language";
             if (!is_dir($basepath)) {
                 mkdir_recursive($basepath);
             }
         }
 
-        $filename = "$basepath/$language.lang.php";
-        if ($forRelationshipLabel) {
-            $filename = "$basepath/$language.lang.ext.php";
-        }
+        $filename = "$basepath/_override_$language.lang.php";
         $dir_exists = is_dir($basepath);
 
         $mod_strings = array();
@@ -233,7 +227,7 @@ class ParserLabel
         if ($changed) {
             $GLOBALS [ 'log' ]->debug("ParserLabel::addLabels: writing new mod_strings to $filename");
             $GLOBALS [ 'log' ]->debug('ParserLabel::addLabels: mod_strings='.print_r($mod_strings, true));
-            if (!write_array_to_file('mod_strings', $mod_strings, $filename)) {
+            if (!write_override_label_to_file('mod_strings', $mod_strings, $filename)) {
                 $GLOBALS [ 'log' ]->fatal("Could not write $filename");
             } else {
                 // if we have a cache to worry about, then clear it now


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

Provides static method for compiling extension files with filenames prefixed with _override from Studio taking priority. 

Intended to replace https://github.com/salesagility/SuiteCRM/pull/8081

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows for EXT files to be compiled without using ModuleInstaller::merge_files which is encumbered by the DB and fails on initial install when there is no DB present.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Apply this PR.
2. Make some non-studio language changes in the extensions frame work.
3. Make some studio language changes.
4. Run a Repair & Rebuild.
5. Do a fresh install ensuring the compiled `.ext` files do not exist.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->