### PR TITLE
Fix function declaration of TabController::get_key_array()

### DIFF
--- a/modules/MySettings/TabController.php
+++ b/modules/MySettings/TabController.php
@@ -85,13 +85,13 @@ class TabController
                         }
                     }
                     ACLController :: filterModuleList($tabs);
-                    $tabs = $this->get_key_array($tabs);
+                    $tabs = self::get_key_array($tabs);
                     $system_tabs_result = $tabs;
                 } else {
-                    $system_tabs_result = $this->get_key_array($moduleList);
+                    $system_tabs_result = self::get_key_array($moduleList);
                 }
             } else {
-                $system_tabs_result = $this->get_key_array($moduleList);
+                $system_tabs_result = self::get_key_array($moduleList);
             }
             self::$isCacheValid = true;
         }
@@ -103,7 +103,7 @@ class TabController
     {
         global $moduleList;
         $tabs = $this->get_system_tabs();
-        $unsetTabs = $this->get_key_array($moduleList);
+        $unsetTabs = self::get_key_array($moduleList);
         foreach ($tabs as $tab) {
             unset($unsetTabs[$tab]);
         }
@@ -157,7 +157,7 @@ class TabController
     }
 
 
-    public function get_key_array($arr)
+    public static function get_key_array($arr)
     {
         $new = array();
         if (!empty($arr)) {
@@ -183,7 +183,7 @@ class TabController
         $system_tabs = $this->get_system_tabs();
         $tabs = $user->getPreference($type .'_tabs');
         if (!empty($tabs)) {
-            $tabs = $this->get_key_array($tabs);
+            $tabs = self::get_key_array($tabs);
             if ($type == 'display') {
                 $tabs['Home'] =  'Home';
             }
@@ -199,7 +199,7 @@ class TabController
     {
         global $moduleList;
         $tabs = $this->get_user_tabs($user);
-        $unsetTabs = $this->get_key_array($moduleList);
+        $unsetTabs = self::get_key_array($moduleList);
         foreach ($tabs as $tab) {
             unset($unsetTabs[$tab]);
         }
@@ -213,7 +213,7 @@ class TabController
         $tabs = $user->getPreference('tabs');
     
         if (!empty($tabs)) {
-            $tabs = $this->get_key_array($tabs);
+            $tabs = self::get_key_array($tabs);
             $tabs['Home'] =  'Home';
             foreach ($tabs as $tab) {
                 if (!isset($system_tabs[$tab])) {

--- a/modules/MySettings/TabController.php
+++ b/modules/MySettings/TabController.php
@@ -84,7 +84,7 @@ class TabController
                             unset($tabs[$id]);
                         }
                     }
-                    ACLController :: filterModuleList($tabs);
+                     ACLController::filterModuleList($tabs);
                     $tabs = self::get_key_array($tabs);
                     $system_tabs_result = $tabs;
                 } else {

--- a/modules/MySettings/TabController.php
+++ b/modules/MySettings/TabController.php
@@ -84,7 +84,7 @@ class TabController
                             unset($tabs[$id]);
                         }
                     }
-                     ACLController::filterModuleList($tabs);
+                    ACLController::filterModuleList($tabs);
                     $tabs = self::get_key_array($tabs);
                     $system_tabs_result = $tabs;
                 } else {

--- a/modules/UpgradeWizard/silentUpgrade_dce_step2.php
+++ b/modules/UpgradeWizard/silentUpgrade_dce_step2.php
@@ -676,8 +676,8 @@ if ($upgradeType == constant('DCE_INSTANCE')) {
         $newTB = new TabController();
 
         //make sure new modules list has a key we can reference directly
-        $newModuleList = $newTB->get_key_array($newModuleList);
-        $oldModuleList = $newTB->get_key_array($oldModuleList);
+        $newModuleList = TabController::get_key_array($newModuleList);
+        $oldModuleList = TabController::get_key_array($oldModuleList);
 
         //iterate through list and remove commonalities to get new modules
         foreach ($newModuleList as $remove_mod) {

--- a/modules/UpgradeWizard/uw_utils.php
+++ b/modules/UpgradeWizard/uw_utils.php
@@ -3570,8 +3570,8 @@ function addNewSystemTabsFromUpgrade($from_dir)
         $newTB = new TabController();
 
         //make sure new modules list has a key we can reference directly
-        $newModuleList = $newTB->get_key_array($newModuleList);
-        $oldModuleList = $newTB->get_key_array($oldModuleList);
+        $newModuleList = TabController::get_key_array($newModuleList);
+        $oldModuleList = TabController::get_key_array($oldModuleList);
 
         //iterate through list and remove commonalities to get new modules
         foreach ($newModuleList as $remove_mod) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Declare the function TabController::get_key_array() as static function since
it is intended to be used as such and fix calls to this function that
assumed that it was a non-static function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Statically calling non-static functions is deprecated.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. In `php.ini` change the `error_reporting` setting from something like
```
error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
```
to
```
error_reporting = E_ALL & ~E_STRICT
```
2. Restart Apache (e.g. `service apache2 reload`) or PHP-FPM (e.g. `service php7.1-fpm restart`)
3. In SuiteCRM's Admin panel navigate to "Display Modules and Subpanels"
4. Check Apache error log for messages like
```
PHP Deprecated:  Non-static method TabController::get_key_array() should not be
called statically in
/var/www/html/suitecrm/include/SubPanel/SubPanelDefinitions.php on line 785
```
After applying this PR this message should not appear anymore.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
