### PR TITLE
Fixed #7306 - API v8 not working on php-fcgid - Missing /api/.htaccess

### DIFF
--- a/install/install_utils.php
+++ b/install/install_utils.php
@@ -1023,8 +1023,8 @@ EOQ;
     # -----------------------------
 
     RewriteRule ^Api/(.*)$ - [env=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
-    RewriteRule ^Api/access_token$ Api/index.php/access_token [L]
-    RewriteRule ^Api/V8/(.*?)$ Api/index.php/V8/$1 [L]
+    RewriteRule ^Api/access_token$ Api/index.php [L]
+    RewriteRule ^Api/V8/(.*?)$ Api/index.php [L]
 </IfModule>
 <IfModule mod_headers.c>
     Header unset ETag


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Issue reference: #7306
Issue reference: #8251

This PR fixes the process of rewriting the `.htaccess` file in two ways:
- when rewriting the `.htaccess` file any custom content before the
"# BEGIN SUITECRM RESTRICTIONS" marker and after the
"# END SUITECRM RESTRICTIONS" marker are written to the
new file at their original positions.
Before all custom content was placed before the BEGIN marker and the
BEGIN marker was written twice to the new file.
- remove paths after 'Api/index.php' in generated `.htaccess` file to allow
proper URL rewriting for API V8 calls

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Accessing the API V8 was only possible by using the URL path "Api/index.php/V8/*"
and rewriting the `/.htaccess` when it contained custom content after the END marker
resulted in malformed output (options/commands out of order).

Apparently people that upgraded from a previous version of SuiteCRM still
had an old `/Api/.htaccess` file that has been removed in newer versions.
With that file in place the URL rewriting worked
(e.g. "Api/access_token" to "Api/index.php/access_token")
as expected.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. (optional) Put some comments before the BEGIN marker and some comments after
the END marker in the `.htaccess` file. E.g.
```
#--test before
# BEGIN SUITECRM RESTRICTIONS
...
# END SUITECRM RESTRICTIONS
#--test after
```
2. Rewrite the `.htaccess` file by navigating to Admin panel -> Repair and click on "Rebuild .htaccess File"
3. (optional) Inspect the `.htaccess` file to see whether the custom content (i.e. the comments)
were placed were they belong
4. Use some application (e.g. 'curl' or 'Postman') to obtain an OAuth2 token  
(which requires setting up OAuth2 in SuiteCRM)  
using the URL path "Api/access_token"
5. Query some records, create a record etc. using the API V8 and the OAuth2 token
from step 4 using the URL path "Api/V8/*" (e.g. "Api/V8/module")

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
