### PR TITLE
Fixed #8366 - V8 API Filtering W/ OR Operator Chained Conditions

### DIFF
--- a/Api/V8/JsonApi/Repository/Filter.php
+++ b/Api/V8/JsonApi/Repository/Filter.php
@@ -44,7 +44,14 @@ class Filter
             unset($params['operator']);
         }
 
-        $params = $this->addDeletedParameter($params);
+        $deleted = false;
+        if (isset($params['deleted'])) {
+            if (isset($params['deleted']['eq'])) {
+                $deleted = ($params['deleted']['eq'] == 1);
+            }
+            
+            unset($params['deleted']);
+        }
 
         $where = [];
         foreach ($params as $field => $expr) {
@@ -75,12 +82,25 @@ class Filter
             }
         }
 
-        return implode(sprintf(' %s ', $operator), $where);
+        if (empty($where)) {
+            return sprintf(
+                "%s.deleted = '%d'",
+                $bean->getTableName(),
+                $deleted
+            );
+        }
+
+        return sprintf(
+            "(%s) AND %s.deleted = '%d'",
+            implode(sprintf(' %s ', $operator), $where),
+            $bean->getTableName(),
+            $deleted
+        );
     }
 
     /**
      * Only return deleted records if they were explicitly requested
-     *
+     * @deprecated
      * @param array $params
      * @return array
      */


### PR DESCRIPTION
# Description
Issue reference: #8366 

Grouped out filter params for query.

## Motivation and Context
Without grouping we fail to apply OR filter.
Example of generated query:
```sql
contacts.phone_mobile = '...' OR contacts.phone_work = '...' OR contacts.deleted = '0'
```
Should be:
```sql
(contacts.phone_mobile = '...' OR contacts.phone_work = '...') AND contacts.deleted = '0'
```

## How To Test This
* Create a Contact and set Phone Work and Phone Mobile for some values.
* Apply OR filter to GET modules API call, targeting Contacts.
  ```
  /V8/module/Contacts?filter[operator]=or&filter[phone_mobile][eq]=some_value&filter[phone_work][eq]=some_value
  ```
* Run some more tests with varying filter value.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.