### PR TITLE
fixes for Night sub theme

### DIFF
--- a/themes/SuiteP/css/Night/variables.scss
+++ b/themes/SuiteP/css/Night/variables.scss
@@ -932,9 +932,9 @@ $login-top-bar-bg: $color-7;
 
 // Buttons
 $default-btn-color: $color-81;
-$default-text-disabled-bg: $color-52;
-$default-text-disabled-color: $color-52;
-$default-text-disabled-border-color: $color-45;
+$default-text-disabled-bg: $color-19;
+$default-text-disabled-color: $color-19;
+$default-text-disabled-border-color: $color-19;
 $default-input-group-color: $color-40;
 $default-btn-bg: $color-83;
 $default-btn-bg-hover: $color-28;
@@ -1261,7 +1261,7 @@ $email-template-bg: $color-55;
 $email-new-record-bg-odd: $color-71;
 $email-new-record-bg-even: $color-67;
 $email-panel-bg: $color-60;
-$email-panel-color: $color-80;
+$email-panel-color: $color-81;
 $email-panel-font-size: 18px;
 $email-panel-height: 24px;
 $email-attachment-group-bg: $color-37;


### PR DESCRIPTION
## Description
When using the Night sub theme the email action buttons where not visible due to the colour of the panel being dark and the icons being dark, this change makes the icons light
The disabled text input boxes used the same background colour as the text, so the text was not visible, this change makes the background a dark colour instead of a light colour

## Motivation and Context
Improve usability

## How To Test This
Compile the Night theme CSS and goto the email module
Disabled text fields are a little more complicated but you could test using dev tools in Chrome to make any text box disabled to see the diff - we've created custom modules that have disabled text boxes in certain workflow...

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.