### PR TITLE
Fixed #8499 - API V8 issues for password grants SuiteCRM 7.10.22

### DIFF
--- a/Api/V8/OAuth2/Entity/UserEntity.php
+++ b/Api/V8/OAuth2/Entity/UserEntity.php
@@ -6,11 +6,23 @@ use League\OAuth2\Server\Entities\UserEntityInterface;
 class UserEntity implements UserEntityInterface
 {
     /**
+     * @var $userId
+     */
+    private $userId;
+
+    /**
+     * @param string $userId
+     */
+    public function __construct($userId)
+    {
+        $this->userId = $userId;
+    }
+
+    /**
      * @inheritdoc
      */
     public function getIdentifier()
     {
-        // we skip this right now, since we are not using scopes atm
-        return true;
+        return $this->userId;
     }
 }

--- a/Api/V8/OAuth2/Repository/AccessTokenRepository.php
+++ b/Api/V8/OAuth2/Repository/AccessTokenRepository.php
@@ -62,19 +62,9 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
         /** @var User $user */
         $client = $this->beanManager->getBeanSafe('OAuth2Clients', $clientId);
 
-        /** @var User $user */
-        $user = $this->beanManager->newBeanSafe('Users');
-
         switch ($client->allowed_grant_type) {
             case 'password':
-                if (!empty($_POST['username'])) {
-                    /** @var User $user */
-                    $user = $this->beanManager->newBeanSafe('Users');
-                    $user->retrieve_by_string_fields(
-                        ['user_name' => $_POST['username']]
-                    );
-                    $userId = $user->id;
-                }
+                $userId = $accessTokenEntity->getUserIdentifier();
                 break;
             case 'client_credentials':
                 $userId = $client->assigned_user_id;
@@ -84,8 +74,6 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
         if ($userId === null) {
             throw new InvalidArgumentException('No user found');
         }
-
-        $userId = !empty($user->id) ? $user->id : $client->assigned_user_id;
 
         /** @var OAuth2Tokens $token */
         $token = $this->beanManager->newBeanSafe(OAuth2Tokens::class);

--- a/Api/V8/OAuth2/Repository/UserRepository.php
+++ b/Api/V8/OAuth2/Repository/UserRepository.php
@@ -46,6 +46,6 @@ class UserRepository implements UserRepositoryInterface
             throw new \InvalidArgumentException('The password is invalid: ' . $password);
         }
 
-        return new UserEntity();
+        return new UserEntity($user->id);
     }
 }


### PR DESCRIPTION
## Description
Issue reference: #8499 

Implemented UserIdentifier for OAuth2 password grant.

## Motivation and Context
Fix needed to way of working with with user identifier represented by the access token.

## How To Test This
1. Create password grant oauth2 client. 
2. Request an access token:
   ```bash
   curl -v \
   -H 'Content-type: application/vnd.api+json' \
   -H 'Accept: application/vnd.api+json' \
   --data '{"grant_type":"password","client_id":"[UUID]","client_secret":"[SECRET]","username":"[username]","password":"[password]"}' \
   http://[SUITECRM_INSTANCE]/Api/access_token
   ```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.