### PR TITLE
Fixed #8472 - No or not complete Searchresults using elasticsearch engine

### DIFF
--- a/install/suite_install/Search.php
+++ b/install/suite_install/Search.php
@@ -73,7 +73,9 @@ function install_es()
         'host' => 'localhost',
         'user' => '',
         'pass' => '',
-        'index' => $sugar_config['unique_key']
+        'index' => $sugar_config['unique_key'],
+        'search_wildcard_char' => '%',
+        'search_wildcard_infront' => true
     ];
 
     ksort($sugar_config);
@@ -124,4 +126,3 @@ function installESHooks()
         );
     }
 }
-

--- a/lib/Search/ElasticSearch/ElasticSearchEngine.php
+++ b/lib/Search/ElasticSearch/ElasticSearchEngine.php
@@ -86,6 +86,7 @@ class ElasticSearchEngine extends SearchEngine
         $results = $this->parseHits($hits);
         $end = microtime(true);
         $searchTime = ($end - $start);
+
         return new SearchResults($results, true, $searchTime, $hits['hits']['total']);
     }
 
@@ -123,7 +124,31 @@ class ElasticSearchEngine extends SearchEngine
      */
     private function createSearchParams($query)
     {
-        $params = [
+        $searchStr = $query->getSearchString();
+
+        // Wildcard character required for Elasticsearch
+        $wildcardBe = "*";
+
+        // Override frontend wildcard character
+        if (isset($GLOBALS['sugar_config']['search_wildcard_char'])) {
+            $wildcardFe = $GLOBALS['sugar_config']['search_wildcard_char'];
+            if ($wildcardFe !== $wildcardBe && strlen($wildcardFe) === 1) {
+                $searchStr = str_replace($wildcardFe, $wildcardBe, $searchStr);
+            }
+        }
+
+        // Add wildcard at the beginning of the search string
+        if (isset($GLOBALS['sugar_config']['search_wildcard_infront']) &&
+            $GLOBALS['sugar_config']['search_wildcard_infront'] === true && $searchStr[0] !== $wildcardBe) {
+            $searchStr = $wildcardBe . $searchStr;
+        }
+
+        // Add wildcard at the end of search string
+        if ((!substr_compare($searchStr, $wildcardBe, -strlen($wildcardBe))) === 0) {
+            $searchStr .= $wildcardBe;
+        }
+
+        return [
             'index' => $this->index,
             'body' => [
                 'stored_fields' => [],
@@ -131,7 +156,7 @@ class ElasticSearchEngine extends SearchEngine
                 'size' => $query->getSize(),
                 'query' => [
                     'query_string' => [
-                        'query' => $query->getSearchString(),
+                        'query' => $searchStr,
                         'fields' => ['name.*^5', '_all'],
                         'analyzer' => 'standard',
                         'default_operator' => 'OR',
@@ -140,8 +165,6 @@ class ElasticSearchEngine extends SearchEngine
                 ],
             ],
         ];
-
-        return $params;
     }
 
     /**

--- a/tests/unit/phpunit/lib/SuiteCRM/Search/ElasticSearch/ElasticSearchEngineTest.php
+++ b/tests/unit/phpunit/lib/SuiteCRM/Search/ElasticSearch/ElasticSearchEngineTest.php
@@ -62,7 +62,7 @@ class ElasticSearchEngineTest extends \SuiteCRM\Search\SearchTestAbstract
         global $sugar_config;
 
         $engine = new ElasticSearchEngine();
-        $searchString = "hello search";
+        $searchString = "hello search*";
         $size = 30;
         $from = 5;
 
@@ -96,7 +96,7 @@ class ElasticSearchEngineTest extends \SuiteCRM\Search\SearchTestAbstract
         global $sugar_config;
 
         $engine = new ElasticSearchEngine();
-        $searchString = "test";
+        $searchString = "test*";
         $size = 30;
 
         $query = SearchQuery::fromString($searchString, $size);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Issue reference: #8472
Issue reference: #7742

This PR adds support for the config values
	$GLOBALS['sugar_config']['search_wildcard_char']
	and
	$GLOBALS['sugar_config']['search_wildcard_infront']
to ElasticSearchEngine::createSearchParams().
And it fixes resolving related bean IDs in SearchResults::getRelatedId() when
there is more than one level of relationships.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Using the ElasticSearchEngine can cause fatal PHP errors (and therefor resulting
in incomplete search results) and
search results returned by the ElasticSearchEngine can appear incomplete
when one expects the default search wildcard character '%' to work as it would
when using filters (SQL) or the legacy 'Advanced Search' engine.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Search Engine configuration: put the following config values in the `config_override.php`:
```
$sugar_config['search_wildcard_char'] = '%';
$sugar_config['search_wildcard_infront'] = true;  // or false if you prefer
$sugar_config['aod']['enable_aod'] = false;
$sugar_config['search']['controller'] = 'Search';
$sugar_config['search']['defaultEngine'] = 'ElasticSearchEngine';
$sugar_config['search']['ElasticSearch']['enabled'] = true;
$sugar_config['search']['ElasticSearch']['host'] = '<YOUR_ES_HOST>';
```
2. Make sure the ElasticSearch server is up and running
3. If don't already have an ElasticSearch index you'll need to schedule a
full indexing via Admin panel -> Elasticsearch -> Schedule full indexing.
Wait until the scheduler job is done.
4. Enter a search term that should match at least one existing record
in the global search form at the top of the page.
E.g.: If you have a company record named "My ACME Company" try
to search for "acme" or "%acme" or "company" or "%company".
5. Create a Tasks record that is related to a Contacts record which again
is related to an Accounts record.
6. Try searching for that Tasks record

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
