### PR TITLE
Fixed #8461 fixed #8462 : Implement effective opcache file clearing

### DIFF
--- a/ModuleInstall/ModuleInstaller.php
+++ b/ModuleInstall/ModuleInstaller.php
@@ -1358,9 +1358,7 @@ class ModuleInstaller
                 }
 
                 $relName = strpos($filename, "MetaData") !== false ? substr($filename, 0, strlen($filename) - 12) : $filename;
-                $out = sugar_fopen("custom/Extension/application/Ext/TableDictionary/$relName.php", 'w') ;
-                fwrite($out, $str . "include('custom/metadata/$filename');\n\n?>") ;
-                fclose($out) ;
+                sugar_file_put_contents("custom/Extension/application/Ext/TableDictionary/$relName.php", $str . "include('custom/metadata/$filename');\n\n?>");
             }
 
 
@@ -1849,9 +1847,7 @@ class ModuleInstaller
                     if (!file_exists("custom/$extpath")) {
                         mkdir_recursive("custom/$extpath", true);
                     }
-                    $out = sugar_fopen("custom/$extpath/$name", 'w');
-                    fwrite($out, $extension);
-                    fclose($out);
+                    sugar_file_put_contents("custom/$extpath/$name", $extension);
                 } else {
                     if (file_exists("custom/$extpath/$name")) {
                         unlink("custom/$extpath/$name");
@@ -1882,9 +1878,7 @@ class ModuleInstaller
             if (!file_exists("custom/$extpath")) {
                 mkdir_recursive("custom/$extpath", true);
             }
-            $out = sugar_fopen("custom/$extpath/$name", 'w');
-            fwrite($out, $extension);
-            fclose($out);
+            sugar_file_put_contents("custom/$extpath/$name", $extension);
         } else {
             if (file_exists("custom/$extpath/$name")) {
                 unlink("custom/$extpath/$name");
@@ -1925,7 +1919,7 @@ class ModuleInstaller
             if (!file_exists("custom/Extension/application/Ext/Include")) {
                 mkdir_recursive("custom/Extension/application/Ext/Include", true);
             }
-            file_put_contents("custom/Extension/application/Ext/Include/{$this->id_name}.php", $str);
+            sugar_file_put_contents("custom/Extension/application/Ext/Include/{$this->id_name}.php", $str);
         }
     }
 

--- a/ModuleInstall/ModuleInstaller.php
+++ b/ModuleInstall/ModuleInstaller.php
@@ -475,7 +475,7 @@ class ModuleInstaller
     public function rebuildExt($ext, $filename)
     {
         $this->log(translate('LBL_MI_REBUILDING') . " $ext...");
-        $this->merge_files("Ext/$ext/", $filename);
+        $this->merge_files("Ext/$ext", $filename);
     }
 
     /**
@@ -1358,7 +1358,10 @@ class ModuleInstaller
                 }
 
                 $relName = strpos($filename, "MetaData") !== false ? substr($filename, 0, strlen($filename) - 12) : $filename;
-                sugar_file_put_contents("custom/Extension/application/Ext/TableDictionary/$relName.php", $str . "include('custom/metadata/$filename');\n\n?>");
+                sugar_file_put_contents(
+                    "custom/Extension/application/Ext/TableDictionary/$relName.php",
+                    $str . "include('custom/metadata/$filename');\n\n?>"
+                );
             }
 
 
@@ -1723,7 +1726,7 @@ class ModuleInstaller
     {
         foreach ($languages as $language=>$value) {
             $this->log(translate('LBL_MI_REBUILDING') . " Language...$language");
-            $this->merge_files('Ext/Language/', $language.'.lang.ext.php', $language);
+            $this->merge_files('Ext/Language', $language.'.lang.ext.php', $language);
             if ($modules!="") {
                 foreach ($modules as $module) {
                     LanguageManager::clearLanguageCache($module, $language);
@@ -1742,7 +1745,7 @@ class ModuleInstaller
     public function rebuild_dashletcontainers()
     {
         $this->log(translate('LBL_MI_REBUILDING') . " DC Actions...");
-        $this->merge_files('Ext/DashletContainer/Containers/', 'dcactions.ext.php');
+        $this->merge_files('Ext/DashletContainer/Containers', 'dcactions.ext.php');
     }
 
     public function rebuild_tabledictionary()

--- a/include/DetailView/DetailView2.php
+++ b/include/DetailView/DetailView2.php
@@ -106,9 +106,8 @@ class DetailView2 extends EditView
                 if (!file_exists('modules/'.$this->module.'/metadata')) {
                     sugar_mkdir('modules/'.$this->module.'/metadata');
                 }
-                $fp = sugar_fopen('modules/'.$this->module.'/metadata/$metadataFileName.php', 'w');
-                fwrite($fp, $parser->parse($htmlFile, $dictionary[$focus->object_name]['fields'], $this->module));
-                fclose($fp);
+                sugar_file_put_contents('modules/'.$this->module.'/metadata/$metadataFileName.php', 
+                    $parser->parse($htmlFile, $dictionary[$focus->object_name]['fields'], $this->module));
             }
 
             //Flag an error... we couldn't create the best guess meta-data file

--- a/include/DetailView/DetailView2.php
+++ b/include/DetailView/DetailView2.php
@@ -106,8 +106,10 @@ class DetailView2 extends EditView
                 if (!file_exists('modules/'.$this->module.'/metadata')) {
                     sugar_mkdir('modules/'.$this->module.'/metadata');
                 }
-                sugar_file_put_contents('modules/'.$this->module.'/metadata/$metadataFileName.php', 
-                    $parser->parse($htmlFile, $dictionary[$focus->object_name]['fields'], $this->module));
+                sugar_file_put_contents(
+                    'modules/'.$this->module.'/metadata/$metadataFileName.php',
+                    $parser->parse($htmlFile, $dictionary[$focus->object_name]['fields'], $this->module)
+                );
             }
 
             //Flag an error... we couldn't create the best guess meta-data file

--- a/include/EditView/EditView2.php
+++ b/include/EditView/EditView2.php
@@ -261,9 +261,10 @@ class EditView
                     sugar_mkdir('modules/' . $this->module . '/metadata');
                 }
 
-                $fp = sugar_fopen('modules/' . $this->module . '/metadata/' . $metadataFileName . '.php', 'w');
-                fwrite($fp, $parser->parse($htmlFile, $dictionary[$focus->object_name]['fields'], $this->module));
-                fclose($fp);
+                sugar_file_put_contents(
+                    'modules/' . $this->module . '/metadata/' . $metadataFileName . '.php',
+                    $parser->parse($htmlFile, $dictionary[$focus->object_name]['fields'], $this->module)
+                );
             }
 
             // Flag an error... we couldn't create the best guess meta-data file

--- a/include/SubPanel/SubPanel.php
+++ b/include/SubPanel/SubPanel.php
@@ -316,9 +316,8 @@ class SubPanel
         //  	$GLOBALS['log']->debug('SubPanel.php->saveSubPanelDefOverride(): '.$name);
         $newValue = override_value_to_string($name, 'override_subpanel_name', $filename);
         mkdir_recursive('custom/Extension/modules/'. $panel->parent_bean->module_dir . '/Ext/Layoutdefs', true);
-        $fp = sugar_fopen('custom/Extension/modules/'. $panel->parent_bean->module_dir . "/Ext/Layoutdefs/$extname.php", 'w');
-        fwrite($fp, "<?php\n//auto-generated file DO NOT EDIT\n$newValue\n?>");
-        fclose($fp);
+        sugar_file_put_contents('custom/Extension/modules/'. $panel->parent_bean->module_dir . "/Ext/Layoutdefs/$extname.php",
+		"<?php\n//auto-generated file DO NOT EDIT\n$newValue\n?>");
         require_once('ModuleInstall/ModuleInstaller.php');
         $moduleInstaller = new ModuleInstaller();
         $moduleInstaller->silent = true; // make sure that the ModuleInstaller->log() function doesn't echo while rebuilding the layoutdefs

--- a/include/SubPanel/SubPanel.php
+++ b/include/SubPanel/SubPanel.php
@@ -316,8 +316,10 @@ class SubPanel
         //  	$GLOBALS['log']->debug('SubPanel.php->saveSubPanelDefOverride(): '.$name);
         $newValue = override_value_to_string($name, 'override_subpanel_name', $filename);
         mkdir_recursive('custom/Extension/modules/'. $panel->parent_bean->module_dir . '/Ext/Layoutdefs', true);
-        sugar_file_put_contents('custom/Extension/modules/'. $panel->parent_bean->module_dir . "/Ext/Layoutdefs/$extname.php",
-		"<?php\n//auto-generated file DO NOT EDIT\n$newValue\n?>");
+        sugar_file_put_contents(
+            'custom/Extension/modules/'. $panel->parent_bean->module_dir . "/Ext/Layoutdefs/$extname.php",
+            "<?php\n//auto-generated file DO NOT EDIT\n$newValue\n?>"
+        );
         require_once('ModuleInstall/ModuleInstaller.php');
         $moduleInstaller = new ModuleInstaller();
         $moduleInstaller->silent = true; // make sure that the ModuleInstaller->log() function doesn't echo while rebuilding the layoutdefs

--- a/include/SugarCache/SugarCache.php
+++ b/include/SugarCache/SugarCache.php
@@ -108,9 +108,12 @@ class SugarCache
     /**
      * Try to reset any opcode caches we know about
      *
+     *  @param Bool $full_reset -- only reset the opcache on full reset,
+     *  for removing individual files from cache use the fine grained method cleanFile
+     *
      * @todo make it so developers can extend this somehow
      */
-    public static function cleanOpcodes()
+    public static function cleanOpcodes($full_reset = false)
     {
         // APC
         if (function_exists('apc_clear_cache') && ini_get('apc.stat') == 0) {
@@ -138,8 +141,14 @@ class SugarCache
             }
         }
         // Zend OPcache
-        if (function_exists('opcache_reset')) {
-            opcache_reset();
+        if (
+            extension_loaded('Zend OPcache') &&
+            ($opcache_status = opcache_get_status(false)) !== false &&
+            $opcache_status['opcache_enabled'] && $full_reset
+        ) {
+            if (!opcache_reset()) {
+                LoggerManager::getLogger()->error("OPCache - could not reset");
+            }
         }
     }
 
@@ -154,9 +163,35 @@ class SugarCache
         }
 
         // Zend OPcache
-        if (function_exists('opcache_invalidate'))
-        {
-            opcache_invalidate($file, true);
+        if (
+            extension_loaded('Zend OPcache') &&
+            ($opcache_status = opcache_get_status(false)) !== false &&
+            $opcache_status['opcache_enabled']
+        ) {
+            // three attempts incase concurrent opcache operations pose a lock
+            for ($i = 3; $i && !opcache_invalidate($file, true); --$i) {
+                sleep(0.2);
+            }
+
+            if (!$i) {
+                LoggerManager::getLogger()->warn("OPCache - could not invalidate file: $file");
+            }
+        }
+    }
+
+    /**
+     * cleanDir
+     * Call this function to remove files in a directory from cache
+     *
+     * @param string $dir - String value of the directory to remove from cache
+     *
+     */
+    public static function cleanDir($dir)
+    {
+        foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir)) as $file) {
+            if ((new SplFileInfo($file))->getExtension() == 'php') {
+                sugarCache::cleanFile($file);
+            }
         }
     }
 }
@@ -215,7 +250,7 @@ function sugar_cache_reset()
 function sugar_cache_reset_full()
 {
     SugarCache::instance()->resetFull();
-    SugarCache::cleanOpcodes();
+    SugarCache::cleanOpcodes(true);
 }
 
 /**

--- a/include/connectors/sources/default/source.php
+++ b/include/connectors/sources/default/source.php
@@ -196,7 +196,7 @@ abstract class source
         if (!file_exists("custom/modules/Connectors/connectors/sources/{$dir}")) {
             mkdir_recursive("custom/modules/Connectors/connectors/sources/{$dir}");
         }
-        file_put_contents("custom/modules/Connectors/connectors/sources/{$dir}/config.php", $config_str);
+        sugar_file_put_contents("custom/modules/Connectors/connectors/sources/{$dir}/config.php", $config_str);
     }
 
     /**

--- a/include/dir_inc.php
+++ b/include/dir_inc.php
@@ -42,11 +42,16 @@ if (!defined('sugarEntry') || !sugarEntry) {
  */
 
 
+require_once 'include/SugarCache/SugarCache.php';
 
 function copy_recursive($source, $dest)
 {
     if (is_file($source)) {
-        return(copy($source, $dest));
+        $result = copy($source, $dest);
+        if ((new SplFileInfo($dest))->getExtension() == 'php') {
+            SugarCache::cleanFile($dest);
+        }
+        return $result;
     }
     if (!is_dir($dest)) {
         sugar_mkdir($dest);

--- a/include/utils/logic_utils.php
+++ b/include/utils/logic_utils.php
@@ -90,9 +90,8 @@ function write_logic_file($module_name, $contents)
 {
     $file = "modules/".$module_name . '/logic_hooks.php';
     $file = create_custom_directory($file);
-    $fp = sugar_fopen($file, 'wb');
-    fwrite($fp, $contents);
-    fclose($fp);
+
+    return sugar_file_put_contents($file, $contents) !== false;
 
     //end function write_logic_file
 }

--- a/include/utils/php_zip_utils.php
+++ b/include/utils/php_zip_utils.php
@@ -44,6 +44,8 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
+require_once 'include/SugarCache/SugarCache.php';
+
 function unzip($zip_archive, $zip_dir)
 {
     return unzip_file($zip_archive, null, $zip_dir);
@@ -71,8 +73,12 @@ function unzip_file($zip_archive, $archive_file, $zip_dir)
 
     if ($archive_file !== null) {
         $res = $zip->extractTo(UploadFile::realpath($zip_dir), $archive_file);
+        if ((new SplFileInfo($archive_file))->getExtension() == 'php') {
+            SugarCache::cleanFile(UploadFile::realpath($zip_dir).'/'.$archive_file);
+        }
     } else {
         $res = $zip->extractTo(UploadFile::realpath($zip_dir));
+        SugarCache::cleanDir(UploadFile::realpath($zip_dir));
     }
     
     if ($res !== true) {

--- a/include/utils/sugar_file_utils.php
+++ b/include/utils/sugar_file_utils.php
@@ -132,6 +132,28 @@ function sugar_fopen($filename, $mode, $use_include_path = false, $context = nul
 }
 
 /**
+ * sugar_fclose
+ * Call this function instead of fclose to make sure the closed file
+ * is removed from caches
+ *
+ * @param resource $handle - Handle of the file to close
+ *
+ * @return bool - Returns true on success, false otherwise
+ */
+function sugar_fclose($handle)
+{
+    $filename = stream_get_meta_data($handle)['uri'];
+
+    $result = fclose($handle);
+
+    if ((new SplFileInfo($filename))->getExtension() == 'php') {
+        SugarCache::cleanFile($filename);
+    }
+
+    return $result;
+}
+
+/**
  * sugar_file_put_contents
  * Call this function instead of file_put_contents to apply pre-configured permission
  * settings when creating the file.  This method is basically
@@ -160,7 +182,9 @@ function sugar_file_put_contents($filename, $data, $flags = null, $context = nul
     }
 
     $result = file_put_contents($filename, $data, $flags, $context);
-    SugarCache::cleanFile($filename);
+    if ((new SplFileInfo($filename))->getExtension() == 'php') {
+        SugarCache::cleanFile($filename);
+    }
 
     return $result;
 }
@@ -206,7 +230,11 @@ function sugar_file_put_contents_atomic($filename, $data, $mode = 'wb')
     }
 
     if (file_exists($filename)) {
-        return sugar_chmod($filename, 0755);
+        $result = sugar_chmod($filename, 0755);
+        if ((new SplFileInfo($filename))->getExtension() == 'php') {
+            SugarCache::cleanFile($filename);
+        }
+        return $result;
     }
 
     return false;

--- a/include/utils/zip_utils.php
+++ b/include/utils/zip_utils.php
@@ -42,6 +42,8 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
+require_once 'include/SugarCache/SugarCache.php';
+
 if (!class_exists("ZipArchive")) {
     require_once('include/pclzip/pclzip.lib.php');
     if (isset($GLOBALS['log']) && class_implements($GLOBALS['log'], 'LoggerTemplate')) {
@@ -64,6 +66,8 @@ if (!class_exists("ZipArchive")) {
                     die("Error: " . $archive->errorInfo(true));
                 }
                 return false;
+            } else {
+                SugarCache::cleanDir($zip_dir);
             }
         } else {
             if ($archive->extract(PCLZIP_OPT_PATH, $zip_dir) == 0) {
@@ -71,6 +75,8 @@ if (!class_exists("ZipArchive")) {
                     die("Error: " . $archive->errorInfo(true));
                 }
                 return false;
+            } else {
+                SugarCache::cleanDir($zip_dir);
             }
         }
     }
@@ -100,6 +106,10 @@ if (!class_exists("ZipArchive")) {
                 }
 
                 return false;
+            } else {
+                if ((new SplFileInfo($archive_file))->getExtension() == 'php') {
+                    SugarCache::cleanFile($to_dir.'/'.$archive_file);
+                }
             }
         } else {
             if ($archive->extract(
@@ -114,6 +124,10 @@ if (!class_exists("ZipArchive")) {
                 }
 
                 return false;
+            } else {
+                if ((new SplFileInfo($archive_file))->getExtension() == 'php') {
+                    SugarCache::cleanFile($to_dir.'/'.$archive_file);
+                }
             }
         }
     }

--- a/install/performSetup.php
+++ b/install/performSetup.php
@@ -535,16 +535,12 @@ if (!is_null($_SESSION['scenarios'])) {
 
 
 //Write the tabstructure to custom so that the grouping are not shown for the un-selected scenarios
-$fp = sugar_fopen('custom/include/tabConfig.php', 'w');
 $fileContents = "<?php \n" .'$GLOBALS["tabStructure"] ='.var_export($GLOBALS['tabStructure'], true).';';
-fwrite($fp, $fileContents);
-fclose($fp);
+$fp = sugar_file_put_contents('custom/include/tabConfig.php', $fileContents);
 
 //Write the dashlets to custom so that the dashlets are not shown for the un-selected scenarios
-$fp = sugar_fopen('custom/modules/Home/dashlets.php', 'w');
 $fileContents = "<?php \n" .'$defaultDashlets ='.var_export($defaultDashlets, true).';';
-fwrite($fp, $fileContents);
-fclose($fp);
+$fp = sugar_file_put_contents('custom/modules/Home/dashlets.php', $fileContents);
 
 
 // End of the scenario implementations

--- a/install/performSetup.php
+++ b/install/performSetup.php
@@ -536,11 +536,11 @@ if (!is_null($_SESSION['scenarios'])) {
 
 //Write the tabstructure to custom so that the grouping are not shown for the un-selected scenarios
 $fileContents = "<?php \n" .'$GLOBALS["tabStructure"] ='.var_export($GLOBALS['tabStructure'], true).';';
-$fp = sugar_file_put_contents('custom/include/tabConfig.php', $fileContents);
+sugar_file_put_contents('custom/include/tabConfig.php', $fileContents);
 
 //Write the dashlets to custom so that the dashlets are not shown for the un-selected scenarios
 $fileContents = "<?php \n" .'$defaultDashlets ='.var_export($defaultDashlets, true).';';
-$fp = sugar_file_put_contents('custom/modules/Home/dashlets.php', $fileContents);
+sugar_file_put_contents('custom/modules/Home/dashlets.php', $fileContents);
 
 
 // End of the scenario implementations

--- a/modules/AOP_Case_Updates/AOPAssignManager.php
+++ b/modules/AOP_Case_Updates/AOPAssignManager.php
@@ -309,10 +309,7 @@ class AOPAssignManager
     \$lastUser = {$arrayString};
 ?>
 eoq;
-        if ($fh = @sugar_fopen($file, 'w')) {
-            fwrite($fh, $content);
-            fclose($fh);
-        }
+        sugar_file_put_contents($file, $content);
 
         return true;
     }

--- a/modules/Administration/Common.php
+++ b/modules/Administration/Common.php
@@ -164,11 +164,12 @@ function create_field_label($module, $language, $key, $value, $overwrite=false)
             }
 
             if (sugar_file_put_contents($filename, create_field_lang_pak_contents(
-                    $old_contents,
-                    $key,
-                    $value,
-                    $language,
-                    $module))) {
+                $old_contents,
+                $key,
+                $value,
+                $language,
+                $module
+            )) !== false) {
                 $return_value = true;
                 $GLOBALS['log']->info("Successful write to: $filename");
             } else {
@@ -224,14 +225,14 @@ function save_custom_app_list_strings_contents(&$contents, $language, $custom_di
     if ($dir_exists) {
         $filename = "$dirname/$language.lang.php";
 
-        if(sugar_file_put_contents($filename, $contents)) {
+        if (sugar_file_put_contents($filename, $contents) !== false) {
                 $return_value = true;
-                $GLOBALS['log']->info("Successful write to: $filename");
+                LoggerManager::getLogger()->info("Successful write to: $filename");
         } else {
-            $GLOBALS['log']->info("Unable to write edited language pack to file: $filename");
+            LoggerManager::getLogger()->info("Unable to write edited language pack to file: $filename");
         }
     } else {
-        $GLOBALS['log']->info("Unable to create dir: $dirname");
+        LoggerManager::getLogger()->info("Unable to create dir: $dirname");
     }
     if ($return_value) {
         $cache_key = 'app_list_strings.'.$language;
@@ -260,17 +261,14 @@ function save_custom_app_list_strings(&$app_list_strings, $language)
     if ($dir_exists) {
         $filename = "$dirname/$language.lang.php";
 
-        if ($handle) {
-            $contents =create_dropdown_lang_pak_contents(
-                $app_list_strings,
-                $language
-            );
+        $contents =create_dropdown_lang_pak_contents(
+            $app_list_strings,
+            $language
+        );
 
-            if (sugar_file_put_contents($filename, $contents)) {
-                $return_value = true;
-                $GLOBALS['log']->info("Successful write to: $filename");
-            }
-
+        if (sugar_file_put_contents($filename, $contents) !== false) {
+            $return_value = true;
+            $GLOBALS['log']->info("Successful write to: $filename");
         } else {
             $GLOBALS['log']->info("Unable to write edited language pak to file: $filename");
         }

--- a/modules/Administration/Common.php
+++ b/modules/Administration/Common.php
@@ -162,24 +162,15 @@ function create_field_label($module, $language, $key, $value, $overwrite=false)
             } else {
                 $old_contents = '';
             }
-            $handle = sugar_fopen($filename, 'wb');
 
-
-            if ($handle) {
-                $contents =create_field_lang_pak_contents(
+            if (sugar_file_put_contents($filename, create_field_lang_pak_contents(
                     $old_contents,
                     $key,
                     $value,
                     $language,
-                    $module
-                );
-
-                if (fwrite($handle, $contents)) {
-                    $return_value = true;
-                    $GLOBALS['log']->info("Successful write to: $filename");
-                }
-
-                fclose($handle);
+                    $module))) {
+                $return_value = true;
+                $GLOBALS['log']->info("Successful write to: $filename");
             } else {
                 $GLOBALS['log']->info("Unable to write edited language pak to file: $filename");
             }
@@ -232,17 +223,12 @@ function save_custom_app_list_strings_contents(&$contents, $language, $custom_di
 
     if ($dir_exists) {
         $filename = "$dirname/$language.lang.php";
-        $handle = @sugar_fopen($filename, 'wt');
 
-        if ($handle) {
-            if (fwrite($handle, $contents)) {
+        if(sugar_file_put_contents($filename, $contents)) {
                 $return_value = true;
                 $GLOBALS['log']->info("Successful write to: $filename");
-            }
-
-            fclose($handle);
         } else {
-            $GLOBALS['log']->info("Unable to write edited language pak to file: $filename");
+            $GLOBALS['log']->info("Unable to write edited language pack to file: $filename");
         }
     } else {
         $GLOBALS['log']->info("Unable to create dir: $dirname");
@@ -273,7 +259,6 @@ function save_custom_app_list_strings(&$app_list_strings, $language)
 
     if ($dir_exists) {
         $filename = "$dirname/$language.lang.php";
-        $handle = @sugar_fopen($filename, 'wt');
 
         if ($handle) {
             $contents =create_dropdown_lang_pak_contents(
@@ -281,12 +266,11 @@ function save_custom_app_list_strings(&$app_list_strings, $language)
                 $language
             );
 
-            if (fwrite($handle, $contents)) {
+            if (sugar_file_put_contents($filename, $contents)) {
                 $return_value = true;
                 $GLOBALS['log']->info("Successful write to: $filename");
             }
 
-            fclose($handle);
         } else {
             $GLOBALS['log']->info("Unable to write edited language pak to file: $filename");
         }

--- a/modules/Administration/SugarSpriteBuilder.php
+++ b/modules/Administration/SugarSpriteBuilder.php
@@ -401,19 +401,18 @@ background-position: -{$offset_x}px -{$offset_y}px;
                 if ($this->cssMinify) {
                     $css_content = cssmin::minify($css_content);
                 }
-                $fh = fopen("$outputDir/$cssFileName", $fileMode);
-                fwrite($fh, $css_content);
-                fclose($fh);
+                sugar_file_put_contents("$outputDir/$cssFileName", $css_content,
+                    $fileMode == 'a' ? FILE_APPEND : 0);
 
                 /* save metadata */
                 $add_php_tag = (file_exists("$outputDir/$metaFileName") && $isRepeat) ? false : true;
-                $fh = fopen("$outputDir/$metaFileName", $fileMode);
+                $fh = sugar_fopen("$outputDir/$metaFileName", $fileMode);
                 if ($add_php_tag) {
                     fwrite($fh, '<?php');
                 }
                 fwrite($fh, "\n/* sprites metadata - $name */\n");
                 fwrite($fh, $metadata."\n");
-                fclose($fh);
+                sugar_fclose($fh);
 
             // if width & height
             } else {

--- a/modules/Administration/SugarSpriteBuilder.php
+++ b/modules/Administration/SugarSpriteBuilder.php
@@ -401,8 +401,11 @@ background-position: -{$offset_x}px -{$offset_y}px;
                 if ($this->cssMinify) {
                     $css_content = cssmin::minify($css_content);
                 }
-                sugar_file_put_contents("$outputDir/$cssFileName", $css_content,
-                    $fileMode == 'a' ? FILE_APPEND : 0);
+                sugar_file_put_contents(
+                    "$outputDir/$cssFileName",
+                    $css_content,
+                    $fileMode == 'a' ? FILE_APPEND : 0
+                );
 
                 /* save metadata */
                 $add_php_tag = (file_exists("$outputDir/$metaFileName") && $isRepeat) ? false : true;

--- a/modules/Administration/undoupdateclass.php
+++ b/modules/Administration/undoupdateclass.php
@@ -53,7 +53,7 @@ foreach ($beanFiles as $Classname => $filename) {
         $handle = file_get_contents($Newfilename);
         $data = preg_replace("/class SugarCore".$Classname."/", 'class '.$Classname, $handle);
         $data1 = preg_replace("/function SugarCore".$Classname."/", 'function '.$Classname, $data);
-        file_put_contents($Newfilename, $data1);
+        sugar_file_put_contents($Newfilename, $data1);
         rename($Newfilename, $filename);
     }
 }

--- a/modules/Administration/updateclass.php
+++ b/modules/Administration/updateclass.php
@@ -60,7 +60,6 @@ foreach ($beanFiles as $classname => $filename) {
         sugar_rename($filename, $newfilename);
         
         //Create a new SugarBean that extends CoreBean
-        $fileHandle = sugar_fopen($filename, 'w') ;
         $newclass = <<<FABRICE
 <?php
 if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
@@ -114,7 +113,6 @@ else{
 }
 ?>
 FABRICE;
-        fwrite($fileHandle, $newclass);
-        fclose($fileHandle);
+        sugar_file_put_contents($filename, $newclass);
     }
 }

--- a/modules/Administration/upgrade_custom_relationships.php
+++ b/modules/Administration/upgrade_custom_relationships.php
@@ -86,7 +86,7 @@ function upgrade_custom_relationships($modules = array())
                                     '$dictionary["' . $module . '"]["fields"]["' . $relName . '"]=' . var_export_helper($rhsDef) . ";",
                                     $fileContents
                                 );
-                                file_put_contents($filePath, $out);
+                                sugar_file_put_contents($filePath, $out);
                             }
                         }
                     }
@@ -105,7 +105,7 @@ function upgrade_custom_relationships($modules = array())
                                     "'get_subpanel_data' => '{$def["join_key_lhs"]}',",
                                     $fileContents
                                 );
-                                file_put_contents($filePath, $out);
+                                sugar_file_put_contents($filePath, $out);
                             }
                         }
                     }

--- a/modules/Configurator/Configurator.php
+++ b/modules/Configurator/Configurator.php
@@ -224,9 +224,7 @@ class Configurator
             $GLOBALS['log']->fatal("Unable to write to the config_override.php file. Check the file permissions");
             return;
         }
-        $fp = sugar_fopen('config_override.php', 'w');
-        fwrite($fp, $override);
-        fclose($fp);
+        sugar_file_put_contents('config_override.php', $override);
     }
 
     public function overrideClearDuplicates($array_name, $key)

--- a/modules/Configurator/controller.php
+++ b/modules/Configurator/controller.php
@@ -224,15 +224,11 @@ class ConfiguratorController extends SugarController
                 unset($GLOBALS['tabStructure']['LBL_TABGROUP_DEFAULT']);
             }
             //Write the tabstructure to custom so that the grouping are not shown for the un-selected scenarios
-            $fp = sugar_fopen('custom/include/tabConfig.php', 'w');
             $fileContents = "<?php \n" .'$GLOBALS["tabStructure"] ='.var_export($GLOBALS['tabStructure'], true).';';
-            fwrite($fp, $fileContents);
-            fclose($fp);
+            sugar_file_put_contents('custom/include/tabConfig.php', $fileContents);
             //Write the dashlets to custom so that the dashlets are not shown for the un-selected scenarios
-            $fp = sugar_fopen('custom/modules/Home/dashlets.php', 'w');
             $fileContents = "<?php \n" .'$defaultDashlets ='.var_export($defaultDashlets, true).';';
-            fwrite($fp, $fileContents);
-            fclose($fp);
+            sugar_file_put_contents('custom/modules/Home/dashlets.php', $fileContents);
             // End of the scenario implementations
         }
 

--- a/modules/ModuleBuilder/MB/MBLanguage.php
+++ b/modules/ModuleBuilder/MB/MBLanguage.php
@@ -249,9 +249,7 @@ class MBLanguage
                 }
             }
 
-            $fp = sugar_fopen($app_save_path . '/'. $lang, 'w');
-            fwrite($fp, $appFile);
-            fclose($fp);
+            sugar_file_put_contents($app_save_path . '/'. $lang, $appFile);
         }
     }
 

--- a/modules/ModuleBuilder/MB/MBModule.php
+++ b/modules/ModuleBuilder/MB/MBModule.php
@@ -403,9 +403,7 @@ class MBModule
                     if ($overwrite || ! file_exists($nto)) {
                         $contents = file_get_contents($nfrom) ;
                         $contents = str_replace($findArray, $replaceArray, $contents) ;
-                        $fw = sugar_fopen($nto, 'w') ;
-                        fwrite($fw, $contents) ;
-                        fclose($fw) ;
+                        sugar_file_put_contents($nto, $contents) ;
                     }
                 }
             }
@@ -485,22 +483,19 @@ class MBModule
         $smarty->assign('class', $class) ;
 
         if (! file_exists($path . '/' . $class [ 'name' ] . '.php')) {
-            $fp = sugar_fopen($path . '/' . $class ['name'] . '.php', 'w');
-            fwrite($fp, $smarty->fetch('modules/ModuleBuilder/tpls/MBModule/Class.tpl'));
-            fclose($fp);
+            sugar_file_put_contents($path . '/' . $class ['name'] . '.php', 
+                $smarty->fetch('modules/ModuleBuilder/tpls/MBModule/Class.tpl'));
         }
         //write vardefs
-        $fp = sugar_fopen($path . '/vardefs.php', 'w') ;
-        fwrite($fp, $smarty->fetch('modules/ModuleBuilder/tpls/MBModule/vardef.tpl')) ;
-        fclose($fp) ;
+        sugar_file_put_contents($path . '/vardefs.php', 
+           $smarty->fetch('modules/ModuleBuilder/tpls/MBModule/vardef.tpl')) ;
         
         if (! file_exists($path . '/metadata')) {
             mkdir_recursive($path . '/metadata') ;
         }
         if (! empty($this->config [ 'studio' ])) {
-            $fp = sugar_fopen($path . '/metadata/studio.php', 'w') ;
-            fwrite($fp, $smarty->fetch('modules/ModuleBuilder/tpls/MBModule/Studio.tpl')) ;
-            fclose($fp) ;
+            sugar_file_put_contents($path . '/metadata/studio.php',
+                $smarty->fetch('modules/ModuleBuilder/tpls/MBModule/Studio.tpl')) ;
         } else {
             if (file_exists($path . '/metadata/studio.php')) {
                 unlink($path . '/metadata/studio.php') ;
@@ -515,9 +510,8 @@ class MBModule
         $smarty->assign('showvCard', in_array('person', array_keys($this->config[ 'templates' ]))) ;
         $smarty->assign('showimport', $this->config['importable']);
         //write sugar generated class
-        $fp = sugar_fopen($path . '/' . 'Menu.php', 'w') ;
-        fwrite($fp, $smarty->fetch('modules/ModuleBuilder/tpls/MBModule/Menu.tpl')) ;
-        fclose($fp) ;
+        sugar_file_put_contents($path . '/' . 'Menu.php',
+            $smarty->fetch('modules/ModuleBuilder/tpls/MBModule/Menu.tpl')) ;
     }
 
     public function addInstallDefs(&$installDefs)
@@ -690,9 +684,7 @@ class MBModule
                         $contents = str_replace("'{$old_name}'", "'{$this->key_name}'", $contents) ;
                     }
                     
-                    $fp = sugar_fopen($new_dir . '/' . $e, 'w') ;
-                    fwrite($fp, $contents) ;
-                    fclose($fp) ;
+                    sugar_file_put_contents($new_dir . '/' . $e, $contents) ;
                 }
             }
         }
@@ -771,9 +763,7 @@ class MBModule
             $layout = "<?php\n" . '$module_name=\'' . $module_name . "';\n" . '$subpanel_layout = ' . var_export_helper($layout) . ";" ;
             $GLOBALS [ 'log' ]->debug("About to save this file to $filepath") ;
             $GLOBALS [ 'log' ]->debug($layout) ;
-            $fw = sugar_fopen($filepath, 'w') ;
-            fwrite($fw, $layout) ;
-            fclose($fw) ;
+            sugar_file_put_contents($filepath, $layout) ;
         }
     }
 

--- a/modules/ModuleBuilder/MB/MBModule.php
+++ b/modules/ModuleBuilder/MB/MBModule.php
@@ -483,19 +483,25 @@ class MBModule
         $smarty->assign('class', $class) ;
 
         if (! file_exists($path . '/' . $class [ 'name' ] . '.php')) {
-            sugar_file_put_contents($path . '/' . $class ['name'] . '.php', 
-                $smarty->fetch('modules/ModuleBuilder/tpls/MBModule/Class.tpl'));
+            sugar_file_put_contents(
+                $path . '/' . $class ['name'] . '.php',
+                $smarty->fetch('modules/ModuleBuilder/tpls/MBModule/Class.tpl')
+            );
         }
         //write vardefs
-        sugar_file_put_contents($path . '/vardefs.php', 
-           $smarty->fetch('modules/ModuleBuilder/tpls/MBModule/vardef.tpl')) ;
+        sugar_file_put_contents(
+            $path . '/vardefs.php',
+            $smarty->fetch('modules/ModuleBuilder/tpls/MBModule/vardef.tpl')
+        );
         
         if (! file_exists($path . '/metadata')) {
             mkdir_recursive($path . '/metadata') ;
         }
         if (! empty($this->config [ 'studio' ])) {
-            sugar_file_put_contents($path . '/metadata/studio.php',
-                $smarty->fetch('modules/ModuleBuilder/tpls/MBModule/Studio.tpl')) ;
+            sugar_file_put_contents(
+                $path . '/metadata/studio.php',
+                $smarty->fetch('modules/ModuleBuilder/tpls/MBModule/Studio.tpl')
+            );
         } else {
             if (file_exists($path . '/metadata/studio.php')) {
                 unlink($path . '/metadata/studio.php') ;
@@ -510,8 +516,10 @@ class MBModule
         $smarty->assign('showvCard', in_array('person', array_keys($this->config[ 'templates' ]))) ;
         $smarty->assign('showimport', $this->config['importable']);
         //write sugar generated class
-        sugar_file_put_contents($path . '/' . 'Menu.php',
-            $smarty->fetch('modules/ModuleBuilder/tpls/MBModule/Menu.tpl')) ;
+        sugar_file_put_contents(
+            $path . '/' . 'Menu.php',
+            $smarty->fetch('modules/ModuleBuilder/tpls/MBModule/Menu.tpl')
+        );
     }
 
     public function addInstallDefs(&$installDefs)

--- a/modules/ModuleBuilder/MB/MBPackage.php
+++ b/modules/ModuleBuilder/MB/MBPackage.php
@@ -310,9 +310,7 @@ class MBPackage
         }
         if (mkdir_recursive($path)) {
             $manifest = $this->getManifest() . $this->buildInstall($path);
-            $fp = sugar_fopen($this->getBuildDir() . '/manifest.php', 'w');
-            fwrite($fp, $manifest);
-            fclose($fp);
+            sugar_file_put_contents($this->getBuildDir() . '/manifest.php', $manifest);
         }
         if (file_exists('modules/ModuleBuilder/MB/LICENSE.txt')) {
             copy('modules/ModuleBuilder/MB/LICENSE.txt', $this->getBuildDir() . '/LICENSE.txt');
@@ -1039,9 +1037,7 @@ class MBPackage
             if (mkdir_recursive($tmppath)) {
                 copy_recursive($this->getPackageDir(), $tmppath . '/' . $this->name);
                 $manifest = $this->getManifest(true, $export) . $this->exportProjectInstall($package, $export);
-                $fp = sugar_fopen($tmppath . '/manifest.php', 'w');
-                fwrite($fp, $manifest);
-                fclose($fp);
+                sugar_file_put_contents($tmppath . '/manifest.php', $manifest);
                 if (file_exists('modules/ModuleBuilder/MB/LICENSE.txt')) {
                     copy('modules/ModuleBuilder/MB/LICENSE.txt', $tmppath . '/LICENSE.txt');
                 } else {
@@ -1050,9 +1046,7 @@ class MBPackage
                     }
                 }
                 $readme_contents = $this->readme;
-                $readmefp = sugar_fopen($tmppath . '/README.txt', 'w');
-                fwrite($readmefp, $readme_contents);
-                fclose($readmefp);
+                sugar_file_put_contents($tmppath . '/README.txt', $readme_contents);
             }
         }
         require_once 'include/utils/zip_utils.php';

--- a/modules/ModuleBuilder/parsers/relationships/AbstractRelationships.php
+++ b/modules/ModuleBuilder/parsers/relationships/AbstractRelationships.php
@@ -520,7 +520,7 @@ class AbstractRelationships
                 $out .= '$dictionary["' . $object . '"]["fields"]["' . $definition [ 'name' ] . '"] = '
                          . var_export_helper($definition) . ";\n";
             }
-            file_put_contents($filename, $out);
+            sugar_file_put_contents($filename, $out);
             
             $installDefs [ $moduleName ] = array(
                 'from' => "{$installDefPrefix}/relationships/vardefs/{$relName}_{$moduleName}.php" ,

--- a/modules/Studio/parsers/StudioParser.php
+++ b/modules/Studio/parsers/StudioParser.php
@@ -349,7 +349,6 @@ EOQ;
             $file = $this->curFile;
         }
 
-        $fp = sugar_fopen($file, 'w');
         $output = $contents ? $contents : $this->curText;
         if (strpos($file, 'SearchForm.html') > 0) {
             $fileparts = preg_split("'<!--\s*(BEGIN|END)\s*:\s*main\s*-->'", $output);
@@ -374,8 +373,7 @@ EOQ;
             }
         }
 
-        fwrite($fp, $output);
-        fclose($fp);
+        sugar_file_put_contents($file, $output);
     }
 
     public function handleSaveLabels($module_name, $language)
@@ -429,13 +427,11 @@ EOQ;
         } else {
             $file_cache = create_cache_directory('studio/'.$preview_file);
         }
-        $fp = sugar_fopen($file_cache, 'w');
         $view = $this->disableInputs($view);
         if (!$preview_file) {
             $view = $this->enableLabelEditor($view);
         }
-        fwrite($fp, $view);
-        fclose($fp);
+        sugar_file_put_contents($file_cache, $view);
         return $this->cacheXTPL($file, $file_cache, $preview_file);
     }
 
@@ -513,9 +509,7 @@ EOQ;
 
         $buffer = str_replace($form_string, '', $buffer);
         $buffer = $this->disableInputs($buffer);
-        $xtpl_fp_cache = sugar_fopen($xtpl_cache, 'w');
-        fwrite($xtpl_fp_cache, $buffer);
-        fclose($xtpl_fp_cache);
+        sugar_file_put_contents($xtpl_cache, $buffer);
         return $xtpl_cache;
     }
 

--- a/modules/UpgradeWizard/silentUpgrade_step1.php
+++ b/modules/UpgradeWizard/silentUpgrade_step1.php
@@ -996,14 +996,10 @@ function repairTableDictionaryExtFile()
 
 
                     if ($altered) {
-                        if (function_exists('sugar_fopen')) {
-                            $fp = @sugar_fopen($entry, 'w');
+                        if (function_exists('sugar_file_put_contents')) {
+                            @sugar_file_put_contents($entry, $contents);
                         } else {
-                            $fp = fopen($entry, 'wb');
-                        }
-
-                        if ($fp && fwrite($fp, $contents)) {
-                            fclose($fp);
+                            file_put_contents($entry, $contents);
                         }
                     }
                 }

--- a/modules/UpgradeWizard/upgradeMetaHelper.php
+++ b/modules/UpgradeWizard/upgradeMetaHelper.php
@@ -38,7 +38,7 @@
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
-
+require_once(__DIR__.'/../../include/utils/sugar_file_utils.php');
 
 class UpgradeMetaHelper
 {
@@ -339,17 +339,15 @@ class UpgradeMetaHelper
                 include('modules/'.$module_name.'/vardefs.php');
                 $bean_name = $beanList[$module_name];
                 $newFile = $this->upgrade_dir.'/modules/'.$module_name.'/metadata/'.$lowerCaseView.'defs.php';
-                $evfp = fopen($newFile, 'wb');
 
                 $bean_name = $bean_name == 'aCase' ? 'Case' : $bean_name;
-                fwrite($evfp, $parser->parse(
+                sugar_file_put_contents($newFile, $parser->parse(
                     $file,
                     $dictionary[$bean_name]['fields'],
                     $module_name,
                     true,
                     $this->path_to_master_copy.'/modules/'.$module_name.'/metadata/'.$lowerCaseView.'defs.php'
                 ));
-                fclose($evfp);
             } //if
         } //foreach
     }

--- a/modules/UpgradeWizard/upgradeMetaHelper.php
+++ b/modules/UpgradeWizard/upgradeMetaHelper.php
@@ -38,7 +38,7 @@
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
-require_once(__DIR__.'/../../include/utils/sugar_file_utils.php');
+require_once 'include/utils/sugar_file_utils.php';
 
 class UpgradeMetaHelper
 {

--- a/modules/UpgradeWizard/uw_utils.php
+++ b/modules/UpgradeWizard/uw_utils.php
@@ -3736,7 +3736,7 @@ function fix_dropdown_list()
                     //Now write out the file contents
                     //Create backup just in case
                     copy($file, $file . '.php_bak');
-                    if (!sugar_file_put_contents($file, $contents)) {
+                    if (sugar_file_put_contents($file, $contents) === false) {
                         $GLOBALS['log']->error("Unable to update file contents in fix_dropdown_list for {$file}");
                     } //if-else
                 }
@@ -3854,7 +3854,7 @@ function fix_dropdown_list()
                 if ($touched) {
                     //Create a backup just in case
                     copy($file, $file . '.bak');
-                    if (!sugar_file_put_contents($file, $contents)) {
+                    if (sugar_file_put_contents($file, $out) === false) {
                         //If we can't update the file, just return
                         $GLOBALS['log']->error("Unable to update file contents in fix_dropdown_list.");
                         return;

--- a/modules/UpgradeWizard/uw_utils.php
+++ b/modules/UpgradeWizard/uw_utils.php
@@ -42,6 +42,8 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
+require_once __DIR__ . '/../../include/dir_inc.php';
+
 /**
  * Implodes some parts of version with specified delimiter, beta & rc parts are removed all time
  *
@@ -122,7 +124,7 @@ function commitMakeBackupFiles($rest_dir, $install_file, $unzip_dir, $zip_from_d
                 RecursiveDirectoryIterator::SKIP_DOTS | RecursiveIteratorIterator::SELF_FIRST
             )
         );
-	    
+
         // keep this around for canceling
         $_SESSION['uw_restore_dir'] = getUploadRelativeName($rest_dir);
 
@@ -143,7 +145,7 @@ function commitMakeBackupFiles($rest_dir, $install_file, $unzip_dir, $zip_from_d
             if (is_file($oldFile)) {
                 if (is_writable($rest_dir)) {
                     logThis('Backing up file: ' . $oldFile, $path);
-                    if (!copy($oldFile, $rest_dir . '/' . $cleanFile)) {
+                    if (!copy_recursive($oldFile, $rest_dir . '/' . $cleanFile)) {
                         logThis('*** ERROR: could not backup file: ' . $oldFile, $path);
                         $errors[] = "{$mod_strings['LBL_UW_BACKUP']}::{$mod_strings['ERR_UW_FILE_NOT_COPIED']}: {$oldFile}";
                     } else {
@@ -233,7 +235,7 @@ function commitCopyNewFiles($unzip_dir, $zip_from_dir, $path='')
                 continue;
             }
 
-            if (!copy($srcFile, $targetFile)) {
+            if (!copy_recursive($srcFile, $targetFile)) {
                 logThis('*** ERROR: could not copy file: ' . $targetFile, $path);
             } else {
                 $copiedFiles[] = $targetFile;
@@ -320,7 +322,7 @@ function copyRecursiveBetweenDirectories($from, $to)
                     continue;
                 }
 
-                if (!copy($srcFile, $targetFile)) {
+                if (!copy_recursive($srcFile, $targetFile)) {
                     logThis("*** ERROR: could not copy file $srcFile to $targetFile");
                 }
             }
@@ -398,7 +400,7 @@ function deleteAndOverWriteSelectedFiles($unzip_dir, $zip_from_dir, $delete_dirs
 
                     //logThis('Copying file to destination: ' . $targetFile);
 
-                    if (!copy($srcFile, $targetFile)) {
+                    if (!copy_recursive($srcFile, $targetFile)) {
                         logThis('*** ERROR: could not copy file: ' . $targetFile);
                     } else {
                         $copiedFiles[] = $targetFile;
@@ -1308,7 +1310,11 @@ function logThis($entry, $path='')
     }
 
     if (is_resource($fp)) {
-        fclose($fp);
+        if (function_exists('sugar_fclose')) {
+            sugar_fclose($fp);
+	} else {
+            fclose($fp);
+        }
     }
 }
 
@@ -1322,6 +1328,10 @@ function logThis($entry, $path='')
  **/
 function updateQuickCreateDefs()
 {
+    if (file_exists(__DIR__.'/../../include/utils/sugar_file_utils.php')) {
+        require_once(__DIR__.'/../../include/utils/sugar_file_utils.php');
+    }
+
     $d = dir('modules');
     $studio_modules = array();
 
@@ -1351,7 +1361,11 @@ function updateQuickCreateDefs()
                 if (file_exists($quickcreatedefs) && is_readable($quickcreatedefs)) {
                     $file = file($quickcreatedefs);
                     //replace 'EditView' with 'QuickCreate'
-                    $fp = fopen($quickcreatedefs, 'wb');
+                    if (function_exists('sugar_fopen')) {
+                        $fp = sugar_fopen($quickcreatedefs, 'wb');
+                    } else {
+                        $fp = fopen($quickcreatedefs, 'wb');
+                    }
                     foreach ($file as &$line) {
                         if (preg_match('/^\s*\'EditView\'\s*=>\s*$/', $line) > 0) {
                             $line = "'QuickCreate' =>\n";
@@ -1359,7 +1373,11 @@ function updateQuickCreateDefs()
                         fwrite($fp, $line);
                     }
                     //write back.
-                    fclose($fp);
+                    if (function_exists('sugar_fclose')) {
+                        sugar_fclose($fp);
+                    } else {
+                        fclose($fp);
+                    }
                 } else {
                     $GLOBALS['log']->debug("Failed to replace 'EditView' with QuickCreate because $quickcreatedefs is either not readable or does not exist.");
                 }
@@ -3501,7 +3519,7 @@ function upgradeTeamColumn($bean, $column_name)
         }
         if ($fh = @sugar_fopen($file, 'wt')) {
             fwrite($fh, $contents);
-            fclose($fh);
+            sugar_fclose( $fh );
         }
 
 
@@ -3718,11 +3736,7 @@ function fix_dropdown_list()
                     //Now write out the file contents
                     //Create backup just in case
                     copy($file, $file . '.php_bak');
-                    $fp = @sugar_fopen($file, 'w');
-                    if ($fp) {
-                        fwrite($fp, $contents);
-                        fclose($fp);
-                    } else {
+                    if (!sugar_file_put_contents($file, $contents)) {
                         $GLOBALS['log']->error("Unable to update file contents in fix_dropdown_list for {$file}");
                     } //if-else
                 }
@@ -3840,11 +3854,7 @@ function fix_dropdown_list()
                 if ($touched) {
                     //Create a backup just in case
                     copy($file, $file . '.bak');
-                    $fp = @sugar_fopen($file, 'w');
-                    if ($fp) {
-                        fwrite($fp, $out);
-                        fclose($fp);
-                    } else {
+                    if (!sugar_file_put_contents($file, $contents)) {
                         //If we can't update the file, just return
                         $GLOBALS['log']->error("Unable to update file contents in fix_dropdown_list.");
                         return;
@@ -4357,7 +4367,6 @@ function writeSilentUpgradeVars()
     $cacheFileDir = "{$GLOBALS['sugar_config']['cache_dir']}/silentUpgrader";
     $cacheFile = "{$cacheFileDir}/silentUpgradeCache.php";
 
-    require_once('include/dir_inc.php');
     if (!mkdir_recursive($cacheFileDir)) {
         return false;
     }
@@ -4615,7 +4624,6 @@ function repairSearchFields($globString='modules/*/metadata/SearchFields.php', $
         logThis('Begin repairSearchFields', $path);
     }
 
-    require_once('include/dir_inc.php');
     require_once('modules/DynamicFields/templates/Fields/TemplateRange.php');
     require('include/modules.php');
 


### PR DESCRIPTION
This pull request makes sure that all modifications of php files are notified to OPcache by SuiteCRM core methods that save and close php files.

## Description
OPcache is an opcode cache for PHP and was included in PHP since PHP version 5.5 and is enabled by default in many distributions.

OPcache led to multiple issues in the past and still causes issues. This is caused by the dynamic nature of SuiteCRM: it writes php code and then includes these files directly after writing, which causes OPcache to not detect these modifications in time. The webserver then runs a previously cached version. It would require the dreaded "Quick Repair and Rebuild" to re-align the cache.
The changes in this pull request effectively remediate these issues by making sure that OPcache always is notified of potential modifications of php files.

## Motivation and Context
This PR is a follow up on PR #7711, which already solved some OPcache related bugs.

Originally OPcache clearing was realised by sugar_cache_reset() and sugar_cache_reset_full() which called opcache_reset(). This was not effective, because calling this method, the OPcache will only reset after completing the php routine, meanwhile holding a lock on OPcache, thereby prohibiting opcache_invalidate() from clearing single php files.

On multiple occasions, php files are modified, and then immediately read again. In the scenario where opcache_reset() was used, php would run the previously cached file, causing errors, like #8461 and #8462 .

To remediate this, 
- explicit clearing of written php files from the cache was implemented in core methods (sugar_fclose, sugar_put_file_contents, copy_recursive, unzip). The cache for overwritten php files is invalidated and these files will be re-cached when they are executed.
- all routines that potentially overwrite php files were changed to make sure that they use these core methods to close / write / copy / unzip
- opcache_reset() is now only executed on calling sugar_cache_reset_full(), which in turn is executed only at the end of a SuiteCRM upgrade.

Other than fixing these bugs, this PR allows for further optimisation of the OPcache performance, as there will be no need to check files for modified timestamps anymore. The following option can therefore be switched off, which enhances performance (php.ini):
``opcache.validate_timestamps=0``

Any routine in SuiteCRM potentially overwriting a php file should make sure to either close open files with sugar_fclose() or writing the file with sugar_put_file_contents() or copying files with copy_recursive()

## How To Test This
See #8461 and #8462 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.