### PR TITLE
Fix #7983: Remove warning and fatal due to mismatched parameters

### DIFF
--- a/include/SugarFields/Fields/Time/SugarFieldTime.php
+++ b/include/SugarFields/Fields/Time/SugarFieldTime.php
@@ -86,7 +86,7 @@ class SugarFieldTime extends SugarFieldBase
         return $this->fetch('include/SugarFields/Fields/Time/SearchView.tpl');
     }
 
-    public function save(&$bean, &$inputData, &$field, &$def, $prefix = '')
+    public function save(&$bean, $inputData, $field, $properties, $prefix = '')
     {
         global $timedate;
         if (!isset($inputData[$prefix.$field])) {


### PR DESCRIPTION
## Description
Make the declaration match the parent
https://github.com/salesagility/SuiteCRM/blob/hotfix-7.10.x/include/SugarFields/Fields/Base/SugarFieldBase.php#L601

This clears a warning and a fatal, as seen on the Issue.

## How To Test This
See Issue #7983

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

