### PR TITLE
Allow `date_created` and `date_modified` to be usable in Merging records

### DIFF
--- a/modules/MergeRecords/Step3.php
+++ b/modules/MergeRecords/Step3.php
@@ -42,9 +42,6 @@ if (!defined('sugarEntry') || !sugarEntry) {
  */
 
 
-
-
-
 require_once('include/JSON.php');
 $timedate = TimeDate::getInstance();
 global $app_strings;
@@ -54,35 +51,6 @@ global $current_language;
 global $urlPrefix;
 global $currentModule;
 global $theme;
-global $filter_for_valid_editable_attributes;
-global $invalid_attribute_by_name;
-//filter condition for fields in vardefs that can participate in merge.
-$filter_for_valid_editable_attributes =
-    array(
-        array('type'=>'datetimecombo','source'=>'db'),
-         array('type'=>'datetime','source'=>'db'),
-         array('type'=>'varchar','source'=>'db'),
-         array('type'=>'enum','source'=>'db'),
-         array('type'=>'multienum','source'=>'db'),
-         array('type'=>'text','source'=>'db'),
-         array('type'=>'date','source'=>'db'),
-         array('type'=>'time','source'=>'db'),
-         array('type'=>'bool','source'=>'db'),
-         array('type'=>'int','source'=>'db'),
-         array('type'=>'long','source'=>'db'),
-         array('type'=>'double','source'=>'db'),
-         array('type'=>'float','source'=>'db'),
-         array('type'=>'short','source'=>'db'),
-         array('dbType'=>'varchar','source'=>'db'),
-         array('dbType'=>'double','source'=>'db'),
-         array('type'=>'relate'),
-    );
-
-$filter_for_valid_related_attributes   = array( array('type'=>'link'),);
-$filter_for_invalid_related_attributes   = array(array('type'=>'link','link_type'=>'one'));
-
-//following attributes will be ignored from the merge process.
-$invalid_attribute_by_name= array('date_entered'=>'date_entered','date_modified'=>'date_modified','modified_user_id'=>'modified_user_id', 'created_by'=>'created_by','deleted'=>'deleted');
 
 $merge_ids_array = array();
 if (isset($_REQUEST['change_parent']) && $_REQUEST['change_parent']=='1') {
@@ -167,7 +135,7 @@ foreach ($temp_field_array as $field_array) {
         $b_values_different = false;
         $section_name='merge_row_similar';
 
-        //Prcoess locaton of the field. if values are different show field in first section. else 2nd.
+        //Process locaton of the field. if values are different show field in first section, else 2nd.
         $select_row_curr_field_value = $focus->merge_bean->$tempName;
         foreach ($merge_ids_array as $id) {
             if (($mergeBeanArray[$id]->$tempName=='' and $select_row_curr_field_value =='') or $mergeBeanArray[$id]->$tempName == $select_row_curr_field_value) {
@@ -449,7 +417,35 @@ function display_field_value($value)
  */
 function show_field($field_def)
 {
-    global $filter_for_valid_editable_attributes,$invalid_attribute_by_name;
+//filter condition for fields in vardefs that can participate in merge.
+$filter_for_valid_editable_attributes =
+    array(
+        array('type'=>'datetimecombo','source'=>'db'),
+         array('type'=>'datetime','source'=>'db'),
+         array('type'=>'varchar','source'=>'db'),
+         array('type'=>'enum','source'=>'db'),
+         array('type'=>'multienum','source'=>'db'),
+         array('type'=>'text','source'=>'db'),
+         array('type'=>'date','source'=>'db'),
+         array('type'=>'time','source'=>'db'),
+         array('type'=>'bool','source'=>'db'),
+         array('type'=>'int','source'=>'db'),
+         array('type'=>'long','source'=>'db'),
+         array('type'=>'double','source'=>'db'),
+         array('type'=>'float','source'=>'db'),
+         array('type'=>'short','source'=>'db'),
+         array('dbType'=>'varchar','source'=>'db'),
+         array('dbType'=>'double','source'=>'db'),
+         array('type'=>'relate'),
+    );
+
+    //following attributes will be ignored from the merge process.
+    $invalid_attribute_by_name= array(
+        'modified_user_id'=>'modified_user_id', 
+        'created_by'=>'created_by',
+        'deleted'=>'deleted',
+    );
+
     //field in invalid attributes list?
     if (isset($invalid_attribute_by_name[$field_def['name']])) {
         return false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This comes from a topic [in the Forums](https://community.suitecrm.com/t/date-last-modified-field-no-longer-displaying-in-contact-merge-since-7-11-10/71160)

It's a long story:

- there was old code to disallow `date_created` and `date_modified` from being usable in **Merging records** function
- it was badly written code
- it wasn't working, for a long time, probably
- then @JackBuchanan fixed it when fixing something else! https://github.com/salesagility/SuiteCRM/commit/80d3f00fad7f1cd4332cc17860db218a4a085405
- then a user complained (see Forum link above)

So what I did:
- allowed those two fields, they are definitely useful in some cases
- they are **off by default**, so this will only affect people who enable the **Duplicate Merge** in Studio
- removed the unnecessary global variables from the code, instead defined them in the only place they are used
- removed a couple of other unused variables

## How To Test This
1. Use the **Merge** function from some module's List view - these fields aren't there
2. Enable their **Duplicate Merge** property in Studio
3. Now they should appear in merge screen
4. Generally test the Merge function isn't broken

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

