### PR TITLE
Fix a PHP 7.4 deprecation warning in Crypt Blowfish.

### DIFF
--- a/include/Pear/Crypt_Blowfish/Blowfish.php
+++ b/include/Pear/Crypt_Blowfish/Blowfish.php
@@ -300,7 +300,7 @@ class Crypt_Blowfish
         for ($i = 0; $i < 18; $i++) {
             $data = 0;
             for ($j = 4; $j > 0; $j--) {
-                $data = $data << 8 | ord($key{$k});
+                $data = $data << 8 | ord($key[$k]);
                 $k = ($k+1) % $len;
             }
             $this->_P[$i] ^= $data;


### PR DESCRIPTION
## Description

Array items should always be accessed via `[]` rather than `{}`. This fixes a deprecation warning in PHP 7.4.

## Motivation and Context
PHP 7.4 deprecates the ability to access array items like `$array{1}` in favor of the usual `$array[1]`. I don't like changing vendored libraries, but this is a very minor change that fixes a deprecation warning that would otherwise cause an exception in a future version of PHP.

## How To Test This
Pretty much just sanity check the code and make sure tests pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.