### PR TITLE
Fix array accessor deprecations in tcpdf.php.

### DIFF
--- a/include/tcpdf/barcodes.php
+++ b/include/tcpdf/barcodes.php
@@ -742,7 +742,7 @@ class TCPDFBarcode
         $k = 0;
         for ($i = 0; $i < $len; ++$i) {
             $w += 1;
-            if (($i == ($len - 1)) or (($i < ($len - 1)) and ($seq[$i] != $seq{($i+1)}))) {
+            if (($i == ($len - 1)) or (($i < ($len - 1)) and ($seq[$i] != $seq[($i+1)]))) {
                 if ($seq[$i] == '1') {
                     $t = true; // bar
                 } else {
@@ -971,7 +971,7 @@ class TCPDFBarcode
                 $new_code = '';
                 $hclen = (strlen($code) / 2);
                 for ($i = 0; $i < $hclen; ++$i) {
-                    $new_code .= chr((int)($code{(2 * $i)} . $code{(2 * $i + 1)}));
+                    $new_code .= chr((int)($code[(2 * $i)] . $code[(2 * $i + 1)]));
                 }
                 $code = $new_code;
                 break;

--- a/include/tcpdf/barcodes.php
+++ b/include/tcpdf/barcodes.php
@@ -325,7 +325,7 @@ class TCPDFBarcode
         $k = 0;
         $clen = strlen($code);
         for ($i = 0; $i < $clen; ++$i) {
-            $char = $code{$i};
+            $char = $code[$i];
             if (!isset($chr[$char])) {
                 // invalid character
                 return false;
@@ -336,7 +336,7 @@ class TCPDFBarcode
                 } else {
                     $t = false; // space
                 }
-                $w = $chr[$char]{$j};
+                $w = $chr[$char][$j];
                 $bararray['bcode'][$k] = array('t' => $t, 'w' => $w, 'h' => 1, 'p' => 0);
                 $bararray['maxw'] += $w;
                 ++$k;
@@ -392,10 +392,10 @@ class TCPDFBarcode
         $code_ext = '';
         $clen = strlen($code);
         for ($i = 0 ; $i < $clen; ++$i) {
-            if (ord($code{$i}) > 127) {
+            if (ord($code[$i]) > 127) {
                 return false;
             }
-            $code_ext .= $encode[$code{$i}];
+            $code_ext .= $encode[$code[$i]];
         }
         return $code_ext;
     }
@@ -416,7 +416,7 @@ class TCPDFBarcode
         $sum = 0;
         $clen = strlen($code);
         for ($i = 0 ; $i < $clen; ++$i) {
-            $k = array_keys($chars, $code{$i});
+            $k = array_keys($chars, $code[$i]);
             $sum += $k[0];
         }
         $j = ($sum % 43);
@@ -518,10 +518,10 @@ class TCPDFBarcode
         $code_ext = '';
         $clen = strlen($code);
         for ($i = 0 ; $i < $clen; ++$i) {
-            if (ord($code{$i}) > 127) {
+            if (ord($code[$i]) > 127) {
                 return false;
             }
-            $code_ext .= $encode[$code{$i}];
+            $code_ext .= $encode[$code[$i]];
         }
         // checksum
         $code .= $this->checksum_code93($code);
@@ -531,7 +531,7 @@ class TCPDFBarcode
         $k = 0;
         $clen = strlen($code);
         for ($i = 0; $i < $clen; ++$i) {
-            $char = $code{$i};
+            $char = $code[$i];
             if (!isset($chr[$char])) {
                 // invalid character
                 return false;
@@ -542,7 +542,7 @@ class TCPDFBarcode
                 } else {
                     $t = false; // space
                 }
-                $w = $chr[$char]{$j};
+                $w = $chr[$char][$j];
                 $bararray['bcode'][$k] = array('t' => $t, 'w' => $w, 'h' => 1, 'p' => 0);
                 $bararray['maxw'] += $w;
                 ++$k;
@@ -574,7 +574,7 @@ class TCPDFBarcode
         $p = 1;
         $check = 0;
         for ($i = ($len - 1); $i >= 0; --$i) {
-            $k = array_keys($chars, $code{$i});
+            $k = array_keys($chars, $code[$i]);
             $check += ($k[0] * $p);
             ++$p;
             if ($p > 20) {
@@ -588,7 +588,7 @@ class TCPDFBarcode
         $p = 1;
         $check = 0;
         for ($i = $len; $i >= 0; --$i) {
-            $k = array_keys($chars, $code{$i});
+            $k = array_keys($chars, $code[$i]);
             $check += ($k[0] * $p);
             ++$p;
             if ($p > 15) {
@@ -611,11 +611,11 @@ class TCPDFBarcode
         $len = strlen($code);
         $sum = 0;
         for ($i = 0; $i < $len; $i+=2) {
-            $sum += $code{$i};
+            $sum += $code[$i];
         }
         $sum *= 3;
         for ($i = 1; $i < $len; $i+=2) {
-            $sum += ($code{$i});
+            $sum += ($code[$i]);
         }
         $r = $sum % 10;
         if ($r > 0) {
@@ -657,7 +657,7 @@ class TCPDFBarcode
             $p = 2;
             $check = 0;
             for ($i = ($clen - 1); $i >= 0; --$i) {
-                $check += (hexdec($code{$i}) * $p);
+                $check += (hexdec($code[$i]) * $p);
                 ++$p;
                 if ($p > 7) {
                     $p = 2;
@@ -672,7 +672,7 @@ class TCPDFBarcode
         $seq = '110'; // left guard
         $clen = strlen($code);
         for ($i = 0; $i < $clen; ++$i) {
-            $digit = $code{$i};
+            $digit = $code[$i];
             if (!isset($chr[$digit])) {
                 // invalid character
                 return false;
@@ -716,7 +716,7 @@ class TCPDFBarcode
         $seq = '11011010';
         $clen = strlen($code);
         for ($i = 0; $i < $clen; ++$i) {
-            $digit = $code{$i};
+            $digit = $code[$i];
             if (!isset($chr[$digit])) {
                 // invalid character
                 return false;
@@ -742,8 +742,8 @@ class TCPDFBarcode
         $k = 0;
         for ($i = 0; $i < $len; ++$i) {
             $w += 1;
-            if (($i == ($len - 1)) or (($i < ($len - 1)) and ($seq{$i} != $seq{($i+1)}))) {
-                if ($seq{$i} == '1') {
+            if (($i == ($len - 1)) or (($i < ($len - 1)) and ($seq[$i] != $seq{($i+1)}))) {
+                if ($seq[$i] == '1') {
                     $t = true; // bar
                 } else {
                     $t = false; // space
@@ -795,8 +795,8 @@ class TCPDFBarcode
         $k = 0;
         $clen = strlen($code);
         for ($i = 0; $i < $clen; $i = ($i + 2)) {
-            $char_bar = $code{$i};
-            $char_space = $code{$i+1};
+            $char_bar = $code[$i];
+            $char_space = $code[$i+1];
             if ((!isset($chr[$char_bar])) or (!isset($chr[$char_space]))) {
                 // invalid character
                 return false;
@@ -805,7 +805,7 @@ class TCPDFBarcode
             $seq = '';
             $chrlen = strlen($chr[$char_bar]);
             for ($s = 0; $s < $chrlen; $s++) {
-                $seq .= $chr[$char_bar]{$s} . $chr[$char_space]{$s};
+                $seq .= $chr[$char_bar][$s] . $chr[$char_space][$s];
             }
             $seqlen = strlen($seq);
             for ($j = 0; $j < $seqlen; ++$j) {
@@ -814,7 +814,7 @@ class TCPDFBarcode
                 } else {
                     $t = false; // space
                 }
-                $w = $seq{$j};
+                $w = $seq[$j];
                 $bararray['bcode'][$k] = array('t' => $t, 'w' => $w, 'h' => 1, 'p' => 0);
                 $bararray['maxw'] += $w;
                 ++$k;
@@ -984,7 +984,7 @@ class TCPDFBarcode
         $sum = $startid;
         $clen = strlen($code);
         for ($i = 0; $i < $clen; ++$i) {
-            $sum +=  (strpos($keys, $code{$i}) * ($i+1));
+            $sum +=  (strpos($keys, $code[$i]) * ($i+1));
         }
         $check = ($sum % 103);
         // add start, check and stop codes
@@ -993,9 +993,9 @@ class TCPDFBarcode
         $k = 0;
         $len = strlen($code);
         for ($i = 0; $i < $len; ++$i) {
-            $ck = strpos($keys, $code{$i});
+            $ck = strpos($keys, $code[$i]);
             if (($i == 0) or ($i > ($len-4))) {
-                $char_num = ord($code{$i});
+                $char_num = ord($code[$i]);
                 $seq = $chr[$char_num];
             } elseif (($ck >= 0) and isset($chr[$ck])) {
                 $seq = $chr[$ck];
@@ -1009,7 +1009,7 @@ class TCPDFBarcode
                 } else {
                     $t = false; // space
                 }
-                $w = $seq{$j};
+                $w = $seq[$j];
                 $bararray['bcode'][$k] = array('t' => $t, 'w' => $w, 'h' => 1, 'p' => 0);
                 $bararray['maxw'] += $w;
                 ++$k;
@@ -1042,14 +1042,14 @@ class TCPDFBarcode
         // calculate check digit
         $sum_a = 0;
         for ($i = 1; $i < $data_len; $i+=2) {
-            $sum_a += $code{$i};
+            $sum_a += $code[$i];
         }
         if ($len > 12) {
             $sum_a *= 3;
         }
         $sum_b = 0;
         for ($i = 0; $i < $data_len; $i+=2) {
-            $sum_b += ($code{$i});
+            $sum_b += ($code[$i]);
         }
         if ($len < 13) {
             $sum_b *= 3;
@@ -1061,7 +1061,7 @@ class TCPDFBarcode
         if ($code_len == $data_len) {
             // add check digit
             $code .= $r;
-        } elseif ($r !== (int)$code{$data_len}) {
+        } elseif ($r !== (int)$code[$data_len]) {
             // wrong checkdigit
             return false;
         }
@@ -1170,9 +1170,9 @@ class TCPDFBarcode
         $seq = '101'; // left guard bar
         if ($upce) {
             $bararray = array('code' => $upce_code, 'maxw' => 0, 'maxh' => 1, 'bcode' => array());
-            $p = $upce_parities[$code{1}][$r];
+            $p = $upce_parities[$code[1]][$r];
             for ($i = 0; $i < 6; ++$i) {
-                $seq .= $codes[$p[$i]][$upce_code{$i}];
+                $seq .= $codes[$p[$i]][$upce_code[$i]];
             }
             $seq .= '010101'; // right guard bar
         } else {
@@ -1180,17 +1180,17 @@ class TCPDFBarcode
             $half_len = ceil($len / 2);
             if ($len == 8) {
                 for ($i = 0; $i < $half_len; ++$i) {
-                    $seq .= $codes['A'][$code{$i}];
+                    $seq .= $codes['A'][$code[$i]];
                 }
             } else {
-                $p = $parities[$code{0}];
+                $p = $parities[$code[0]];
                 for ($i = 1; $i < $half_len; ++$i) {
-                    $seq .= $codes[$p[$i-1]][$code{$i}];
+                    $seq .= $codes[$p[$i-1]][$code[$i]];
                 }
             }
             $seq .= '01010'; // center guard bar
             for ($i = $half_len; $i < $len; ++$i) {
-                $seq .= $codes['C'][$code{$i}];
+                $seq .= $codes['C'][$code[$i]];
             }
             $seq .= '101'; // right guard bar
         }
@@ -1198,8 +1198,8 @@ class TCPDFBarcode
         $w = 0;
         for ($i = 0; $i < $clen; ++$i) {
             $w += 1;
-            if (($i == ($clen - 1)) or (($i < ($clen - 1)) and ($seq{$i} != $seq{($i+1)}))) {
-                if ($seq{$i} == '1') {
+            if (($i == ($clen - 1)) or (($i < ($clen - 1)) and ($seq[$i] != $seq[($i+1)]))) {
+                if ($seq[$i] == '1') {
                     $t = true; // bar
                 } else {
                     $t = false; // space
@@ -1230,7 +1230,7 @@ class TCPDFBarcode
         if ($len == 2) {
             $r = $code % 4;
         } elseif ($len == 5) {
-            $r = (3 * ($code{0} + $code{2} + $code{4})) + (9 * ($code{1} + $code{3}));
+            $r = (3 * ($code[0] + $code[2] + $code[4])) + (9 * ($code[1] + $code[3]));
             $r %= 10;
         } else {
             return false;
@@ -1281,10 +1281,10 @@ class TCPDFBarcode
         );
         $p = $parities[$len][$r];
         $seq = '1011'; // left guard bar
-        $seq .= $codes[$p[0]][$code{0}];
+        $seq .= $codes[$p[0]][$code[0]];
         for ($i = 1; $i < $len; ++$i) {
             $seq .= '01'; // separator
-            $seq .= $codes[$p[$i]][$code{$i}];
+            $seq .= $codes[$p[$i]][$code[$i]];
         }
         $bararray = array('code' => $code, 'maxw' => 0, 'maxh' => 1, 'bcode' => array());
         return $this->binseq_to_array($seq, $bararray);
@@ -1336,7 +1336,7 @@ class TCPDFBarcode
         // calculate checksum
         $sum = 0;
         for ($i = 0; $i < $len; ++$i) {
-            $sum += (int)$code{$i};
+            $sum += (int)$code[$i];
         }
         $chkd = ($sum % 10);
         if ($chkd > 0) {
@@ -1350,7 +1350,7 @@ class TCPDFBarcode
         $bararray['maxw'] += 2;
         for ($i = 0; $i < $len; ++$i) {
             for ($j = 0; $j < 5; ++$j) {
-                $h = $barlen[$code{$i}][$j];
+                $h = $barlen[$code[$i]][$j];
                 $p = floor(1 / $h);
                 $bararray['bcode'][$k++] = array('t' => 1, 'w' => 1, 'h' => $h, 'p' => $p);
                 $bararray['bcode'][$k++] = array('t' => 0, 'w' => 1, 'h' => 2, 'p' => 0);
@@ -1464,8 +1464,8 @@ class TCPDFBarcode
             $row = 0;
             $col = 0;
             for ($i = 0; $i < $len; ++$i) {
-                $row += $checktable[$code{$i}][0];
-                $col += $checktable[$code{$i}][1];
+                $row += $checktable[$code[$i]][0];
+                $col += $checktable[$code[$i]][1];
             }
             $row %= 6;
             $col %= 6;
@@ -1482,7 +1482,7 @@ class TCPDFBarcode
         }
         for ($i = 0; $i < $len; ++$i) {
             for ($j = 0; $j < 4; ++$j) {
-                switch ($barmode[$code{$i}][$j]) {
+                switch ($barmode[$code[$i]][$j]) {
                     case 1: {
                         $p = 0;
                         $h = 2;
@@ -1555,17 +1555,17 @@ class TCPDFBarcode
         $code = 'A'.strtoupper($code).'A';
         $len = strlen($code);
         for ($i = 0; $i < $len; ++$i) {
-            if (!isset($chr[$code{$i}])) {
+            if (!isset($chr[$code[$i]])) {
                 return false;
             }
-            $seq = $chr[$code{$i}];
+            $seq = $chr[$code[$i]];
             for ($j = 0; $j < 8; ++$j) {
                 if (($j % 2) == 0) {
                     $t = true; // bar
                 } else {
                     $t = false; // space
                 }
-                $w = $seq{$j};
+                $w = $seq[$j];
                 $bararray['bcode'][$k] = array('t' => $t, 'w' => $w, 'h' => 1, 'p' => 0);
                 $bararray['maxw'] += $w;
                 ++$k;
@@ -1607,7 +1607,7 @@ class TCPDFBarcode
         $p = 1;
         $check = 0;
         for ($i = ($len - 1); $i >= 0; --$i) {
-            $digit = $code{$i};
+            $digit = $code[$i];
             if ($digit == '-') {
                 $dval = 10;
             } else {
@@ -1629,7 +1629,7 @@ class TCPDFBarcode
             $p = 1;
             $check = 0;
             for ($i = $len; $i >= 0; --$i) {
-                $digit = $code{$i};
+                $digit = $code[$i];
                 if ($digit == '-') {
                     $dval = 10;
                 } else {
@@ -1648,17 +1648,17 @@ class TCPDFBarcode
         $code = 'S'.$code.'S';
         $len += 3;
         for ($i = 0; $i < $len; ++$i) {
-            if (!isset($chr[$code{$i}])) {
+            if (!isset($chr[$code[$i]])) {
                 return false;
             }
-            $seq = $chr[$code{$i}];
+            $seq = $chr[$code[$i]];
             for ($j = 0; $j < 6; ++$j) {
                 if (($j % 2) == 0) {
                     $t = true; // bar
                 } else {
                     $t = false; // space
                 }
-                $w = $seq{$j};
+                $w = $seq[$j];
                 $bararray['bcode'][$k] = array('t' => $t, 'w' => $w, 'h' => 1, 'p' => 0);
                 $bararray['maxw'] += $w;
                 ++$k;
@@ -1729,7 +1729,7 @@ class TCPDFBarcode
         $bararray = array('code' => $code, 'maxw' => 0, 'maxh' => 2, 'bcode' => array());
         $len = strlen($seq);
         for ($i = 0; $i < $len; ++$i) {
-            switch ($seq{$i}) {
+            switch ($seq[$i]) {
                 case '1': {
                     $p = 1;
                     $h = 1;
@@ -1802,9 +1802,9 @@ class TCPDFBarcode
             }
         }
         $binary_code = bcmul($binary_code, 10);
-        $binary_code = bcadd($binary_code, $tracking_number{0});
+        $binary_code = bcadd($binary_code, $tracking_number[0]);
         $binary_code = bcmul($binary_code, 5);
-        $binary_code = bcadd($binary_code, $tracking_number{1});
+        $binary_code = bcadd($binary_code, $tracking_number[1]);
         $binary_code .= substr($tracking_number, 2, 18);
         // convert to hexadecimal
         $binary_code = $this->dec_to_hex($binary_code);
@@ -1921,7 +1921,7 @@ class TCPDFBarcode
         $bitval = 1;
         $len = strlen($hex);
         for ($pos = ($len - 1); $pos >= 0; --$pos) {
-            $dec = bcadd($dec, bcmul(hexdec($hex{$pos}), $bitval));
+            $dec = bcadd($dec, bcmul(hexdec($hex[$pos]), $bitval));
             $bitval = bcmul($bitval, 16);
         }
         return $dec;

--- a/include/tcpdf/fonts/utils/makefont.php
+++ b/include/tcpdf/fonts/utils/makefont.php
@@ -222,7 +222,7 @@ r47930 - 2009-06-02 16:21:39 -0700 (Tue, 02 Jun 2009) - jenny - Updating with ch
         fclose($f);
         if ($type == 'Type1') {
             //Find first two sections and discard third one
-            $header = (ord($file{0}) == 128);
+            $header = (ord($file[0]) == 128);
             if ($header) {
                 //Strip first binary header
                 $file = substr($file, 6);
@@ -232,7 +232,7 @@ r47930 - 2009-06-02 16:21:39 -0700 (Tue, 02 Jun 2009) - jenny - Updating with ch
                 die('Error: font file does not seem to be valid Type1');
             }
             $size1 = $pos + 6;
-            if ($header and (ord($file{$size1}) == 128)) {
+            if ($header and (ord($file[$size1]) == 128)) {
                 //Strip second binary header
                 $file = substr($file, 0, $size1).substr($file, $size1+6);
             }
@@ -334,7 +334,7 @@ function ReadMap($enc)
     }
     $cc2gn = array();
     foreach ($a as $l) {
-        if ($l{0} == '!') {
+        if ($l[0] == '!') {
             $e = preg_split('/[ \\t]+/', rtrim($l));
             $cc = hexdec(substr($e[0], 1));
             $gn = $e[2];
@@ -384,8 +384,8 @@ function ReadUFM($file, &$cidtogidmap)
                 }
                 // Set GID
                 if (($cc >= 0) and ($cc < 0xFFFF) and $glyph) {
-                    $cidtogidmap{($cc * 2)} = chr($glyph >> 8);
-                    $cidtogidmap{(($cc * 2) + 1)} = chr($glyph & 0xFF);
+                    $cidtogidmap[($cc * 2)] = chr($glyph >> 8);
+                    $cidtogidmap[(($cc * 2) + 1)] = chr($glyph & 0xFF);
                 }
             }
             if (($gn == '.notdef') and (!isset($fm['MissingWidth']))) {

--- a/include/tcpdf/tcpdf.php
+++ b/include/tcpdf/tcpdf.php
@@ -6876,7 +6876,7 @@ if (!class_exists('TCPDF', false)) {
                 $strarr = array();
                 $strlen = strlen($str);
                 for ($i=0; $i < $strlen; ++$i) {
-                    $strarr[] = ord($str{$i});
+                    $strarr[] = ord($str[$i]);
                 }
                 // insert new value on cache
                 $this->cache_UTF8StringToArray['_'.$str] = $strarr;
@@ -6888,7 +6888,7 @@ if (!class_exists('TCPDF', false)) {
             $str .= ''; // force $str to be a string
             $length = strlen($str);
             for ($i = 0; $i < $length; ++$i) {
-                $char = ord($str{$i}); // get one string character at time
+                $char = ord($str[$i]); // get one string character at time
                 if (count($bytes) == 0) { // get starting octect
                     if ($char <= 0x7F) {
                         $unicode[] = $char; // use the character "as is" because is ASCII
@@ -7286,7 +7286,7 @@ if (!class_exists('TCPDF', false)) {
                 $j = 0;
                 for ($i = 0; $i < 256; ++$i) {
                     $t = $rc4[$i];
-                    $j = ($j + $t + ord($k{$i})) % 256;
+                    $j = ($j + $t + ord($k[$i])) % 256;
                     $rc4[$i] = $rc4[$j];
                     $rc4[$j] = $t;
                 }
@@ -7306,7 +7306,7 @@ if (!class_exists('TCPDF', false)) {
                 $rc4[$a] = $rc4[$b];
                 $rc4[$b] = $t;
                 $k = $rc4[($rc4[$a] + $rc4[$b]) % 256];
-                $out .= chr(ord($text{$i}) ^ $k);
+                $out .= chr(ord($text[$i]) ^ $k);
             }
             return $out;
         }

--- a/include/tcpdf/tcpdf.php
+++ b/include/tcpdf/tcpdf.php
@@ -5895,7 +5895,7 @@ if (!class_exists('TCPDF', false)) {
                             //Strip first binary header
                             $font = substr($font, 6);
                         }
-                        if ($header and (ord($font{$info['length1']}) == 128)) {
+                        if ($header and (ord($font[$info['length1']]) == 128)) {
                             //Strip second binary header
                             $font = substr($font, 0, $info['length1']).substr($font, ($info['length1'] + 6));
                         }
@@ -10552,7 +10552,7 @@ if (!class_exists('TCPDF', false)) {
                     case 'V':
                     case 'L':
                     case 'C': {
-                        $line{$len-1} = strtolower($cmd);
+                        $line[$len-1] = strtolower($cmd);
                         $this->_out($line);
                         break;
                     }

--- a/include/tcpdf/tcpdf.php
+++ b/include/tcpdf/tcpdf.php
@@ -5890,7 +5890,7 @@ if (!class_exists('TCPDF', false)) {
                     $font = file_get_contents($fontfile);
                     $compressed = (substr($file, -2) == '.z');
                     if ((!$compressed) and (isset($info['length2']))) {
-                        $header = (ord($font{0}) == 128);
+                        $header = (ord($font[0]) == 128);
                         if ($header) {
                             //Strip first binary header
                             $font = substr($font, 6);
@@ -7136,7 +7136,7 @@ if (!class_exists('TCPDF', false)) {
          */
         public function addHtmlLink($url, $name, $fill=0, $firstline=false, $color='', $style=-1)
         {
-            if (!$this->empty_string($url) and ($url{0} == '#')) {
+            if (!$this->empty_string($url) and ($url[0] == '#')) {
                 // convert url to internal link
                 $page = (int)substr($url, 1);
                 $url = $this->AddLink();
@@ -10501,7 +10501,7 @@ if (!class_exists('TCPDF', false)) {
             $cnt = count($lines);
             for ($i=0; $i < $cnt; ++$i) {
                 $line = $lines[$i];
-                if (($line == '') or ($line{0} == '%')) {
+                if (($line == '') or ($line[0] == '%')) {
                     continue;
                 }
                 $len = strlen($line);
@@ -11243,7 +11243,7 @@ if (!class_exists('TCPDF', false)) {
                     $tagname = strtolower($tag[1]);
                     // check if we are inside a table header
                     if ($tagname == 'thead') {
-                        if ($element{0} == '/') {
+                        if ($element[0] == '/') {
                             $thead = false;
                         } else {
                             $thead = true;
@@ -11253,7 +11253,7 @@ if (!class_exists('TCPDF', false)) {
                     }
                     $dom[$key]['tag'] = true;
                     $dom[$key]['value'] = $tagname;
-                    if ($element{0} == '/') {
+                    if ($element[0] == '/') {
                         // closing html tag
                         $dom[$key]['opening'] = false;
                         $dom[$key]['parent'] = end($level);
@@ -11396,10 +11396,10 @@ if (!class_exists('TCPDF', false)) {
                                 }
                             }
                             // font style
-                            if (isset($dom[$key]['style']['font-weight']) and (strtolower($dom[$key]['style']['font-weight']{0}) == 'b')) {
+                            if (isset($dom[$key]['style']['font-weight']) and (strtolower($dom[$key]['style']['font-weight'][0]) == 'b')) {
                                 $dom[$key]['fontstyle'] .= 'B';
                             }
-                            if (isset($dom[$key]['style']['font-style']) and (strtolower($dom[$key]['style']['font-style']{0}) == 'i')) {
+                            if (isset($dom[$key]['style']['font-style']) and (strtolower($dom[$key]['style']['font-style'][0]) == 'i')) {
                                 $dom[$key]['fontstyle'] .= '"I';
                             }
                             // font color
@@ -11416,9 +11416,9 @@ if (!class_exists('TCPDF', false)) {
                                 foreach ($decors as $dec) {
                                     $dec = trim($dec);
                                     if (!$this->empty_string($dec)) {
-                                        if ($dec{0} == 'u') {
+                                        if ($dec[0] == 'u') {
                                             $dom[$key]['fontstyle'] .= 'U';
-                                        } elseif ($dec{0} == 'l') {
+                                        } elseif ($dec[0] == 'l') {
                                             $dom[$key]['fontstyle'] .= 'D';
                                         }
                                     }
@@ -11434,7 +11434,7 @@ if (!class_exists('TCPDF', false)) {
                             }
                             // check for text alignment
                             if (isset($dom[$key]['style']['text-align'])) {
-                                $dom[$key]['align'] = strtoupper($dom[$key]['style']['text-align']{0});
+                                $dom[$key]['align'] = strtoupper($dom[$key]['style']['text-align'][0]);
                             }
                             // check for border attribute
                             if (isset($dom[$key]['style']['border'])) {
@@ -11457,10 +11457,10 @@ if (!class_exists('TCPDF', false)) {
                             // font size
                             if (isset($dom[$key]['attribute']['size'])) {
                                 if ($key > 0) {
-                                    if ($dom[$key]['attribute']['size']{0} == '+') {
+                                    if ($dom[$key]['attribute']['size'][0] == '+') {
                                         $dom[$key]['fontsize'] = $dom[($dom[$key]['parent'])]['fontsize'] + (int)substr($dom[$key]['attribute']['size'],
                                                 1);
-                                    } elseif ($dom[$key]['attribute']['size']{0} == '-') {
+                                    } elseif ($dom[$key]['attribute']['size'][0] == '-') {
                                         $dom[$key]['fontsize'] = $dom[($dom[$key]['parent'])]['fontsize'] - (int)substr($dom[$key]['attribute']['size'],
                                                 1);
                                     } else {
@@ -11498,8 +11498,8 @@ if (!class_exists('TCPDF', false)) {
                         if (($dom[$key]['value'] == 'pre') or ($dom[$key]['value'] == 'tt')) {
                             $dom[$key]['fontname'] = $this->default_monospaced_font;
                         }
-                        if (($dom[$key]['value']{0} == 'h') and ((int)$dom[$key]['value']{1} > 0) and ((int)$dom[$key]['value']{1} < 7)) {
-                            $headsize = (4 - (int)$dom[$key]['value']{1}) * 2;
+                        if (($dom[$key]['value'][0] == 'h') and ((int)$dom[$key]['value'][1] > 0) and ((int)$dom[$key]['value'][1] < 7)) {
+                            $headsize = (4 - (int)$dom[$key]['value'][1]) * 2;
                             $dom[$key]['fontsize'] = $dom[0]['fontsize'] + $headsize;
                             $dom[$key]['fontstyle'] .= 'B';
                         }
@@ -11547,7 +11547,7 @@ if (!class_exists('TCPDF', false)) {
                         }
                         // check for text alignment
                         if (isset($dom[$key]['attribute']['align']) and (!$this->empty_string($dom[$key]['attribute']['align'])) and ($dom[$key]['value'] !== 'img')) {
-                            $dom[$key]['align'] = strtoupper($dom[$key]['attribute']['align']{0});
+                            $dom[$key]['align'] = strtoupper($dom[$key]['attribute']['align'][0]);
                         }
                     } // end opening tag
                 } else {
@@ -12501,9 +12501,9 @@ if (!class_exists('TCPDF', false)) {
                             foreach ($decors as $dec) {
                                 $dec = trim($dec);
                                 if (!$this->empty_string($dec)) {
-                                    if ($dec{0} == 'u') {
+                                    if ($dec[0] == 'u') {
                                         $this->HREF['style'] .= 'U';
-                                    } elseif ($dec{0} == 'l') {
+                                    } elseif ($dec[0] == 'l') {
                                         $this->HREF['style'] .= 'D';
                                     }
                                 }
@@ -12565,7 +12565,7 @@ if (!class_exists('TCPDF', false)) {
                         $imglink = '';
                         if (isset($this->HREF['url']) and !$this->empty_string($this->HREF['url'])) {
                             $imglink = $this->HREF['url'];
-                            if ($imglink{0} == '#') {
+                            if ($imglink[0] == '#') {
                                 // convert url to internal link
                                 $page = (int)substr($imglink, 1);
                                 $imglink = $this->AddLink();


### PR DESCRIPTION
## Description

PHP 7.4 deprecates the ability to access array values with `$array{1}`, instead favoring `$array[1]`. This replaces instances of this syntax in the vendored `tcpdf.php` file.

These deprecation warnings will presumably become exceptions in a future version of PHP.

## How To Test This

Make sure CI passes and do a sanity check of the code.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.