### PR TITLE
Fix #7651: [WARN] CSS File Dawn/yui.css not found

### DIFF
--- a/include/SugarTheme/SugarTheme.php
+++ b/include/SugarTheme/SugarTheme.php
@@ -623,7 +623,6 @@ class SugarTheme
         $html = '
             <!-- qtip & suggestion box -->
             <link rel="stylesheet" type="text/css" href="include/javascript/qtip/jquery.qtip.min.css" />';
-        $html .= '<link rel="stylesheet" type="text/css" href="'.$this->getCSSURL('yui.css').'" />';
         $html .= '<link rel="stylesheet" type="text/css" href="include/javascript/jquery/themes/base/jquery.ui.all.css" />';
 
         // sprites


### PR DESCRIPTION
According to Dillon's comment here https://github.com/salesagility/SuiteCRM/issues/7651#issuecomment-534480674

... this can be removed (again) to prevent the log message, now that SuiteR and Suite7 are no longer part of SuiteCRM.