### PR TITLE
fixes #1241 - Reverts commit b3246d3 / adds condition for lookup rela…

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -3627,6 +3627,9 @@ class SugarBean
         $used_join_key = array();
 
         //walk through the fields and for every relationship field add their relationship_info field
+        //in case these fields have source 'non-db'. The module name of the parent bean is passed to
+        //make sure that relationship_info fields are only added when the module name of the
+        //relationship_info field matches the parent module, for which this query is being built.
         //relationshipfield-aliases are resolved in SugarBean::create_new_list_query
         // through their relationship_info field
         if (isset($parentbean)) {


### PR DESCRIPTION
This commit follows up on PR #61. It concerns relationship fields. These fields require fields of type "relationship_info" to obtain information on how to query them. 

Due to a bug in the display of the accept status in subpanels (bug #743) bugfix b3246d3 was committed, which effectively defeats its purpose.

This pull requests reverts this commit and adds an additional check to remediate #743

## Description

Relationship fields, such as the "role" field between Opportunities and Contacts require a relationship_info field that holds the information to which link a relationship field belongs. This field is therefore defined in the vardefs as well.

To be able to query this field, normally the relationship_info field is added as a "query_only" field so that the relationship field can effectively be queried.

## Motivation and Context

As the vardefs well-define how each field should be queried, with PR #61 the ability was added to the SugarBean class to query relationship fields, without the need to supply their belonging relationship_info field. Instead, when querying a relationship field, the SugarBean class looks up the required relationship info field by itself.

This would not only remove the requirement to add the relationship_info fields as query_only fields for subpanels, but would also enable to use studio to add existing relationship fields in studio to the Listview and Filters without the need to add any relationship_info field.

This change however broke the display of the accept status (issue #743) of meetings, calls and events in subpanels. It is caused by the fact that accept status have multiple relationship_info fields, each for Meetings, Calls and Events, and the lookup did not discern these.

With commit b3246d3 this was fixed, however this broke the ability of SugarBean to query relationship_info fields by itself (issue #1241), effectively undoing PR #61.

This PR reverts b3246d3 and adds a check to make sure only the relationship_info field matching the parent module is used. Effectively it replaces the condition

`(!isset($value['link_type']) || $value['link_type'] != 'relationship_info')`

with

`$this->load_relationship($value['link']) && $this->{$value['link']}->getRelatedModuleName() == $parentModule`

It thereby caters all scenarios:
 - relationship fields having only one relationship_info field
 - relationship fields having multiple relationship_info fields
 - with and without its relationship_info supplied as "query_only" field

## How To Test This
See #1241

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
