### PR TITLE
Fix modulebuilder labels edit fixes #6051

### DIFF
--- a/modules/ModuleBuilder/tpls/labels.tpl
+++ b/modules/ModuleBuilder/tpls/labels.tpl
@@ -55,9 +55,11 @@
 <input class='button' name = 'renameModBtn' id = "renameModBtn" type='button' value='{$mod_strings.LBL_BTN_RENAME_MODULE}'
        onclick='document.location.href = "index.php?action=wizard&module=Studio&wizard=StudioWizard&option=RenameTabs"'>
 {/if}
+{if !empty($labels_choice)}
 <div style="float: right">
             {html_options name='labels' options=$labels_choice selected=$labels_current onchange='this.form.action.value="EditLabels";ModuleBuilder.handleSave("editlabels")'}
             </div>
+{/if}
 <hr >
 <input type='hidden' name='to_pdf' value='1'>
 

--- a/modules/ModuleBuilder/views/view.modulelabels.php
+++ b/modules/ModuleBuilder/views/view.modulelabels.php
@@ -83,7 +83,7 @@ class ViewModulelabels extends SugarView
         }
         //need to change the following to interface with MBlanguage.
 
-        $smarty->assign('MOD', $mbModule->getModStrings($selected_lang));
+        $smarty->assign('MOD_LABELS', $mbModule->getModStrings($selected_lang));
         $smarty->assign('APP', $GLOBALS['app_strings']);
         $smarty->assign('selected_lang', $selected_lang);
         $smarty->assign('view_package', $package_name);


### PR DESCRIPTION
Fixes display of module labels in Modulebuilder

## Description
Opening Module Builder and clicking on "Labels" for a module doesn't list any labels, see #6051

## Motivation and Context
Solves the display of labels in the ModuleBuilder editing function. This function was broken by #5519, which fixed an issue for labels editing in Studio.

It also hides the dropdown for "frequently used labels" / "all labels" when it is not populated with values (in modulebuilder).

## How To Test This
1. Open Module Builder
2. Create a new Package
3. Create a new Module of type "Basic"
4. Click on "Labels" on the navigation tree on the left

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.