### PR TITLE
Cleanup detailviewdefs for module Users

### DIFF
--- a/modules/Users/metadata/detailviewdefs.php
+++ b/modules/Users/metadata/detailviewdefs.php
@@ -80,20 +80,6 @@ $viewdefs['Users']['DetailView'] = array(
                         ),
                 ),
         ),
-    'useTabs' => true,
-    'tabDefs' =>
-        array(
-            'LBL_USER_INFORMATION' =>
-                array(
-                    'newTab' => true,
-                    'panelDefault' => 'expanded',
-                ),
-            'LBL_EMPLOYEE_INFORMATION' =>
-                array(
-                    'newTab' => true,
-                    'panelDefault' => 'expanded',
-                ),
-        ),
     'panels' =>
         array(
             'LBL_USER_INFORMATION' =>


### PR DESCRIPTION
The Detailviewdefs for Users contain an entry for useTabs and tabDefs twice, once correctly under "templateMeta" and once in the wrong place of the definition hierarchy, probably caused by a merge failure.

## Description
Cleans up the detailviewdefs to remove the stray useTabs and tabDefs

## Motivation and Context
It doesn't solve any problem, for this reason no issue was created.

## How To Test This
 - Click on Admin / User Management
 - Click on a user
 -> the details of the user should be displayed, as they did before

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.