### PR TITLE
Incompatible method SugarWidgetSubPanelEditRoleButton::displayList - fixes #5624

### DIFF
--- a/include/generic/SugarWidgets/SugarWidgetSubPanelEditRoleButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelEditRoleButton.php
@@ -53,7 +53,7 @@ class SugarWidgetSubPanelEditRoleButton extends SugarWidgetField
         return '&nbsp;';
     }
 
-    public function displayList($layout_def)
+    public function displayList(&$layout_def)
     {
         global $app_strings;
         global $subpanel_item_count;


### PR DESCRIPTION
## Description
Opening an Opportunity issues the following entry in the webserver error log:

```Declaration of SugarWidgetSubPanelEditRoleButton::displayList($layout_def) should be compatible with SugarWidgetField::displayList(&$layout_def)```

## Motivation and Context
This PR makes the method SugarWidgetSubPanelEditRoleButton::displayList compatible to it's parent class SugarWidgetField, it follows up on PR  #5635.

## How To Test This
Open an opportunity, check the error log file of the webserver to see if a new entry like above appears.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.