### PR TITLE
Use smarty foreach key instead of item key

### DIFF
--- a/modules/AOR_Reports/Dashlets/AORReportsDashlet/dashletConfigure.tpl
+++ b/modules/AOR_Reports/Dashlets/AORReportsDashlet/dashletConfigure.tpl
@@ -150,7 +150,7 @@
                     </script>
                 </td>
             </tr>
-            {foreach from=$parameters item=condition}
+            {foreach from=$parameters item=condition key=key}
             <tr>
                 <td scope='row'>
                     {$MOD.LBL_PARAMETERS}
@@ -158,9 +158,9 @@
                 <td>
                     <div id="parameterOptions{$id}">
 
-                            <input type='hidden' name='parameter_id[{$condition.key}]' value='{$condition.id}'>
-                            <input type='hidden' name='parameter_operator[{$condition.key}]' value='{$condition.operator}'>
-                            <input type='hidden' name='parameter_type[{$condition.key}]' value='{$condition.value_type}'>
+                            <input type='hidden' name='parameter_id[{$key}]' value='{$condition.id}'>
+                            <input type='hidden' name='parameter_operator[{$key}]' value='{$condition.operator}'>
+                            <input type='hidden' name='parameter_type[{$key}]' value='{$condition.value_type}'>
 
                         {if $condition.value_type == "Period"}
                             {$condition.module_display} - <em>{$condition.field_display}</em> - {$condition.operator_display}


### PR DESCRIPTION
Use foreach key instead of item key else its indexed from 1 instead of 0.
https://www.smarty.net/docsv2/en/language.function.foreach.tpl

As parameters are indexed from 0 in AOR_Reports but in dashlet it starts at 1 so params do not work.

This is a bug in 7.8.x but code has not changed since so expect its the same.