### PR TITLE
Fix usage of deprecated Redis::delete() function

### DIFF
--- a/include/SugarCache/SugarCacheRedis.php
+++ b/include/SugarCache/SugarCacheRedis.php
@@ -152,7 +152,7 @@ class SugarCacheRedis extends SugarCacheAbstract
         $key
         ) {
         $key = $this->_fixKeyName($key);
-        $this->_getRedisObject()->delete($key);
+        $this->_getRedisObject()->del($key);
     }
     
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Replace usage of Redis::delete() with Redis::del()

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The function Redis::delete() is deprecated.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Enable Redis caching. E.g. in `config_override.php`:

```
$sugar_config['external_cache_disabled_redis'] = false;
$sugar_config['external_cache']['redis']['host'] = 'redis';
$sugar_config['external_cache']['redis']['port'] = '6379';
```

Use SuiteCRM a bit. Key/Values should be stored and get deleted as usual.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
