### PR TITLE
Auto-close success message boxes in ModuleBuilder

### DIFF
--- a/modules/ModuleBuilder/javascript/ModuleBuilder.js
+++ b/modules/ModuleBuilder/javascript/ModuleBuilder.js
@@ -660,6 +660,9 @@ if (typeof('console') == 'undefined') {
               width: 500,
               close: true
             });
+            window.setTimeout(function() {
+                YAHOO.SUGAR.MessageBox.hide();
+            }, 1000);
             ModuleBuilder.updateContent(o);
           }
 
@@ -733,6 +736,9 @@ if (typeof('console') == 'undefined') {
               width: 500,
               close: true
             });
+            window.setTimeout(function() {
+                YAHOO.SUGAR.MessageBox.hide();
+            }, 1000);
             successCall(o);
           }
         }

--- a/tests/_support/Step/Acceptance/ModuleBuilder.php
+++ b/tests/_support/Step/Acceptance/ModuleBuilder.php
@@ -33,8 +33,8 @@ class ModuleBuilder extends Administration
             $I->fillField(['name' => 'description'], 'test module');
             $I->click('Save');
 
-            // Close confirmation window
-            $I->closePopupSuccess();
+            // Wait until confirmation window has disappeared
+            $this->waitUntilPopupSuccessDisappeared();
 
             // Create new module
             $I->click('New Module');
@@ -67,9 +67,6 @@ class ModuleBuilder extends Administration
 
             $I->wait(1);
             $I->click('Save'); // Will this be an issue with languages?
-
-            // Close popup
-            $I->closePopupSuccess();
 
             // Deploy module
 
@@ -118,13 +115,14 @@ class ModuleBuilder extends Administration
         $I->waitForElementVisible(['name' => 'savebtn']);
     }
 
-    public function closePopupSuccess(): void
+    /**
+     * Wait until confirmation window has disappeared
+     */
+    public function waitUntilPopupSuccessDisappeared()
     {
         $I = $this;
-        $I->wait(1);
-        $I->executeJS('return typeof document.getElementById("sugarMsgWindow") !== "undefined";');
-        $I->waitForText('This operation is completed successfully', null, '#sugarMsgWindow_c');
-        $I->click('.container-close');
+        $I->waitForElementNotVisible('#sugarMsgWindow_c');
+        $I->waitForElementNotVisible('#sugarMsgWindow_mask');
     }
 
     /**
@@ -148,9 +146,6 @@ class ModuleBuilder extends Administration
         if ($packageExists) {
             $I->acceptPopup();
         }
-
-        // Close popup
-        $I->closePopupSuccess();
 
         // Wait for page to refresh and look for new package link
         $I->waitForElement('#newPackageLink');

--- a/tests/acceptance/Core/ModuleBuilderFieldsCest.php
+++ b/tests/acceptance/Core/ModuleBuilderFieldsCest.php
@@ -119,10 +119,8 @@ class ModuleBuilderFieldsCest
         $I->waitForElementVisible(['name' => 'viewfieldsbtn']);
         $I->click(['name' => 'viewfieldsbtn']);
 
-        // Close popup
-        $I->waitForElementVisible('#sugarMsgWindow_mask');
-        $I->waitForText('This operation is completed successfully', 30, '#sugarMsgWindow_c');
-        $I->click('.container-close');
+        // Wait until confirmation window has disappeared
+        $moduleBuilder->waitUntilPopupSuccessDisappeared();
 
         // Add field button
         $I->waitForElementVisible('[name="addfieldbtn"]');
@@ -146,15 +144,14 @@ class ModuleBuilderFieldsCest
         // Click save
         $I->click(['name' => 'fsavebtn']);
 
-        $moduleBuilder->closePopupSuccess();
-
         // Add to layout viewlayoutsbtn
         $moduleBuilder->selectModule(\Page\ModuleFields::$PACKAGE_NAME, \Page\ModuleFields::$NAME);
         // View Layouts button
         $I->waitForElementVisible(['name' => 'viewlayoutsbtn']);
         $I->click(['name' => 'viewlayoutsbtn']);
 
-        $moduleBuilder->closePopupSuccess();
+        // Wait until confirmation window has disappeared
+        $moduleBuilder->waitUntilPopupSuccessDisappeared();
 
         // Click Edit View
         $I->waitForElementVisible('.bodywrapper');
@@ -175,7 +172,6 @@ class ModuleBuilderFieldsCest
 
         $I->checkOption('#syncCheckbox');
         $I->click('Save');
-        $moduleBuilder->closePopupSuccess();
     }
 
 
@@ -200,10 +196,8 @@ class ModuleBuilderFieldsCest
         $I->waitForElementVisible(['name' => 'viewfieldsbtn']);
         $I->click(['name' => 'viewfieldsbtn']);
 
-        // Close popup
-        $I->waitForElementVisible('#sugarMsgWindow_mask');
-        $I->waitForText('This operation is completed successfully', 30, '#sugarMsgWindow_c');
-        $I->click('.container-close');
+        // Wait until confirmation window has disappeared
+        $moduleBuilder->waitUntilPopupSuccessDisappeared();
 
         // Add field button
         $I->waitForElementVisible('[name="addfieldbtn"]');
@@ -227,15 +221,14 @@ class ModuleBuilderFieldsCest
         // Click save
         $I->click(['name' => 'fsavebtn']);
 
-        $moduleBuilder->closePopupSuccess();
-
         // Add to layout viewlayoutsbtn
         $moduleBuilder->selectModule(\Page\ModuleFields::$PACKAGE_NAME, \Page\ModuleFields::$NAME);
         // View Layouts button
         $I->waitForElementVisible(['name' => 'viewlayoutsbtn']);
         $I->click(['name' => 'viewlayoutsbtn']);
 
-        $moduleBuilder->closePopupSuccess();
+        // Wait until confirmation window has disappeared
+        $moduleBuilder->waitUntilPopupSuccessDisappeared();
 
         // Click Edit View
         $I->waitForElementVisible('.bodywrapper');
@@ -256,7 +249,6 @@ class ModuleBuilderFieldsCest
 
         $I->checkOption('#syncCheckbox');
         $I->click('Save');
-        $moduleBuilder->closePopupSuccess();
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Auto-close annoying success message boxes in Module Builder.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When working with the Module Builder every 2nd click a success message box
pops up which then requires clicking on the tiny "close" link.
This makes working with the Module Builder an unnerving task.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Create a new package + module in Module Builder, create some fields, etc.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
