### PR TITLE
Fix #8525 Always show bulk action button and delete only when need

### DIFF
--- a/include/ListView/ListViewDisplay.php
+++ b/include/ListView/ListViewDisplay.php
@@ -353,17 +353,9 @@ class ListViewDisplay
                 }
             }
         } else {
-            // delete
-            if (
-                ACLController::checkAccess($this->seed->module_dir, 'delete', true)
-                && $this->delete
-            ) {
-                if ($this->show_action_dropdown_as_delete) {
-                    $menuItems[] = $this->buildDeleteLink($location);
-                } else {
-                    $menuItems[] = $this->buildBulkActionButton($location);
-                }
-            }
+
+            // Bulk Action button always
+            $menuItems[] = $this->buildBulkActionButton($location);
 
             // Compose email
             if (isset($this->email) && $this->email === true) {
@@ -412,10 +404,10 @@ class ListViewDisplay
                 $menuItems[] = $item;
             }
 
-
+            // delete
             if (
-                $this->delete
-                && !$this->show_action_dropdown_as_delete
+                ACLController::checkAccess($this->seed->module_dir, 'delete', true)
+                && $this->delete
             ) {
                 $menuItems[] = $this->buildDeleteLink($location);
             }
@@ -620,66 +612,66 @@ class ListViewDisplay
                 alert('{$app_strings['LBL_LISTVIEW_NO_SELECTED']}');
                 return false;
             }
-			if ( document.forms['targetlist_form'] ) {
-				var form = document.forms['targetlist_form'];
-				form.reset;
-			} else
-				var form = document.createElement ( 'form' ) ;
-			form.setAttribute ( 'name' , 'targetlist_form' );
-			form.setAttribute ( 'method' , 'post' ) ;
-			form.setAttribute ( 'action' , 'index.php' );
-			document.body.appendChild ( form ) ;
-			if ( !form.module ) {
-			    var input = document.createElement('input');
-			    input.setAttribute ( 'name' , 'module' );
-			    input.setAttribute ( 'value' , '{$this->seed->module_dir}' );
-			    input.setAttribute ( 'type' , 'hidden' );
-			    form.appendChild ( input ) ;
-			    var input = document.createElement('input');
-			    input.setAttribute ( 'name' , 'action' );
-			    input.setAttribute ( 'value' , 'TargetListUpdate' );
-			    input.setAttribute ( 'type' , 'hidden' );
-			    form.appendChild ( input ) ;
-			}
-			if ( !form.uids ) {
-			    var input = document.createElement('input');
-			    input.setAttribute ( 'name' , 'uids' );
-			    input.setAttribute ( 'type' , 'hidden' );
-			    form.appendChild ( input ) ;
-			}
-			if ( !form.prospect_list ) {
-			    var input = document.createElement('input');
-			    input.setAttribute ( 'name' , 'prospect_list' );
-			    input.setAttribute ( 'type' , 'hidden' );
-			    form.appendChild ( input ) ;
-			}
-			if ( !form.return_module ) {
-			    var input = document.createElement('input');
-			    input.setAttribute ( 'name' , 'return_module' );
-			    input.setAttribute ( 'type' , 'hidden' );
-			    form.appendChild ( input ) ;
-			}
-			if ( !form.return_action ) {
-			    var input = document.createElement('input');
-			    input.setAttribute ( 'name' , 'return_action' );
-			    input.setAttribute ( 'type' , 'hidden' );
-			    form.appendChild ( input ) ;
-			}
-			if ( !form.select_entire_list ) {
-			    var input = document.createElement('input');
-			    input.setAttribute ( 'name' , 'select_entire_list' );
-			    input.setAttribute ( 'value', document.MassUpdate.select_entire_list.value);
-			    input.setAttribute ( 'type' , 'hidden' );
-			    form.appendChild ( input ) ;
-			}
-			if ( !form.current_query_by_page ) {
-			    var input = document.createElement('input');
-			    input.setAttribute ( 'name' , 'current_query_by_page' );
-			    input.setAttribute ( 'value', '{$current_query_by_page}' );
-			    input.setAttribute ( 'type' , 'hidden' );
-			    form.appendChild ( input ) ;
-			}
-			open_popup('ProspectLists','600','400','',true,false,{ 'call_back_function':'set_return_and_save_targetlist','form_name':'targetlist_form','field_to_name_array':{'id':'prospect_list'} } );
+            if ( document.forms['targetlist_form'] ) {
+                var form = document.forms['targetlist_form'];
+                form.reset;
+            } else
+                var form = document.createElement ( 'form' ) ;
+            form.setAttribute ( 'name' , 'targetlist_form' );
+            form.setAttribute ( 'method' , 'post' ) ;
+            form.setAttribute ( 'action' , 'index.php' );
+            document.body.appendChild ( form ) ;
+            if ( !form.module ) {
+                var input = document.createElement('input');
+                input.setAttribute ( 'name' , 'module' );
+                input.setAttribute ( 'value' , '{$this->seed->module_dir}' );
+                input.setAttribute ( 'type' , 'hidden' );
+                form.appendChild ( input ) ;
+                var input = document.createElement('input');
+                input.setAttribute ( 'name' , 'action' );
+                input.setAttribute ( 'value' , 'TargetListUpdate' );
+                input.setAttribute ( 'type' , 'hidden' );
+                form.appendChild ( input ) ;
+            }
+            if ( !form.uids ) {
+                var input = document.createElement('input');
+                input.setAttribute ( 'name' , 'uids' );
+                input.setAttribute ( 'type' , 'hidden' );
+                form.appendChild ( input ) ;
+            }
+            if ( !form.prospect_list ) {
+                var input = document.createElement('input');
+                input.setAttribute ( 'name' , 'prospect_list' );
+                input.setAttribute ( 'type' , 'hidden' );
+                form.appendChild ( input ) ;
+            }
+            if ( !form.return_module ) {
+                var input = document.createElement('input');
+                input.setAttribute ( 'name' , 'return_module' );
+                input.setAttribute ( 'type' , 'hidden' );
+                form.appendChild ( input ) ;
+            }
+            if ( !form.return_action ) {
+                var input = document.createElement('input');
+                input.setAttribute ( 'name' , 'return_action' );
+                input.setAttribute ( 'type' , 'hidden' );
+                form.appendChild ( input ) ;
+            }
+            if ( !form.select_entire_list ) {
+                var input = document.createElement('input');
+                input.setAttribute ( 'name' , 'select_entire_list' );
+                input.setAttribute ( 'value', document.MassUpdate.select_entire_list.value);
+                input.setAttribute ( 'type' , 'hidden' );
+                form.appendChild ( input ) ;
+            }
+            if ( !form.current_query_by_page ) {
+                var input = document.createElement('input');
+                input.setAttribute ( 'name' , 'current_query_by_page' );
+                input.setAttribute ( 'value', '{$current_query_by_page}' );
+                input.setAttribute ( 'type' , 'hidden' );
+                form.appendChild ( input ) ;
+            }
+            open_popup('ProspectLists','600','400','',true,false,{ 'call_back_function':'set_return_and_save_targetlist','form_name':'targetlist_form','field_to_name_array':{'id':'prospect_list'} } );
 EOF;
         $js = str_replace(array("\r","\n"), '', $js);
         return "<a href='javascript:void(0)' class=\"parent-dropdown-action-handler\" id=\"targetlist_listview_". $loc ." \" onclick=\"$js\">{$app_strings['LBL_ADD_TO_PROSPECT_LIST_BUTTON_LABEL']}</a>";


### PR DESCRIPTION
Fix #8525 
Fix #8309 

## Description
The bulk action button should always be displayed, and delete button only when the user has ACL permissions for this.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The problem was that bulk action button only display, when user have delete ACL permissions. this is not correct as explained here #8525
In the same way the user does not have delete permission but "Delete" button exist in list. With this change delete button only display when user have delete permissions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->