### PR TITLE
Fix Dropdown with single select

### DIFF
--- a/include/SugarFields/Fields/Enum/SearchView.tpl
+++ b/include/SugarFields/Fields/Enum/SearchView.tpl
@@ -40,4 +40,4 @@
 
 *}
 {{capture name=display_size assign=size}}{{$displayParams.size|default:6}}{{/capture}}
-{html_options id='{{$vardef.name}}' name='{{$vardef.name}}[]' options={{sugarvar key='options' string=true}} size="{{$size}}" class="templateGroupChooser" {{if $size > 1}}multiple="1"{{/if}} selected={{sugarvar key='value' string=true}}}
+{html_options id='{{$vardef.name}}' name='{{$vardef.name}}{{if $size > 1}}[]{{/if}}' options={{sugarvar key='options' string=true}} size="{{$size}}" class="templateGroupChooser" {{if $size > 1}}multiple="1"{{/if}} selected={{sugarvar key='value' string=true}}}


### PR DESCRIPTION
name of the select should not have [] when multiple is not set

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
removed [] when size = 1
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
- set 'displayParams' = array('size'=>1) in Opportunities searchdefs for Lead Source or assigned user
- Go to Opportunities 
- Open the Filter
- Click on Save
- The red cross is displayed

<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Disable multiple select in a searchdefs file does not work correctly.
It generates a query and shows a saved search even when nothing was selected

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->