### PR TITLE
Fixed #8489 - No validation when using header save button in AOS_Products

### DIFF
--- a/modules/AOS_Products/tpls/EditViewHeader.tpl
+++ b/modules/AOS_Products/tpls/EditViewHeader.tpl
@@ -71,8 +71,8 @@
       {{sugar_button module="$module" id="$button" view="$view"}}
    {{/foreach}}
 {{else}}
-{{sugar_button module="$module" id="SAVE" view="$view"}}
-{{sugar_button module="$module" id="CANCEL" view="$view"}}
+{{sugar_button module="$module" id="SAVE" view="$view" form_id="$form_id"}}
+{{sugar_button module="$module" id="CANCEL" view="$view" form_id="$form_id"}}
 {{/if}}
 {{if empty($form.hideAudit) || !$form.hideAudit}}
 {{sugar_button module="$module" id="Audit" view="$view"}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
It solves issue #8489 
## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
In `EditViewHeader.tpl` file of `AOS_Products` module,  element `form_id` was missing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, on click of header `Save` button, form will validate properly.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to `Products` module.
2. Create new record.
3. Click on 'Save' button available on header section without filling any mandatory fields and check whether you gets an error or not.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->