### PR TITLE
Fix #5487 - Report groups repeat for each record

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -522,9 +522,7 @@ class AOR_Report extends Basic
                 $select_field = $field->field_function . '(' . $select_field . ')';
             }
 
-            if ($field->group_by == 1) {
-                $query_array['group_by'][] = $select_field;
-            }
+            $query_array['group_by'][] = $select_field;
 
             $query_array['select'][] = $select_field . " AS '" . $field_label . "'";
             if (isset($extra['select']) && $extra['select']) {


### PR DESCRIPTION
## Description
The main report group by field in reports needlessly requires the field in the report to be grouped to function correctly, which is not clear in the UI and can cause duplicate sub grouped reports to appear if you do which to group the field within the report 

## How To Test This
Create a report e.g on Accounts, 
add field e.g assigned user and some other fields
set assigned user as the main group by feild, but not grouped in the report
see tat you now only get one group for each user, where previously you would have gotten a duplicate group by the number of time the assign user appears

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->