### PR TITLE
special_query_modules: AOR_Reports and not SugarCRM Reports module

### DIFF
--- a/include/utils.php
+++ b/include/utils.php
@@ -173,7 +173,7 @@ function make_sugar_config(&$sugar_config)
         'portal_view' => 'single_user',
         'resource_management' => array(
             'special_query_limit' => 50000,
-            'special_query_modules' => array('Reports', 'Export', 'Import', 'Administration', 'Sync'),
+            'special_query_modules' => array('AOR_Reports', 'Export', 'Import', 'Administration', 'Sync'),
             'default_limit' => 1000,
         ),
         'require_accounts' => empty($requireAccounts) ? true : $requireAccounts,
@@ -387,7 +387,7 @@ function get_sugar_config_defaults()
         'portal_view' => 'single_user',
         'resource_management' => array(
             'special_query_limit' => 50000,
-            'special_query_modules' => array('Reports', 'Export', 'Import', 'Administration', 'Sync'),
+            'special_query_modules' => array('AOR_Reports', 'Export', 'Import', 'Administration', 'Sync'),
             'default_limit' => 1000,
         ),
         'require_accounts' => true,

--- a/modules/UpgradeWizard/silentUpgrade_dce_step1.php
+++ b/modules/UpgradeWizard/silentUpgrade_dce_step1.php
@@ -136,7 +136,7 @@ function checkResourceSettings()
             'special_query_limit' => 50000,
             'special_query_modules' =>
             array(
-              0 => 'Reports',
+              0 => 'AOR_Reports',
               1 => 'Export',
               2 => 'Import',
               3 => 'Administration',

--- a/modules/UpgradeWizard/silentUpgrade_dce_step2.php
+++ b/modules/UpgradeWizard/silentUpgrade_dce_step2.php
@@ -122,7 +122,7 @@ function checkResourceSettings()
             'special_query_limit' => 50000,
             'special_query_modules' =>
             array(
-              0 => 'Reports',
+              0 => 'AOR_Reports',
               1 => 'Export',
               2 => 'Import',
               3 => 'Administration',

--- a/modules/UpgradeWizard/silentUpgrade_step1.php
+++ b/modules/UpgradeWizard/silentUpgrade_step1.php
@@ -156,7 +156,7 @@ function checkResourceSettings()
                 'special_query_limit' => 50000,
                 'special_query_modules' =>
                     [
-                        0 => 'Reports',
+                        0 => 'AOR_Reports',
                         1 => 'Export',
                         2 => 'Import',
                         3 => 'Administration',

--- a/modules/UpgradeWizard/silentUpgrade_step2.php
+++ b/modules/UpgradeWizard/silentUpgrade_step2.php
@@ -110,7 +110,7 @@ function checkResourceSettings()
                 'special_query_limit' => 50000,
                 'special_query_modules' =>
                     [
-                        0 => 'Reports',
+                        0 => 'AOR_Reports',
                         1 => 'Export',
                         2 => 'Import',
                         3 => 'Administration',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
special_query_modules is still referencing the SugarCRM Reports module.
It should set AOR_Reports instead

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allow larger reports to be displayed or exported

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->