### PR TITLE
fix #8462: clear OPcache before re-reading hook array

### DIFF
--- a/include/utils/logic_utils.php
+++ b/include/utils/logic_utils.php
@@ -51,6 +51,9 @@ function get_hook_array($module_name)
     // This will load an array of the hooks to process
     $file = "custom/modules/$module_name/logic_hooks.php";
     if (file_exists($file)) {
+        if (function_exists('opcache_invalidate')) {
+            opcache_invalidate($file); // will reset OPcache
+        }
         include($file);
     } else {
         LoggerManager::getLogger()->warn('File not found: ' . $file);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix for #8462: opcache / Module Loader only installs last hook

## Description
Fix for #8462 
There is already a proposed fix for that, but from what I have tested - when uninstalling the extension, only last hook is being removed. This fix is clearer and have no risks

## Motivation and Context
Fix bug caused by hook array being read from OPcache:
https://stackoverflow.com/questions/24074220/php-include-doesnt-read-changes-of-source-file

## How To Test This
Need to install an extension with more than 1 hook, and have OPcache enabled

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.