### PR TITLE
Fix #7766 - Invalid depreciated log in SugarBean fixUpFormatting

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -2571,9 +2571,8 @@ class SugarBean
                         //do nothing
                 }
                 if ($reformatted) {
-                    $GLOBALS['log']->deprecated('Formatting correction: ' . $this->module_dir . '->' . $field .
-                        ' had formatting automatically corrected. This will be removed in the future, ' .
-                        'please upgrade your external code');
+                    $GLOBALS['log']->info('Formatting correction: ' . $this->module_dir . '->' . $field .
+                        ' had formatting automatically corrected.');
                 }
             }
         }


### PR DESCRIPTION
##  Description
SugarBean fixUpFormatting wrongly log a depreciation log, despite be used constantly within the core code base. This changes Depreciation log to more appropriate Info log

## How To Test This
1. Enable deprecation logs
2. Edit and save in a few modules
3. See that the logs no longer appear
4. Enable Info logs
5. See that a more generic log now appears

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->