### PR TITLE
Fix #8637 - dirInArray bug breaking Windows upgrades

### DIFF
--- a/modules/UpgradeWizard/systemCheck.php
+++ b/modules/UpgradeWizard/systemCheck.php
@@ -80,6 +80,7 @@ $filesOut = "
 
 $isWindows = is_windows();
 foreach ($files as $file) {
+    $file = $file->getPathname();
     if (dirInArray($file, $skipDirs)) {
         continue;
     }

--- a/modules/UpgradeWizard/uw_utils.php
+++ b/modules/UpgradeWizard/uw_utils.php
@@ -4577,9 +4577,11 @@ function whetherNeedToSkipDir($dir, $skipDirs)
 function dirInArray($dir, $dirsArray)
 {
     $dir = clean_path($dir);
+    $cwd = clean_path(getcwd());
+
     foreach ($dirsArray as $aDir) {
         // Match the substring only at the beginning of the path:
-        if (strpos($dir, getcwd() . '/' . $aDir) === 0) {
+        if (strpos($dir, $cwd . '/' . $aDir) === 0) {
             return true;
         }
     }


### PR DESCRIPTION
## Description
Fix for issue #8637
Supersedes #8638 which only addresses part of the problem

Upgrade process breaks in Windows systems with error 
```
PHP Fatal error: Uncaught Error: Cannot use object of type SplFileInfo as array in include\utils\file_utils.php:57
Stack trace:
#0 modules\UpgradeWizard\uw_utils.php(4579): clean_path(Object(SplFileInfo))
```

The same issue causes the `skipDirs` function to fail doing its job, without any noticeable error. This can have fatal consequences for the upgrade,and it might fail with resource-exhaustion errors (or sometimes just crash silently).

## How To Test This
Test upgrade on Window and Linux.

Note the subtleties of the fact that these files are copied into the system in early steps of the upgrade. When the broken files got copied in, the system becomes "infected" with the bug - even if that upgrade didn't finish, and the version didn't change.

On some systems, you might need to manually pre-copy these files into the system, if it breaks before you even have a chance to upload the new upgrade package...

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
