### PR TITLE
Fix group reports by relate field (like Opportunities grouped by Account)

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -474,6 +474,12 @@ class AOR_Report extends Basic
 
             if ($data['type'] == 'relate' && isset($data['id_name'])) {
                 $field->field = $data['id_name'];
+                $data_new = $field_module->field_defs[$field->field];
+                if (isset($data_new['source']) && $data_new['source'] == 'non-db' && $data_new['type'] != 'link' && isset($data['link'])) {
+                    $data_new['type'] = 'link';
+                    $data_new['relationship'] = $data['link'];
+                }
+                $data = $data_new;
             }
 
             if ($data['type'] == 'currency' && !stripos(
@@ -500,7 +506,12 @@ class AOR_Report extends Basic
                     $query_array
                 );
             } else {
-                $select_field = $this->db->quoteIdentifier($table_alias) . '.' . $field->field;
+      	       if ($data['type'] == 'link' && $data['source'] == 'non-db') {
+	                $select_field = $this->db->quoteIdentifier($field_module->table_name.':'.$data['relationship']) . '.id';
+        	   }
+        	   else {
+               		$select_field = $this->db->quoteIdentifier($table_alias) . '.' . $field->field;
+        	   }
             }
 
             if ($field->sort_by != '') {
@@ -895,23 +906,6 @@ class AOR_Report extends Basic
             $field = BeanFactory::newBean('AOR_Fields');
             $field->retrieve($row['id']);
 
-            if ($field->field_function != 'COUNT' || $field->format != '') {
-                // Fix grouping on assignment displays ID and not name #5427
-                $report_bean = BeanFactory::getBean($this->report_module);
-                $field_def = $report_bean->field_defs[$field->field];
-                if ($field_def['type'] == 'relate' && isset($field_def['id_name'])) {
-                    $related_bean = BeanFactory::getBean($field_def['module']);
-                    $related_bean->retrieve($group_value);
-                    $moduleFieldByGroupValues[] = ($related_bean instanceof Person) ? $related_bean->full_name : $related_bean->name;
-                } elseif ($field_def['type'] == 'enum') {
-                    $moduleFieldByGroupValues[] = $app_list_strings[$field_def['options']][$group_value];
-                } else {
-                     $moduleFieldByGroupValues[] = $group_value;
-                }
-                continue;
-                // End
-            }
-
             $path = unserialize(base64_decode($field->module_path));
 
             $field_bean = new $beanList[$this->report_module]();
@@ -926,6 +920,23 @@ class AOR_Report extends Basic
                     $field_module = getRelatedModule($field_module, $rel);
                     $field_alias = $field_alias . ':' . $rel;
                 }
+            }
+
+            if ($field->field_function != 'COUNT' || $field->format != '') {
+                // Fix grouping on assignment displays ID and not name #5427
+                $report_bean = BeanFactory::getBean($field_module);
+                $field_def = $report_bean->field_defs[$field->field];
+                if ($field_def['type'] == 'relate' && isset($field_def['id_name'])) {
+                    $related_bean = BeanFactory::getBean($field_def['module']);
+                    $related_bean->retrieve($group_value);
+                    $moduleFieldByGroupValues[] = ($related_bean instanceof Person) ? $related_bean->full_name : $related_bean->name;
+                } elseif ($field_def['type'] == 'enum') {
+                    $moduleFieldByGroupValues[] = $app_list_strings[$field_def['options']][$group_value];
+                } else {
+                     $moduleFieldByGroupValues[] = $group_value;
+                }
+                continue;
+                // End
             }
 
             $currency_id = isset($row[$field_alias . '_currency_id']) ? $row[$field_alias . '_currency_id'] : '';


### PR DESCRIPTION
Reports : Fix group reports by relate field:
  ex: Opportunities grouped by Account
or related field of a related field
 ex: Opportunities grouped by Account Assigned to

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Groups are not displayed when the group is on a relate field:
1- Go to SuiteCRM Demo
2- Create a report based on Opportunities
3- Add a few fields
4 - Add Account Name
5- Group by Account name (checkbox + main group)
or 
5- Group by Account Assigned to (checkbox + main group)

<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Groups do not work on a relate field
## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->