### PR TITLE
Fix getOffset recession from #7608, subpanel "end" navigation

### DIFF
--- a/include/ListView/ListView.php
+++ b/include/ListView/ListView.php
@@ -8,7 +8,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
  *
  * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
- * Copyright (C) 2011 - 2018 SalesAgility Ltd.
+ * Copyright (C) 2011 - 2020 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the
@@ -879,9 +879,10 @@ class ListView
         if ($this->query_where_has_changed || isset($GLOBALS['record_has_changed'])) {
             $this->setSessionVariable($localVarName, 'offset', 0);
         }
+        // this might return several kinds of values: 0, '', 'end', etc
         $offset = $this->getSessionVariable($localVarName, 'offset');
-        if (isset($offset)) {
-            return (int)$offset;
+        if (isset($offset) && ($offset !== '')) {
+            return $offset;
         }
 
         return 0;
@@ -931,7 +932,7 @@ class ListView
         if (isset($_SESSION[$this->getSessionVariableName($localVarName, $varName)])) {
             return $_SESSION[$this->getSessionVariableName($localVarName, $varName)];
         }
-        return "";
+        return '';
     }
 
     public function getUserVariable($localVarName, $varName)


### PR DESCRIPTION
## Description

This started with #3576, continued with #7608, leading to a fix #7612.

But the ghastly `getOffset` function handles all kinds of values and types, like 0, 10, '', or 'end', and the fix doesn't take that into account.

https://community.suitecrm.com/t/campaign-module-sub-panel-navigation-is-not-working/71790

So it breaks the "end" navigation in _all_ subpanels. So I am fixing _that_ by moving back to a code that is closer to the original, and fixes the first bug in a less impacting manner... so that I can hope I am not breaking something else. 🤷‍♂️ 

## How To Test This
- to facilitate testing, set a low subpanel limit by adding something like `$sugar_config['list_max_entries_per_subpanel'] = '3';` to `config_override.php`
- get any subpanel to show excessive items, so that a second page is needed.
- click the "end" navigation button on the subpanel:
![image](https://user-images.githubusercontent.com/15945027/80228950-a0651300-8647-11ea-8722-3bf7d4a0131d.png)

- test also the previous issues that I link above, to check for regressions to the regression 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
