### PR TITLE
Support regex email subject case ID parsing

### DIFF
--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -6013,29 +6013,44 @@ class InboundEmail extends SugarBean
     public function getCaseIdFromCaseNumber($emailName, $aCase)
     {
         //$emailSubjectMacro
-        $exMacro = explode('%1', $aCase->getEmailSubjectMacro());
-        $open = $exMacro[0];
-        $close = $exMacro[1];
-
-        if ($sub = stristr($emailName, $open)) {
-            // eliminate everything up to the beginning of the macro and return the rest
-            // $sub is [CASE:XX] xxxxxxxxxxxxxxxxxxxxxx
-            $sub2 = str_replace($open, '', $sub);
-            // $sub2 is XX] xxxxxxxxxxxxxx
-            $sub3 = substr($sub2, 0, strpos($sub2, $close));
-
-            // case number is supposed to be numeric
-            if (ctype_digit($sub3)) {
-                // filter out deleted records in order to create a new case
-                // if email is related to deleted one (bug #49840)
-                $query = 'SELECT id FROM cases WHERE case_number = '
-                    . $this->db->quoted($sub3)
-                    . ' and deleted = 0';
-                $results = $this->db->query($query, true);
-                $row = $this->db->fetchByAssoc($results);
-                if (!empty($row['id'])) {
-                    return $row['id'];
+        $macro = $aCase->getEmailSubjectMacro();
+        $match_id = null;
+        
+        if (substr($macro, 0, 1) == '/' && substr($macro, -1) == '/'){
+            if (preg_match($macro, $emailName, $matches)) {
+                if (array_key_exists('id', $matches)) {
+                    $match_id = $matches['id'];
+                } else {
+                    $match_id = $matches[1];
                 }
+            }
+        } else {
+            $exMacro = explode('%1', $aCase->getEmailSubjectMacro());
+            $open = $exMacro[0];
+            $close = $exMacro[1];
+
+            if ($sub = stristr($emailName, $open)) {
+                // eliminate everything up to the beginning of the macro and return the rest
+                // $sub is [CASE:XX] xxxxxxxxxxxxxxxxxxxxxx
+                $sub2 = str_replace($open, '', $sub);
+                // $sub2 is XX] xxxxxxxxxxxxxx
+                $sub3 = substr($sub2, 0, strpos($sub2, $close));
+                
+                $match_id = $sub3;
+            }
+        }
+        
+        // case number is supposed to be numeric
+        if (!is_null($match_id) && ctype_digit($match_id)) {
+            // filter out deleted records in order to create a new case
+            // if email is related to deleted one (bug #49840)
+            $query = 'SELECT id FROM cases WHERE case_number = '
+                . $this->db->quoted($match_id)
+                . ' and deleted = 0';
+            $results = $this->db->query($query, true);
+            $row = $this->db->fetchByAssoc($results);
+            if (!empty($row['id'])) {
+                return $row['id'];
             }
         }
 


### PR DESCRIPTION
Allow using regex to parse subject to extract CaseID.
We have seen many cases where clients seem to slightly change the subject to the point it does not parse correctly, or they have translated `CASE` into another language, removed the semicolon or square brackets etc.
This adds ability to use regex string instead of plain string.
Partial backwards compatibility has been added to check for `/` at the start and end of the macro string to detect if its regex, of-course if someone has used these as their ident then may fail.