### PR TITLE
Convert $db->query to pQuery in a few places

### DIFF
--- a/campaign_tracker.php
+++ b/campaign_tracker.php
@@ -71,8 +71,8 @@ if (empty($_REQUEST['track'])) {
 $track = $db->quote($track);
 
 if (preg_match('/^[0-9A-Za-z\-]*$/', $track)) {
-    $query = "SELECT refer_url FROM campaigns WHERE tracker_key='$track'";
-    $res = $db->query($query);
+    $query = "SELECT refer_url FROM campaigns WHERE tracker_key = '?'";
+    $res = $db->pQuery($query, [$track]);
 
     $row = $db->fetchByAssoc($res);
 

--- a/include/Localization/Localization.php
+++ b/include/Localization/Localization.php
@@ -220,7 +220,7 @@ class Localization
             );
 
             $q = "SELECT id, name, symbol, conversion_rate FROM currencies WHERE status = 'Active' and deleted = 0";
-            $r = $db->query($q);
+            $r = $db->pQuery($q);
 
             while ($a = $db->fetchByAssoc($r)) {
                 $load = array();

--- a/include/SugarObjects/forms/PersonFormBase.php
+++ b/include/SugarObjects/forms/PersonFormBase.php
@@ -222,16 +222,16 @@ abstract class PersonFormBase extends FormBase
 
         if (!empty($emailStr)) {
             $emailStr = substr($emailStr, 1);
-            $query = 'SELECT DISTINCT er.bean_id AS id FROM email_addr_bean_rel er, ' .
-                 'email_addresses ea WHERE ea.id = er.email_address_id ' .
-                 'AND ea.deleted = 0 AND er.deleted = 0 AND er.bean_module = \'' . $this->moduleName . '\' ' .
-                 'AND email_address_caps IN (' . $emailStr . ')';
+            $query = "SELECT DISTINCT er.bean_id AS id FROM email_addr_bean_rel er,
+                email_addresses ea WHERE ea.id = er.email_address_id 
+                AND ea.deleted = 0 AND er.deleted = 0 AND er.bean_module = '?'
+                AND email_address_caps IN (?)";
 
-            $result = $db->query($query);
+            $result = $db->pQuery($query, [$this->moduleName, $emailStr]);
             while (($row = $db->fetchByAssoc($result)) != null) {
                 if (!isset($rows[$row['id']])) {
-                    $query2 = "SELECT id, first_name, last_name, title FROM {$focus->table_name} WHERE deleted=0 AND id = '" . $row['id'] . "'";
-                    $result2 = $db->query($query2);
+                    $query2 = "SELECT id, first_name, last_name, title FROM ? WHERE deleted = 0 AND id = '?'";
+                    $result2 = $db->pQuery($query2, [$focus->table_name, $row['id']]);
                     $r = $db->fetchByAssoc($result2);
                     if (isset($r['id'])) {
                         $rows[]=$r;

--- a/include/social/get_feed_data.php
+++ b/include/social/get_feed_data.php
@@ -216,8 +216,8 @@ if ($facebook_enabled) {
         $date = date("Y-m-d H:i:s", strtotime($single['created_time']));
 
 
-        $sql_check = "SELECT * FROM sugarfeed WHERE description = '" . $message . "' AND date_entered = '" . $date . "'";
-        $results = $db->query($sql_check);
+        $sql_check = "SELECT * FROM sugarfeed WHERE description = '?' AND date_entered = '?'";
+        $results = $db->pQuery($sql_check, [$message, $date]);
 
         while ($row = $db->fetchByAssoc($results)) {
             $found_record = $row;

--- a/tests/unit/phpunit/include/database/DBManagerTest.php
+++ b/tests/unit/phpunit/include/database/DBManagerTest.php
@@ -74,4 +74,21 @@ class DBManagerTest extends SuitePHPUnitFrameworkTestCase
             "SELECT foo FROM bar WHERE baz = 'foo?';"
         );
     }
+    
+    // Make sure createPreparedQuery returns the correct SQL query when
+    // using ? without quotes.
+    public function testcreatePreparedQueryWithNoQuotes()
+    {
+        $db = DBManagerFactory::getInstance();
+
+        // Match baz to the input variable with a question mark appended... for some reason.
+        $sql = "SELECT ? FROM bar WHERE baz = 'qux';";
+
+        $stmt = $db->prepareQuery($sql);
+
+        $this->assertEquals(
+            $db->createPreparedQuery($stmt, ["foo"]),
+            "SELECT foo FROM bar WHERE baz = 'qux';"
+        );
+    }
 }


### PR DESCRIPTION
## Description

I converted a few uses of the `query` method to `pQuery` so we could split out the variables from being inside the query itself.

I also updated the code formatting in a few places to make it more consistent and added another unit test for pQuery.

## Motivation and Context

Part of #7261, using prepared statements is better for the security of the application and protects against SQL injection vulnerabilities. As I've said in that issue, pQuery doesn't fix vulnerabilities itself since it doesn't actually clean malicious inputs, but it's part of the way toward making this possible.

## How To Test This

Make sure the test suite passes, and test the campaign tracker, ACL Roles, person form, the homepage feed, and localization functionality.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.