### PR TITLE
Deprecate getCurrencyType()

### DIFF
--- a/modules/Opportunities/Opportunity.php
+++ b/modules/Opportunities/Opportunity.php
@@ -484,6 +484,10 @@ class Opportunity extends SugarBean
         return $ret_array;
     }
 }
+
+/**
+ * @deprecated This function is unused and will be removed in a future release.
+ */
 function getCurrencyType()
 {
 }

--- a/modules/Opportunities/vardefs.php
+++ b/modules/Opportunities/vardefs.php
@@ -150,9 +150,7 @@ $dictionary['Opportunity'] = array('table' => 'opportunities', 'audited' => true
             array(
                 'name' => 'amount',
                 'vname' => 'LBL_AMOUNT',
-                //'function'=>array('vname'=>'getCurrencyType'),
                 'type' => 'currency',
-//    'disable_num_format' => true,
                 'dbType' => 'double',
                 'comment' => 'Unconverted amount of the opportunity',
                 'importable' => 'required',

--- a/tests/unit/phpunit/modules/Opportunities/OpportunityTest.php
+++ b/tests/unit/phpunit/modules/Opportunities/OpportunityTest.php
@@ -264,17 +264,4 @@ class OpportunityTest extends SuitePHPUnitFrameworkTestCase
         $result = $opportunity->get_account_detail('1');
         $this->assertTrue(is_array($result));
     }
-
-    public function testgetCurrencyType()
-    {
-        // Execute the method and test that it works and doesn't throw an exception.
-        try {
-            getCurrencyType();
-            $this->assertTrue(true);
-        } catch (Exception $e) {
-            $this->fail($e->getMessage() . "\nTrace:\n" . $e->getTraceAsString());
-        }
-
-        $this->markTestIncomplete('This method has no implementation');
-    }
 }


### PR DESCRIPTION
## Description

This function is unused and has no implementation, so I've deprecated it.

## Motivation and Context

It's dead code. It should be added to #7744 once this PR is merged.

## How To Test This

Make sure the tests pass, search the repo to make sure nothing is using the function.

## Types of changes
Deprecated some code.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.