### PR TITLE
Deprecate functions in Users/Forms.php and remove pointless usages of them.

### DIFF
--- a/modules/Studio/Forms.php
+++ b/modules/Studio/Forms.php
@@ -43,12 +43,21 @@ if (!defined('sugarEntry') || !sugarEntry) {
 }
 
 //for users
+/**
+ * @deprecated This function is unused and will be removed in a future release. It was moved to UserEditView.js.
+ */
 function user_get_validate_record_js()
 {
 }
+/**
+ * @deprecated This function is unused and will be removed in a future release. It was moved to UserEditView.js.
+ */
 function user_get_chooser_js()
 {
 }
+/**
+ * @deprecated This function is unused and will be removed in a future release. It was moved to UserEditView.js.
+ */
 function user_get_confsettings_js()
 {
 };

--- a/modules/Users/Forms.php
+++ b/modules/Users/Forms.php
@@ -53,24 +53,26 @@ if (!defined('sugarEntry') || !sugarEntry) {
 
 /**
  * Create javascript to validate the data entered into a record.
- * Portions created by SugarCRM are Copyright (C) SugarCRM, Inc.
- * All Rights Reserved.
- * Contributor(s): ______________________________________..
+ *
+ * @deprecated This function is unused and will be removed in a future release. It was moved to UserEditView.js.
  */
 function user_get_validate_record_js()
 {
-    // NO LONGER USED, MOVED TO UserEditView.js
     return '';
 }
 
+/**
+ * @deprecated This function is unused and will be removed in a future release. It was moved to UserEditView.js.
+ */
 function user_get_chooser_js()
 {
-    // NO LONGER USED, MOVED TO UserEditView.js
     return '';
 }
 
+/**
+ * @deprecated This function is unused and will be removed in a future release. It was moved to UserEditView.js.
+ */
 function user_get_confsettings_js()
 {
-    // NO LONGER USED, MOVED TO UserEditView.js
     return '';
 }

--- a/modules/Users/SetTimezone.php
+++ b/modules/Users/SetTimezone.php
@@ -46,7 +46,6 @@ if (!defined('sugarEntry') || !sugarEntry) {
 
 
 require_once('include/JSON.php');
-require_once('modules/Users/Forms.php');
 
 global $app_strings;
 global $app_list_strings;

--- a/modules/Users/tpls/wizard.tpl
+++ b/modules/Users/tpls/wizard.tpl
@@ -535,7 +535,6 @@ function hideOverlay() {
 -->
 </script>
 {/literal}
-{$JAVASCRIPT}
 {literal}
 <script type="text/javascript" language="Javascript">
     {/literal}

--- a/modules/Users/views/view.wizard.php
+++ b/modules/Users/views/view.wizard.php
@@ -48,7 +48,6 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * Contributor(s): ______________________________________..
  ********************************************************************************/
 
-require_once('modules/Users/Forms.php');
 require_once('modules/Configurator/Configurator.php');
 
 class ViewWizard extends SugarView
@@ -78,7 +77,6 @@ class ViewWizard extends SugarView
         $favicon = $themeObject->getImageURL('sugar_icon.ico', false);
         $this->ss->assign('FAVICON_URL', getJSPath($favicon));
         $this->ss->assign('CSS', '<link rel="stylesheet" type="text/css" href="'.SugarThemeRegistry::current()->getCSSURL('wizard.css').'" />');
-        $this->ss->assign('JAVASCRIPT', user_get_validate_record_js().user_get_chooser_js().user_get_confsettings_js());
         $this->ss->assign('PRINT_URL', 'index.php?'.$GLOBALS['request_string']);
         $this->ss->assign('SKIP_WELCOME', isset($_REQUEST['skipwelcome']) && $_REQUEST['skipwelcome'] == 1);
         $this->ss->assign('ID', $current_user->id);


### PR DESCRIPTION
## Description

They've returned an empty string for years, so they have no need to exist anymore. I've removed their usages and deprecated the functions.

## Motivation and Context

It's dead code. It should be added to #7744 once this PR is merged.

This deprecates the following functions, which only returned an empty string anyway:
- `user_get_validate_record_js`
- `user_get_chooser_js`
- `user_get_confsettings_js`

## How To Test This
Make sure the tests pass and the user wizard renders.

## Types of changes
Deprecation.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.