### PR TITLE
Incorrect check for group folder

### DIFF
--- a/include/SugarFolders/SugarFolders.php
+++ b/include/SugarFolders/SugarFolders.php
@@ -741,7 +741,7 @@ class SugarFolder
         $secureReturn = [];
 
         foreach ($return as $item) {
-            if ($item->isgroup === 1 || $item['created_by'] === $user->id || is_admin($user)) {
+            if ($item['is_group'] == 1 || $item['created_by'] === $user->id || is_admin($user)) {
                 $secureReturn[] = $item;
             }
         }


### PR DESCRIPTION
If user is not admin and not the user that created group folder then check is `$item->isgroup` instead of `$item['is_group']`.

This leads to no group account being visible in folders list for non admin/created_by users.

SuiteCRM 7.10.25