### PR TITLE
Fixed #6046 - SQL 'rank' is a reserved word, can't be used as a field…

### DIFF
--- a/include/database/MysqlManager.php
+++ b/include/database/MysqlManager.php
@@ -828,6 +828,9 @@ class MysqlManager extends DBManager
             $ref['default'] = '';
         }
 
+        // Quote the name column incase it has been reserved by dbms
+        $ref['name'] = $this->quoteIdentifier($ref['name']);
+
         if ($return_as_array) {
             return $ref;
         } else {


### PR DESCRIPTION
… name in MySQL 8.0.2 and later

Function oneColumnSQLRep has been modified to add quotation marks to column names for SQL queries.

## Description
<!--- Describe your changes in detail -->
Quotation marks added to column names to avoid issues with reserved words in MySql 8 or higher.
Fix Issue #6046 

## Motivation and Context
This change allows us to use the most recent versions of MySQL.

## How To Test This
The most direct way to test is to perform a new installation using MySQL 8.0.19 and see that it installs successfully.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.