### PR TITLE
Fix issues with saving drafts and new messages

### DIFF
--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -4677,6 +4677,12 @@ eoq;
                 $bean->new_with_id = true;
                 $bean->type = 'out';
                 $bean->status = 'draft';
+		$bean->date_entered = null;
+		$bean->date_modified = null;
+		$bean->uid = null;
+		$bean->date_start = null;
+		$bean->time_start = null;
+		$bean->last_synced = null;		    
             }
         }
 

--- a/modules/Emails/EmailsController.php
+++ b/modules/Emails/EmailsController.php
@@ -253,6 +253,7 @@ class EmailsController extends SugarController
 
             if ($this->bean->send()) {
                 $this->bean->status = 'sent';
+                $this->bean->date_sent_received = TimeDate::getInstance()->nowDb();
                 $this->bean->save();
             } else {
                 // Don't save status if the email is a draft.

--- a/modules/Emails/EmailsController.php
+++ b/modules/Emails/EmailsController.php
@@ -409,6 +409,16 @@ class EmailsController extends SugarController
      */
     public function action_DeleteDraft()
     {
+        if($this->bean->status != 'draft'){
+            $this->view = 'ajax';
+            $response['errors'] = [
+                'type' => get_class($this->bean),
+                'id' => $this->bean->id,
+                'title' => "Can not delete this Email as not a draft"
+            ];
+            echo json_encode($response);
+            return;
+        }
         $this->bean->deleted = '1';
         $this->bean->status = 'draft';
         $this->bean->save();

--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -986,21 +986,27 @@
           contentType: false,   // tell jQuery not to set contentType
           url: 'index.php?module=Emails'
         }).done(function (response) {
-          $(self).trigger("discardDraftDone", [self, response]);
+          response = JSON.parse(response);
+          if (typeof response.errors !== "undefined") {
+            mb.showHeader();
+            mb.setBody(response.errors.title);
+            mb.showFooter();
+            $(self).trigger("discardDraftError", [self, response]);
+          } else {
+            $(self).trigger("discardDraftDone", [self, response]);
+            mb.remove();
+            if ($(self).find('input[type="hidden"][name="return_module"]').val() !== '') {
+              location.href = 'index.php?module=' + $('#' + self.attr('id') + ' input[type="hidden"][name="return_module"]').val() +
+                '&action=' +
+                $(self).find('input[type="hidden"][name="return_action"]').val();
+            } else {
+              // The user is viewing in the modal view
+              location.reload();
+            }
+          }
         }).error(function (response) {
           mb.setBody(SUGAR.language.translate('', 'LBL_ERROR_SAVING_DRAFT'));
           $(self).trigger("discardDraftBody", [self, response]);
-        }).always(function (response) {
-          $(self).trigger("discardDraftAlways", [self, response]);
-          mb.remove();
-          if ($(self).find('input[type="hidden"][name="return_module"]').val() !== '') {
-            location.href = 'index.php?module=' + $('#' + self.attr('id') + ' input[type="hidden"][name="return_module"]').val() +
-              '&action=' +
-              $(self).find('input[type="hidden"][name="return_action"]').val();
-          } else {
-            // The user is viewing in the modal view
-            location.reload();
-          }
         });
       });
       mb.on('cancel', function () {


### PR DESCRIPTION
SuiteCRM 7.10.25

When replying to a received message, if you press `Save Draft` or `Discard Draft` it affects the received message instead of creating a new one and making changes to that.

Also when sending new messages the `date_sent_received ` is incorrect based on original message date.

Trying to discard a draft before it has even been saved removes the original message instead of throwing error.