### PR TITLE
SugarFolder doing Insert instead of Update

### DIFF
--- a/include/SugarFolders/SugarFolders.php
+++ b/include/SugarFolders/SugarFolders.php
@@ -1223,11 +1223,9 @@ class SugarFolder
     {
         $this->dynamic_query = $this->db->quote($this->dynamic_query);
 
-        if ((!empty($this->id) && $this->new_with_id == false) || (empty($this->id) && $this->new_with_id == true)) {
-            if (empty($this->id) && $this->new_with_id == true) {
-                $guid = create_guid();
-                $this->id = $guid;
-            }
+        if (empty($this->id) || (!empty($this->id) && $this->new_with_id == true)) {
+            if (empty($this->id))
+                $this->id = create_guid();
 
             $query = "INSERT INTO folders (id, name, folder_type, parent_folder, has_child, is_group, " .
                 "is_dynamic, dynamic_query, assign_to_id, created_by, modified_by, deleted) VALUES (" .
@@ -1247,10 +1245,6 @@ class SugarFolder
                 // create default subscription
                 $this->addSubscriptionsToGroupFolder();
             }
-
-            // if parent_id is set, update parent's has_child flag
-            $query3 = "UPDATE folders SET has_child = 1 WHERE id = " . $this->db->quoted($this->parent_folder);
-            $r3 = $this->db->query($query3);
         } else {
             $query = "UPDATE folders SET " .
                 "name = " . $this->db->quoted($this->name) . ", " .
@@ -1259,6 +1253,12 @@ class SugarFolder
                 "assign_to_id = " . $this->db->quoted($this->assign_to_id) . ", " .
                 "modified_by = " . $this->db->quoted($this->currentUser->id) . " " .
                 "WHERE id = " . $this->db->quoted($this->id);
+        }
+        
+        // if parent_id is set, update parent's has_child flag
+        if (!empty($this->parent_folder)) {
+            $query3 = "UPDATE folders SET has_child = 1 WHERE id = " . $this->db->quoted($this->parent_folder);
+            $this->db->query($query3);
         }
 
         return $this->db->query($query, true);

--- a/modules/InboundEmail/Save.php
+++ b/modules/InboundEmail/Save.php
@@ -219,7 +219,7 @@ $focus->save();
 
 
 // Folders
-$foldersFound = $focus->db->query('SELECT id FROM folders WHERE folders.id LIKE "'.$focus->id.'"');
+$foldersFound = $focus->db->query('SELECT id FROM folders WHERE folders.id = "'.$focus->id.'"');
 $foldersFoundRow = $focus->db->fetchRow($foldersFound);
 $sf = new SugarFolder();
 if (empty($foldersFoundRow)) {
@@ -300,10 +300,10 @@ if (empty($foldersFoundRow)) {
 } else {
     // Update folders
     require_once("include/SugarFolders/SugarFolders.php");
-    $foldersFound = $focus->db->query('SELECT * FROM folders WHERE folders.id LIKE "'.$focus->id.'" OR '.
-        'folders.parent_folder LIKE "'.$focus->id.'"');
+    $foldersFound = $focus->db->query('SELECT * FROM folders WHERE folders.id = "'.$focus->id.'" OR '.
+        'folders.parent_folder = "'.$focus->id.'"');
     while ($row = $focus->db->fetchRow($foldersFound)) {
-        $name = '';
+        $name = $row['name'];
         switch ($row['folder_type']) {
             case 'inbound':
                 $name = $focus->mailbox . ' ('.$focus->name.')';


### PR DESCRIPTION
SuiteCRM 7.10.25

OLD: https://github.com/salesagility/SuiteCRM/blob/v7.8.31/include/SugarFolders/SugarFolders.php#L891

Seems there was a regression from old 7.8.x on how SugarFolders handles updates/inserts of folders.

Ive reverted it with some tweeks to prevent running empty update statements when there is no `parent_folder`.