### PR TITLE
Fix User Incoming Email folder subscriptions

### DIFF
--- a/include/SugarFolders/SugarFolders.php
+++ b/include/SugarFolders/SugarFolders.php
@@ -355,21 +355,19 @@ class SugarFolder
 
         $cleanSubscriptions = array();
 
-        // Remove the duplications
-        $subs = array_unique($subs);
+        // Remove the duplications/empty and trims all entries
+        $subs = array_unique(array_filter($subs));
+        $subs = array_map('trim', $subs);
 
         // Ensure parent folders are selected, regardless.
         foreach ($subs as $id) {
-            $id = trim($id);
-            if (!empty($id)) {
-                $cleanSubscriptions[] = $id;
-                $queryChk = "SELECT parent_folder FROM folders WHERE id = " . $this->db->quoted($id);
-                $rChk = $this->db->query($queryChk);
-                $aChk = $this->db->fetchByAssoc($rChk);
+            $cleanSubscriptions[] = $id;
+            $queryChk = "SELECT parent_folder FROM folders WHERE id = " . $this->db->quoted($id);
+            $rChk = $this->db->query($queryChk);
+            $aChk = $this->db->fetchByAssoc($rChk);
 
-                if (!empty($aChk['parent_folder'])) {
-                    $cleanSubscriptions = $this->getParentIDRecursive($aChk['parent_folder'], $cleanSubscriptions);
-                }
+            if (!empty($aChk['parent_folder'])) {
+                $cleanSubscriptions = $this->getParentIDRecursive($aChk['parent_folder'], $cleanSubscriptions);
             }
         }
 

--- a/modules/Emails/EmailUIAjax.php
+++ b/modules/Emails/EmailUIAjax.php
@@ -65,7 +65,7 @@ function handleSubs($subs, $email, $json, $user = null)
     }
 
     $GLOBALS['log']->debug("********** EMAIL 2.0 - Asynchronous - at: setFolderViewSelection");
-    $viewFolders = $subs;
+    $viewFolders = array_unique(array_filter($subs));
     $user->setPreference('showFolders', base64_encode(serialize($viewFolders)), '', 'Emails');
     $tree = $email->et->getMailboxNodes(false);
     $return = $tree->generateNodesRaw();
@@ -74,8 +74,8 @@ function handleSubs($subs, $email, $json, $user = null)
 
     $sub = array();
     foreach ($viewFolders as $f) {
-        $query = 'SELECT * FROM folders WHERE folders.id LIKE "' . $f
-            . '" OR folders.parent_folder LIKE "' . $f . '"';
+        $query = 'SELECT * FROM folders WHERE folders.id = "' . $f
+            . '" OR folders.parent_folder = "' . $f . '"';
         $result = $db->query($query);
         while (($row = $db->fetchByAssoc($result))) {
             $sub[] = $row['id'];


### PR DESCRIPTION
SuiteCRM 7.10.25

If you unsubscribe to all IncomingEmail accounts the system will give you all accounts due to use of  `LIKE ''` statement when finding folders to subscribe to.
This prevents that by..
- changing `LIKE` to an equal comparison
- doing array_unqiue+array_filter to prevent duplication