### PR TITLE
Fix pulling deleted system outbound SMTP account

### DIFF
--- a/include/OutboundEmail/OutboundEmail.php
+++ b/include/OutboundEmail/OutboundEmail.php
@@ -404,7 +404,7 @@ class OutboundEmail
      */
     public function getSystemMailerSettings()
     {
-        $q = "SELECT id FROM outbound_email WHERE type = 'system'";
+        $q = "SELECT id FROM outbound_email WHERE type = 'system' AND deleted = 0";
         $r = $this->db->query($q);
         $a = $this->db->fetchByAssoc($r);
 


### PR DESCRIPTION
SuiteCRM 7.10.25

If you happen to delete default system outbound email account it creates a second one but the SQL query does not check only for non-deleted accounts.