### PR TITLE
Update authentication module to utilise get_custom_file_if_exists

### DIFF
--- a/include/entryPoint.php
+++ b/include/entryPoint.php
@@ -130,7 +130,7 @@ require_once 'modules/ACL/ACLController.php';
 require_once 'modules/Administration/Administration.php';
 require_once 'modules/Administration/updater_utils.php';
 require_once 'modules/Users/User.php';
-require_once 'modules/Users/authentication/AuthenticationController.php';
+require_once get_custom_file_if_exists('modules/Users/authentication/AuthenticationController.php');
 require_once 'include/utils/LogicHook.php';
 require_once 'include/SugarTheme/SugarTheme.php';
 require_once 'include/MVC/SugarModule.php';

--- a/modules/Users/authentication/AuthenticationController.php
+++ b/modules/Users/authentication/AuthenticationController.php
@@ -82,17 +82,7 @@ class AuthenticationController
         if ($type == 'SugarAuthenticate' && !empty($GLOBALS['system_config']->settings['system_ldap_enabled']) && empty($_SESSION['sugar_user'])) {
             $type = 'LDAPAuthenticate';
         }
-
-        // check in custom dir first, in case someone want's to override an auth controller
-        if (file_exists('custom/modules/Users/authentication/'.$type.'/' . $type . '.php')) {
-            require_once('custom/modules/Users/authentication/'.$type.'/' . $type . '.php');
-        } elseif (file_exists('modules/Users/authentication/'.$type.'/' . $type . '.php')) {
-            require_once('modules/Users/authentication/'.$type.'/' . $type . '.php');
-        } else {
-            require_once('modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php');
-            $type = 'SugarAuthenticate';
-        }
-
+        
         if (!empty($_REQUEST['no_saml'])
             && (
                 (is_subclass_of($type, 'SAMLAuthenticate') || 'SAMLAuthenticate' == $type) ||
@@ -101,6 +91,16 @@ class AuthenticationController
             $type = 'SugarAuthenticate';
         }
 
+        // check if authentication type exists, fall back to SugarAuthenticate
+        $authenticateFile = get_custom_file_if_exists('modules/Users/authentication/'.$type.'/' . $type . '.php');
+        
+        if (!file_exists($authenticateFile) {
+            $type = 'SugarAuthenticate';
+            $authenticateFile = get_custom_file_if_exists('modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php');
+        }
+        
+        require_once($authenticateFile);
+        
         return new $type();
     }
 

--- a/modules/Users/authentication/AuthenticationController.php
+++ b/modules/Users/authentication/AuthenticationController.php
@@ -49,6 +49,9 @@ class AuthenticationController
     public $authenticated = false;
     public $loginSuccess = false;// if a user has successfully logged in
 
+    const MODULE_FOLDER = 'modules/Users/authentication';
+    const DEFAULT_TYPE = 'SugarAuthenticate';
+
     protected static $authcontrollerinstance = null;
 
     /**
@@ -76,10 +79,10 @@ class AuthenticationController
     {
         if (!$type) {
             $type = !empty($GLOBALS['sugar_config']['authenticationClass'])
-                ? $GLOBALS['sugar_config']['authenticationClass'] : 'SugarAuthenticate';
+                ? $GLOBALS['sugar_config']['authenticationClass'] : self::DEFAULT_TYPE;
         }
 
-        if ($type == 'SugarAuthenticate' && !empty($GLOBALS['system_config']->settings['system_ldap_enabled']) && empty($_SESSION['sugar_user'])) {
+        if ($type == self::DEFAULT_TYPE && !empty($GLOBALS['system_config']->settings['system_ldap_enabled']) && empty($_SESSION['sugar_user'])) {
             $type = 'LDAPAuthenticate';
         }
         
@@ -88,15 +91,15 @@ class AuthenticationController
                 (is_subclass_of($type, 'SAMLAuthenticate') || 'SAMLAuthenticate' == $type) ||
                 (is_subclass_of($type, 'SAML2Authenticate') || 'SAML2Authenticate' == $type)
             )) {
-            $type = 'SugarAuthenticate';
+            $type = self::DEFAULT_TYPE;
         }
 
         // check if authentication type exists, fall back to SugarAuthenticate
-        $authenticateFile = get_custom_file_if_exists('modules/Users/authentication/'.$type.'/' . $type . '.php');
+        $authenticateFile = get_custom_file_if_exists("{self::MODULE_FOLDER}/{$type}/{$type}.php");
         
-        if (!file_exists($authenticateFile) {
-            $type = 'SugarAuthenticate';
-            $authenticateFile = get_custom_file_if_exists('modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php');
+        if (!file_exists($authenticateFile)) {
+            $type = self::DEFAULT_TYPE;
+            $authenticateFile = get_custom_file_if_exists("{self::MODULE_FOLDER}/{$type}/{$type}.php");
         }
         
         require_once($authenticateFile);

--- a/modules/Users/authentication/AuthenticationController.php
+++ b/modules/Users/authentication/AuthenticationController.php
@@ -95,11 +95,11 @@ class AuthenticationController
         }
 
         // check if authentication type exists, fall back to SugarAuthenticate
-        $authenticateFile = get_custom_file_if_exists("{self::MODULE_FOLDER}/{$type}/{$type}.php");
+        $authenticateFile = get_custom_file_if_exists("{${self::MODULE_FOLDER}}/{$type}/{$type}.php");
         
         if (!file_exists($authenticateFile)) {
             $type = self::DEFAULT_TYPE;
-            $authenticateFile = get_custom_file_if_exists("{self::MODULE_FOLDER}/{$type}/{$type}.php");
+            $authenticateFile = get_custom_file_if_exists("{${self::MODULE_FOLDER}}/{$type}/{$type}.php");
         }
         
         require_once($authenticateFile);

--- a/modules/Users/authentication/AuthenticationController.php
+++ b/modules/Users/authentication/AuthenticationController.php
@@ -95,11 +95,11 @@ class AuthenticationController
         }
 
         // check if authentication type exists, fall back to SugarAuthenticate
-        $authenticateFile = get_custom_file_if_exists("{${self::MODULE_FOLDER}}/{$type}/{$type}.php");
+        $authenticateFile = get_custom_file_if_exists(self::MODULE_FOLDER . "/$type}/{$type}.php");
         
         if (!file_exists($authenticateFile)) {
             $type = self::DEFAULT_TYPE;
-            $authenticateFile = get_custom_file_if_exists("{${self::MODULE_FOLDER}}/{$type}/{$type}.php");
+            $authenticateFile = get_custom_file_if_exists(self::MODULE_FOLDER . "/{$type}/{$type}.php");
         }
         
         require_once($authenticateFile);

--- a/modules/Users/authentication/EmailAuthenticate/EmailAuthenticate.php
+++ b/modules/Users/authentication/EmailAuthenticate/EmailAuthenticate.php
@@ -50,7 +50,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * based on the users validation
  *
  */
-require_once get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{AuthenticationController::DEFAULT_TYPE}/{AuthenticationController::DEFAULT_TYPE}.php");
+require_once get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{${AuthenticationController::DEFAULT_TYPE}}/{${AuthenticationController::DEFAULT_TYPE}}.php");
 class EmailAuthenticate extends SugarAuthenticate
 {
     const EMAIL_AUTHENTICATE_DIRECTORY = 'EmailAuthenticate';

--- a/modules/Users/authentication/EmailAuthenticate/EmailAuthenticate.php
+++ b/modules/Users/authentication/EmailAuthenticate/EmailAuthenticate.php
@@ -50,11 +50,13 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * based on the users validation
  *
  */
-require_once('modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php');
+require_once get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{AuthenticationController::DEFAULT_TYPE}/{AuthenticationController::DEFAULT_TYPE}.php");
 class EmailAuthenticate extends SugarAuthenticate
 {
+    const EMAIL_AUTHENTICATE_DIRECTORY = 'EmailAuthenticate';
+
     public $userAuthenticateClass = 'EmailAuthenticateUser';
-    public $authenticationDir = 'EmailAuthenticate';
+    public $authenticationDir = self::EMAIL_AUTHENTICATE_DIRECTORY;
     /**
      * Constructs EmailAuthenticate
      * This will load the user authentication class

--- a/modules/Users/authentication/EmailAuthenticate/EmailAuthenticate.php
+++ b/modules/Users/authentication/EmailAuthenticate/EmailAuthenticate.php
@@ -50,7 +50,10 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * based on the users validation
  *
  */
-require_once get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{${AuthenticationController::DEFAULT_TYPE}}/{${AuthenticationController::DEFAULT_TYPE}}.php");
+require_once get_custom_file_if_exists(
+    AuthenticationController::MODULE_FOLDER . DIRECTORY_SEPARATOR . AuthenticationController::DEFAULT_TYPE . DIRECTORY_SEPARATOR . AuthenticationController::DEFAULT_TYPE . '.php'
+);
+
 class EmailAuthenticate extends SugarAuthenticate
 {
     const EMAIL_AUTHENTICATE_DIRECTORY = 'EmailAuthenticate';

--- a/modules/Users/authentication/EmailAuthenticate/EmailAuthenticateUser.php
+++ b/modules/Users/authentication/EmailAuthenticate/EmailAuthenticateUser.php
@@ -48,7 +48,9 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * This file is where the user authentication occurs. No redirection should happen in this file.
  *
  */
-require_once get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{${SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}}/SugarAuthenticateUser.php");
+require_once get_custom_file_if_exists(
+    AuthenticationController::MODULE_FOLDER . DIRECTORY_SEPARATOR . SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY . '/SugarAuthenticateUser.php'
+);
 class EmailAuthenticateUser extends SugarAuthenticateUser
 {
     public $passwordLength = 4;

--- a/modules/Users/authentication/EmailAuthenticate/EmailAuthenticateUser.php
+++ b/modules/Users/authentication/EmailAuthenticate/EmailAuthenticateUser.php
@@ -48,7 +48,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * This file is where the user authentication occurs. No redirection should happen in this file.
  *
  */
-require_once get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}/SugarAuthenticateUser.php");
+require_once get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{${SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}}/SugarAuthenticateUser.php");
 class EmailAuthenticateUser extends SugarAuthenticateUser
 {
     public $passwordLength = 4;

--- a/modules/Users/authentication/EmailAuthenticate/EmailAuthenticateUser.php
+++ b/modules/Users/authentication/EmailAuthenticate/EmailAuthenticateUser.php
@@ -48,7 +48,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * This file is where the user authentication occurs. No redirection should happen in this file.
  *
  */
-require_once('modules/Users/authentication/SugarAuthenticate/SugarAuthenticateUser.php');
+require_once get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}/SugarAuthenticateUser.php");
 class EmailAuthenticateUser extends SugarAuthenticateUser
 {
     public $passwordLength = 4;
@@ -130,7 +130,7 @@ class EmailAuthenticateUser extends SugarAuthenticateUser
             return;
         }
 
-        require_once("include/SugarPHPMailer.php");
+        require_once(get_custom_file_if_exists("include/SugarPHPMailer.php"));
         global $locale;
         $OBCharset = $locale->getPrecedentPreference('default_email_charset');
         $notify_mail = new SugarPHPMailer();

--- a/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticate.php
+++ b/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticate.php
@@ -50,7 +50,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * based on the users validation
  *
  */
-require_once get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{AuthenticationController::DEFAULT_TYPE}/{AuthenticationController::DEFAULT_TYPE}.php");
+require_once get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{${AuthenticationController::DEFAULT_TYPE}}/{${AuthenticationController::DEFAULT_TYPE}}.php");
 
 class LDAPAuthenticate extends SugarAuthenticate
 {

--- a/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticate.php
+++ b/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticate.php
@@ -50,11 +50,14 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * based on the users validation
  *
  */
-require_once('modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php');
+require_once get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{AuthenticationController::DEFAULT_TYPE}/{AuthenticationController::DEFAULT_TYPE}.php");
+
 class LDAPAuthenticate extends SugarAuthenticate
 {
+    const LDAP_AUTHENTICATE_DIRECTORY = 'LDAPAuthenticate';
+
     public $userAuthenticateClass = 'LDAPAuthenticateUser';
-    public $authenticationDir = 'LDAPAuthenticate';
+    public $authenticationDir = self::LDAP_AUTHENTICATE_DIRECTORY;
     /**
      * Constructs LDAPAuthenticate
      * This will load the user authentication class

--- a/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticate.php
+++ b/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticate.php
@@ -50,7 +50,9 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * based on the users validation
  *
  */
-require_once get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{${AuthenticationController::DEFAULT_TYPE}}/{${AuthenticationController::DEFAULT_TYPE}}.php");
+require_once get_custom_file_if_exists(
+    AuthenticationController::MODULE_FOLDER . DIRECTORY_SEPARATOR . AuthenticationController::DEFAULT_TYPE . DIRECTORY_SEPARATOR . AuthenticationController::DEFAULT_TYPE . '.php'
+);
 
 class LDAPAuthenticate extends SugarAuthenticate
 {

--- a/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php
+++ b/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php
@@ -46,8 +46,12 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * This file is where the user authentication occurs. No redirection should happen in this file.
  *
  */
-require_once(get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{${LDAPAuthenticate::LDAP_AUTHENTICATE_DIRECTORY}}/LDAPConfigs/default.php"));
-require_once get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{${SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}}/SugarAuthenticateUser.php");
+require_once get_custom_file_if_exists(
+    AuthenticationController::MODULE_FOLDER . DIRECTORY_SEPARATOR . LDAPAuthenticate::LDAP_AUTHENTICATE_DIRECTORY . '/LDAPConfigs/default..php'
+);
+require_once get_custom_file_if_exists(
+    AuthenticationController::MODULE_FOLDER . DIRECTORY_SEPARATOR . SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY . '/SugarAuthenticateUser.php'
+);
 
 define('DEFAULT_PORT', 389);
 class LDAPAuthenticateUser extends SugarAuthenticateUser

--- a/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php
+++ b/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php
@@ -46,8 +46,8 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * This file is where the user authentication occurs. No redirection should happen in this file.
  *
  */
-require_once(get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{LDAPAuthenticate::LDAP_AUTHENTICATE_DIRECTORY}/LDAPConfigs/default.php"));
-require_once get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}/SugarAuthenticateUser.php");
+require_once(get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{${LDAPAuthenticate::LDAP_AUTHENTICATE_DIRECTORY}}/LDAPConfigs/default.php"));
+require_once get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{${SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}}/SugarAuthenticateUser.php");
 
 define('DEFAULT_PORT', 389);
 class LDAPAuthenticateUser extends SugarAuthenticateUser

--- a/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php
+++ b/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php
@@ -46,8 +46,8 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * This file is where the user authentication occurs. No redirection should happen in this file.
  *
  */
-require_once('modules/Users/authentication/LDAPAuthenticate/LDAPConfigs/default.php');
-require_once('modules/Users/authentication/SugarAuthenticate/SugarAuthenticateUser.php');
+require_once(get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{LDAPAuthenticate::LDAP_AUTHENTICATE_DIRECTORY}/LDAPConfigs/default.php"));
+require_once get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}/SugarAuthenticateUser.php");
 
 define('DEFAULT_PORT', 389);
 class LDAPAuthenticateUser extends SugarAuthenticateUser

--- a/modules/Users/authentication/SAML2Authenticate/SAML2Authenticate.php
+++ b/modules/Users/authentication/SAML2Authenticate/SAML2Authenticate.php
@@ -42,7 +42,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-require_once get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{AuthenticationController::DEFAULT_TYPE}/{AuthenticationController::DEFAULT_TYPE}.php");
+require_once get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{${AuthenticationController::DEFAULT_TYPE}}/{${AuthenticationController::DEFAULT_TYPE}}.php");
 
 /**
  * Returns the XML metadata which can be used to register the SP with the IDP
@@ -91,7 +91,7 @@ class SAML2Authenticate extends SugarAuthenticate
      */
     public function pre_login()
     {
-        require_once get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{$this->authenticationDir}/lib/onelogin/settings.php");
+        require_once get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{$this->authenticationDir}/lib/onelogin/settings.php");
         $auth = new OneLogin_Saml2_Auth($settingsInfo);
 
         if (!empty($_POST['SAMLResponse'])) {
@@ -189,7 +189,7 @@ class SAML2Authenticate extends SugarAuthenticate
      */
     public function preLogout()
     {
-        require_once get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{$this->authenticationDir}/lib/onelogin/settings.php");
+        require_once get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{$this->authenticationDir}/lib/onelogin/settings.php");
         $auth = new OneLogin_Saml2_Auth($settingsInfo);
 
         $returnTo = null;

--- a/modules/Users/authentication/SAML2Authenticate/SAML2Authenticate.php
+++ b/modules/Users/authentication/SAML2Authenticate/SAML2Authenticate.php
@@ -42,7 +42,9 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-require_once get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{${AuthenticationController::DEFAULT_TYPE}}/{${AuthenticationController::DEFAULT_TYPE}}.php");
+require_once get_custom_file_if_exists(
+    AuthenticationController::MODULE_FOLDER . DIRECTORY_SEPARATOR . AuthenticationController::DEFAULT_TYPE . DIRECTORY_SEPARATOR . AuthenticationController::DEFAULT_TYPE . '.php'
+);
 
 /**
  * Returns the XML metadata which can be used to register the SP with the IDP
@@ -91,7 +93,7 @@ class SAML2Authenticate extends SugarAuthenticate
      */
     public function pre_login()
     {
-        require_once get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{$this->authenticationDir}/lib/onelogin/settings.php");
+        require_once get_custom_file_if_exists(AuthenticationController::MODULE_FOLDER . "/{$this->authenticationDir}/lib/onelogin/settings.php");
         $auth = new OneLogin_Saml2_Auth($settingsInfo);
 
         if (!empty($_POST['SAMLResponse'])) {
@@ -189,7 +191,7 @@ class SAML2Authenticate extends SugarAuthenticate
      */
     public function preLogout()
     {
-        require_once get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{$this->authenticationDir}/lib/onelogin/settings.php");
+        require_once get_custom_file_if_exists(AuthenticationController::MODULE_FOLDER . "/{$this->authenticationDir}/lib/onelogin/settings.php");
         $auth = new OneLogin_Saml2_Auth($settingsInfo);
 
         $returnTo = null;

--- a/modules/Users/authentication/SAML2Authenticate/SAML2Authenticate.php
+++ b/modules/Users/authentication/SAML2Authenticate/SAML2Authenticate.php
@@ -42,7 +42,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-require_once __DIR__ . '/../../../../modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php';
+require_once get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{AuthenticationController::DEFAULT_TYPE}/{AuthenticationController::DEFAULT_TYPE}.php");
 
 /**
  * Returns the XML metadata which can be used to register the SP with the IDP
@@ -70,8 +70,10 @@ function getSAML2Metadata($settingsInfo) {
  */
 class SAML2Authenticate extends SugarAuthenticate
 {
+    const SAML2_AUTHENTICATE_DIRECTORY = 'SAML2Authenticate';
+
     public $userAuthenticateClass = 'SAML2AuthenticateUser';
-    public $authenticationDir = 'SAML2Authenticate';
+    public $authenticationDir = self::SAML2_AUTHENTICATE_DIRECTORY;
 
     /**
      * @var OneLogin_Saml2_Auth
@@ -89,7 +91,7 @@ class SAML2Authenticate extends SugarAuthenticate
      */
     public function pre_login()
     {
-        require_once __DIR__ . '/../SAML2Authenticate/lib/onelogin/settings.php';
+        require_once get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{$this->authenticationDir}/lib/onelogin/settings.php");
         $auth = new OneLogin_Saml2_Auth($settingsInfo);
 
         if (!empty($_POST['SAMLResponse'])) {
@@ -187,7 +189,7 @@ class SAML2Authenticate extends SugarAuthenticate
      */
     public function preLogout()
     {
-        require_once dirname(dirname(__FILE__)) . '/SAML2Authenticate/lib/onelogin/settings.php';
+        require_once get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{$this->authenticationDir}/lib/onelogin/settings.php");
         $auth = new OneLogin_Saml2_Auth($settingsInfo);
 
         $returnTo = null;

--- a/modules/Users/authentication/SAML2Authenticate/SAML2AuthenticateUser.php
+++ b/modules/Users/authentication/SAML2Authenticate/SAML2AuthenticateUser.php
@@ -42,7 +42,9 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-require_once get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{${SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}}/SugarAuthenticateUser.php");
+require_once get_custom_file_if_exists(
+    AuthenticationController::MODULE_FOLDER . DIRECTORY_SEPARATOR . SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY . '/SugarAuthenticateUser.php'
+);
 
 /**
  * Class SAML2AuthenticateUser

--- a/modules/Users/authentication/SAML2Authenticate/SAML2AuthenticateUser.php
+++ b/modules/Users/authentication/SAML2Authenticate/SAML2AuthenticateUser.php
@@ -42,7 +42,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-require_once __DIR__ . '/../../../../modules/Users/authentication/SugarAuthenticate/SugarAuthenticateUser.php';
+require_once get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}/SugarAuthenticateUser.php");
 
 /**
  * Class SAML2AuthenticateUser

--- a/modules/Users/authentication/SAML2Authenticate/SAML2AuthenticateUser.php
+++ b/modules/Users/authentication/SAML2Authenticate/SAML2AuthenticateUser.php
@@ -42,7 +42,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-require_once get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}/SugarAuthenticateUser.php");
+require_once get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{${SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}}/SugarAuthenticateUser.php");
 
 /**
  * Class SAML2AuthenticateUser

--- a/modules/Users/authentication/SugarAuthenticate/FactorAuthEmailCode.php
+++ b/modules/Users/authentication/SugarAuthenticate/FactorAuthEmailCode.php
@@ -42,7 +42,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-include_once get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}/FactorAuthInterface.php");
+include_once get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{${SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}}/FactorAuthInterface.php");
 include_once get_custom_file_if_exists('include/SugarPHPMailer.php');
 
 class FactorAuthEmailCode implements FactorAuthInterface
@@ -73,7 +73,7 @@ class FactorAuthEmailCode implements FactorAuthInterface
         $factorMessage = SugarAuthenticate::getFactorMessages();
         $ss->assign('factor_message', $factorMessage);
 
-        $ss->display(get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}/FactorAuthEmailCode.tpl"));
+        $ss->display(get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{${SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}}/FactorAuthEmailCode.tpl"));
     }
 
     /**

--- a/modules/Users/authentication/SugarAuthenticate/FactorAuthEmailCode.php
+++ b/modules/Users/authentication/SugarAuthenticate/FactorAuthEmailCode.php
@@ -42,9 +42,8 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-
-include_once get_custom_file_if_exists('modules/Users/authentication/SugarAuthenticate/FactorAuthInterface.php');
-include_once __DIR__ . '/../../../../include/SugarPHPMailer.php';
+include_once get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}/FactorAuthInterface.php");
+include_once get_custom_file_if_exists('include/SugarPHPMailer.php');
 
 class FactorAuthEmailCode implements FactorAuthInterface
 {
@@ -74,7 +73,7 @@ class FactorAuthEmailCode implements FactorAuthInterface
         $factorMessage = SugarAuthenticate::getFactorMessages();
         $ss->assign('factor_message', $factorMessage);
 
-        $ss->display(__DIR__ . '/FactorAuthEmailCode.tpl');
+        $ss->display(get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}/FactorAuthEmailCode.tpl"));
     }
 
     /**

--- a/modules/Users/authentication/SugarAuthenticate/FactorAuthEmailCode.php
+++ b/modules/Users/authentication/SugarAuthenticate/FactorAuthEmailCode.php
@@ -42,7 +42,9 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-include_once get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{${SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}}/FactorAuthInterface.php");
+include_once get_custom_file_if_exists(
+    AuthenticationController::MODULE_FOLDER . DIRECTORY_SEPARATOR . SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY . '/FactorAuthInterface.php'
+);
 include_once get_custom_file_if_exists('include/SugarPHPMailer.php');
 
 class FactorAuthEmailCode implements FactorAuthInterface
@@ -73,7 +75,7 @@ class FactorAuthEmailCode implements FactorAuthInterface
         $factorMessage = SugarAuthenticate::getFactorMessages();
         $ss->assign('factor_message', $factorMessage);
 
-        $ss->display(get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{${SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}}/FactorAuthEmailCode.tpl"));
+        $ss->display(get_custom_file_if_exists(AuthenticationController::MODULE_FOLDER . DIRECTORY_SEPARATOR . SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY . "/FactorAuthEmailCode.tpl"));
     }
 
     /**

--- a/modules/Users/authentication/SugarAuthenticate/FactorAuthFactory.php
+++ b/modules/Users/authentication/SugarAuthenticate/FactorAuthFactory.php
@@ -43,7 +43,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
 }
 
 
-include_once __DIR__ . '/../../../../include/Exceptions/SuiteException.php';
+include_once get_custom_file_if_exists('include/Exceptions/SuiteException.php');
 
 class FactorAuthFactory
 {

--- a/modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php
+++ b/modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php
@@ -69,7 +69,7 @@ class SugarAuthenticate
      */
     public function __construct()
     {
-        require_once(get_custom_file_if_exists(AuthenticationController::MODULE_FOLDER . "/${$this->authenticationDir}/{$this->userAuthenticateClass}.php"));
+        require_once(get_custom_file_if_exists(AuthenticationController::MODULE_FOLDER . "/{$this->authenticationDir}/{$this->userAuthenticateClass}.php"));
 
         $this->userAuthenticate = new $this->userAuthenticateClass();
     }

--- a/modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php
+++ b/modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php
@@ -69,7 +69,7 @@ class SugarAuthenticate
      */
     public function __construct()
     {
-        require_once(get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/${$this->authenticationDir}/{$this->userAuthenticateClass}.php"));
+        require_once(get_custom_file_if_exists(AuthenticationController::MODULE_FOLDER . "/${$this->authenticationDir}/{$this->userAuthenticateClass}.php"));
 
         $this->userAuthenticate = new $this->userAuthenticateClass();
     }

--- a/modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php
+++ b/modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php
@@ -51,7 +51,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
 class SugarAuthenticate
 {
     const SUGAR_AUTHENTICATE_DIRECTORY = 'SugarAuthenticate';
-    
+
     public $userAuthenticateClass = 'SugarAuthenticateUser';
     public $authenticationDir = self::SUGAR_AUTHENTICATE_DIRECTORY;
 
@@ -69,7 +69,7 @@ class SugarAuthenticate
      */
     public function __construct()
     {
-        require_once(get_custom_file_if_exists("{AuthentcationController::MODULE_FOLDER}/${$this->authenticationDir}/{$this->userAuthenticateClass}.php"));
+        require_once(get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/${$this->authenticationDir}/{$this->userAuthenticateClass}.php"));
 
         $this->userAuthenticate = new $this->userAuthenticateClass();
     }

--- a/modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php
+++ b/modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php
@@ -50,8 +50,10 @@ if (!defined('sugarEntry') || !sugarEntry) {
  */
 class SugarAuthenticate
 {
+    const SUGAR_AUTHENTICATE_DIRECTORY = 'SugarAuthenticate';
+    
     public $userAuthenticateClass = 'SugarAuthenticateUser';
-    public $authenticationDir = 'SugarAuthenticate';
+    public $authenticationDir = self::SUGAR_AUTHENTICATE_DIRECTORY;
 
 
     /**
@@ -67,13 +69,7 @@ class SugarAuthenticate
      */
     public function __construct()
     {
-        // check in custom dir first, in case someone want's to override an auth controller
-
-        if (file_exists('custom/modules/Users/authentication/'.$this->authenticationDir.'/' . $this->userAuthenticateClass . '.php')) {
-            require_once('custom/modules/Users/authentication/'.$this->authenticationDir.'/' . $this->userAuthenticateClass . '.php');
-        } elseif (file_exists('modules/Users/authentication/'.$this->authenticationDir.'/' . $this->userAuthenticateClass . '.php')) {
-            require_once('modules/Users/authentication/'.$this->authenticationDir.'/' . $this->userAuthenticateClass . '.php');
-        }
+        require_once(get_custom_file_if_exists("{AuthentcationController::MODULE_FOLDER}/${$this->authenticationDir}/{$this->userAuthenticateClass}.php"));
 
         $this->userAuthenticate = new $this->userAuthenticateClass();
     }
@@ -112,7 +108,7 @@ class SugarAuthenticate
         $_SESSION['waiting_error']='';
         $_SESSION['hasExpiredPassword']='0';
         if ($this->userAuthenticate->loadUserOnLogin($username, $password, $fallback, $PARAMS)) {
-            require_once('modules/Users/password_utils.php');
+            require_once(get_custom_file_if_exists('modules/Users/password_utils.php'));
             if (hasPasswordExpired($username)) {
                 $_SESSION['hasExpiredPassword'] = '1';
             }
@@ -183,7 +179,7 @@ class SugarAuthenticate
         $GLOBALS['log']->debug("authenticated_user_language is $authenticated_user_language");
 
         // Clear all uploaded import files for this user if it exists
-        require_once('modules/Import/ImportCacheFiles.php');
+        require_once(get_custom_file_if_exists('modules/Import/ImportCacheFiles.php'));
         $tmp_file_name = ImportCacheFiles::getImportDir()."/IMPORT_" . $GLOBALS['current_user']->id;
 
         if (file_exists($tmp_file_name)) {

--- a/modules/Users/authentication/SugarAuthenticate/SugarAuthenticateUser.php
+++ b/modules/Users/authentication/SugarAuthenticate/SugarAuthenticateUser.php
@@ -42,9 +42,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-
-
-include_once get_custom_file_if_exists('modules/Users/authentication/SugarAuthenticate/FactorAuthFactory.php');
+include_once get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}/FactorAuthFactory.php");
 
 /**
  * This file is where the user authentication occurs. No redirection should happen in this file.
@@ -249,7 +247,7 @@ class SugarAuthenticateUser
         $emailTemplateId = $sugar_config['passwordsetting']['factoremailtmpl'];
         $emailTemplate->retrieve($emailTemplateId);
 
-        include_once __DIR__ . '/../../../../include/SugarPHPMailer.php';
+        include_once get_custom_file_if_exists('include/SugarPHPMailer.php');
         $mailer = new SugarPHPMailer();
         $mailer->setMailerForSystem();
 

--- a/modules/Users/authentication/SugarAuthenticate/SugarAuthenticateUser.php
+++ b/modules/Users/authentication/SugarAuthenticate/SugarAuthenticateUser.php
@@ -42,7 +42,9 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-include_once get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{${SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}}/FactorAuthFactory.php");
+include_once get_custom_file_if_exists(
+    AuthenticationController::MODULE_FOLDER . DIRECTORY_SEPARATOR . SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY . '/FactorAuthFactory.php'
+);
 
 /**
  * This file is where the user authentication occurs. No redirection should happen in this file.

--- a/modules/Users/authentication/SugarAuthenticate/SugarAuthenticateUser.php
+++ b/modules/Users/authentication/SugarAuthenticate/SugarAuthenticateUser.php
@@ -42,7 +42,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-include_once get_custom_file_if_exists("{AuthenticationController::MODULE_FOLDER}/{SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}/FactorAuthFactory.php");
+include_once get_custom_file_if_exists("{${AuthenticationController::MODULE_FOLDER}}/{${SugarAuthenticate::SUGAR_AUTHENTICATE_DIRECTORY}}/FactorAuthFactory.php");
 
 /**
  * This file is where the user authentication occurs. No redirection should happen in this file.


### PR DESCRIPTION
## Description
The authentication module has many local file includes which makes it very challenging to customise any of the functionality in the /custom folder.
This PR replaces all local includes/requires to use the get_custom_file_if_exists util function allowing any individual file to be customised.
There is also a lot of repetition of folder names that I have extracted into constants to avoid magic-strings.

## Motivation and Context
It is really frustrating to customise any files in this module without having to replicate the entire module into the custom folder.
For me this was related to implementing this: https://github.com/salesagility/SuiteCRM/pull/6850#issuecomment-555936024

## How To Test This
Standard login / logout through each of the authentication modules.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
