### PR TITLE
Fix #7152 - Cases Update text not saving when using html field

### DIFF
--- a/include/SugarTinyMCE.php
+++ b/include/SugarTinyMCE.php
@@ -133,8 +133,10 @@ class SugarTinyMCE
         $jsConfig = $json->encode($config);
 
         $instantiateCall = '';
+        $unique = 'default';
         if (!empty($targets)) {
             $exTargets = explode(",", $targets);
+            $unique = $exTargets[0];
             foreach ($exTargets as $instance) {
                 $instantiateCall .= "tinyMCE.execCommand('mceAddControl', false, document.getElementById('{$instance}'));\n";
             }
@@ -145,12 +147,12 @@ class SugarTinyMCE
 <script type="text/javascript" language="Javascript">
 <!--
 $(document).ready(function(){
-	load_mce();
+	load_mce_{$unique}();
 });
 if (SUGAR.ajaxUI && SUGAR.ajaxUI.hist_loaded){
-    load_mce();
+    load_mce_{$unique}();
 }
-function load_mce() {
+function load_mce_{$unique}() {
     if (!SUGAR.util.isTouchScreen()) {
         if(tinyMCE.editors.length == 0 ){
             tinyMCE.init({$jsConfig});


### PR DESCRIPTION

## Description
Cases Update text fails to save on edit view when using html variation of the field field(currently the default), as tinymce is not loading correctly when multiple fields are using it, this pr changes TinyMCE to be instance specific when loading, to prevent conflicts.

## Motivation and Context
Fix #7152 

## How To Test This
Try to update an exsiting case from edit view when using the html field

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->