### PR TITLE
FIX #8759 - Method create_list_count_query() in SugarBean breaks the query

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -4292,10 +4292,16 @@ class SugarBean
      */
     public function create_list_count_query($query)
     {
+        preg_match_all('/(\sORDER\s*BY)/is', $query, $matches);
         // remove the 'order by' clause which is expected to be at the end of the query
         $pattern = '/\sORDER BY.*/is';
+
+        if (count($matches[0]) > 1) {
+            $pattern = '/ORDER\s*BY(?!.*\sORDER\s*BY).*/is';
+        }
         $replacement = '';
         $query = preg_replace($pattern, $replacement, $query);
+
         //handle distinct clause
         $star = '*';
         if (substr_count(strtolower($query), 'distinct')) {

--- a/tests/unit/phpunit/data/SugarBeanTest.php
+++ b/tests/unit/phpunit/data/SugarBeanTest.php
@@ -3089,6 +3089,64 @@ class SugarBeanTest extends SuitePHPUnitFrameworkTestCase
         $this->db->query($query);
     }
 
+
+    public function test_create_list_count_query()
+    {
+        // Create a lead and cache it
+        $bean = new SugarBean();
+        $bean->table_name = 'table_name';
+
+        $query = "SELECT
+                     DISTINCT table_name.id,
+                              table_name.created_by,
+                              table_name.assigned_user_id,
+                              table_name.name
+                  FROM table_name
+                  LEFT JOIN related_table_name gi ON gi.id = (
+                      select id
+                      from related_table_name
+                      where related_table_name.table_name_id = table_name.id
+                      order by parent_type asc limit 1 )
+                  where table_name.deleted=0 ORDER BY table_name.date_entered DESC";
+
+        $result = $bean->create_list_count_query($query);
+
+        $pattern0 = "/(\sORDER\s*BY\s)/is";
+        preg_match_all($pattern0, $query, $matches0);
+        self::assertEquals(2, count($matches0[0]));
+
+        $pattern1 = "/where table_name\.deleted=0\s*$/si";
+        preg_match_all($pattern1, $result, $matches1);
+        self::assertEquals(1, count($matches1[0]));
+
+        $pattern2 = "/ORDER BY parent_type asc/si";
+        preg_match_all($pattern2, $result, $matches2);
+        self::assertEquals(1, count($matches2[0]));
+
+
+        $query1 = "SELECT
+                     DISTINCT table_name.id,
+                              table_name.created_by,
+                              table_name.assigned_user_id,
+                              table_name.name
+                  FROM table_name
+                  where table_name.deleted=0 ORDER BY table_name.date_entered DESC";
+
+        $result1 = $bean->create_list_count_query($query1);
+
+        $pattern3 = "/\sORDER\s*BY/is";
+        preg_match_all($pattern3, $query1, $matches3);
+        self::assertEquals(1, count($matches3[0]));
+
+        $pattern4 = "/where table_name\.deleted=0$/si";
+        preg_match_all($pattern4, $result1, $matches4);
+        self::assertEquals(1, count($matches4[0]));
+
+        $pattern5 = "/ORDER BY parent_type asc/si";
+        preg_match($pattern5, $result1, $matches5);
+        self::assertEquals(0, count($matches5));
+    }
+
     /**
      * TODO: Tests that need to be written.
      * @see SugarBean::load_relationships()
@@ -3116,7 +3174,6 @@ class SugarBeanTest extends SuitePHPUnitFrameworkTestCase
      * @see SugarBean::is_relate_field()
      * @see SugarBean::process_order_by()
      * @see SugarBean::process_list_query()
-     * @see SugarBean::create_list_count_query()
      * @see SugarBean::fill_in_additional_list_fields()
      * @see SugarBean::get_detail()
      * @see SugarBean::process_detail_query()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Read #8759

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Read #8759


## How To Test This
<!--- Please describe in detail how to test your changes. -->

Read #8759

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->