### PR TITLE
Fix #8785 - Incorrect Syntax in install.php

### DIFF
--- a/install.php
+++ b/install.php
@@ -260,7 +260,7 @@ if (isset($_REQUEST['sugar_body_only']) && $_REQUEST['sugar_body_only'] == "1") 
         // TODO--low: validate file size & image width/height and save, show status result to client js
 
         if (isset($_REQUEST['callback']) && $_REQUEST['callback'] === 'uploadLogoCallback') {
-            echo "<script>window.top.window.uploadLogoCallback" . json_encode($result) . ");</script>";
+            echo "<script>window.top.window.uploadLogoCallback(" . json_encode($result) . ");</script>";
         }
 
         return;


### PR DESCRIPTION
Hi.
You miss a bracket in line 263 file install.php.

Now:
echo "<script>window.top.window.uploadLogoCallback" . json_encode($result) . ");</script>";
Need:
echo "<script>window.top.window.uploadLogoCallback(" . json_encode($result) . ");</script>";

Without this bracket browther throw error:
Uncaught SyntaxError: Unexpected token '{'
and can't finish upload process.

Best regards, Aleksandr. ;)