### PR TITLE
Fix incongruent SugarFieldBase class customization

### DIFF
--- a/include/SugarFields/SugarFieldHandler.php
+++ b/include/SugarFields/SugarFieldHandler.php
@@ -120,7 +120,7 @@ class SugarFieldHandler
                     !is_dir('include/SugarFields/Fields/'.$field)) {
                     return null;
                 }
-                $file = 'include/SugarFields/Fields/Base/SugarFieldBase.php';
+                $file = get_custom_file_if_exists('include/SugarFields/Fields/Base/SugarFieldBase.php');
                 $type = 'Base';
             }
             require_once($file);


### PR DESCRIPTION
## Description

We can create custom SugarFields classes in `custom/include/SugarFields/Fields/`.

But if the class we're overriding is the `Base` class, in `custom/include/SugarFields/Fields/Base/SugarFieldBase.php`, it gets picked up for some fields, but not for others:

![image](https://user-images.githubusercontent.com/15945027/87053842-562d1000-c1fa-11ea-8deb-7ee7b7ec2f3e.png)

This is because there are actually two ways for the base class to get loaded:

A - no class is found for that field type, so the default is loaded here https://github.com/salesagility/SuiteCRM/blob/hotfix-7.10.x/include/SugarFields/SugarFieldHandler.php#L123 (doesn't pick up the custom class, and this is what my PR fixes)

B - the field type is `varchar`, so it gets changed to `base` in function `fixupFieldType`. This new name will cause the custom class to get loaded here https://github.com/salesagility/SuiteCRM/blob/hotfix-7.10.x/include/SugarFields/SugarFieldHandler.php#L110.

## How To Test This

Create a file in `custom/include/SugarFields/Fields/Base/SugarFieldBase.php` with these contents:

```php 
<?php

if (!defined('sugarEntry') || !sugarEntry) {
    die('Not A Valid Entry Point');
}

require_once 'include/SugarFields/Fields/Base/SugarFieldBase.php';

class CustomSugarFieldBase extends SugarFieldBase {

    public function save(&$bean, $params, $field, $properties, $prefix = '') {
        parent::save($bean, $params, $field, $properties, $prefix);
    }
}
```
Go into any Edit view and hit **Save** button. Check that the function gets called for **_all_** fields that use the SugarFieldBase, not just varchars.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

