### PR TITLE
Allow massupdate currency field

### DIFF
--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -539,6 +539,7 @@ eoq;
                             $newhtml .= $this->addParent($displayname, $field);
                             break;
                         case "int":
+                        case "currency":
                             if (!empty($field['massupdate']) && empty($field['auto_increment'])) {
                                 $even = !$even;
                                 $newhtml .= $this->addInputType($displayname, $field['name']);


### PR DESCRIPTION
Allow mass update currency fields

## Description
I am trying to add the price field to the Product module mass update form by setting the field "massupdate" option to '1'. However, the part of the code that generates the mass update form does not handle the currency field.

## Motivation and Context
The capability of updating the price of the products in bulk is going to be helpful for many companies.

## How To Test This
Make any currency field massupdate-able. In the module list view, select a record and click "Bulk Action" > "Mass Update"

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.