### PR TITLE
Add 'Contains' as valid opp for multinum

### DIFF
--- a/modules/AOR_Reports/controller.php
+++ b/modules/AOR_Reports/controller.php
@@ -363,8 +363,10 @@ class AOR_ReportsController extends SugarController
                 );
                 break;
             case 'enum':
-            case 'multienum':
                 $valid_opp = array('Equal_To', 'Not_Equal_To');
+                break;
+            case 'multienum':
+                $valid_opp = array('Equal_To', 'Not_Equal_To', 'Contains');
                 break;
             default:
                 $valid_opp = array('Equal_To', 'Not_Equal_To', 'Contains', 'Starts_With', 'Ends_With',);


### PR DESCRIPTION
Add 'Contains' operator to AOR multienum field

## Description
SuiteCRM save multi enumeration in database as string separated by commas. In AOR, 'Equal To' and 'Not Equal To' operator is not likely to match a string with multiple selections. 'Contains' is a more appropriate operator.

## How To Test This
Create some records in a table with multienum field. Create a report with a condition for the multienum field.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.
