### PR TITLE
Array and string offset access syntax with curly braces is deprecated

### DIFF
--- a/include/Pear/Crypt_Blowfish/Blowfish.php
+++ b/include/Pear/Crypt_Blowfish/Blowfish.php
@@ -300,7 +300,7 @@ class Crypt_Blowfish
         for ($i = 0; $i < 18; $i++) {
             $data = 0;
             for ($j = 4; $j > 0; $j--) {
-                $data = $data << 8 | ord($key{$k});
+                $data = $data << 8 | ord($key[$k]);
                 $k = ($k+1) % $len;
             }
             $this->_P[$i] ^= $data;


### PR DESCRIPTION
Fix an array and string offset access syntax with curly braces in Crypt_Blowfish

## Description
Array and string offset access syntax with curly braces is deprecated in include/Pear/Crypt_Blowfish/Blowfish.php on line 303

## Motivation and Context
It is deprecated and may crash some views

## How To Test This
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
