### PR TITLE
Fix handling of file names with underscores in download.php

### DIFF
--- a/download.php
+++ b/download.php
@@ -112,10 +112,13 @@ if ((!isset($_REQUEST['isProfile']) && empty($_REQUEST['id'])) || empty($_REQUES
             sugar_die("Remote file detected, location header sent.");
         }
     } // if
-    $temp = explode("_", $_REQUEST['id'], 2);
+
+    // split the id by the last underscore, isolating names like 'photo' or 'photo_c' for handling below:
+    $temp = explode('_', $_REQUEST['id']);
     if (is_array($temp)) {
-        $image_field = isset($temp[1]) ? $temp[1] : null;
-        $image_id = $temp[0];
+        $image_field = (count($temp) > 1) ? array_pop($temp) : null;
+        $image_field = ($image_field === 'c') ? array_pop($temp) . '_c' : $image_field;
+        $image_id = implode('_', $temp);
     }
     if (isset($_REQUEST['ieId']) && isset($_REQUEST['isTempFile'])) {
         $local_location = sugar_cached("modules/Emails/{$_REQUEST['ieId']}/attachments/{$_REQUEST['id']}");
@@ -164,7 +167,8 @@ if ((!isset($_REQUEST['isProfile']) && empty($_REQUEST['id'])) || empty($_REQUES
 
             // Fix for issue #1195: because the module was created using Module Builder and it does not create any _cstm table,
             // there is a need to check whether the field has _c extension.
-            $query = "SELECT " . $image_field . " FROM " . $file_type . " ";
+            $file_type = $db->quote($file_type);
+            $query = "SELECT " . $db->quote($image_field) . " FROM " . $file_type . " ";
             if (substr($image_field, -2) == "_c") {
                 $query .= "LEFT JOIN " . $file_type . "_cstm cstm ON cstm.id_c = " . $file_type . ".id ";
             }


### PR DESCRIPTION

## Description
From Forums topic: photo files with extra underscores weren't downloading correctly.
https://community.suitecrm.com/t/broken-photo-for-id-like-zcrm-12345/74087/21?u=pgr

## Motivation and Context
The code in `download.php` is using a simplistic method to extract the ending in `_photo` or `photo_c` used by image fields. It assumes the filename has no additional underscores, which is not always the case.

## How To Test This
- Studio: Add Photo field to detail views in Contacts module (which has an existing `photo` field by default, it just needs adding to view)
- Studio: Add Photo field Products module (which does not have an existing `photo` field by default) and add it to Detail view
- QR & R
- add a couple of photos in records from both modules
- check that the detail view displays the uploaded photos correctly in both modules
- try the same with Bean ids that are not UUIDs, but are set from the database with values including underscores (this is typical of import situations and integration solutions).

(User in Forums thread has confirmed the fix works well)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

