### PR TITLE
Fixes module name on logic_hook install

### DIFF
--- a/install/suite_install/Projects.php
+++ b/install/suite_install/Projects.php
@@ -45,7 +45,7 @@ function install_projects()
     $hooks = array(
         //Projects
         array(
-            'module' => 'Projects',
+            'module' => 'Project',
             'hook' => 'before_delete',
             'order' => 1,
             'description' => 'Delete Project Tasks',


### PR DESCRIPTION
Fixes module name from `Projects` to `Project` to install the logic_hook to the correct location. Fixes #8816 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->