### PR TITLE
Turn privates to protecteds to fix EmailMan overrides

### DIFF
--- a/modules/EmailMan/EmailMan.php
+++ b/modules/EmailMan/EmailMan.php
@@ -137,12 +137,12 @@ class EmailMan extends SugarBean
      *
      * @var bool
      */
-    private $optInWarn;
+    protected $optInWarn;
 
     /**
      * @var string
      */
-    private $targetId;
+    protected $targetId;
 
     /**
      * @return string
@@ -1404,7 +1404,7 @@ class EmailMan extends SugarBean
      * @param EmailAddress $emailAddress
      * @return boolean return true on success otherwise false
      */
-    private function sendOptInEmailViaMailer(SugarBean $focus, EmailAddress $emailAddress)
+    protected function sendOptInEmailViaMailer(SugarBean $focus, EmailAddress $emailAddress)
     {
         global $log;
         global $app_strings;
@@ -1509,7 +1509,7 @@ class EmailMan extends SugarBean
      * @param \Contact|\Account|\Prospect|\SugarBean $bean
      * @return bool true === block email from being sent
      */
-    private function shouldBlockEmail(SugarBean $bean)
+    protected function shouldBlockEmail(SugarBean $bean)
     {
         global $sugar_config;
 


### PR DESCRIPTION
## Description
Problems customizing EmailMan class with a custom class.

## How To Test This
Create custom class in `custom/modules/EmailMan/CustomEmailMan.php`with something like this...

```php
require_once 'modules/EmailMan/EmailMan.php';

class CustomEmailMan extends EmailMan {

    public function sendEmail(SugarPHPMailer $mail, $save_emails = 1, $testmode = false, $previewmode = false) {
         [... code copied from original function, using function $this->shouldBlockEmail() ....]
    }
}
```

You get a PHP error:
``` 
Sun Aug  9 18:47:59 2020 [1183][1][PHP S] [E_ERROR] 
'Uncaught Error: Call to private method EmailMan::shouldBlockEmail() 
from context 'CustomEmailMan' 
in custom/modules/EmailMan/CustomEmailMan.php:126
```

This is wrong because this class is meant to be overridable, so these functions should be either `public` or `protected`.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
