### PR TITLE
Remove echo (old debugging code?)

### DIFF
--- a/modules/Users/User.php
+++ b/modules/Users/User.php
@@ -1450,7 +1450,7 @@ EOQ;
                 $query = "SELECT reports_to_id FROM users WHERE id='" . $this->db->quote($check_user) . "'";
                 $result = $this->db->query($query, true, "Error checking for reporting-loop");
                 $row = $this->db->fetchByAssoc($result);
-                echo("fetched: " . $row['reports_to_id'] . " from " . $check_user . "<br>");
+                //echo("fetched: " . $row['reports_to_id'] . " from " . $check_user . "<br>");
                 $check_user = $row['reports_to_id'];
             }
 


### PR DESCRIPTION
## Description
Fixes this:

![image](https://user-images.githubusercontent.com/15945027/91601164-11ebff80-e961-11ea-91a1-a808e5b2569a.png)

## How To Test This
1. Users module
2. Inline edit some field
3. See how the string `Fetched from:` appears in the field, followed by the id of the user to whom they report to.
4. Cringe

PHP Storm informs me that the only usage of this function, besides being called from User->Save, is from Test code.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

