### PR TITLE
Fix quotes in required fields labels when converting a lead

### DIFF
--- a/modules/Leads/views/view.convertlead.php
+++ b/modules/Leads/views/view.convertlead.php
@@ -323,7 +323,7 @@ class ViewConvertLead extends SugarView
         foreach ($focus->field_defs as $field => $def) {
             if (isset($def['required']) && $def['required']) {
                 $jsOut .= "
-            SUGAR.convert.requiredFields.$module.$field = '". translate($def['vname'], $module) . "';\n";
+            SUGAR.convert.requiredFields.$module.$field = '". str_replace("'","&#39;",translate($def['vname'], $module)) . "';\n";
             }
         }
 


### PR DESCRIPTION
Required fields are not managed if one of the field labels contains a quote

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
- Rename Opportunity name to Nom de l'opportunité
- Convert a lead and check Create an opportunity
- The opportunity name can be left empty even though it is required
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->