### PR TITLE
Fixes DynamicField reference

### DIFF
--- a/ModuleInstall/ModuleInstaller.php
+++ b/ModuleInstall/ModuleInstaller.php
@@ -1325,7 +1325,7 @@ class ModuleInstaller
     {
         global $beanList, $beanFiles;
         require_once('modules/DynamicFields/DynamicField.php');
-        $dyField = BeanFactory::newBean('DynamicFields');
+        $dyField = new DynamicField();
 
         foreach ($fields as $field) {
             $class = $beanList[ $field['module']];


### PR DESCRIPTION
fixes #8888

<!--- Provide a general summary of your changes in the Title above -->

## Description
See notes in issue #8888

## Motivation and Context
Just trying to fix a bug.

## How To Test This
```php
$dyField = BeanFactory::newBean('DynamicFields');
$GLOBALS['log']->fatal("dyField: " . print_r($dyField, true)); // empty. bad. 

$dyField = new DynamicField();
$GLOBALS['log']->fatal("dyField: " . print_r($dyField, true)); // not empty. good.
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
