### PR TITLE
Fix duplicate Compose Email Modal from Activities subpanel

### DIFF
--- a/include/generic/SugarWidgets/SugarWidgetSubPanelTopComposeEmailButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelTopComposeEmailButton.php
@@ -117,7 +117,7 @@ class SugarWidgetSubPanelTopComposeEmailButton extends SugarWidgetSubPanelTopBut
         $client = $current_user->getEmailClient();
 
         if ($client == 'sugar') {
-            $button .= "<input class='button' type='button' id='$inputID' value='$this->form_value'>";
+            $button .= "<input class='button' onclick='return false;' type='button' id='$inputID' value='$this->form_value'>";
         }
 
         return $button;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

Fixes an issue which causes the Compose Email modal to fire twice when clicking the Activities subpanel button.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Fixes #8730 
Fixes #6601

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Navigate to a Lead or Contact
2. Open Activities subpanel, click "Compose Email"
3. See a single dialogue opens.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->