### PR TITLE
Fix Campaign Bounce Handling mine type recognition

### DIFF
--- a/modules/Campaigns/ProcessBouncedEmails.php
+++ b/modules/Campaigns/ProcessBouncedEmails.php
@@ -59,14 +59,14 @@ function retrieveErrorReportAttachment(Email $email)
 
     $email->getNotes($email->id);
     foreach ($email->attachments as $note) {
-        if ($note->file_mime_type == 'message/rfc822') {
+        if (stripos($note->file_mime_type, 'rfc822') !== false) {
             $note_content = $note->getAttachmentContent();
             if ($note_content !== false) {
                 // XXX: we don't know the encoding of the attached email, but
                 // assume it's quoted-printable.
                 $contents .= quoted_printable_decode($note_content);
             }
-        } elseif ($note->file_mime_type == 'message/delivery-status') {
+        } elseif (stripos($note->file_mime_type, 'delivery-status') !== false) {
             $note_content = $note->getAttachmentContent();
             if ($note_content !== false) {
                 $contents .= $note_content;


### PR DESCRIPTION
## Description
Depending on email provider or other factors sometimes bounce emails from email Campaign are not recognised despite being valid bounce emails. This appear to be being caused by mine type being not an exact match for what it is expecting

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->