### PR TITLE
Optimistic locking false positives

### DIFF
--- a/modules/AOS_Invoices/vardefs.php
+++ b/modules/AOS_Invoices/vardefs.php
@@ -754,7 +754,7 @@ $dictionary['AOS_Invoices'] = array(
                 'relationship_type' => 'one-to-many',
             ),
     ),
-    'optimistic_lock' => true,
+    'optimistic_locking' => true,
 );
 require_once('include/SugarObjects/VardefManager.php');
 VardefManager::createVardef('AOS_Invoices', 'AOS_Invoices', array('basic', 'assignable', 'security_groups'));

--- a/modules/AOS_Line_Item_Groups/vardefs.php
+++ b/modules/AOS_Line_Item_Groups/vardefs.php
@@ -360,7 +360,7 @@ $dictionary['AOS_Line_Item_Groups'] = array(
     'relationship_type'=>'one-to-many',
     ),
 ),
-    'optimistic_lock'=>true,
+    'optimistic_locking'=>false,
 );
 require_once('include/SugarObjects/VardefManager.php');
 VardefManager::createVardef('AOS_Line_Item_Groups', 'AOS_Line_Item_Groups', array('basic','assignable'));

--- a/modules/AOS_PDF_Templates/vardefs.php
+++ b/modules/AOS_PDF_Templates/vardefs.php
@@ -337,7 +337,7 @@ $dictionary['AOS_PDF_Templates'] = array(
 ),
     'relationships'=>array(
 ),
-    'optimistic_lock'=>true,
+    'optimistic_locking'=>true,
 );
 require_once('include/SugarObjects/VardefManager.php');
 VardefManager::createVardef('AOS_PDF_Templates', 'AOS_PDF_Templates', array('basic','assignable','security_groups'));

--- a/modules/AOS_Products/vardefs.php
+++ b/modules/AOS_Products/vardefs.php
@@ -345,7 +345,7 @@ $dictionary['AOS_Products'] = array(
             'relationship_type' => 'one-to-many',
         ),
     ),
-    'optimistic_lock' => true,
+    'optimistic_locking' => true,
 );
 require_once('include/SugarObjects/VardefManager.php');
 VardefManager::createVardef('AOS_Products', 'AOS_Products', array('basic', 'assignable', 'security_groups'));

--- a/modules/AOS_Products_Quotes/vardefs.php
+++ b/modules/AOS_Products_Quotes/vardefs.php
@@ -530,7 +530,7 @@ $dictionary['AOS_Products_Quotes'] = array(
             'relationship_type' => 'one-to-many',
         ),
     ),
-    'optimistic_lock' => true,
+    'optimistic_locking' => false,
 );
 require_once('include/SugarObjects/VardefManager.php');
 VardefManager::createVardef('AOS_Products_Quotes', 'AOS_Products_Quotes', array('basic', 'assignable'));

--- a/modules/AOS_Quotes/vardefs.php
+++ b/modules/AOS_Quotes/vardefs.php
@@ -860,7 +860,7 @@ $dictionary['AOS_Quotes'] = array(
             ),
 
     ),
-    'optimistic_lock' => true,
+    'optimistic_locking' => true,
 );
 require_once('include/SugarObjects/VardefManager.php');
 VardefManager::createVardef('AOS_Quotes', 'AOS_Quotes', array('basic', 'assignable', 'security_groups'));

--- a/modules/OptimisticLock/LockResolve.php
+++ b/modules/OptimisticLock/LockResolve.php
@@ -1,14 +1,11 @@
 <?php
-if (!defined('sugarEntry') || !sugarEntry) {
-    die('Not A Valid Entry Point');
-}
 /**
  *
  * SugarCRM Community Edition is a customer relationship management program developed by
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
  *
  * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
- * Copyright (C) 2011 - 2018 SalesAgility Ltd.
+ * Copyright (C) 2011 - 2020 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the
@@ -41,24 +38,54 @@ if (!defined('sugarEntry') || !sugarEntry) {
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
 function display_conflict_between_objects($object_1, $object_2, $field_defs, $module_dir, $display_name)
 {
+    global $timedate;
+
     $mod_strings = return_module_language($GLOBALS['current_language'], 'OptimisticLock');
     $title = '<tr><td >&nbsp;</td>';
-    $object1_row= '<tr class="oddListRowS1"><td><b>'. $mod_strings['LBL_YOURS'] . '</b></td>';
-    $object2_row= '<tr class="evenListRowS1"><td><b>' . $mod_strings['LBL_IN_DATABASE'] . '</b></td>';
+    $object1_row = '<tr class="oddListRowS1"><td><b>' . $mod_strings['LBL_YOURS'] . '</b></td>';
+    $object2_row = '<tr class="evenListRowS1"><td><b>' . $mod_strings['LBL_IN_DATABASE'] . '</b></td>';
     $exists = false;
 
-    foreach ($field_defs as  $name=>$ignore) {
+    $skip = ['team_name', 'date_entered', 'date_modified'];
+
+    foreach ($field_defs as $name => $att) {
         $value = $object_1[$name];
-        // FIXME: Replace the comparison here with a function from SugarWidgets
-        if (!is_scalar($value) || $name == 'team_name') {
+        $compare = $object_2->$name;
+
+        if (!is_scalar($value) || $compare instanceof Link || in_array($name, $skip)) {
             continue;
         }
-        if ($value != $object_2->$name && !($object_2->$name instanceof Link)) {
-            $title .= '<td ><b>&nbsp;' . translate($field_defs[$name]['vname'], $module_dir). '</b></td>';
-            $object1_row .= '<td>&nbsp;' . $value. '</td>';
-            $object2_row .= '<td>&nbsp;' . $object_2->$name . '</td>';
+
+        switch ($att['type']) {
+            case 'date':
+            case 'datetime':
+            case 'datetimecombo':
+                $ob1Date = $timedate->fromUserType($value, $att['type']) ?: $timedate->fromDbType($value, $att['type']);
+                $ob2Date = $timedate->fromUserType($compare, $att['type']) ?: $timedate->fromDbType($compare, $att['type']);
+                $value = !empty($ob1Date) ? $timedate->asUserType($ob1Date, $att['type']) : '';
+                $compare = !empty($ob2Date) ? $timedate->asUserType($ob2Date, $att['type']) : '';
+                $match = $value === $compare;
+                break;
+            case 'bool':
+                $match = (bool)$value === (bool)$compare;
+                break;
+            Default:
+                $value = SugarCleaner::cleanHtml($value, true);
+                $compare = SugarCleaner::cleanHtml($compare, true);
+                $match = $value == $compare;
+                break;
+        }
+
+        if (!$match) {
+            $title .= '<td ><b>&nbsp;' . translate($att['vname'], $module_dir) . '</b></td>';
+            $object1_row .= '<td>&nbsp;' . $value . '</td>';
+            $object2_row .= '<td>&nbsp;' . $compare . '</td>';
             $exists = true;
         }
     }
@@ -66,23 +93,21 @@ function display_conflict_between_objects($object_1, $object_2, $field_defs, $mo
     if ($exists) {
         echo "<b>{$mod_strings['LBL_CONFLICT_EXISTS']}<a href='index.php?action=DetailView&module=$module_dir&record={$object_1['id']}'  target='_blank'>$display_name</a> </b> <br><table  class='list view' border='0' cellspacing='0' cellpadding='2'>$title<td  >&nbsp;</td></tr>$object1_row<td><a href='index.php?&module=OptimisticLock&action=LockResolve&save=true'>{$mod_strings['LBL_ACCEPT_YOURS']}</a></td></tr>$object2_row<td><a href='index.php?&module=$object_2->module_dir&action=DetailView&record=$object_2->id'>{$mod_strings['LBL_ACCEPT_DATABASE']}</a></td></tr></table><br>";
     } else {
-        echo "<b>{$mod_strings['LBL_RECORDS_MATCH']}</b><br>";
+        SugarApplication::redirect('index.php?&module=OptimisticLock&action=LockResolve&save=true');
     }
 }
 
 if (isset($_SESSION['o_lock_object'])) {
-    global $beanFiles, $moduleList;
-    $object = 	$_SESSION['o_lock_object'];
-    require_once($beanFiles[$beanList[$_SESSION['o_lock_module']]]);
-    $current_state = new $_SESSION['o_lock_class']();
-    $current_state->retrieve($object['id']);
+    $object = $_SESSION['o_lock_object'];
+    $module = $_SESSION['o_lock_module'];
+    $currentState = BeanFactory::getBean($module, $object['id']);
 
     if (isset($_REQUEST['save'])) {
         $_SESSION['o_lock_fs'] = true;
-        echo  $_SESSION['o_lock_save'];
+        echo $_SESSION['o_lock_save'];
         die();
     }
-    display_conflict_between_objects($object, $current_state, $current_state->field_defs, $current_state->module_dir, $_SESSION['o_lock_class']);
+    display_conflict_between_objects($object, $currentState, $currentState->field_defs, $currentState->module_dir, $_SESSION['o_lock_class']);
 } else {
     echo $mod_strings['LBL_NO_LOCKED_OBJECTS'];
 }

--- a/modules/SecurityGroups/vardefs.php
+++ b/modules/SecurityGroups/vardefs.php
@@ -63,7 +63,7 @@ $dictionary['SecurityGroup'] = array(
 ),
     'relationships'=>array(
 ),
-    'optimistic_lock'=>true,
+    'optimistic_locking'=>false,
 );
 require_once('include/SugarObjects/VardefManager.php');
 VardefManager::createVardef('SecurityGroups', 'SecurityGroup', array('basic','assignable'));

--- a/modules/SugarFeed/vardefs.php
+++ b/modules/SugarFeed/vardefs.php
@@ -135,7 +135,7 @@ $dictionary['SugarFeed'] = array(
                   )),
     ),
 
-    'optimistic_lock'=>true,
+    'optimistic_locking'=>false,
 );
 
 VardefManager::createVardef('SugarFeed', 'SugarFeed', array('basic',


### PR DESCRIPTION
## Description
Optimistic locking can display false positive as it doesn't work correctly with dates checkbox or html encoded fields
Addtiknaly somne moduels such as Quotes and Invoices have the optimistice locking definition incorrectly set so optimistic locking does not trigger on these modules 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->