### PR TITLE
Fix #8913 - Email compose body field missing

### DIFF
--- a/include/SugarFields/Fields/Wysiwyg/SugarFieldWysiwyg.php
+++ b/include/SugarFields/Fields/Wysiwyg/SugarFieldWysiwyg.php
@@ -82,7 +82,7 @@ class SugarFieldWysiwyg extends SugarFieldBase {
         $config['plugins']  = 'print code preview fullpage searchreplace autolink directionality visualblocks visualchars fullscreen image link media codesample table charmap hr pagebreak nonbreaking anchor insertdatetime advlist lists textcolor wordcount imagetools contextmenu colorpicker textpattern ';
         $config['elements'] = "#{$form_name} "."#".$vardef['name'];
         $config['selector'] = "#{$form_name} "."#".$vardef['name'];
-        $config['content_css'] = 'include/javascript/mozaik/vendor/tinymce/tinymce/skins/lightgray/content.min.css';
+        $config['content_css'] = 'vendor/tinymce/tinymce/skins/lightgray/content.min.css';
         $config['toolbar1'] = 'formatselect | bold italic strikethrough forecolor backcolor | link | alignleft aligncenter alignright alignjustify  | numlist bullist outdent indent  | removeformat';
         $config['theme'] = 'modern';
 

--- a/themes/SuiteP/tpls/_head.tpl
+++ b/themes/SuiteP/tpls/_head.tpl
@@ -78,5 +78,5 @@
     <link rel="stylesheet" type="text/css" href="themes/SuiteP/css/colourSelector.php">
     <script type="text/javascript" src='{sugar_getjspath file="themes/SuiteP/js/jscolor.js"}'></script>
     <script type="text/javascript" src='{sugar_getjspath file="cache/include/javascript/sugar_field_grp.js"}'></script>
-    <script type="text/javascript" src='{sugar_getjspath file="include/javascript/mozaik/vendor/tinymce/tinymce/tinymce.min.js"}'></script>
+    <script type="text/javascript" src='{sugar_getjspath file="vendor/tinymce/tinymce/tinymce.min.js"}'></script>
 </head>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Email compose body field missing due to invalid ref to tinymce

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->