### PR TITLE
Fix Saving strips +/- value from start of strings

### DIFF
--- a/include/export_utils.php
+++ b/include/export_utils.php
@@ -313,9 +313,8 @@ function export($type, $records = null, $members = false, $sample=false)
                 }
                 }
 
-
                 // Keep as $key => $value for post-processing
-                $new_arr[$key] = preg_replace("/\"/", "\"\"", $value);
+                $new_arr[$key] = preg_replace("/\"/", "\"\"", cleanCSV($value));
             }
 
             // Use Bean ID as key for records

--- a/include/utils.php
+++ b/include/utils.php
@@ -1000,6 +1000,20 @@ function clean($string, $maxLength)
 }
 
 /**
+ * @param $string
+ * @return string
+ */
+function cleanCSV($string)
+{
+    $check = '/^[=@]/';
+    if (!is_numeric($string)) {
+        $check = '/^[=@+-]/';
+    }
+
+    return preg_replace($check, "", $string);
+}
+
+/**
  * Copy the specified request variable to the member variable of the specified object.
  * Do no copy if the member variable is already set.
  * Portions created by SugarCRM are Copyright (C) SugarCRM, Inc.
@@ -2512,8 +2526,7 @@ function securexss($value)
     }
     
     static $xss_cleanup = ['&quot;' => '&#38;', '"' => '&quot;', "'" => '&#039;', '<' => '&lt;', '>' => '&gt;', '`' => '&#96;'];
-    
-    $value = preg_replace('/^[=@+-]/', '', $value);
+
     $value = preg_replace(array('/javascript:/i', '/\0/'), array('java script:', ''), $value);
     $value = preg_replace('/javascript:/i', 'java script:', $value);
 

--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -1044,7 +1044,7 @@ class AOR_Report extends Basic
 
     private function encloseForCSV($field)
     {
-        return '"' . $field . '"';
+        return '"' .  cleanCSV($field) . '"';
     }
 
     public function build_report_csv()


### PR DESCRIPTION


## Description
see issues #8934 and #8936


## How To Test This
see that +/- are not strippped from test and role sand reports main group work as expected

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->