### PR TITLE
Fix #8941 - Cannot delete reports fields

### DIFF
--- a/modules/AOR_Fields/fieldLines.js
+++ b/modules/AOR_Fields/fieldLines.js
@@ -357,7 +357,7 @@ function insertFieldLine(){
 function markFieldLineDeleted(ln)
 {
     // collapse line; update deleted value
-    document.getElementById('aor_fields_body' + ln).style.display = 'none';
+    document.getElementById('field_line' + ln).style.display = 'none';
     document.getElementById('aor_fields_deleted' + ln).value = '1';
     document.getElementById('aor_fields_delete_line' + ln).onclick = '';
 


### PR DESCRIPTION
## Description
After upgrading to 7.10.28 7.11.16/17 you cannot longer delete fields from reports

## How To Test This
See  that you can not delete fields from reports

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->