### PR TITLE
Show popup help field in EditView.

### DIFF
--- a/themes/SuiteP/include/EditView/tab_panel_content.tpl
+++ b/themes/SuiteP/include/EditView/tab_panel_content.tpl
@@ -50,15 +50,15 @@
                                 {{/if}}
                                 {{if isset($colData.field.popupHelp) || isset($fields[$colData.field.name]) && isset($fields[$colData.field.name].popupHelp) }}
                                     {{if isset($colData.field.popupHelp)}}
-                                        {{capture name="popupText" assign="popupText"}}
-                                            {sugar_translate label="{$colData.field.popupHelp}" module='{{$module}}'}
-                                        {{/capture}}
+                                        {capture name="popupText" assign="popupText"}
+                                            {sugar_translate label="{{$colData.field.popupHelp}}" module="{{$module}}"}
+                                        {/capture}
                                     {{elseif isset($fields[$colData.field.name].popupHelp)}}
                                         {capture name="popupText" assign="popupText"}
                                             {sugar_translate label="{{$fields[$colData.field.name].popupHelp}}" module='{{$module}}'}
                                         {/capture}
                                     {{/if}}
-                                    {sugar_help text=$popupText WIDTH=-1}
+                                    {sugar_help text=$popupText WIDTH=400}
                                 {{/if}}
                                 {/minify}
                             </div>


### PR DESCRIPTION
When clicking on the "help popup" button in the EditView, the help text shall be shown. There is no reason for setting it's size to -1

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

When clicking on the small "i" button next to a field in the EditView, it's help description shall be shown in a popup window.

Also, consistent use of Smarty brackets is recommended.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

We want to show additional field explanations and guidelines to our users.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

Set the "popupHelp" property for a field of your choice. When opening the edit view for the entity which the field belongs to, there shall be a "i" button next to the field. When clicking on this i, a popup with the set description shall open.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->