### PR TITLE
Fixed #8956 - Email compose body not shown up in detail views

### DIFF
--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -1053,7 +1053,7 @@
       }
 
       if (typeof opts.tinyMceOptions.selector === "undefined") {
-        opts.tinyMceOptions.selector = 'form[name="ComposeView"] textarea#description';
+        opts.tinyMceOptions.selector = 'form[name="ComposeView"] textarea[id=description]';
       }
 
       if ($(self).find('#from_addr_name').length !== 0) {


### PR DESCRIPTION
Changed CSS Class for Fixing Bug

## Description
WYSIWYG wasn`t applied for correct textarea field ("description") because there is a field with the same ID in detail view.
So I`ve changed the CSS id, so that it  applies correctly.

## Motivation and Context
WYSIWYG wasn`t applied for correct textarea field ("description") because there is a field with the same ID in detail view.
So I`ve changed the CSS id, so that it  applies correctly.

## How To Test This
Please test WYSIWYG in detail view by clicking on email field with email. In modal window for writing email the field description should be shown up as WYSIWYG. It should also work in list view.

## Types of changes
Changes in CSS id in javascript code
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->