### PR TITLE
Improved solution for BeanFactory caching incomplete beans

### DIFF
--- a/data/BeanFactory.php
+++ b/data/BeanFactory.php
@@ -58,6 +58,11 @@ class BeanFactory
     protected static $loadedBeans = [];
 
     /**
+     * @var array
+     */
+    protected static $shallowBeans = [];
+
+    /**
      * @var int
      */
     protected static $maxLoaded = 10;
@@ -143,6 +148,37 @@ class BeanFactory
             return false;
         }
 
+        return $bean;
+    }
+
+    /**
+     * Shallow beans are created by SugarBean during the fill_in_relationship_fields method, and they differ from
+     * 'complete' bean in that they do not have their own relate fields completed.
+     *
+     * We can use these beans for filling relate fields, but we should not be caching them and serving them anywhere
+     * else.
+     *
+     * @param $module
+     * @param null $id
+     * @param array $params
+     * @param bool $deleted
+     * @return bool|mixed|SugarBean
+     */
+    public static function getShallowBean($module, $id = null, $params = array(), $deleted = true)
+    {
+        if (isset(self::$loadedBeans[$module][$id])) {
+            return self::getBean($module, $id, $params, $deleted);
+        }
+        $key = $module . $id;
+        if (isset(self::$shallowBeans[$key])) {
+            return self::$shallowBeans[$key];
+        }
+        if (count(self::$shallowBeans) > self::$maxLoaded) {
+            array_shift(self::$shallowBeans);
+        }
+        $bean = self::getBean($module, $id, $params, $deleted);
+        self::$shallowBeans[$key] = $bean;
+        self::unregisterBean($module, $id);
         return $bean;
     }
 

--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -4970,7 +4970,7 @@ class SugarBean
                          ($this->object_name == $related_module && $this->$id_name != $this->id))
                     ) {
                         if (!empty($this->$id_name) && isset($this->$name)) {
-                            $mod = BeanFactory::getBean($related_module, $this->$id_name);
+                            $mod = BeanFactory::getShallowBean($related_module, $this->$id_name);
                             if ($mod) {
                                 if (!empty($field['rname'])) {
                                     $rname = $field['rname'];
@@ -4980,8 +4980,6 @@ class SugarBean
                                         $this->$name = $mod->name;
                                     }
                                 }
-                                // The related bean is incomplete due to $fill_in_rel_depth, we don't want to cache it
-                                BeanFactory::unregisterBean($related_module, $this->$id_name);
                             }
                         }
                     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes issues resulting from #8387 

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

#8387 addresses an issue where BeanFactory can cache beans which are not complete - missing fields as a result of how the SugarBean `fill_in_relationship_fields` method works.

However, the solution in #8387 can cause its own set of problems in installations which have large numbers of `after_retrieve` logic hooks and/or calculated fields, causing a significant performance drop.

The solution proposed in this PR solves both the original issue of incomplete beans being cached by BeanFactory, and also the performance issue by keeping a register of "shallow" beans which are only used to compute relate fields.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Performance issues will appear when an installation has a large number of relate fields, expanded subpanels, after_retrieve logic hooks and/or functions fields.
Each call to SugarBean->fill_in_relationship_fields() will cause new shallow beans to be created, because BeanFactory won't cache them.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->