### PR TITLE
Fixed #7747 - Can't rename custom relationship labels

### DIFF
--- a/include/SugarObjects/LanguageManager.php
+++ b/include/SugarObjects/LanguageManager.php
@@ -198,8 +198,8 @@ class LanguageManager
         $lang_paths = array(
             'modules/' . $module . '/language/' . $lang . '.lang.php',
             'modules/' . $module . '/language/' . $lang . '.lang.override.php',
-            'custom/modules/' . $module . '/language/' . $lang . '.lang.php',
             'custom/modules/' . $module . '/Ext/Language/' . $lang . '.lang.ext.php',
+            'custom/modules/' . $module . '/language/' . $lang . '.lang.php',
         );
 
         #27023, if this module template language file was not attached , get the template from this module vardef cache file if exsits and load the template language files.


### PR DESCRIPTION
Fixes the issue [#7747](https://github.com/salesagility/SuiteCRM/issues/7747).

## Description
If a label is defined in a custom language file within custom/Extension/<module>/Ext/Language/<filename>.php , an administrator user won't be able to change the label from studio. 

This happens because the priority of the custom label files that will be watched isn't sorted in the right order.

In this message within SuiteCRM Community forum https://community.suitecrm.com/t/renaming-relationship-label/18549/10, a user mentions that there was a SugarCRM hotfix that applies the solution proposed in this PR. The SugarCRM link isn't working anymore.

Note that from the moment that this PR is merged and the software updated, the labels displayed ultimately will be those in custom/modules/<modules>/language .

## Motivation and Context
This fix is required if an Administrator user wants to customize a label within studio that was already customized in Extension.

## How To Test This
- Set a label within custom/Extension/<module>/Ext/Language/<filename>.php 
- Go to studio and make a modification of the same label
- Check that the value of the label set in studio appears correctly

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.