### PR TITLE
Fix Hardcoded 'by' label in calls history (issue #8999)

### DIFF
--- a/modules/Calls/language/en_us.lang.php
+++ b/modules/Calls/language/en_us.lang.php
@@ -162,4 +162,5 @@ $mod_strings = array(
     'LBL_LIST_STATUS'=>'Status',
     'LBL_LIST_DATE_MODIFIED'=>'Date Modified',
     'LBL_LIST_DUE_DATE'=>'Due Date',
+    'LBL_RESCHEDULED_BY'=>'by',
 );

--- a/modules/Calls/reschedule_history.php
+++ b/modules/Calls/reschedule_history.php
@@ -42,7 +42,7 @@ require_once('modules/Calls_Reschedule/Calls_Reschedule.php');
 
 function reschedule_history($focus, $field, $value, $view)
 {
-    global $app_list_strings;
+    global $app_list_strings,$mod_strings;
 
     if ($view == 'DetailView') {
         $html = '';
@@ -57,7 +57,7 @@ function reschedule_history($focus, $field, $value, $view)
         while ($row = $focus->db->fetchByAssoc($result)) {
             $reschedule->retrieve($row['id']);
                        
-            $html .= '<li>'.$app_list_strings["call_reschedule_dom"][$reschedule->reason].' - '.$reschedule->date_entered.' by '.$reschedule->created_by_name.'</li>';
+            $html .= '<li>'.$app_list_strings["call_reschedule_dom"][$reschedule->reason].' - '.$reschedule->date_entered.' '.$mod_strings['LBL_RESCHEDULED_BY'].' '.$reschedule->created_by_name.'</li>';
         }
 
         $html .= '</ul>';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->