### PR TITLE
Add "dependent actions" option to Workflows

### DIFF
--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -930,6 +930,7 @@ class AOW_WorkFlow extends Basic
         $processed->load_relationship('aow_actions');
 
         $pass = true;
+        $stopOnActionFail = isset($this->dependent_actions) && $this->dependent_actions;
 
         $sql = "SELECT id FROM aow_actions WHERE aow_workflow_id = '".$this->id."' AND deleted = 0 ORDER BY action_order ASC";
         $result = $this->db->query($sql);
@@ -963,6 +964,9 @@ class AOW_WorkFlow extends Basic
                 if (!$flow_action->run_action($bean, unserialize(base64_decode($action->parameters)), $in_save)) {
                     $pass = false;
                     $processed->aow_actions->add($action->id, array('status' => 'Failed'));
+                    if ($stopOnActionFail) {
+                        break;
+                    }
                 } else {
                     $processed->aow_actions->add($action->id, array('status' => 'Complete'));
                 }

--- a/modules/AOW_WorkFlow/language/en_us.lang.php
+++ b/modules/AOW_WorkFlow/language/en_us.lang.php
@@ -76,5 +76,6 @@ $mod_strings = array(
     'LBL_ACTION_LINES' => 'Actions',
     'LBL_ADD_ACTION' => 'Add Action',
     'LBL_MULTIPLE_RUNS' => 'Repeated Runs',
+    'LBL_DEPENDENT_ACTIONS' => 'Dependent Actions',
     'LBL_RUN_WHEN' => 'Run'
 );

--- a/modules/AOW_WorkFlow/metadata/detailviewdefs.php
+++ b/modules/AOW_WorkFlow/metadata/detailviewdefs.php
@@ -117,6 +117,11 @@ $viewdefs ['AOW_WorkFlow'] =
                             'name' => 'multiple_runs',
                             'label' => 'LBL_MULTIPLE_RUNS',
                         ),
+                        1 =>
+                        array(
+                            'name' => 'dependent_actions',
+                            'label' => 'LBL_DEPENDENT_ACTIONS',
+                        ),
                     ),
                     4 =>
                     array(

--- a/modules/AOW_WorkFlow/metadata/editviewdefs.php
+++ b/modules/AOW_WorkFlow/metadata/editviewdefs.php
@@ -108,6 +108,11 @@ $viewdefs ['AOW_WorkFlow'] =
                             'name' => 'multiple_runs',
                             'label' => 'LBL_MULTIPLE_RUNS',
                         ),
+                        1 =>
+                        array(
+                            'name' => 'dependent_actions',
+                            'label' => 'LBL_DEPENDENT_ACTIONS',
+                        ),
                     ),
                     4 =>
                     array(

--- a/modules/AOW_WorkFlow/vardefs.php
+++ b/modules/AOW_WorkFlow/vardefs.php
@@ -144,6 +144,14 @@ $dictionary['AOW_WorkFlow'] = array(
                 'default' => '0',
                 'reportable' => false,
             ),
+        'dependent_actions' =>
+            array(
+                'name' => 'dependent_actions',
+                'vname' => 'LBL_DEPENDENT_ACTIONS',
+                'type' => 'bool',
+                'default' => '0',
+                'reportable' => false,
+            ),
         'condition_lines' =>
             array(
                 'required' => false,


### PR DESCRIPTION
Add a new flag to Workflows - "dependent actions"
* In case it's on - if one of the WF actions fails, it will not move on to the next actions
* In case it's off (default) - continue to next actions on fail. Same behavior as now

## Description
Add option to make WF actions dependent - if one fails, the others should not run.
Default (off) is the same behavior as now (continue to other actions 
in case an action fails)

## Motivation and Context
In case you want to create a Workflow doing multiple actions but one of them fails - in some cases you won't want other actions to run.

## How To Test This
#### Backward Compatibility:
1. Create a WF with multiple actions (I.E. update one entity, send email, update other entity)
2. Make one of the actions to fail. (I.E. the send email action - by using wrong credential).
3. Run the WF
4. Make sure all actions ran even if one of them failed

#### New Feature:
1. Use same steps as in the backward compatibility
2. Turn "dependent actions" flag on
3. Make sure the actions after the failed action did not run

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [X] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->