### PR TITLE
Fixed #9024 - API returns error when Note lacks attachment

### DIFF
--- a/Api/V8/Service/ModuleService.php
+++ b/Api/V8/Service/ModuleService.php
@@ -375,7 +375,7 @@ class ModuleService
 
             if ($property === 'filecontents') {
                 continue;
-            } elseif ($property === 'filename') {
+            } elseif ($property === 'filename' && !empty($value)) {
                 $createFile = true;
                 continue;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
The API incorrectly assumes that if the `filename` attribute exists, that the client is attempting to perform an upload. This is not always the case and in fact, many clients will return many of the attributes that are provided by a `GET` request. 

The PR makes the application check if the `filename` is Not Empty before assuming that a file upload is in progress. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fixes #9024 
It builds on #8408

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create a Note with no attachment
2. Attempt to Edit the note by performing a `PATCH` request with a blank (empty string) `filename` attribute. 
The request should succeed. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->