### PR TITLE
TinyMCE Font Does Not Match Default

### DIFF
--- a/include/SugarFields/Fields/Wysiwyg/SugarFieldWysiwyg.php
+++ b/include/SugarFields/Fields/Wysiwyg/SugarFieldWysiwyg.php
@@ -83,7 +83,8 @@ class SugarFieldWysiwyg extends SugarFieldBase {
         $config['elements'] = "#{$form_name} "."#".$vardef['name'];
         $config['selector'] = "#{$form_name} "."#".$vardef['name'];
         $config['content_css'] = 'vendor/tinymce/tinymce/skins/lightgray/content.min.css';
-        $config['toolbar1'] = 'formatselect | bold italic strikethrough forecolor backcolor | link | alignleft aligncenter alignright alignjustify  | numlist bullist outdent indent  | removeformat';
+        $config['toolbar1'] = 'formatselect | fontselect | bold italic strikethrough forecolor backcolor | link | alignleft aligncenter alignright alignjustify  | numlist bullist outdent indent  | removeformat';
+        $config['font_formats'] = 'Lato=lato; Arial=arial,helvetica,sans-serif; Arial Black=arial black,avant garde; Book Antiqua=book antiqua,palatino; Comic Sans MS=comic sans ms,sans-serif; Courier New=courier new,courier; Georgia=georgia,palatino; Helvetica=helvetica; Impact=impact,chicago; Symbol=symbol; Tahoma=tahoma,arial,helvetica,sans-serif; Terminal=terminal,monaco; Times New Roman=times new roman,times; Trebuchet MS=trebuchet ms,geneva; Verdana=verdana,geneva;';
         $config['theme'] = 'modern';
 
         $jsConfig = $json->encode($config);


### PR DESCRIPTION
The default fonts available in TinyMCE do not match SuiteCRM Theme and cannot be changed in the UI.


## Description
Two changes are required.

Enable font selection in TinyMCE
Add Lato Font as first option

## Motivation and Context
Fonts cannot be changed easily

## How To Test This
Load any wysiwyg field and check that the font selector shows
Load any wysiwyg field and check that the font Luto appears first

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.