### PR TITLE
Prevent Notice Error During Import

### DIFF
--- a/modules/Import/Importer.php
+++ b/modules/Import/Importer.php
@@ -501,7 +501,7 @@ class Importer
         * Bug 34854: Added all conditions besides the empty check on date modified.
         */
         if ((!empty($focus->new_with_id) && !empty($focus->date_modified)) ||
-             (empty($focus->new_with_id) && $timedate->to_db($focus->date_modified) != $timedate->to_db($timedate->to_display_date_time($focus->fetched_row['date_modified'])))
+             (is_array($focus->fetched_row) && empty($focus->new_with_id) && $timedate->to_db($focus->date_modified) != $timedate->to_db($timedate->to_display_date_time($focus->fetched_row['date_modified'])))
         ) {
             $focus->update_date_modified = false;
         }


### PR DESCRIPTION
## Description
Check if fetched_row is an array before relying upon it for the condition.
Prevents notice in PHP7.4

## Motivation and Context
PHP Notice error thrown when $focus->fetched_row is not an array.

## How To Test This
1) PHP version > 7.4
2) PHP Error level include Notice
3) Import new record

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.