### PR TITLE
Maintain pagebreak tag

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -2452,8 +2452,10 @@ class SugarBean
                     $type .= $def['dbType'];
                 }
 
-                if (isset($def['type']) && ($def['type'] == 'html' || $def['type'] == 'longhtml')) {
-                    $this->$key = htmlentities(SugarCleaner::cleanHtml($this->$key, true));
+                if (isset($def['type']) && ($def['type'] == 'html' || $def['type'] == 'longhtml' || $def['type'] == 'longtext') ) {
+                    if (strpos($this->$key, 'pagebreak') === false) {
+                        $this->$key = htmlentities(SugarCleaner::cleanHtml($this->$key, true));
+                    }
                 } elseif (
                     (strpos($type, 'char') !== false || strpos($type, 'text') !== false || $type == 'enum') &&
                     !empty($this->$key)


### PR DESCRIPTION
If tag is 'pagebreak' then do not run SugarCleaner on it

<!--- Provide a general summary of your changes in the Title above -->

## Description
Solution for fixing this bug. The pagebreak tag is still unfortunately getting removed when the PDF template is generated.
More details: https://github.com/salesagility/SuiteCRM/issues/4435

## Motivation and Context
The pagebreak gets removed when a template get saved in PDF Templates module

## How To Test This
PDF Template > Create > Create a template and insert the pagebreak tag 

![tag](https://user-images.githubusercontent.com/1866104/109380738-be715480-78a4-11eb-87db-ba611d7b5210.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->