### PR TITLE
Fixed #9049 - Remove the Prospsects and ProspectLists from the modInv…

### DIFF
--- a/include/modules.php
+++ b/include/modules.php
@@ -266,8 +266,6 @@ $modInvisList = [
     'CampaignTrackers',
     'CampaignLog',
     'EmailMan',
-    'Prospects',
-    'ProspectLists',
     'Groups',
     'InboundEmail',
     'ACLActions',


### PR DESCRIPTION
…isList - make them visible - will result in them being available for a meta/modules call and subsequent module calls

## Description
Removed Prospects and ProspectLists from the module invisible list (making them visible) fixing bug 9049

## Motivation and Context
Ability to manage targets just like Leads and Contacts through the API

## How To Test This
After this change the Prospects and ProspectLists appear in the meta modules list and can be managed using the same module methods as used for Leads and Contacts

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
