### PR TITLE
Fixed #8676: New Scheduled Reports does not run

### DIFF
--- a/modules/AOR_Scheduled_Reports/AOR_Scheduled_Reports.php
+++ b/modules/AOR_Scheduled_Reports/AOR_Scheduled_Reports.php
@@ -191,7 +191,8 @@ class AOR_Scheduled_Reports extends basic
             return true;
         }
 
-        $lastRun = $timedate->fromDb($this->last_run);
+        $lastRun = $this->last_run ? $timedate->fromDb($this->last_run) : $timedate->fromDb($this->date_entered);
+        
         $this->handleTimeZone($lastRun);
         $next = $cron->getNextRunDate($lastRun);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Fixes #8676 
If a Scheduled Report is created and it is not immediately eligible to run (for example, it's scheduled to run at midnight and it's currently the afternoon), then a Fatal PHP error is thrown**. 

This error could likely prevent _other_ scheduled reports from running - this is especially relevant if you have other reports scheduled at different times.

This PR fixes the issue by filling in a reasonable value for the `$lastRun` variable. This allows us to have the correct type for the `handleTimeZone()` function. 

** The Fatal error was caused by providing a `false` value to the `handleTimeZone(DateTime $date)` function.

Thanks @afernandez2000 for providing a recommended fix.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This allows you to create Scheduled Reports in a system that may have multiple. It will not break the existing reports while we're waiting for the new one to be run for the first time.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create a scheduled report. Set it to run every */5 minutes
2. Create a second scheduled report. Set it to run every */10 minutes
Assuming you create the records at 13:01
Expected:
At 13:05, you should get your first report. 
Actual:
You do not get the report and the "Run Report Generation Scheduled Tasks" job has failed

3. Apply the PR
Expected:
At 13:05, you get the first report
At 13:10, you get both reports
No errors or failures

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->