### PR TITLE
9067 - Fix the drop down width

### DIFF
--- a/themes/SuiteP/css/suitep-base/editview.scss
+++ b/themes/SuiteP/css/suitep-base/editview.scss
@@ -735,6 +735,7 @@ slot {
 select {
   font-weight: normal;
   color: $main-font-color;
+  max-width: 90%;
 }
 
 option[selected] {


### PR DESCRIPTION
- when the text option in a drop down exceeded the width of the div containing it, the drop down would overflow. This limits the size of the drop down to be 100% of the container width.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Drop down was overflowing, issue described in 9067. The fix I am suggesting limits drop down width do that it will not exceed the length of the text input fields

## Motivation and Context
When trying to customise the software I have added drop down options that are too long for the container, it makes the view harder to read as the overflow can cover labels and hide information.

## How To Test This
- go to drop down editor
- choose a drop down
- add option to drop down with very long text vaue
- view drop down on edit view and ensure that the drop down does not exceed the length of the text inputs

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->