### PR TITLE
Fix #9075 - Removing deleted related beans via link

### DIFF
--- a/data/Link2.php
+++ b/data/Link2.php
@@ -573,27 +573,29 @@ class Link2
 
         foreach ($rel_keys as $key) {
             //We must use beans for LogicHooks and other business logic to fire correctly
-            if (!($key instanceof SugarBean)) {
-                $key = $this->getRelatedBean($key);
-                if (!($key instanceof SugarBean)) {
+            $keyBean = $key;
+            if (!($keyBean instanceof SugarBean)) {
+                $keyBean = $this->getRelatedBean($keyBean);
+                if (!($keyBean instanceof SugarBean)) {
                     $GLOBALS['log']->error('Unable to load related bean by id');
-
-                    return false;
+//                    Note these beans as failed and continue
+                    $failures[] = $key;
+                    continue;
                 }
             }
 
-            if (empty($key->id) || empty($this->focus->id)) {
+            if (empty($keyBean->id) || empty($this->focus->id)) {
                 return false;
             }
 
             if ($this->getSide() == REL_LHS) {
-                $success = $this->relationship->remove($this->focus, $key);
+                $success = $this->relationship->remove($this->focus, $keyBean);
             } else {
-                $success = $this->relationship->remove($key, $this->focus);
+                $success = $this->relationship->remove($keyBean, $this->focus);
             }
 
             if ($success == false) {
-                $failures[] = $key->id;
+                $failures[] = $keyBean->id;
             }
         }
 


### PR DESCRIPTION
When removing related ids, if a bean fails to load, place this id in the failures array and continue.

## Description
If bean fails to load/not instanceof SugarBean, track the failed id in the $failure array.
This has also required creating a new variable in order to track both the id and the bean (as failing to load the bean was overwriting the id itself with null)

## Motivation and Context
Proposed fix for issue #9075

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.