### PR TITLE
date_end of Calls is not calculated correctly

### DIFF
--- a/modules/Calls/Call.php
+++ b/modules/Calls/Call.php
@@ -182,16 +182,20 @@ class Call extends SugarBean
     {
         global $timedate;
 
-        if (!empty($this->date_start)) {
-            if (!empty($this->duration_hours) && !empty($this->duration_minutes)) {
+        if (isset($this->date_start)) {
+            $td = $timedate->fromDb($this->date_start);
+            if (!$td) {
+                $this->date_start = $timedate->to_db($this->date_start);
                 $td = $timedate->fromDb($this->date_start);
-                if ($td) {
-                    $this->date_end = $td->modify(
-                        "+{$this->duration_hours} hours {$this->duration_minutes} mins"
-                    )->asDb();
+            }
+            if ($td) {
+                if (isset($this->duration_hours) && $this->duration_hours != '') {
+                    $td->modify("+{$this->duration_hours} hours");
                 }
-            } else {
-                $this->date_end = $this->date_start;
+                if (isset($this->duration_minutes) && $this->duration_minutes != '') {
+                    $td->modify("+{$this->duration_minutes} mins");
+                }
+                $this->date_end = $td->asDb();
             }
         }
 


### PR DESCRIPTION
If duration is 0h 15min or 2h 0mn, date end is stored as equal to date start due to !empty condition

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Copied date end calculation from Meeting.php
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
- Create a call with duration 15 minutes
- Look at the date_end stored in the database
- date_end is equal to date_start
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Wrong date end in database

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->