### PR TITLE
Fix #9106 - Update securexss for backwards compatibility

### DIFF
--- a/include/utils.php
+++ b/include/utils.php
@@ -2537,10 +2537,24 @@ function securexss($uncleanString)
         return $new;
     }
 
+    static $xss_cleanup = [
+        '&quot;' => '&#38;',
+        '"' => '&quot;',
+        "'" => '&#039;',
+        '<' => '&lt;',
+        '>' => '&gt;',
+        '`' => '&#96;'
+    ];
+
+    $uncleanString = preg_replace(array('/javascript:/i', '/\0/', '/javascript:/i'),
+        array('java script:', '', 'java script:'), $uncleanString);
+
+    $partialString = str_replace(array_keys($xss_cleanup), $xss_cleanup, $uncleanString);
+
     $antiXss = new AntiXSS();
     $antiXss->removeEvilAttributes(['style']);
 
-    return $antiXss->xss_clean($uncleanString);
+    return $antiXss->xss_clean($partialString);
 }
 
 function securexsskey($value, $die = true)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Issue reference: #9106

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Re-adds functionality that was removed from the ```securexss``` method which was causing different encoded values to be returned.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Check Travis 

(This has been tested internally).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->