### PR TITLE
Fix core listviewdefs.php for Outbound Email Accounts module to use c…

### DIFF
--- a/modules/OutboundEmailAccounts/metadata/listviewdefs.php
+++ b/modules/OutboundEmailAccounts/metadata/listviewdefs.php
@@ -9,26 +9,18 @@ array(
     'default' => true,
     'link' => true,
   ),
-//  'ASSIGNED_USER_NAME' =>
-//  array (
-//    'width' => '9%',
-//    'label' => 'LBL_ASSIGNED_TO_NAME',
-//    'module' => 'Employees',
-//    'id' => 'ASSIGNED_USER_ID',
-//    'default' => true,
-//  ),
-  'USERNAME' =>
+  'MAIL_SMTPUSER' =>
   array(
     'type' => 'varchar',
     'label' => 'LBL_USERNAME',
     'width' => '10%',
-    'default' => false,
+    'default' => true,
   ),
-  'smtp_servername' =>
+  'MAIL_SMTPSERVER' =>
   array(
     'type' => 'varchar',
     'label' => 'LBL_SMTP_SERVERNAME',
     'width' => '10%',
-    'default' => false,
+    'default' => true,
   ),
 );


### PR DESCRIPTION
Fix core listviewdefs.php for Outbound Email Accounts module to use correct fields by default.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Updated the core listviewdefs.php file in the Outbound Email Accounts module to use correct Username and Server Name column fields by default.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Originally, the Username and Server Name column fields that are available in the list view columns are the incorrect ones, so that when they were set to visible, they would always be blank. This fix resolves the issue by replacing them with the correct fields.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to Outbound Email Accounts list view.
2. Open the Column Chooser and make sure the Username and Server Name columns are set to Visible.
3. Check that the fields are filled in with the expected values.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->