### PR TITLE
Fix for: #9179 AOR_Charts getShortenedLabel fails on utf8 characters

### DIFF
--- a/modules/AOR_Charts/AOR_Chart.php
+++ b/modules/AOR_Charts/AOR_Chart.php
@@ -671,7 +671,7 @@ EOF;
     private function getShortenedLabel($label, $maxLabelSize = 20)
     {
         if (strlen($label) > $maxLabelSize) {
-            return substr($label, 0, $maxLabelSize).'...';
+            return mb_substr($label, 0, $maxLabelSize).'...';
         }
         return $label;
     }


### PR DESCRIPTION
Replaced substr with mb_substr

Changes to be committed:
	modified:   AOR_Chart.php



## Description
Fix for issue #9179
substr sometimes cuts string with utf8 characters in a way, that json_encode can't encode it.

## Motivation and Context
Display graphs with labels contianing utf8 characters.

## How To Test This
Described in issue #9179

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)

