### PR TITLE
Fix Issue #8969: Studio saving issue

### DIFF
--- a/modules/ModuleBuilder/parsers/StandardField.php
+++ b/modules/ModuleBuilder/parsers/StandardField.php
@@ -53,12 +53,27 @@ class StandardField extends DynamicField
     protected function loadCustomDef($field)
     {
         global $beanList;
+        /**
+         * Fix Case #13626
+         * Makes sure to use the override vardef file when loading custom defs
+         * Otherwise, will overwrite override file on save with new changes, removing previous ones
+         */
+        if (!empty($beanList[$this->module]) && is_file("custom/Extension/modules/{$this->module}/Ext/Vardefs/_override_sugarfield_$field.php")) {
+            $bean_name = get_valid_bean_name($this->module);
+            $dictionary = array($bean_name => array("fields" => array($field => array())));
+            include("$this->base_path/_override_sugarfield_$field.php");
+            if (!empty($dictionary[$bean_name]) && isset($dictionary[$bean_name]["fields"][$field])) {
+                $this->custom_def = $dictionary[$bean_name]["fields"][$field];
+            }
+        }
         if (!empty($beanList[$this->module]) && is_file("custom/Extension/modules/{$this->module}/Ext/Vardefs/sugarfield_$field.php")) {
             $bean_name = get_valid_bean_name($this->module);
             $dictionary = array($bean_name => array("fields" => array($field => array())));
             include("$this->base_path/sugarfield_$field.php");
             if (!empty($dictionary[$bean_name]) && isset($dictionary[$bean_name]["fields"][$field])) {
-                $this->custom_def = $dictionary[$bean_name]["fields"][$field];
+                foreach ($dictionary[$bean_name]["fields"][$field] as $def_name => $def) {
+                    $this->custom_def[$def_name] = $def;
+                }
             }
         }
     }


### PR DESCRIPTION
Fix Issue #8969: Studio field changes no longer overwrite the _override file every time, which was causing previous changes to be removed.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Fix issue #8969 
Updates loadCustomDef function in StandardField class to also load custom defs from _override files as well as the regular sugarfield files in the Extensions framework.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixed issue #8969 where existing Studio changes were being overwritten when making new ones.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Navigate to studio and edit a field in any module
2. Click Save
3. Once confirmed changes were saved, make a change in a different part of the field and save.
4. Confirm that the previous changes made in step 1 were kept.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->