### PR TITLE
Workaround for issue: #9191 Big problem with UTF-8 charaters between …

### DIFF
--- a/index.php
+++ b/index.php
@@ -42,6 +42,8 @@ if (!defined('sugarEntry')) {
     define('sugarEntry', true);
 }
 
+define ('PORTABLE_UTF8__DISABLE_AUTO_FILTER', false );
+
 include 'include/MVC/preDispatch.php';
 $startTime = microtime(true);
 require_once 'include/entryPoint.php';


### PR DESCRIPTION
…7.11.18 anf 7.11.20

By no means is this proper fix. All it does is disables portable-utf8.
It's for people with existing data, so that they don't suffer data corruption and loss of functionality.

 Changes to be committed:
	modified:   index.php

<!--- Provide a general summary of your changes in the Title above -->

Added contatnt to index.php to disable porable-utf8 problem.

## Description
Qick fix to disable protable-utf8, so that there is no data mix in DB...

## Motivation and Context
Customers complained, that existing data is not searcheable any more.

With new data there is problem that utf normalization is different than with existing data.

To properly introduce new utf-8 normalization there should be some data migration autmatization during upgrade process.

But weven with this, there is problem that browsers can't handle UTF-8 NFC very gracefuly (deletein UTF-8 NFC character is confusing for users).

## How To Test This
Search will find existing UTF8 data again.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Quick & Dirty workaround
