### PR TITLE
Update CaseUpdatesHook.php

### DIFF
--- a/modules/AOP_Case_Updates/CaseUpdatesHook.php
+++ b/modules/AOP_Case_Updates/CaseUpdatesHook.php
@@ -104,7 +104,7 @@ class CaseUpdatesHook
 
             return;
         }
-        if ($_REQUEST['module'] === 'Import') {
+        if (isset($_REQUEST['module']) && $_REQUEST['module'] === 'Import') {
             return;
         }
         //Grab the update field and create a new update with it.


### PR DESCRIPTION
Fix undef index error when hook fired off on CLI

```
PHP Notice:  Undefined index: module in /var/www/html/modules/AOP_Case_Updates/CaseUpdatesHook.php on line 105
PHP Notice:  Undefined index: module in /var/www/html/modules/AOP_Case_Updates/CaseUpdatesHook.php on line 105
```