### PR TITLE
Fixed #9197 - "Edit SuiteCRM Dashlet" container styling.

### DIFF
--- a/themes/SuiteP/css/suitep-base/dashboard.scss
+++ b/themes/SuiteP/css/suitep-base/dashboard.scss
@@ -570,7 +570,9 @@ td.dashlet-title > h3 > span {
   box-shadow: 0 5px 15px rgba(0, 0, 0, .5);
   margin: 0 auto;
   border: none;
+  max-height: 650px;
   max-width: 900px;
+  overflow-y: auto;
 }
 
 .yui-skin-sam.masked #dlg.SuiteP-configureDashlet.yui-module.yui-overlay.yui-panel .container-close {


### PR DESCRIPTION
### Description
Fix bottom section of "Edit SuiteCRM Dashlet" container not reachable when lots of fields are used.
Add attribute "max-height: 650px;" and "overflow-y: auto;" to
element ".yui-skin-sam.masked #dlg.SuiteP-configureDashlet.yui-module.yui-overlay.yui-panel".

### Motivation and Context
Trying to setup the fields of any Dashlet.

### How To Test This
Rebuild sass

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->