### PR TITLE
Fixed #9199 - "Edit SuiteCRM Dashlet" select styling.

### DIFF
--- a/themes/SuiteP/css/suitep-base/forms.scss
+++ b/themes/SuiteP/css/suitep-base/forms.scss
@@ -1532,6 +1532,7 @@ option:checked {
 
 select[multiple] {
   background-image: none !important;
+  max-width: 215px;
   overflow: auto !important;
   vertical-align: text-top;
 }


### PR DESCRIPTION
### Description
Fix right section of "Edit SuiteCRM Dashlet" container not reachable when select has option values
which are long.
Add attribute "max-width:215px;" to element "select[multiple]".

### Motivation and Context
Trying to reach right section of any Dashlet.

### How To Test This
Rebuild sass

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->