### PR TITLE
Fixed #9201 - Filter form label styling.

### DIFF
--- a/themes/SuiteP/css/suitep-base/listview.scss
+++ b/themes/SuiteP/css/suitep-base/listview.scss
@@ -1772,7 +1772,7 @@ div.qtip.qtip-default {
 
 #search_form label {
   font-weight: bold;
-  white-space: nowrap;
+  line-height: $line-height-base;
 }
 
 .modal-content #search_form label {


### PR DESCRIPTION
### Description
Fix labels in module filters using long text overflowing into the next element.
Remove attribute "white-space: nowrap;"
Add attribute "line-height: $line-height-base;" to
element "#search_form label".

### Motivation and Context
Avoid labels overflowing into the next element.

### How To Test This
Rebuild sass

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->