### PR TITLE
Fix Invalid Module for printing PDF

### DIFF
--- a/modules/AOS_PDF_Templates/PDF_Lib/mpdf.php
+++ b/modules/AOS_PDF_Templates/PDF_Lib/mpdf.php
@@ -8484,8 +8484,7 @@ public $aliasNbPgHex;
             header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
             header('Content-Type: application/force-download');
             header('Content-Type: application/octet-stream', false);
-            header('Content-Type: application/download', false);
-            header('Content-Type: application/pdf', false);
+            header('Content-Type: application/pdf');
             if (!isset($_SERVER['HTTP_ACCEPT_ENCODING']) or empty($_SERVER['HTTP_ACCEPT_ENCODING'])) {
                 // don't use length if server using compression
                 header('Content-Length: '.strlen($this->buffer));


### PR DESCRIPTION
## Description
Pdf can't be print on some hosting because headers are wrong (like OVH)

Try to print a PDF from a contact on OVH hosting. IT will give an error message "Invalid Module".
From formLetterPdf.php
Im not the only person with this bug see this example:
https://community.suitecrm.com/t/blank-page-when-creating-pdf-template/56937

## Motivation and Context
Fix PDF printing for all.

## How To Test This
Try to print a PDF from a contact on OVH hosting

## Types of changes
Fix headers

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->