### PR TITLE
Fix #9237 where dates in aow actions & conditions are not saved or displayed correctly

### DIFF
--- a/modules/AOW_Actions/AOW_Action.php
+++ b/modules/AOW_Actions/AOW_Action.php
@@ -118,6 +118,8 @@ class AOW_Action extends Basic
                             } else {
                                 if ($post_data[$key . 'param'][$i]['value_type'][$p_id] == 'Value' && is_array($p_value)) {
                                     $param_value[$p_id] = encodeMultienumValue($p_value);
+                                }else{
+                                    $param_value[$p_id] = fixUpFormatting($params["record_type"], $post_data[$key . 'param'][$i]["field"][$p_id], $p_value);
                                 }
                             }
                         }

--- a/modules/AOW_WorkFlow/aow_utils.php
+++ b/modules/AOW_WorkFlow/aow_utils.php
@@ -618,7 +618,11 @@ function getModuleField(
         $fieldlist[$fieldname]['name'] = $aow_field;
     } elseif (isset($fieldlist[$fieldname]['type']) && ($fieldlist[$fieldname]['type'] == 'datetimecombo' || $fieldlist[$fieldname]['type'] == 'datetime' || $fieldlist[$fieldname]['type'] == 'date')) {
         $value = $focus->convertField($value, $fieldlist[$fieldname]);
-        $displayValue = $timedate->to_display_date_time($value);
+        if($fieldlist[$fieldname]['type'] === "date"){
+            $displayValue = $timedate->to_display_date($value);
+        }else{
+            $displayValue = $timedate->to_display_date_time($value);
+        }
         $fieldlist[$fieldname]['value'] = $fieldlist[$aow_field]['value'] = $displayValue;
         $fieldlist[$fieldname]['name'] = $aow_field;
     } else {


### PR DESCRIPTION
Fix #9237 where dates in aow actions & conditions are not saved or displayed correctly
Use fixUpFormatting in actions and only display as datetime if field type is datetime else use date

<!--- Provide a general summary of your changes in the Title above -->

## Description
Use fixUpFormatting in actions the same way its used for condtions

Use to_display_date when field type is date instead of defaulting to to_display_date_time
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
See #9237
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
See #9237
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->