### PR TITLE
Fix Issue #6994: Update pollMonitoredInboxesAOP to double check that …

### DIFF
--- a/modules/Schedulers/_AddJobsHere.php
+++ b/modules/Schedulers/_AddJobsHere.php
@@ -602,8 +602,14 @@ function pollMonitoredInboxesAOP()
                     $isGroupFolderExists = false;
                     $users = array();
                     if ($groupFolderId != null && $groupFolderId != "") {
+                        // FIX #6994 - Unable to retrieve Sugar Folder due to incorrect groupFolderId
                         $sugarFolder->retrieve($groupFolderId);
-                        $isGroupFolderExists = true;
+                        if (empty($sugarFolder->id)) {
+                            $sugarFolder->retrieve($aopInboundEmailX->id);
+                        }
+                        if (!empty($sugarFolder->id)) {
+                            $isGroupFolderExists = true;
+                        }
                     } // if
                     $messagesToDelete = array();
                     if ($aopInboundEmailX->isMailBoxTypeCreateCase()) {


### PR DESCRIPTION
…SugarFolder has been retrieved correctly.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Fixing issue #6994 by updating the pollMonitoredInboxesAOP scheduled task (lines 605 - 611) to make sure it gets the SugarFolder correctly. First attempts using the InboundEmail->groupfolder_id value as normal, if that fails, then attempts using InboundEmail->id instead. If that fails as well, then the $isGroupFolderExists value is not set to true.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There is a bug where if the value in the groupfolder_id does not match with a SugarFolder id, then the logs will end up being filled with the message ```[FATAL] *** FOLDERS: addBean() is trying to save to a non-saved or non-existent folder```.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Make sure that the task pollMonitoredInboxesAOP is active.
Set up an Inbound Email account.
Once running, check the logs for the above error message.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->