### PR TITLE
Add the `Overview` label to Security Groups detailview

### DIFF
--- a/modules/SecurityGroups/metadata/detailviewdefs.php
+++ b/modules/SecurityGroups/metadata/detailviewdefs.php
@@ -1,46 +1,60 @@
 <?php
 
 $module_name = 'SecurityGroups';
-$viewdefs[$module_name]['DetailView'] = array(
-'templateMeta' => array('form' => array('buttons'=>array('EDIT', 'DUPLICATE', 'DELETE',
-                                                         )),
-                        'maxColumns' => '2',
-                        'widths' => array(
-                                        array('label' => '10', 'field' => '30'),
-                                        array('label' => '10', 'field' => '30')
-                                        ),
+$viewdefs[$module_name]['DetailView'] =
+    array(
+        'templateMeta' =>
+            array(
+                'form' =>
+                    array(
+                        'buttons' =>
+                            array(
+                                'EDIT', 'DUPLICATE', 'DELETE',
+                            )),
+                'maxColumns' => '2',
+                'widths' => array(
+                    0 =>
+                        array(
+                            'label' => '10',
+                            'field' => '30'
                         ),
-                        
-'panels' =>array(
-  
-  array(
-    'name',
-    'assigned_user_name',
-  ),
+                    1 =>
+                        array(
+                            'label' => '10',
+                            'field' => '30'
+                        )
+                ),
+            ),
+
+        'panels' =>
+            array(
+                'LBL_PANEL_OVERVIEW' =>
+                    array(
+                        0 =>
+                            array(
+                                'name',
+                                'assigned_user_name',
+                            ),
 
 
-
-
-
-
-  
-  array(
-    array(
-      'name' => 'date_entered',
-      'customCode' => '{$fields.date_entered.value} {$APP.LBL_BY} {$fields.created_by_name.value}',
-      'label' => 'LBL_DATE_ENTERED',
-    ),
-    array(
-      'name' => 'date_modified',
-      'customCode' => '{$fields.date_modified.value} {$APP.LBL_BY} {$fields.modified_by_name.value}',
-      'label' => 'LBL_DATE_MODIFIED',
-    ),
-  ),
-  array(
-    'noninheritable',
-  ),
-  array(
-    'description',
-  ),
-)
-);
+                        array(
+                            array(
+                                'name' => 'date_entered',
+                                'customCode' => '{$fields.date_entered.value} {$APP.LBL_BY} {$fields.created_by_name.value}',
+                                'label' => 'LBL_DATE_ENTERED',
+                            ),
+                            array(
+                                'name' => 'date_modified',
+                                'customCode' => '{$fields.date_modified.value} {$APP.LBL_BY} {$fields.modified_by_name.value}',
+                                'label' => 'LBL_DATE_MODIFIED',
+                            ),
+                        ),
+                        array(
+                            'noninheritable',
+                        ),
+                        array(
+                            'description',
+                        ),
+                    ),
+            )
+    );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This fix adds the Overview label to the tab header in the Security Groups detailview

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
1. Go to Security Groups detailview
2. See the change 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [X] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->