### PR TITLE
Fixed #9620 - API V8 Token Expiration DateTime isn't stored in UTC

### DIFF
--- a/Api/V8/OAuth2/Repository/AccessTokenRepository.php
+++ b/Api/V8/OAuth2/Repository/AccessTokenRepository.php
@@ -80,7 +80,7 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
 
         $token->access_token = $accessTokenEntity->getIdentifier();
 
-        $token->access_token_expires = $accessTokenEntity->getExpiryDateTime()->format('Y-m-d H:i:s');
+        $token->access_token_expires = $accessTokenEntity->getExpiryDateTime()->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s');
 
         $token->client = $clientId;
 

--- a/Api/V8/OAuth2/Repository/RefreshTokenRepository.php
+++ b/Api/V8/OAuth2/Repository/RefreshTokenRepository.php
@@ -47,7 +47,7 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
         }
 
         $token->refresh_token = $refreshTokenEntity->getIdentifier();
-        $token->refresh_token_expires = $refreshTokenEntity->getExpiryDateTime()->format('Y-m-d H:i:s');
+        $token->refresh_token_expires = $refreshTokenEntity->getExpiryDateTime()->setTimezone('UTC'))->format('Y-m-d H:i:s');
         $token->save();
     }
 


### PR DESCRIPTION
Made the fix to issue #9260 by formatting the Token Expiration DateTime object for both Refresh and Access Tokens.

How To Test This
To Test, simply request a token and then check database to be sure it is stored in UTC.

Types of changes
[x ] Bug fix (non-breaking change which fixes an issue)
Final checklist
[x ] My code follows the code style of this project found here.
[ ]My change requires a change to the documentation.
[x ] I have read the How to Contribute guidelines.