### PR TITLE
Update AccountsListViewSmarty.php

### DIFF
--- a/modules/Accounts/AccountsListViewSmarty.php
+++ b/modules/Accounts/AccountsListViewSmarty.php
@@ -142,9 +142,11 @@ EOF;
         );
 
         foreach ($replaces as $i => $j) {
-            $tmp = $ret['buttons'][$j];
-            $ret['buttons'][$j] = $ret['buttons'][$i];
-            $ret['buttons'][$i] = $tmp;
+            if ( isset($ret['buttons'][$i], $ret['buttons'][$j]) ) {
+                $tmp = $ret['buttons'][$j];
+                $ret['buttons'][$j] = $ret['buttons'][$i];
+                $ret['buttons'][$i] = $tmp;
+            }
         }
 
         return $ret;


### PR DESCRIPTION
Function: buildActionsLink - add check for array variables to silence PHP warnings.   Fix for issue #6688

## Description
Current code doesn't check whether array indices are set before trying to access them.  Fix checks that they exist first.

## Motivation and Context
To silence PHP warnings in logs.

## How To Test This
Access company listing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->