### PR TITLE
Check for custom Templates in Global Search

### DIFF
--- a/lib/Search/UI/SearchFormView.php
+++ b/lib/Search/UI/SearchFormView.php
@@ -56,7 +56,7 @@ class SearchFormView extends View
 {
     public function __construct()
     {
-        parent::__construct(__DIR__ . '/templates/search.form.tpl');
+        parent::__construct(__DIR__ .'/'. get_custom_file_if_exists('templates/search.form.tpl'));
     }
 
     /** @inheritdoc */

--- a/lib/Search/UI/SearchResultsView.php
+++ b/lib/Search/UI/SearchResultsView.php
@@ -55,6 +55,6 @@ class SearchResultsView extends View
      */
     public function __construct()
     {
-        parent::__construct(__DIR__ . '/templates/search.results.tpl');
+        parent::__construct(__DIR__ .'/'. get_custom_file_if_exists('templates/search.results.tpl'));
     }
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
The global search (elastic specifically) uses hard coded templates which makes this functionality hard to customise. This change adds a check for custom files similarly to how other parts of the CRM do.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To allow customising the Search templates for the search form and results
## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->