### PR TITLE
Displaying properly the line breaks of text fields in the notification templates

### DIFF
--- a/include/language/en_us.notify_template.html
+++ b/include/language/en_us.notify_template.html
@@ -47,6 +47,8 @@
 Subject: {QUOTE_SUBJECT}<br/>
 Status: {QUOTE_STATUS}<br/>
 Expected Close Date: {QUOTE_CLOSEDATE}<br/>
+</p>
+<p style="white-space: pre-line">
 Description: {QUOTE_DESCRIPTION}
 </p>
 <p>You may <a href={URL}>review this Quote</a>.</p>
@@ -60,6 +62,8 @@ Description: {QUOTE_DESCRIPTION}
 <p>
 Name: {ACCOUNT_NAME}<br/>
 Type: {ACCOUNT_TYPE}<br/>
+</p>
+<p style="white-space: pre-line">
 Description: {ACCOUNT_DESCRIPTION}
 </p>
 <p>You may <a href={URL}>review this Account</a>.</p>
@@ -74,6 +78,8 @@ Description: {ACCOUNT_DESCRIPTION}
 Subject: {CASE_SUBJECT}<br/>
 Priority: {CASE_PRIORITY}<br/>
 Status: {CASE_STATUS}<br/>
+</p>
+<p style="white-space: pre-line">
 Description: {CASE_DESCRIPTION}
 </p>
 <p>You may <a href={URL}>review this Case</a>.</p>
@@ -89,6 +95,8 @@ Subject: {TASK_SUBJECT}<br/>
 Priority: {TASK_PRIORITY}<br/>
 Due Date: {TASK_DUEDATE}<br/>
 Status: {TASK_STATUS}<br/>
+</p>
+<p style="white-space: pre-line">
 Description: {TASK_DESCRIPTION}
 </p>
 <p>You may <a href={URL}>review this Task</a>.</p>
@@ -111,6 +119,8 @@ End Date: {MEETING_ENDDATE}
 Meeting URL: {MEETING_URL}
 </p>
 <!-- END: Meeting_External_API -->
+</p>
+<p style="white-space: pre-line">
 <p>Description: {MEETING_DESCRIPTION}<br/>
 </p>
 <p>---</p>
@@ -130,6 +140,8 @@ Location: {MEETING_LOCATION}<br/>
 Status: {MEETING_STATUS}<br/>
 Start Date: {MEETING_STARTDATE}<br/>
 End Date: {MEETING_ENDDATE}<br/>
+</p>
+<p style="white-space: pre-line">
 Description: {MEETING_DESCRIPTION}
 </p>
 <p>You may <a href={URL}>review this Meeting</a>.</p>
@@ -166,6 +178,8 @@ Date Sent: {EMAIL_DATESENT}
 <p><b>{ASSIGNER}</b> has assigned a Contact to <b>{ASSIGNED_USER}</b>.</p>
 <p>
 Name: {CONTACT_NAME}<br/>
+</p>
+<p style="white-space: pre-line">
 Description: {CONTACT_DESCRIPTION}
 </p>
 <p>You may <a href={URL}>review this Contact</a>.</p>
@@ -180,6 +194,8 @@ Description: {CONTACT_DESCRIPTION}
 Name: {LEAD_NAME}<br/>
 Lead Source: {LEAD_SOURCE}<br/>
 Status: {LEAD_STATUS}<br/>
+</p>
+<p style="white-space: pre-line">
 Description: {LEAD_DESCRIPTION}
 </p>
 <p>You may <a href={URL}>review this Lead</a>.</p>
@@ -195,6 +211,8 @@ Name: {OPPORTUNITY_NAME}<br/>
 Amount: {OPPORTUNITY_AMOUNT}<br/>
 Expected Close Date: {OPPORTUNITY_CLOSEDATE}<br/>
 Sales Stage: {OPPORTUNITY_STAGE}<br/>
+</p>
+<p style="white-space: pre-line">
 Description: {OPPORTUNITY_DESCRIPTION}
 </p>
 <p>You may <a href={URL}>review this Opportunity</a>.</p>
@@ -213,6 +231,8 @@ Priority: {BUG_PRIORITY}<br/>
 Status: {BUG_STATUS}<br/>
 Resolution: {BUG_RESOLUTION}<br/>
 Release: {BUG_RELEASE}<br/>
+</p>
+<p style="white-space: pre-line">
 Description: {BUG_DESCRIPTION}<br/>
 Work Log: {BUG_WORK_LOG}
 </p>
@@ -238,6 +258,8 @@ Subject: {CALL_SUBJECT}<br/>
 Status: {CALL_STATUS}<br/>
 Start Date: {CALL_STARTDATE}<br/>
 Duration: {CALL_HOURS}h, {CALL_MINUTES}m<br/>
+</p>
+<p style="white-space: pre-line">
 Description: {CALL_DESCRIPTION}<br/>
 </p>
 <p>---</p>
@@ -256,6 +278,8 @@ Subject: {CALL_SUBJECT}<br/>
 Status: {CALL_STATUS}<br/>
 Start Date: {CALL_STARTDATE}<br/>
 Duration: {CALL_HOURS}h, {CALL_MINUTES}m<br/>
+</p>
+<p style="white-space: pre-line">
 Description: {CALL_DESCRIPTION}
 </p>
 <p>You may <a href={URL}>review this Call</a>.</p>
@@ -282,6 +306,8 @@ Subject: {CAMPAIGN_NAME}<br/>
 Amount: {CAMPAIGN_AMOUNT}<br/>
 Close Date: {CAMPAIGN_CLOSEDATE}<br/>
 Status: {CAMPAIGN_STATUS}<br/>
+</p>
+<p style="white-space: pre-line">
 Description: {CAMPAIGN_DESCRIPTION}
 </p>
 <p>You may <a href={URL}>review this Campaign</a>.</p>
@@ -310,6 +336,8 @@ Name: {KBDOCUMENT_NAME}<br/>
 Created Date: {KBDOCUMENT_DATE_CREATED}<br/>
 Created By: {KBDOCUMENT_CREATED_BY}<br/>
 Status: {KBDOCUMENT_STATUS}<br/>
+</p>
+<p style="white-space: pre-line">
 Description: {KBDOCUMENT_DESCRIPTION}
 </p>
 <p>You may <a href={URL}>review this Document</a>.</p>


### PR DESCRIPTION
When adding a text that contains line breaks in the Description field of a Meeting record, and the invitation is sent. The invitation message description doesn't display the line breaks that are set in the Description field of the Meeting record.

## Description
The line breaks of the text fields are ignored during the parsing of the template. Adding the CSS property "style="white-space: pre-line" to each of the text fields, solves the problems.

Or another solution would be to modify the login that parses the templates.

## Motivation and Context
The message of the meeting invitation should keep, as much as possible, the format set in the Meeting record.

## How To Test This
1- Create a Meeting with a Description that contains several lines
2- Send the invitation by email
3- Check that the email message displays the Description properly, including the line breaks

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.