### PR TITLE
Update LanguageManager.php - fix custom relationship labels being overwritten

### DIFF
--- a/include/SugarObjects/LanguageManager.php
+++ b/include/SugarObjects/LanguageManager.php
@@ -198,8 +198,8 @@ class LanguageManager
         $lang_paths = array(
             'modules/' . $module . '/language/' . $lang . '.lang.php',
             'modules/' . $module . '/language/' . $lang . '.lang.override.php',
-            'custom/modules/' . $module . '/language/' . $lang . '.lang.php',
             'custom/modules/' . $module . '/Ext/Language/' . $lang . '.lang.ext.php',
+            'custom/modules/' . $module . '/language/' . $lang . '.lang.php',
         );
 
         #27023, if this module template language file was not attached , get the template from this module vardef cache file if exsits and load the template language files.


### PR DESCRIPTION
Changed the order of the $lang_paths to prevent Ext definitions overwritting the custom values for labels in custom modules.

See this thread for details:
https://community.suitecrm.com/t/renaming-relationship-label/18549/15



## Description
Trying to rename the label on the relationship fails. Attempting to do it under “Labels”, it just reverts to it’s old name on save. if you try to do it in the layout editor, it just reverts to it’s old name on save as well.
Note: this only applies to custom modules.

## Motivation and Context
Fixes the bug where custom labels are overwritten back to their default values.

## How To Test This
With a custom module, create a new one-many realationshsip, in the studio try to rename the label.
If the change remains after clicking "save and deploy" then it is fixed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

