### PR TITLE
Adding cache/themes rebuilt after custom property changed in Studio

### DIFF
--- a/modules/DynamicFields/DynamicField.php
+++ b/modules/DynamicFields/DynamicField.php
@@ -669,6 +669,10 @@ class DynamicField
             $fmd->save();
             $this->buildCache($this->module);
             $this->saveExtendedAttributes($field, array_keys($fmd->field_defs));
+            // Fix #9119 - The cache/themes folder needs to be rebuilt after changing custom field properties.
+            // https://github.com/salesagility/SuiteCRM/issues/9119
+            include_once('include/TemplateHandler/TemplateHandler.php');
+            TemplateHandler::clearCache($this->module);
         }
 
         return true;


### PR DESCRIPTION
Closes #9119 and #9300 

## Description
As the issue describes, after changing some of properties of custom fields from studio, the changes don't apply immediately, but until the user needs to do a Quick Repair.

This PR adds the code that rebuilds the cache/themes folder right after updating the custom field.

## Motivation and Context
This should work transparent for the administrator user

## How To Test This
1.Deactivate Developer Mode (important for the themes folder to persist)
2.Create a custom Field from Studio
3.Add it to the EditView of the module
4.Go inside the EditView of the module and check that the field appears (so the cache/themes/module... folder is generated)
5.Go back to Studio and enable the "require" property of the custom field
6.Go back to the EditView and check if the field appears as required (with the red star and validation)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.