### PR TITLE
Fixed #9358 - Meeting invite notification emails are not sending to all invitees.

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -420,6 +420,12 @@ class SugarBean
     public $createdAuditRecords;
 
     /**
+     * Keeps track of emails sent to notify_user ids to avoid duplicate emails
+     * @var array $sentAssignmentNotifications
+     */
+    public $sentAssignmentNotifications = array();
+
+    /**
      * SugarBean constructor.
      * Performs following tasks:
      *
@@ -3201,7 +3207,7 @@ class SugarBean
     {
         global $current_user;
 
-        if ((($this->object_name == 'Meeting' || $this->object_name == 'Call') || $notify_user->receive_notifications) && !$this->sentAssignmentNotifications) {
+        if ((($this->object_name == 'Meeting' || $this->object_name == 'Call') || $notify_user->receive_notifications) && !in_array($notify_user->id, $this->sentAssignmentNotifications, true)) {
             $sendToEmail = $notify_user->emailAddress->getPrimaryAddress($notify_user);
             $sendEmail = true;
             if (empty($sendToEmail)) {
@@ -3266,7 +3272,7 @@ class SugarBean
                     $GLOBALS['log']->fatal("Notifications: error sending e-mail (method: {$notify_mail->Mailer}), " .
                         "(error: {$notify_mail->ErrorInfo})");
                 } else {
-                    $this->sentAssignmentNotifications = true;
+                    $this->sentAssignmentNotifications[] = $notify_user->id;
                     $GLOBALS['log']->info("Notifications: e-mail successfully sent");
                 }
             }

--- a/tests/unit/phpunit/modules/Cases/CaseTest.php
+++ b/tests/unit/phpunit/modules/Cases/CaseTest.php
@@ -214,7 +214,8 @@ class aCaseTest extends SuitePHPUnitFrameworkTestCase
         $aCase = BeanFactory::newBean('Cases');
         $aCase->name = 'test';
         $aCase->priority = 'P1';
-        $aCase->sentAssignmentNotifications = false;
+        $aCase->sentAssignmentNotifications = [];
+        $aCase->sentAssignmentNotifications[] = $notify_user->id;
 
         $aCase->save();
 

--- a/tests/unit/phpunit/modules/Meetings/MeetingTest.php
+++ b/tests/unit/phpunit/modules/Meetings/MeetingTest.php
@@ -247,7 +247,8 @@ class MeetingTest extends SuitePHPUnitFrameworkTestCase
 
         $meeting->date_start = '2016-02-11 17:30:00';
         $meeting->date_end = '2016-02-11 17:30:00';
-        $meeting->sentAssignmentNotifications = false;
+        $meeting->sentAssignmentNotifications = [];
+        $meeting->sentAssignmentNotifications[] = $notify_user->id;
 
         $admin = BeanFactory::newBean('Administration');
         $admin->retrieveSettings();


### PR DESCRIPTION
#### Issue
When creating a meeting in the meetings module, the invite notification emails are only going to the first invited user/contact/lead.

#### Expected Behavior
All invitees should receive a meeting invite email

#### Actual Behavior
1 invitee is emailed.

#### Possible Fix
Check against an array of user ids rather than a boolean when preventing duplicate emails caused by workflow hooks

#### Steps to Reproduce
1. Create a meeting in the meetings module
2. Invite more than 1 user
3. Hit Save and send invites
4. Check logs or mailcatcher if set up

#### Context
Need to make sure all meeting invitees receive an invitation email.
https://github.com/salesagility/SuiteCRM/issues/9358

#### Your Environment
* SuiteCRM Version used: 7.12.0
* Browser name and version: Firefox Version 94.0 (64-bit))
* Environment name and version: PHP 7.4
* Operating System and version: Ubuntu 20.04.3 LTS