### PR TITLE
Fix Issue #9192: Fix duplication of folders_rel table entries.

### DIFF
--- a/include/SugarFolders/SugarFolders.php
+++ b/include/SugarFolders/SugarFolders.php
@@ -695,6 +695,29 @@ class SugarFolder
             return false;
         }
 
+        /*
+        Fix issue #9192 - Duplicating rows for folders_rel
+        First check if a row with the same data already exists
+        If so, return false
+        */
+
+        $q = "SELECT id FROM folders_rel WHERE".
+            " folder_id = ".$this->db->quoted($this->id).
+            " AND polymorphic_module = ".$this->db->quoted($bean->module_dir).
+            " AND polymorphic_id = ".$this->db->quoted($bean->id).
+            " AND deleted = 0";
+
+        $result = $this->db->fetchByAssoc($this->db->query($q));
+        if ($result === false){
+            $GLOBALS['log']->debug("Error in query to check for existing email folders");
+            return false;
+        }
+
+        if($result) {
+            $GLOBALS['log']->debug("*** FOLDERS: addBean() is trying to create an already existing relationship");
+            return false;
+        }
+        
         $guid = create_guid();
 
         $query = "INSERT INTO folders_rel " .


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Fixes a bug when importing emails and using the Sugar Folders module where it would add an identical relationship between Sugar Folders and Inbound Email accounts.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Stops duplicating data in the database for each email imported.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
If the folders_rel table is empty, when importing emails, the Inbound Email account in use should create a new relationship between itself and a Sugar Folder.
Once that relationship exists, it should be the only one of it's kind in the folders_rel table, even after importing more emails with the same Inbound Email account.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->