### PR TITLE
Fix Issue #9362: set correct variable type for $arguments at after_save hook

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -2412,7 +2412,7 @@ class SugarBean
             $this->track_view($current_user->id, $this->module_dir, 'save');
         }
 
-        $this->call_custom_logic('after_save', '');
+        $this->call_custom_logic('after_save');
 
         $this->auditBean($isUpdate);
 
@@ -3072,7 +3072,7 @@ class SugarBean
      * @param string $event
      * @param array $arguments
      */
-    public function call_custom_logic($event, $arguments = null)
+    public function call_custom_logic($event, $arguments = array())
     {
         if (!isset($this->processed) || !$this->processed) {
             //add some logic to ensure we do not get into an infinite loop


### PR DESCRIPTION
## Description
Fix a typing bug


## Motivation and Context
set correct variable type

## How To Test This
add strict types

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.