### PR TITLE
Prevent Email Reminders for Disabled User

### DIFF
--- a/modules/Activities/EmailReminder.php
+++ b/modules/Activities/EmailReminder.php
@@ -301,7 +301,7 @@ class EmailReminder
         while ($row = $db->fetchByAssoc($re)) {
             $user = BeanFactory::newBean('Users');
             $user->retrieve($row['user_id']);
-            if (!empty($user->email1)) {
+            if (!empty($user->email1) && $user->isEnabled() ) {
                 $arr = array(
                     'type' => 'Users',
                     'name' => $user->full_name,

--- a/modules/Users/User.php
+++ b/modules/Users/User.php
@@ -2016,6 +2016,16 @@ EOQ;
     }
 
     /**
+     * Is user enabled
+     *
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return ($this->status !== 'Inactive') && ($this->employee_status === 'Active');
+    }
+
+    /**
      * Is this user a system wide admin
      *
      * @return bool


### PR DESCRIPTION
Email reminders for Meetings and Calls are sent to users, even if their account has been disabled.

This checks to see if the user is enabled before adding them to the recipients of an outbound reminder email.

## Description
Added a new function isEnabled() to the user bean to provide a standardised way to check if a user is active.
Email reminders getRecipients() calls this new user function to check the user is still a current user.

## Motivation and Context
Once a user has been set to Inactive, Terminated or Leave of Absence it's unlikely we should be sending them emails.

## How To Test This
Login as test user
Create a meeting or call with a reminder in the near future.
Switch to another user with admin rights
Disable the test user, either by setting the user status to Inactive or the employee status to Terminated or Leave of Absence.
The reminder email should not be sent.

Repeat the test above steps with the user status set to Active and the employee status set to Active.
The reminder email should be sent as normal.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.