### PR TITLE
Fix #9376 - allow workflows on import

### DIFF
--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -217,13 +217,14 @@ class AOW_WorkFlow extends Basic
      */
     public function run_bean_flows(SugarBean $bean)
     {
-        if (!defined('SUGARCRM_IS_INSTALLING') && (!isset($_REQUEST['module']) || $_REQUEST['module'] != 'Import')) {
-            $query = "SELECT id FROM aow_workflow WHERE aow_workflow.flow_module = '" . $bean->module_dir . "' AND aow_workflow.status = 'Active' AND (aow_workflow.run_when = 'Always' OR aow_workflow.run_when = 'On_Save' OR aow_workflow.run_when = 'Create') AND aow_workflow.deleted = 0 ";
+        $query = "SELECT id FROM aow_workflow WHERE aow_workflow.flow_module = '" . $bean->module_dir . "' AND aow_workflow.status = 'Active' AND (aow_workflow.run_when = 'Always' OR aow_workflow.run_when = 'On_Save' OR aow_workflow.run_when = 'Create') AND aow_workflow.deleted = 0 ";
 
-            $result = $this->db->query($query, false);
-            $flow = BeanFactory::newBean('AOW_WorkFlow');
-            while (($row = $bean->db->fetchByAssoc($result)) != null) {
-                $flow->retrieve($row['id']);
+        $result = $this->db->query($query, false);
+        $flow = BeanFactory::newBean('AOW_WorkFlow');
+        while (($row = $bean->db->fetchByAssoc($result)) != null) {
+            $flow->retrieve($row['id']);
+
+            if ((!defined('SUGARCRM_IS_INSTALLING') && (!isset($_REQUEST['module'])) || $_REQUEST['module'] != 'Import') || $flow->run_on_import) {
                 if ($flow->check_valid_bean($bean)) {
                     $flow->run_actions($bean, true);
                 }

--- a/modules/AOW_WorkFlow/language/en_us.lang.php
+++ b/modules/AOW_WorkFlow/language/en_us.lang.php
@@ -76,5 +76,6 @@ $mod_strings = array(
     'LBL_ACTION_LINES' => 'Actions',
     'LBL_ADD_ACTION' => 'Add Action',
     'LBL_MULTIPLE_RUNS' => 'Repeated Runs',
-    'LBL_RUN_WHEN' => 'Run'
+    'LBL_RUN_WHEN' => 'Run',
+    'LBL_RUN_ON_IMPORT' => 'Run on Import'
 );

--- a/modules/AOW_WorkFlow/metadata/detailviewdefs.php
+++ b/modules/AOW_WorkFlow/metadata/detailviewdefs.php
@@ -117,6 +117,11 @@ $viewdefs ['AOW_WorkFlow'] =
                             'name' => 'multiple_runs',
                             'label' => 'LBL_MULTIPLE_RUNS',
                         ),
+                        1 =>
+                        array(
+                            'name' => 'run_on_import',
+                            'label' => 'LBL_RUN_ON_IMPORT',
+                        ),
                     ),
                     4 =>
                     array(

--- a/modules/AOW_WorkFlow/metadata/editviewdefs.php
+++ b/modules/AOW_WorkFlow/metadata/editviewdefs.php
@@ -108,6 +108,11 @@ $viewdefs ['AOW_WorkFlow'] =
                             'name' => 'multiple_runs',
                             'label' => 'LBL_MULTIPLE_RUNS',
                         ),
+                        1 =>
+                        array(
+                            'name' => 'run_on_import',
+                            'label' => 'LBL_RUN_ON_IMPORT',
+                        ),
                     ),
                     4 =>
                     array(

--- a/modules/AOW_WorkFlow/vardefs.php
+++ b/modules/AOW_WorkFlow/vardefs.php
@@ -213,6 +213,14 @@ $dictionary['AOW_WorkFlow'] = array(
                 'bean_name' => 'AOW_Processed',
                 'source' => 'non-db',
             ),
+        'run_on_import' =>
+            array(
+                'name' => 'run_on_import',
+                'vname' => 'LBL_RUN_ON_IMPORT',
+                'type' => 'bool',
+                'default' => '0',
+                'reportable' => false,
+            ),
     ),
     'relationships' => array(
         'aow_workflow_aow_conditions' =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added checkbox to workflows, allowing users to enable them to trigger when importing records.

## How To Test This
- Create a workflow for a specific module, ticking the run on import field
- Import records to that module & ensure the workflow has triggered

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->