### PR TITLE
Fix #9374 - OAuth password creation Unsupported operand types fatal in php8

### DIFF
--- a/modules/OAuth2Clients/metadata/detailcredentialsviewdefs.php
+++ b/modules/OAuth2Clients/metadata/detailcredentialsviewdefs.php
@@ -56,23 +56,23 @@ $viewdefs[$module_name]['DetailView'] = [
             [
                 0 =>
                     [
-                        'name' => 'name',
+                        0 => 'name',
                     ],
                 2 =>
                     [
-                        'name' => 'is_confidential',
+                        0 => 'is_confidential',
                     ],
                 3 =>
                     [
-                        'name' => 'id',
+                        0 => 'id',
                     ],
                 4 =>
                     [
-                        'name' => 'allowed_grant_type',
+                        0 => 'allowed_grant_type',
                     ],
                 6 =>
                     [
-                        'name' => 'assigned_user_name',
+                        0 => 'assigned_user_name',
                     ],
             ],
         'LBL_PANEL_ASSIGNMENT' =>

--- a/modules/OAuth2Clients/metadata/detailpasswordviewdefs.php
+++ b/modules/OAuth2Clients/metadata/detailpasswordviewdefs.php
@@ -56,19 +56,19 @@ $viewdefs[$module_name]['DetailView'] = [
             [
                 0 =>
                     [
-                        'name' => 'name',
+                        0 => 'name',
                     ],
                 2 =>
                     [
-                        'name' => 'is_confidential',
+                        0 => 'is_confidential',
                     ],
                 3 =>
                     [
-                        'name' => 'id',
+                        0 => 'id',
                     ],
                 4 =>
                     [
-                        'name' => 'allowed_grant_type',
+                        0 => 'allowed_grant_type',
                     ],
             ],
         'LBL_PANEL_ASSIGNMENT' =>

--- a/modules/OAuth2Clients/metadata/detailviewdefs.php
+++ b/modules/OAuth2Clients/metadata/detailviewdefs.php
@@ -56,23 +56,23 @@ $viewdefs[$module_name]['DetailView'] = [
             [
                 0 =>
                     [
-                        'name' => 'name',
+                        0 => 'name',
                     ],
                 1 =>
                     [
-                        'name' => 'redirect_url',
+                        0 => 'redirect_url',
                     ],
                 2 =>
                     [
-                        'name' => 'is_confidential',
+                        0 => 'is_confidential',
                     ],
                 3 =>
                     [
-                        'name' => 'id',
+                        0 => 'id',
                     ],
                 4 =>
                     [
-                        'name' => 'allowed_grant_type',
+                        0 => 'allowed_grant_type',
                     ],
                 5 =>
                     [

--- a/modules/OAuth2Clients/metadata/editcredentialsviewdefs.php
+++ b/modules/OAuth2Clients/metadata/editcredentialsviewdefs.php
@@ -61,7 +61,7 @@ $viewdefs[$module_name]['EditView'] = [
             [
                 0 =>
                     [
-                        'name' => 'name',
+                        0 => 'name',
                     ],
                 1 =>
                     [
@@ -76,11 +76,11 @@ $viewdefs[$module_name]['EditView'] = [
                     ],
                 2 =>
                     [
-                        'name' => 'is_confidential',
+                        0 => 'is_confidential',
                     ],
                 4 =>
                     [
-                        'name' => 'assigned_user_name',
+                        0 => 'assigned_user_name',
                     ],
             ],
     ],

--- a/modules/OAuth2Clients/metadata/editpasswordviewdefs.php
+++ b/modules/OAuth2Clients/metadata/editpasswordviewdefs.php
@@ -61,7 +61,7 @@ $viewdefs[$module_name]['EditView'] = [
             [
                 0 =>
                     [
-                        'name' => 'name',
+                        0 => 'name',
                     ],
                 1 =>
                     [
@@ -76,7 +76,7 @@ $viewdefs[$module_name]['EditView'] = [
                     ],
                 2 =>
                     [
-                        'name' => 'is_confidential',
+                        0 => 'is_confidential',
                     ],
             ],
     ],

--- a/modules/OAuth2Clients/metadata/editviewdefs.php
+++ b/modules/OAuth2Clients/metadata/editviewdefs.php
@@ -56,19 +56,19 @@ $viewdefs[$module_name]['EditView'] = [
             [
                 0 =>
                     [
-                        'name' => 'name',
+                        0 => 'name',
                     ],
                 1 =>
                     [
-                        'name' => 'redirect_url',
+                        0 => 'redirect_url',
                     ],
                 2 =>
                     [
-                        'name' => 'is_confidential',
+                        0 => 'is_confidential',
                     ],
                 3 =>
                     [
-                        'name' => 'allowed_grant_type',
+                        0 => 'allowed_grant_type',
                     ],
                 4 =>
                     [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
see #9374

## How To Test This
See you can now create an  OAuth2 password in php8+

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->