### PR TITLE
Fix #9382 - Outbound Emails editview Unsupported operand types fatal in php 8

### DIFF
--- a/modules/OutboundEmailAccounts/metadata/detailviewdefs.php
+++ b/modules/OutboundEmailAccounts/metadata/detailviewdefs.php
@@ -1,6 +1,5 @@
 <?php
-$module_name = 'OutboundEmailAccounts';
-$viewdefs [$module_name] =
+$viewdefs ['OutboundEmailAccounts'] =
 array(
   'DetailView' =>
   array(
@@ -53,12 +52,7 @@ array(
         0 =>
         array(
           0 => 'name',
-          //1 => 'assigned_user_name',
         ),
-//        1 =>
-//        array (
-//          0 => 'description',
-//        ),
       ),
       'lbl_editview_panel1' =>
       array(

--- a/modules/OutboundEmailAccounts/metadata/editviewdefs.php
+++ b/modules/OutboundEmailAccounts/metadata/editviewdefs.php
@@ -1,119 +1,116 @@
 <?php
-$module_name = 'OutboundEmailAccounts';
-$viewdefs [$module_name] =
+$viewdefs ['OutboundEmailAccounts'] =
+array(
+  'EditView' =>
     array(
-        'EditView' =>
+      'templateMeta' =>
+        array(
+          'maxColumns' => '2',
+          'widths' =>
             array(
-                'templateMeta' =>
-                    array(
-                        'maxColumns' => '2',
-                        'widths' =>
-                            array(
-                                0 =>
-                                    array(
-                                        'label' => '10',
-                                        'field' => '30',
-                                    ),
-                                1 =>
-                                    array(
-                                        'label' => '10',
-                                        'field' => '30',
-                                    ),
-                            ),
-                        'useTabs' => false,
-                        'tabDefs' =>
-                            array(
-                                'DEFAULT' =>
-                                    array(
-                                        'newTab' => false,
-                                        'panelDefault' => 'expanded',
-                                    ),
-                                'LBL_EDITVIEW_PANEL1' =>
-                                    array(
-                                        'newTab' => false,
-                                        'panelDefault' => 'expanded',
-                                    ),
-                            ),
-                        'syncDetailEditViews' => true,
-                    ),
-                'panels' =>
-                    array(
-                        'default' =>
-                            array(
-                                0 =>
-                                    array(
-                                        0 => 'name',
-                                        //1 => 'assigned_user_name',
-                                    ),
-//        1 =>
-//        array (
-//          0 => 'description',
-//        ),
-                            ),
-                        'lbl_editview_panel1' =>
-                            array(
-                                
-                                array(
-                                        'name' => 'smtp_from_name',
-                                        'label' => 'LBL_SMTP_FROM_NAME',
-                                    ),
-                                
-                                array(
-                                        'name' => 'smtp_from_addr',
-                                        'label' => 'LBL_SMTP_FROM_ADDR',
-                                    ),
-                                
-                                array(
-                                    'name' => 'email_provider_chooser',
-                                    'label' => 'LBL_CHOOSE_EMAIL_PROVIDER',
-                                ),
-
-                                array(
-                                    0 =>
-                                        array(
-                                            'name' => 'mail_smtpserver',
-                                            'label' => 'LBL_SMTP_SERVERNAME',
-                                        ),
-                                    1 =>
-                                        array(
-                                            'name' => 'mail_smtpport',
-                                            'label' => 'LBL_SMTP_PORT',
-                                        ),
-                                ),
-
-                                array(
-                                    0 =>
-                                        array(
-                                            'name' => 'mail_smtpauth_req',
-                                            'label' => 'LBL_SMTP_AUTH',
-                                        ),
-                                    1 =>
-                                        array(
-                                            'name' => 'mail_smtpssl',
-                                            'studio' => 'visible',
-                                            'label' => 'LBL_SMTP_PROTOCOL',
-                                        ),
-                                ),
-
-                                array(
-                                    array(
-                                        'name' => 'mail_smtpuser',
-                                        'label' => 'LBL_USERNAME',
-                                    ),
-                                ),
-                                array(
-                                    array(
-                                        'name' => 'password_change',
-                                        'label' => 'LBL_PASSWORD',
-                                    ),
-                                ),
-                                array(
-                                    array(
-                                        'name' => 'sent_test_email_btn',
-                                        'label' => 'LBL_SEND_TEST_EMAIL',
-                                    ),
-                                ),
-                            ),
-                    ),
+              0 =>
+                array(
+                  'label' => '10',
+                  'field' => '30',
+                ),
+              1 =>
+                array(
+                  'label' => '10',
+                  'field' => '30',
+                ),
             ),
-    );
+          'useTabs' => false,
+          'tabDefs' =>
+            array(
+              'DEFAULT' =>
+                array(
+                  'newTab' => false,
+                  'panelDefault' => 'expanded',
+                ),
+              'LBL_EDITVIEW_PANEL1' =>
+                array(
+                  'newTab' => false,
+                  'panelDefault' => 'expanded',
+                ),
+            ),
+          'syncDetailEditViews' => true,
+        ),
+      'panels' =>
+        array(
+          'default' =>
+            array(
+              0 =>
+                array(
+                  0 => 'name',
+                ),
+            ),
+          'lbl_editview_panel1' =>
+            array(
+              array(
+                0 =>
+                  array(
+                    'name' => 'smtp_from_name',
+                    'label' => 'LBL_SMTP_FROM_NAME',
+                  ),
+              ),
+              array(
+                0 =>
+                  array(
+                    'name' => 'smtp_from_addr',
+                    'label' => 'LBL_SMTP_FROM_ADDR',
+                  ),
+              ),
+              array(
+                0 =>
+                  array(
+                    'name' => 'email_provider_chooser',
+                    'label' => 'LBL_CHOOSE_EMAIL_PROVIDER',
+                  ),
+              ),
+              array(
+                0 =>
+                  array(
+                    'name' => 'mail_smtpserver',
+                    'label' => 'LBL_SMTP_SERVERNAME',
+                  ),
+                1 =>
+                  array(
+                    'name' => 'mail_smtpport',
+                    'label' => 'LBL_SMTP_PORT',
+                  ),
+              ),
+              array(
+                0 =>
+                  array(
+                    'name' => 'mail_smtpauth_req',
+                    'label' => 'LBL_SMTP_AUTH',
+                  ),
+                1 =>
+                  array(
+                    'name' => 'mail_smtpssl',
+                    'studio' => 'visible',
+                    'label' => 'LBL_SMTP_PROTOCOL',
+                  ),
+              ),
+              array(
+                array(
+                  'name' => 'mail_smtpuser',
+                  'label' => 'LBL_USERNAME',
+                ),
+              ),
+              array(
+                array(
+                  'name' => 'password_change',
+                  'label' => 'LBL_PASSWORD',
+                ),
+              ),
+              array(
+                array(
+                  'name' => 'sent_test_email_btn',
+                  'label' => 'LBL_SEND_TEST_EMAIL',
+                ),
+              ),
+            ),
+        ),
+    ),
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
see #9382

## How To Test This
See you can now edit an Outbound Email in php8+

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->