### PR TITLE
Clean Historic and Failed Schedulers

### DIFF
--- a/include/SugarQueue/SugarCronJobs.php
+++ b/include/SugarQueue/SugarCronJobs.php
@@ -211,10 +211,12 @@ class SugarCronJobs
             $GLOBALS['log']->fatal("Job runs too frequently, throttled to protect the system.");
             return;
         }
-        // clean old stale jobs
+        // clean stale jobs
         if (!$this->queue->cleanup()) {
             $this->jobFailed();
         }
+        // delete expired jobs
+        $this->queue->clearHistoricJobs();
         // run schedulers
         if (!$this->disable_schedulers) {
             $this->queue->runSchedulers();

--- a/include/SugarQueue/SugarJobQueue.php
+++ b/include/SugarQueue/SugarJobQueue.php
@@ -55,6 +55,7 @@ class SugarJobQueue
      * @var int
      */
     public $jobTries = 5;
+
     /**
      * Job running timeout - longer than that, job is failed by force
      * @var int
@@ -66,6 +67,20 @@ class SugarJobQueue
      * @var string
      */
     protected $job_queue_table;
+
+    /**
+     * Success History Lifetime
+     * Defines the time in days for successful cron jobs to remain before deletion
+     * @var int
+     */
+
+    public $success_lifetime = 30; // 30 days
+    /**
+     * Failure History Lifetime
+     * Defines the time in days for failed cron jobs to remain before deletion
+     * @var int
+     */
+    public $failure_lifetime = 180; // 180 days
 
     /**
      * DB connection
@@ -83,6 +98,12 @@ class SugarJobQueue
         }
         if (!empty($GLOBALS['sugar_config']['jobs']['timeout'])) {
             $this->timeout = $GLOBALS['sugar_config']['jobs']['timeout'];
+        }
+        if (!empty($GLOBALS['sugar_config']['jobs']['failure_lifetime'])) {
+            $this->timeout = $GLOBALS['sugar_config']['jobs']['failure_lifetime'];
+        }
+        if (!empty($GLOBALS['sugar_config']['jobs']['success_lifetime'])) {
+            $this->timeout = $GLOBALS['sugar_config']['jobs']['success_lifetime'];
         }
     }
 
@@ -167,22 +188,44 @@ class SugarJobQueue
     }
 
     /**
-     * Remove old jobs that still are marked as running
+     * Cleanup old, failed or long running jobs
+     * Forcefully remove jobs that are marked as running when they exceed the timeout value
      * @return bool true if no failed job discovered, false if some job were failed
      */
     public function cleanup()
     {
-        // fail jobs that are too old
         $ret = true;
-        // bsitnikovski@sugarcrm.com bugfix #56144: Scheduler Bug
-        $date = $this->db->convert($this->db->quoted($GLOBALS['timedate']->getNow()->modify("-{$this->timeout} seconds")->asDb()), 'datetime');
-        $res = $this->db->query("SELECT id FROM {$this->job_queue_table} WHERE status='".SchedulersJob::JOB_STATUS_RUNNING."' AND date_modified <= $date");
+        $date = $this->db->convert($GLOBALS['timedate']->getNow()->modify("-{$this->timeout} seconds")->asDb(), 'datetime');
+        $sql = "SELECT id FROM {$this->job_queue_table} WHERE status='".SchedulersJob::JOB_STATUS_RUNNING."' AND date_modified <= '{$date}'";
+        $res = $this->db->query($sql);
         while ($row = $this->db->fetchByAssoc($res)) {
             $this->resolveJob($row["id"], SchedulersJob::JOB_FAILURE, translate('ERR_TIMEOUT', 'SchedulersJobs'));
             $ret = false;
         }
-        // TODO: soft-delete old done jobs?
         return $ret;
+    }
+
+    /**
+     * Marks jobs for deletion that have exceeded their history lifetime
+     * Uses different values for successful and failed jobs
+     */
+    public function clearHistoricJobs()
+    {
+        // Process successful jobs
+        $date = $this->db->convert($GLOBALS['timedate']->getNow()->modify("-{$this->success_lifetime} days")->asDb(), 'datetime');
+        $sql = "SELECT id FROM {$this->job_queue_table} WHERE status='".SchedulersJob::JOB_STATUS_DONE."' AND resolution='".SchedulersJob::JOB_SUCCESS."' AND date_modified <= '{$date}'";
+        $res = $this->db->query($sql);
+        while ($row = $this->db->fetchByAssoc($res)) {
+            $this->deleteJob($row["id"]);
+        }
+
+        // Process failed jobs
+        $date = $this->db->convert($GLOBALS['timedate']->getNow()->modify("-{$this->failure_lifetime} days")->asDb(), 'datetime');
+        $sql = "SELECT id FROM {$this->job_queue_table} WHERE status='".SchedulersJob::JOB_STATUS_DONE."' AND resolution!='".SchedulersJob::JOB_SUCCESS."' AND date_modified <= '{$date}'";
+        $res = $this->db->query($sql);
+        while ($row = $this->db->fetchByAssoc($res)) {
+            $this->deleteJob($row["id"]);
+        }
     }
 
     /**

--- a/include/SugarQueue/SugarJobQueue.php
+++ b/include/SugarQueue/SugarJobQueue.php
@@ -100,10 +100,10 @@ class SugarJobQueue
             $this->timeout = $GLOBALS['sugar_config']['jobs']['timeout'];
         }
         if (!empty($GLOBALS['sugar_config']['jobs']['failure_lifetime'])) {
-            $this->timeout = $GLOBALS['sugar_config']['jobs']['failure_lifetime'];
+            $this->failure_lifetime = $GLOBALS['sugar_config']['jobs']['failure_lifetime'];
         }
         if (!empty($GLOBALS['sugar_config']['jobs']['success_lifetime'])) {
-            $this->timeout = $GLOBALS['sugar_config']['jobs']['success_lifetime'];
+            $this->success_lifetime = $GLOBALS['sugar_config']['jobs']['success_lifetime'];
         }
     }
 

--- a/modules/SchedulersJobs/metadata/subpanels/default.php
+++ b/modules/SchedulersJobs/metadata/subpanels/default.php
@@ -60,6 +60,11 @@ $subpanel_layout = array(
              'width'	=> '10%',
              'sortable'	=> true,
         ),
+        'resolution'    => array(
+            'vname'	=> 'LBL_RESOLUTION',
+            'width'	=> '10%',
+            'sortable'	=> true,
+        ),
         'execute_time'	=> array(
              'vname'	=> 'LBL_EXECUTE_TIME',
              'width'	=> '10%',


### PR DESCRIPTION
## Description
Improvements to scheduler processing to delete historic scheduled tasks from the job_queue table.

## Motivation and Context
Historic jobs from the job_queue table are never removed.
If a job fails in a certain condition, the schedulers may no longer run
The subpanel doesn't display the actual job status, only the overall status

## How To Test This
Check that scheduled tasks older than the ['sugar_config']['jobs']['success_lifetime'] and ['sugar_config']['jobs']['failure_lifetime'] values are deleted. 
Check that running jobs that exceed ['sugar_config']['jobs']['timeout'] are correctly marked as failed

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.