### PR TITLE
Optimise Export Memory Usage

### DIFF
--- a/export.php
+++ b/export.php
@@ -49,6 +49,7 @@ require_once('include/export_utils.php');
 global $sugar_config;
 global $current_user;
 global $app_list_strings;
+global $db;
 
 $the_module = clean_string($_REQUEST['module']);
 
@@ -61,12 +62,26 @@ if ($sugar_config['disable_export'] 	|| (!empty($sugar_config['admin_export_only
 //check to see if this is a request for a sample or for a regular export
 if (!empty($_REQUEST['sample'])) {
     //call special method that will create dummy data for bean as well as insert standard help message.
-    $content = exportSample(clean_string($_REQUEST['module']));
+    $content = exportSample($the_module);
 } else {
     if (!empty($_REQUEST['uid'])) {
-        $content = export(clean_string($_REQUEST['module']), $_REQUEST['uid'], isset($_REQUEST['members']) ? $_REQUEST['members'] : false);
+        $ids = explode(',', $_REQUEST['uid']);
     } else {
-        $content = export(clean_string($_REQUEST['module']));
+        $bean = BeanFactory::getBean($the_module);
+        $table_name = $bean->table_name;
+        unset($bean);
+
+        $result = $db->query("SELECT id FROM $table_name;");
+        while ($row = $db->fetchByAssoc($result)) {
+            $ids[] = $row['id'];
+        }
+        unset($result);
+    }
+
+    $idChunks = array_chunk($ids, 1000, true);
+    $content = '';
+    foreach($idChunks as $chunk) {
+        $content .= export($the_module, implode(",", $chunk), isset($_REQUEST['members']) ? $_REQUEST['members'] : false);
     }
 }
 $filename = $_REQUEST['module'];


### PR DESCRIPTION
## Description
This PR passes records to the export function in export_utils in small batches rather than all at once to minimise the memory consumption of the csv export process.

## Motivation and Context
When exporting lots of records at one time, the php memory consumption can quickly exceed the default memory_limit
This change will process the records in small batches, consuming less memory.

Large exports of +/- 100k records can easily exceed 750MB peak memory consumption. With this change consumption remains below the php default value of 128MB ( Approx 74MB in testing, but will vary based on record contents )

## How To Test This
Select all records on the list view and perform a bulk action export
Best performed on a test DB with many thousands of records.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.