### PR TITLE
Fix #9383 unsupported each function in php8

### DIFF
--- a/modules/ModuleBuilder/parsers/relationships/AbstractRelationships.php
+++ b/modules/ModuleBuilder/parsers/relationships/AbstractRelationships.php
@@ -437,7 +437,9 @@ class AbstractRelationships
         mkdir_recursive("$basepath/relationships") ;
         
         $installDefs = array( ) ;
-        list($rhs_module, $properties) = each($relationshipMetaData) ;
+        $rhs_module = key($relationshipMetaData);
+        $properties = current($relationshipMetaData);
+
         $filename = "$basepath/relationships/{$relationshipName}MetaData.php" ;
         $GLOBALS [ 'log' ]->debug(get_class($this) . "->saveRelationshipMetaData(): saving the following to {$filename}" . print_r($properties, true)) ;
         write_array_to_file('dictionary["' . $relationshipName . '"]', $properties, (string)($filename), 'w') ;

--- a/modules/ModuleBuilder/views/view.relationship.php
+++ b/modules/ModuleBuilder/views/view.relationship.php
@@ -140,8 +140,8 @@ class ViewRelationship extends SugarView
             }
         } else {
             $definition = array( ) ;
-            $firstModuleDefinition = each($relatableModules) ;
-            $definition [ 'rhs_module' ] = $firstModuleDefinition [ 'key' ] ;
+            $firstModuleDefinition = [key($relatableModules), current($relatableModules)];
+            $definition [ 'rhs_module' ] = $firstModuleDefinition[0];
             $definition [ 'lhs_module' ] = $moduleName ;
             $definition [ 'lhs_label' ] = translate($moduleName);
             $definition [ 'relationship_type' ] = MB_MANYTOMANY ;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The changes fix the unsupported each() function in PHP8.x
- The fix applied to fix the existing code using each() function
- The fix uses PHP8.x polyfill for the removed each() function

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

=> Setup PHP8 as your project environment:

1) If you are not using a docker environment:

    Upgrade your PHP Version to 8.0 or above as applicable to your System/PHP environment setting.

2) If you are using a docker environment:
    
    Pull down the PHP8 Container by following these steps:-
    
    a) Specify the PHP8 docker image entry inside your docker-compose.yaml file
      A sample entry:
    ```
    php8:
      image: <docker image url>
      container_name: php8
      restart: unless-stopped
      ports:
        - <port_number>:80
      volumes:
        - $LOCAL_DIRECTORY: <project document root e.g. /var/www>
      environment:
        IDE_KEY: $IDE_KEY
      networks:
        local_docker:
            ipv4_address: <ipv4_address>
        ```
c) After saving the above file, issue the command:
`docker-compose up` which will pull down the PHP8 image inside your docker environment.

d) Access the webserver over the specified container port.

e) Access your project directory from this port and now your project must be using the PHP8 environment.

=> Test the App
a) Go to Admin > Module Builder > Select Package > Select Module > Add Relationship
and try to add a relationship.

The expected output is: the relatioship adds successfuly.

Prior to the fix the following error occured with non-supoorted each() function in PHP8.x

```
Fatal error: Uncaught Error: Call to undefined function each() in /var/www/crm/s7git/modules/ModuleBuilder/views/view.relationship.php:143 Stack trace: #0 /var/www/crm/s7git/include/MVC/View/SugarView.php(210): ViewRelationship->display() #1 /var/www/crm/s7git/include/MVC/Controller/SugarController.php(432): SugarView->process() #2 /var/www/crm/s7git/include/MVC/Controller/SugarController.php(363): SugarController->processView() #3 /var/www/crm/s7git/include/MVC/SugarApplication.php(101): SugarController->execute() #4 /var/www/crm/s7git/index.php(57): SugarApplication->execute() #5 {main} thrown in /var/www/crm/s7git/modules/ModuleBuilder/views/view.relationship.php on line 143
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->