### PR TITLE
Fixed #9408 - Emails can't be deleted from inline edit

### DIFF
--- a/include/InlineEditing/InlineEditing.php
+++ b/include/InlineEditing/InlineEditing.php
@@ -341,6 +341,9 @@ function saveField($field, $id, $module, $value)
             require_once('modules/Leads/LeadFormBase.php');
             $bean->$field = $value;
             $bean->account_id = LeadFormBase::handleLeadAccountName($bean);
+        // Fix #9408 Allow deleting an email address from inline Edit
+        } else if($bean->field_defs[$field]['function']['name']=='getEmailAddressWidget'){
+            $bean->$field = empty($value) ? ' ' : $value;
         } else {
             $bean->$field = $value;
         }


### PR DESCRIPTION
Clsoes #9408 

As described in the Issue, Emails can't be deleted from inline edit of a Detail or ListView

## Description
In this PR we add the condition in the Inline Edit file to be able to delete emails from the Inline edit functionality

## Motivation and Context
Any user should be able to Delete an Email.

## How To Test This
Check that emails can be deleted from Inline edit and make sure everything works alright inside inline edit functions.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.