### PR TITLE
Fix #9412 - Wrong email value displayed when aborting an inline edition

### DIFF
--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -350,7 +350,8 @@ $(document).on("click", function(e) {
                     ) + " " + message_field
                 );
                 if (r == true) {
-                    var output = setValueClose(output_value);
+		    // Fix #9412 - Wrong email value displayed when aborting an inline edition
+                    var output = setValueClose(output_value, false);
                     clickListenerActive = false;
                 } else {
                     $("#" + field).focus();


### PR DESCRIPTION
Closes #9412 

## Description
Adding false to the second parameter when calling the function setValueClose(). Replacing line breaks in email field isn't necessary and it produces error.

## Motivation and Context
Setting this parameter, it avoids displayed a wrong value

## How To Test This
Follow the steps defined in the issue #9412 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.