### PR TITLE
Fix #8948 - Make Project Tasks Importable

### DIFF
--- a/modules/ProjectTask/Menu.php
+++ b/modules/ProjectTask/Menu.php
@@ -66,3 +66,11 @@ if (ACLController::checkAccess('ProjectTask', 'list', true)) {
     $module_menu[] = array('index.php?module=ProjectTask&action=index',
     $mod_strings['LNK_PROJECT_TASK_LIST'], 'View_Project_Tasks');
 }
+// Import Project Task
+if (ACLController::checkAccess('ProjectTask', 'import', true)) {
+    $module_menu[] = array(
+        'index.php?module=Import&action=Step1&import_module=ProjectTask&return_module=ProjectTask&return_action=index',
+        isset($mod_strings['LBL_IMPORT_PROJECT_TASKS']) ? $mod_strings['LBL_IMPORT_PROJECT_TASKS'] : '',
+        'Import'
+    );
+}

--- a/modules/ProjectTask/ProjectTask.php
+++ b/modules/ProjectTask/ProjectTask.php
@@ -60,6 +60,7 @@ class ProjectTask extends SugarBean
     public $parent_task_id;
     public $predecessors;
     public $priority;
+    public $importable = true;
 
     // related information
     public $assigned_user_name;

--- a/modules/ProjectTask/language/en_us.lang.php
+++ b/modules/ProjectTask/language/en_us.lang.php
@@ -79,6 +79,7 @@ $mod_strings = array(
     'LBL_ACTUAL_EFFORT' => 'Actual Effort (hrs):',
     'LBL_UTILIZATION' => 'Utilization (%):',
     'LBL_DELETED' => 'Deleted:',
+    'LBL_IMPORT_PROJECT_TASKS' => 'Import Project Tasks',
 
     'LBL_LIST_NAME' => 'Name',
     'LBL_LIST_PARENT_NAME' => 'Project',


### PR DESCRIPTION
Make Project Tasks Importable

## Description
Fix #8948 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This

Go to Project Tasks.
See that you can now import.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->