### PR TITLE
Fix #8280 - Autocomplete Search in line items doesn't show full part …

### DIFF
--- a/themes/SuiteP/css/suitep-base/yui.scss
+++ b/themes/SuiteP/css/suitep-base/yui.scss
@@ -57,7 +57,7 @@
 
   .col-sm-12 .col-sm-8 .yui-ac-container {
     float: left;
-    width: 45%;
+    width: 100%;
   }
 
   .col-sm-12 .col-sm-6 .yui-ac-container {


### PR DESCRIPTION
…number

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
See #8343 for original fix.
Re-created for no action on the original PR.

## Motivation and Context
This now shows all of the part number when autocompleting, in Quotes Line Items

## How To Test This
1. Clear Cache
2. Rebuild Theme
3. See that the autocomplete of the part number now shows the full part number.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->