### PR TITLE
Fix #8525 #8309 Bulk Action button missing and delete button showing for users with no delete access

### DIFF
--- a/include/ListView/ListViewDisplay.php
+++ b/include/ListView/ListViewDisplay.php
@@ -52,11 +52,6 @@ class ListViewDisplay
     public $show_mass_update_form = false;
     public $show_action_dropdown = true;
 
-    /**
-     * @var bool Show Bulk Action button as Delete link
-     */
-    public $show_action_dropdown_as_delete = false;
-
     public $rowCount;
     public $mass = null;
     public $seed;
@@ -353,19 +348,8 @@ class ListViewDisplay
                 }
             }
         } else {
-            // delete
-            if (
-                ACLController::checkAccess($this->seed->module_dir, 'delete', true)
-                && $this->delete
-            ) {
-                if ($this->show_action_dropdown_as_delete) {
-                    $menuItems[] = $this->buildDeleteLink($location);
-                } else {
-                    $menuItems[] = $this->buildBulkActionButton($location);
-                }
-            } else {
-                $menuItems[] = $this->buildBulkActionButton($location);
-            }
+            // Bulk Action label
+            $menuItems[] = $this->buildBulkActionButton($location);
 
             // Compose email
             if (isset($this->email) && $this->email === true) {
@@ -416,10 +400,12 @@ class ListViewDisplay
 
 
             if (
-                $this->delete
-                && !$this->show_action_dropdown_as_delete
+                $this->delete &&
+                ACLController::checkAccess($this->seed->module_dir, 'delete', true)
             ) {
                 $menuItems[] = $this->buildDeleteLink($location);
+            } else {
+                $menuItems[] = "<a style='display:none'></a>";
             }
         }
         $link = array(

--- a/include/ListView/ListViewDisplay.php
+++ b/include/ListView/ListViewDisplay.php
@@ -363,6 +363,8 @@ class ListViewDisplay
                 } else {
                     $menuItems[] = $this->buildBulkActionButton($location);
                 }
+            } else {
+                $menuItems[] = $this->buildBulkActionButton($location);
             }
 
             // Compose email


### PR DESCRIPTION
Similar to proposed fix https://github.com/salesagility/SuiteCRM/pull/8600 . Please close this one if you want me to continue dialogue in the other thread.

Fix https://github.com/salesagility/SuiteCRM/issues/8525 & https://github.com/salesagility/SuiteCRM/issues/8309

## Description
Bulk Action button is not showing for users without delete access. Delete button is still showing for users without delete access.

## Motivation and Context
Provide continuity between different roles in the list view and fix for what I assume was the original design intent.

## How To Test This
Login with a user without delete access for a module and go to the list view of that module. Check Bulk Action menu, notice that it shows 'email' rather than Bulk Action.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->