### PR TITLE
Fixed #9421 - elasticsearch fail indexing individual lead updated by …

### DIFF
--- a/lib/Search/ElasticSearch/ElasticSearchHooks.php
+++ b/lib/Search/ElasticSearch/ElasticSearchHooks.php
@@ -104,6 +104,7 @@ class ElasticSearchHooks
     private function reIndexSafe(SugarBean $bean)
     {
         try {
+            $bean->module_name = strtolower($bean->module_name);
             $this->reIndex($bean);
         } catch (SearchException $exception) {
             $this->handleError($exception);
@@ -161,7 +162,7 @@ class ElasticSearchHooks
      */
     private function isBlacklisted()
     {
-        return !in_array($this->bean->module_name, $this->indexer->getModulesToIndex());
+        return !in_array($this->bean->module_name, array_map("strtolower", $this->indexer->getModulesToIndex()));
     }
 
     private function correctAction()

--- a/modules/Emails/vardefs.php
+++ b/modules/Emails/vardefs.php
@@ -754,6 +754,11 @@ $dictionary['Email'] = array(
             'type' => 'index',
             'fields' => array('category_id')
         ),
+        array(
+            'name' => 'idx_email_uid',
+            'type' => 'index',
+            'fields' => array('uid')
+        ),
     ) // end indices
 );
 


### PR DESCRIPTION
…users on a clean 7.12.2

<!--- Provide a general summary of your changes in the Title above -->

Fix for issue #9421

In a clean SuiteCRM 7.12.2 environment populated with demo data  and with ElasticSearch 7.16.3 enabled fails reindexing when a user update content in a Lead or other modules.

This problem is not reproduced on an environment upgraded from SuiteCRM 6.7.6. 

I can reproduce it in new installations.

## How To Test This

1. Install a new SuiteCRM 7.12.2 populated with demo data provided.
2. Install ElasticSearch 7.16.3 (see above notes for installation)
3. Run a full index in cli with 
4.  Admin > Elasticsearch: enable Elasticsearch with the appropriate parameters
5. Run a Full Index in terminal with `php vendor/bin/robo elastic:index 1`. No errors happen.
6. Admin > Search Settings : set the Search Engine to "Elastic Search Engine".
7. Confirm you can use global search and you get expected results.
8. Set Admin > System Settings > Log Level to *WARN*
9. Monitor *search_index.log* and *suitecrm.log*
10. Edit one Lead
11. You can see errors in **search_index.log** (see above)
12. The Lead is not reindexed. You can confirm it searching with Global Search.
12. Apply my patch.
13. Edit one Lead.
14. No errors related to this happen.

Error from **search_index.log** (solved with [this fix](https://github.com/salesagility/SuiteCRM/commit/2ef11128488ba94fa4b1b5e0c5d2a323a10e054f#diff-41e5ec3c5c1c7ede5abea9e60535ba0dfda12642c539f18149d45d9d273d7b3cR107))
```
[2022-01-20 14:30:28] ElasticSearchIndexer.ERROR: Elasticsearch\Common\Exceptions\BadRequest400Exception: {"error":{"root_cause":[{"type":"invalid_index_name_exception","reason":"Invalid index name [Leads], must be lowercase","index_uuid":"_na_","index":"Leads"}],"type":"invalid_index_name_exception","reason":"Invalid index name [Leads], must be lowercase","index_uuid":"_na_","index":"Leads"},"status":400} in /home/isaac.marco/git/suitecrm/vendor/elasticsearch/elasticsearch/src/Elasticsearch/Connections/Connection.php:693 Stack trace: 
#0 /home/isaac.marco/git/suitecrm/vendor/elasticsearch/elasticsearch/src/Elasticsearch/Connections/Connection.php(333): Elasticsearch\Connections\Connection->process4xxError() 
#1 /home/isaac.marco/git/suitecrm/vendor/react/promise/src/FulfilledPromise.php(28): Elasticsearch\Connections\Connection->Elasticsearch\Connections\{closure}() 
#2 /home/isaac.marco/git/suitecrm/vendor/ezimuel/ringphp/src/Future/CompletedFutureValue.php(55): React\Promise\FulfilledPromise->then() 
#3 /home/isaac.marco/git/suitecrm/vendor/ezimuel/ringphp/src/Core.php(341): GuzzleHttp\Ring\Future\CompletedFutureValue->then() 
#4 /home/isaac.marco/git/suitecrm/vendor/elasticsearch/elasticsearch/src/Elasticsearch/Connections/Connection.php(345): GuzzleHttp\Ring\Core::proxy() 
#5 /home/isaac.marco/git/suitecrm/vendor/elasticsearch/elasticsearch/src/Elasticsearch/Connections/Connection.php(241): Elasticsearch\Connections\Connection->Elasticsearch\Connections\{closure}() 
#6 /home/isaac.marco/git/suitecrm/vendor/elasticsearch/elasticsearch/src/Elasticsearch/Transport.php(110): Elasticsearch\Connections\Connection->performRequest() 
#7 /home/isaac.marco/git/suitecrm/vendor/elasticsearch/elasticsearch/src/Elasticsearch/Client.php(1946): Elasticsearch\Transport->performRequest() 
#8 /home/isaac.marco/git/suitecrm/vendor/elasticsearch/elasticsearch/src/Elasticsearch/Client.php(920): Elasticsearch\Client->performRequest() 
#9 /home/isaac.marco/git/suitecrm/lib/Search/ElasticSearch/ElasticSearchIndexer.php(294): Elasticsearch\Client->index() 
#10 /home/isaac.marco/git/suitecrm/lib/Search/ElasticSearch/ElasticSearchHooks.php(181): SuiteCRM\Search\ElasticSearch\ElasticSearchIndexer->indexBean() 
#11 /home/isaac.marco/git/suitecrm/lib/Search/ElasticSearch/ElasticSearchHooks.php(137): SuiteCRM\Search\ElasticSearch\ElasticSearchHooks->performAction() 
#12 /home/isaac.marco/git/suitecrm/lib/Search/ElasticSearch/ElasticSearchHooks.php(107): SuiteCRM\Search\ElasticSearch\ElasticSearchHooks->reIndex() 
#13 /home/isaac.marco/git/suitecrm/lib/Search/ElasticSearch/ElasticSearchHooks.php(77): SuiteCRM\Search\ElasticSearch\ElasticSearchHooks->reIndexSafe() 
#14 /home/isaac.marco/git/suitecrm/include/utils/LogicHook.php(260): SuiteCRM\Search\ElasticSearch\ElasticSearchHooks->beanSaved() 
#15 /home/isaac.marco/git/suitecrm/include/utils/LogicHook.php(201): LogicHook->process_hooks() 
#16 /home/isaac.marco/git/suitecrm/data/SugarBean.php(3105): LogicHook->call_custom_logic() 
#17 /home/isaac.marco/git/suitecrm/data/SugarBean.php(2421): SugarBean->call_custom_logic() 
#18 /home/isaac.marco/git/suitecrm/include/SugarObjects/templates/person/Person.php(210): SugarBean->save() 
#19 /home/isaac.marco/git/suitecrm/modules/Leads/Lead.php(593): Person->save() 
#20 /home/isaac.marco/git/suitecrm/modules/Leads/LeadFormBase.php(377): Lead->save() 
#21 /home/isaac.marco/git/suitecrm/modules/Leads/Save.php(47): LeadFormBase->handleSave() 
#22 /home/isaac.marco/git/suitecrm/include/MVC/View/SugarView.php(823): include_once('/home/isaac.mar...') 
#23 /home/isaac.marco/git/suitecrm/include/MVC/View/views/view.classic.php(72): SugarView->includeClassicFile() 
#24 /home/isaac.marco/git/suitecrm/include/MVC/View/SugarView.php(210): ViewClassic->display() 
#25 /home/isaac.marco/git/suitecrm/include/MVC/Controller/SugarController.php(432): SugarView->process() 
#26 /home/isaac.marco/git/suitecrm/include/MVC/Controller/SugarController.php(363): SugarController->processView() 
#27 /home/isaac.marco/git/suitecrm/include/MVC/SugarApplication.php(101): SugarController->execute() 
#28 /home/isaac.marco/git/suitecrm/index.php(52): SugarApplication->execute() 
#29 {main} [] []
```

Error from **suitecrm.log** (you get this error only if you just apply the first fix.. this error is solved with [this other fix](https://github.com/salesagility/SuiteCRM/commit/2ef11128488ba94fa4b1b5e0c5d2a323a10e054f#diff-41e5ec3c5c1c7ede5abea9e60535ba0dfda12642c539f18149d45d9d273d7b3cR165)) 

    Thu Jan 20 14:34:44 2022 [5633][1][WARN] Elasticsearch trying to re-indexing a bean but this module is blacklisted: leads

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->