### PR TITLE
Fix #9445 - More than 10 tabs in a views enters in a loop

### DIFF
--- a/modules/Emails/include/ComposeView/ComposeView.tpl
+++ b/modules/Emails/include/ComposeView/ComposeView.tpl
@@ -226,7 +226,7 @@
         $(function(){
             $('#EditView_tabs ul.nav.nav-tabs li > a[data-toggle="tab"]').click(function(e){
                 if(typeof $(this).parent().find('a').first().attr('id') != 'undefined') {
-                    var tab = parseInt($(this).parent().find('a').first().attr('id').match(/^tab(.)*$/)[1]);
+                    var tab = parseInt($(this).parent().find('a').first().attr('id').match(/^tab(?<number>(.)*)$/)[1]);
                     selectTab(tab);
                 }
             });

--- a/themes/SuiteP/include/DetailView/DetailView.tpl
+++ b/themes/SuiteP/include/DetailView/DetailView.tpl
@@ -352,7 +352,7 @@
                     $(function(){
                         $('#content ul.nav.nav-tabs > li > a[data-toggle="tab"]').click(function(e){
                             if(typeof $(this).parent().find('a').first().attr('id') != 'undefined') {
-                                var tab = parseInt($(this).parent().find('a').first().attr('id').match(/^tab(.)*$/)[1]);
+                                var tab = parseInt($(this).parent().find('a').first().attr('id').match(/^tab(?<number>(.)*)$/)[1]);
                                 selectTabDetailView(tab);
                             }
                         });

--- a/themes/SuiteP/include/EditView/EditView.tpl
+++ b/themes/SuiteP/include/EditView/EditView.tpl
@@ -249,7 +249,7 @@ $(document).ready(function() {ldelim}
     $(function(){
         $('#EditView_tabs ul.nav.nav-tabs li > a[data-toggle="tab"]').click(function(e){
             if(typeof $(this).parent().find('a').first().attr('id') != 'undefined') {
-                var tab = parseInt($(this).parent().find('a').first().attr('id').match(/^tab(.)*$/)[1]);
+                var tab = parseInt($(this).parent().find('a').first().attr('id').match(/^tab(?<number>(.)*)$/)[1]);
                 selectTab(tab);
             }
         });


### PR DESCRIPTION
Closes #9445

## Description
As mentioned in the issue, this PR fixes the loop that appears when more than 10 tabs are present in a view. With this fix, the 11th tab, and next ones, will be properly displayed.

There are modifications in each file that is applying this selector.

## Motivation and Context
It solves having more than 10 tabs in a view

## How To Test This
- Add more than 10 tabs in a view
- Open the view and check that all tabs are displayed fine.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.