### PR TITLE
Fix #9451 - Missing duplicate merge filter options in Studio

### DIFF
--- a/include/language/en_us.lang.php
+++ b/include/language/en_us.lang.php
@@ -928,6 +928,9 @@ $app_list_strings = array(
     'custom_fields_merge_dup_dom' => array(
         0 => 'Disabled',
         1 => 'Enabled',
+        2 => 'Filter',
+        3 => 'Default selected filter',
+        4 => 'Only filter',
     ),
 
     'projects_priority_options' => array(

--- a/modules/ModuleBuilder/language/en_us.lang.php
+++ b/modules/ModuleBuilder/language/en_us.lang.php
@@ -615,6 +615,7 @@ $mod_strings = array(
 
 //POPUP HELP
     'LBL_POPHELP_FIELD_DATA_TYPE' => 'Select the appropriate data type based on the type of data that will be entered into the field.',
+    'LBL_POPHELP_DUPLICATE_MERGE'=>'<b>Enabled</b>: The field will appear in the Merge Duplicates feature, but will not be available to use for the filter conditions in the Find Duplicates feature.<br><b>Disabled</b>: The field will not appear in the Merge Duplicates feature, and will not be available to use for the filter conditions in the Find Duplicates feature.<br><b>Filter</b>: The field will appear in the Merge Duplicates feature, and will be available to use for the filter conditions in the Find Duplicates feature.<br><b>Default selected filter</b>: The field will appear in the Merge Duplicates feature, and will be used by default for the filter conditions in the Find Duplicates feature.<br><b>Only filter</b>: The field will not appear in the Merge Duplicates feature, but will be available to use for the filter conditions in the Find Duplicates feature.',
 
 //Revert Module labels
     'LBL_RESET' => 'Reset',


### PR DESCRIPTION
Closes #9451 

## Description
As described in the issue, this PR proposes a solution to add the missing options in Studio for the Merge and Find duplicates vardef field properties.

1- It adds the missing options in the list "custom_fields_merge_dup_dom" 
2- Add the missing Popup help "LBL_POPHELP_DUPLICATE_MERGE". 
**ALERT**:  This last label modification might have confligct with the labels added in the PR #9427 .

## Motivation and Context
This gives full operational options to the Administrator in Studio. If removed the need to add manually code to the vardef to active/deactivate these features

## How To Test This
1- Edit a field in Studio
2- Change the option of the duplicate_merge list. 
3- Check that the properties "duplicate_merge, merge_filter and duplicate_merge_dom_value" are saved correctly in the "custom/Extension/modules/.../Vardefs/XXX.php" files. The results should be something like this:
```
Enabled:
$dictionary[<Módulo>]['fields'][<Campo>]['duplicate_merge']='disabled';
$dictionary[<Módulo>]['fields'][<Campo>]['duplicate_merge_dom_value']='0';
$dictionary[<Módulo>]['fields'][<Campo>]['merge_filter']='disabled';

Disabled:
$dictionary[<Módulo>]['fields'][<Campo>]['duplicate_merge']='enabled';
$dictionary[<Módulo>]['fields'][<Campo>]['duplicate_merge_dom_value']='1';
$dictionary[<Módulo>]['fields'][<Campo>]['merge_filter']='disabled';

Filter:
$dictionary[<Módulo>]['fields'][<Campo>]['duplicate_merge']='enabled';
$dictionary[<Módulo>]['fields'][<Campo>]['duplicate_merge_dom_value']='2';
$dictionary[<Módulo>]['fields'][<Campo>]['merge_filter']='enabled';

Default selected filter:
$dictionary[<Módulo>]['fields'][<Campo>]['duplicate_merge']='enabled';
$dictionary[<Módulo>]['fields'][<Campo>]['duplicate_merge_dom_value']='3';
$dictionary[<Módulo>]['fields'][<Campo>]['merge_filter']='selected';

Only filter:
$dictionary[<Módulo>]['fields'][<Campo>]['duplicate_merge']='disabled';
$dictionary[<Módulo>]['fields'][<Campo>]['duplicate_merge_dom_value']='4';
$dictionary[<Módulo>]['fields'][<Campo>]['merge_filter']='enabled';
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.