### PR TITLE
Fix duplicate results in basic search

### DIFF
--- a/lib/Search/BasicSearch/BasicSearchEngine.php
+++ b/lib/Search/BasicSearch/BasicSearchEngine.php
@@ -47,12 +47,13 @@ use DBManagerFactory;
 use JsonSchema\Exception\RuntimeException;
 use ListViewData;
 use LoggerManager;
+use SugarBean;
 use SuiteCRM\Exception\Exception;
 use SuiteCRM\Search\SearchEngine;
+use SuiteCRM\Search\SearchModules;
 use SuiteCRM\Search\SearchQuery;
 use SuiteCRM\Search\SearchResults;
 use VardefManager;
-use SuiteCRM\Search\SearchModules;
 
 if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
@@ -234,7 +235,9 @@ class BasicSearchEngine extends SearchEngine
                     $where = '';
                 }
 
-                $listData = $listViewData->getListViewData($seed, $where, 0, -1, [], $params);
+                $filter_fields = $this->buildFilterFields($seed);
+
+                $listData = $listViewData->getListViewData($seed, $where, 0, -1, $filter_fields, $params);
 
                 $moduleCounts[$moduleName] = $listData['pageData']['offsets']['total'];
 
@@ -248,5 +251,39 @@ class BasicSearchEngine extends SearchEngine
             'hits' => $moduleCounts,
             'modules' => $moduleResults
         ];
+    }
+
+    /**
+     * Build filter fields for list view data search
+     * @param SugarBean $bean
+     * @return array
+     */
+    protected function buildFilterFields(SugarBean $bean): array
+    {
+        $parsedFilterFields = array();
+        $excludedRelationshipFields = array();
+
+        foreach ($bean->field_defs as $fieldName => $fieldDefinition) {
+            $type = $fieldDefinition['type'] ?? '';
+            $listShow = $fieldDefinition['list-show'] ?? true;
+            if ($type === 'link' || $listShow === false) {
+                continue;
+            }
+
+            $linkType = $fieldDefinition['link_type'] ?? '';
+            if ($linkType === 'relationship_info') {
+                $excludedRelationshipFields[] = $fieldName;
+                $relationshipFields = $fieldDefinition['relationship_fields'] ?? [];
+                if (!empty($relationshipFields)) {
+                    foreach ($relationshipFields as $relationshipField) {
+                        $excludedRelationshipFields[] = $relationshipField;
+                    }
+                }
+            }
+
+            $parsedFilterFields[] = $fieldName;
+        }
+
+        return array_diff($parsedFilterFields, $excludedRelationshipFields);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
When record is linked with multiple activities / history records the basic search results get duplicated.
This is due to a known issue with `ListViewData` search, it requires the `filter_fields` in order to avoid the duplicates.

To fix this we are calculating the `filter_fields` for each module and passing those to the `ListViewData` search


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When record is linked with multiple activities / history records the basic search results get duplicated.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Link several activities / history entries to Leads, Contacts, etc records you are going to search for
2. Open global Search. Search for those records that have the activities attached.
3. There should be no duplicate lines in the results of each module. Meaning a same record should not display twice

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->