### PR TITLE
Fix #9455 - Popup metadata override removed when filtered

### DIFF
--- a/include/Popups/PopupSmarty.php
+++ b/include/Popups/PopupSmarty.php
@@ -264,6 +264,7 @@ class PopupSmarty extends ListViewSmarty
         $this->th->ss->assign('footerTpl', $this->footerTpl);
         $this->th->ss->assign('ASSOCIATED_JAVASCRIPT_DATA', 'var associated_javascript_data = '.$json->encode($associated_row_data). '; var is_show_fullname = '.$is_show_fullname.';');
         $this->th->ss->assign('module', $this->seed->module_dir);
+        $this->th->ss->assign('metadata', empty($_REQUEST['metadata']) ? '' : $_REQUEST['metadata']);
         $request_data = empty($_REQUEST['request_data']) ? '' : $_REQUEST['request_data'];
 
         $this->th->ss->assign('request_data', $request_data);

--- a/include/Popups/tpls/header.tpl
+++ b/include/Popups/tpls/header.tpl
@@ -71,6 +71,7 @@ function clearAll() {
 <input type="hidden" name="module" value="{$module}" />
 <input type="hidden" name="action" value="Popup" />
 <input type="hidden" name="query" value="true" />
+<input type="hidden" name="metadata" value="{$metadata}" />
 <input type="hidden" name="func_name" value="" />
 <input type="hidden" name="request_data" value="{$request_data}" />
 <input type="hidden" name="populate_parent" value="false" />


### PR DESCRIPTION
## Description
custom viewdef when set when opening a module popup, gets reset to the default popup def when the list is filtered, as the metadata value is not stored

## How To Test This
See the viewdef overrides on popup don't get overwritten 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->