### PR TITLE
Fix #9466 - Activity subpanel can't be sorted by date_due/date_end

### DIFF
--- a/modules/Accounts/metadata/subpaneldefs.php
+++ b/modules/Accounts/metadata/subpaneldefs.php
@@ -64,15 +64,15 @@ $layout_defs['Accounts'] = array(
             ),
 
             'collection_list' => array(
+		'meetings' => array(
+                    'module' => 'Meetings',
+                    'subpanel_name' => 'ForActivities',
+                    'get_subpanel_data' => 'meetings',
+                ),
                 'tasks' => array(
                     'module' => 'Tasks',
                     'subpanel_name' => 'ForActivities',
                     'get_subpanel_data' => 'tasks',
-                ),
-                'meetings' => array(
-                    'module' => 'Meetings',
-                    'subpanel_name' => 'ForActivities',
-                    'get_subpanel_data' => 'meetings',
                 ),
                 'calls' => array(
                     'module' => 'Calls',
@@ -99,15 +99,15 @@ $layout_defs['Accounts'] = array(
             ),
 
             'collection_list' => array(
+		'meetings' => array(
+                    'module' => 'Meetings',
+                    'subpanel_name' => 'ForHistory',
+                    'get_subpanel_data' => 'meetings',
+                ),
                 'tasks' => array(
                     'module' => 'Tasks',
                     'subpanel_name' => 'ForHistory',
                     'get_subpanel_data' => 'tasks',
-                ),
-                'meetings' => array(
-                    'module' => 'Meetings',
-                    'subpanel_name' => 'ForHistory',
-                    'get_subpanel_data' => 'meetings',
                 ),
                 'calls' => array(
                     'module' => 'Calls',

--- a/modules/Calls/metadata/subpanels/ForActivities.php
+++ b/modules/Calls/metadata/subpanels/ForActivities.php
@@ -84,8 +84,6 @@ $subpanel_layout = [
         'date_end' => [
             'vname' => 'LBL_LIST_DUE_DATE',
             'width' => '10%',
-            'alias' => 'date_due',
-            'sort_by' => 'date_due',
         ],
         'assigned_user_name' => [
             'name' => 'assigned_user_name',

--- a/modules/Calls/metadata/subpanels/ForHistory.php
+++ b/modules/Calls/metadata/subpanels/ForHistory.php
@@ -106,8 +106,6 @@ $subpanel_layout = [
         'date_end' => [
             'vname' => 'LBL_LIST_DUE_DATE',
             'width' => '10%',
-            'alias' => 'date_due',
-            'sort_by' => 'date_due',
         ],
         'assigned_user_name' => [
             'name' => 'assigned_user_name',

--- a/modules/Contacts/metadata/subpaneldefs.php
+++ b/modules/Contacts/metadata/subpaneldefs.php
@@ -62,6 +62,11 @@ $layout_defs['Contacts'] = array(
                 array('widget_class' => 'SubPanelTopComposeEmailButton'),
             ),
             'collection_list' => array(
+		'meetings' => array(
+                    'module' => 'Meetings',
+                    'subpanel_name' => 'ForActivities',
+                    'get_subpanel_data' => 'meetings',
+                ),
                 'tasks' => array(
                     'module' => 'Tasks',
                     'subpanel_name' => 'ForActivities',
@@ -71,11 +76,6 @@ $layout_defs['Contacts'] = array(
                     'module' => 'Tasks',
                     'subpanel_name' => 'ForActivities',
                     'get_subpanel_data' => 'tasks_parent',
-                ),
-                'meetings' => array(
-                    'module' => 'Meetings',
-                    'subpanel_name' => 'ForActivities',
-                    'get_subpanel_data' => 'meetings',
                 ),
                 'calls' => array(
                     'module' => 'Calls',
@@ -102,6 +102,11 @@ $layout_defs['Contacts'] = array(
             ),
 
             'collection_list' => array(
+		'meetings' => array(
+                    'module' => 'Meetings',
+                    'subpanel_name' => 'ForHistory',
+                    'get_subpanel_data' => 'meetings',
+                ),
                 'tasks' => array(
                     'module' => 'Tasks',
                     'subpanel_name' => 'ForHistory',
@@ -111,11 +116,6 @@ $layout_defs['Contacts'] = array(
                     'module' => 'Tasks',
                     'subpanel_name' => 'ForHistory',
                     'get_subpanel_data' => 'tasks_parent',
-                ),
-                'meetings' => array(
-                    'module' => 'Meetings',
-                    'subpanel_name' => 'ForHistory',
-                    'get_subpanel_data' => 'meetings',
                 ),
                 'calls' => array(
                     'module' => 'Calls',

--- a/modules/Meetings/metadata/subpanels/ForActivities.php
+++ b/modules/Meetings/metadata/subpanels/ForActivities.php
@@ -86,8 +86,6 @@ $subpanel_layout = [
         'date_end' => [
             'vname' => 'LBL_LIST_DUE_DATE',
             'width' => '10%',
-            'alias' => 'date_due',
-            'sort_by' => 'date_due',
         ],
         'assigned_user_name' => [
             'name' => 'assigned_user_name',

--- a/modules/Meetings/metadata/subpanels/ForHistory.php
+++ b/modules/Meetings/metadata/subpanels/ForHistory.php
@@ -107,8 +107,6 @@ $subpanel_layout = [
         'date_end' => [
             'vname' => 'LBL_LIST_DUE_DATE',
             'width' => '10%',
-            'alias' => 'date_due',
-            'sort_by' => 'date_due',
         ],
         'assigned_user_name' => [
             'name' => 'assigned_user_name',


### PR DESCRIPTION
Closes #9466

## Description
As described in the Issue, the Activities subpanel can't be sorted by the field Due Date. 

In this PR we introduce the changes specified in the issue. Thare are:
- Removing the alias of the field date_end in Calls and Meetings in Activity and History subpanels.
- Sorting the collection list of the modules Contacts and Accounts in Activity and History subpanels.

## Motivation and Context
This change makes the subpanels able to sort by the "Due date" field.

## How To Test This
1. Go to the Activity subpanel of any module
2. Try sorting by Due Date
3. Check that isn't working

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->