### PR TITLE
Fix #9470 - Set fdow in Calendar popup date selector for range search and MassUpdate

### DIFF
--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -1238,17 +1238,17 @@ EOQ;
      */
     public function addDate($displayname, $varname)
     {
-        global $timedate;
+        global $timedate, $app_strings, $app_list_strings, $theme, $current_user;
         //letrium ltd
         $displayname = addslashes($displayname);
         $userformat = '(' . $timedate->get_user_date_format() . ')';
         $cal_dateformat = $timedate->get_cal_date_format();
-        global $app_strings, $app_list_strings, $theme;
+	$cal_fdow = $current_user->get_first_day_of_week() ? $current_user->get_first_day_of_week() : '0';
 
         $javascriptend = <<<EOQ
 		 <script type="text/javascript">
 		Calendar.setup ({
-			inputField : "${varname}jscal_field", daFormat : "$cal_dateformat", ifFormat : "$cal_dateformat", showsTime : false, button : "${varname}jscal_trigger", singleClick : true, step : 1, weekNumbers:false
+			inputField : "${varname}jscal_field", daFormat : "$cal_dateformat", ifFormat : "$cal_dateformat", showsTime : false, button : "${varname}jscal_trigger", singleClick : true, step : 1, startWeekday: $cal_fdow, weekNumbers:false
 		});
 		</script>
 EOQ;
@@ -1296,10 +1296,10 @@ EOQ;
      */
     public function addDatetime($displayname, $varname)
     {
-        global $timedate;
+        global $timedate, $app_strings, $app_list_strings, $theme, $current_user;
         $userformat = $timedate->get_user_time_format();
         $cal_dateformat = $timedate->get_cal_date_format();
-        global $app_strings, $app_list_strings, $theme;
+	$cal_fdow = $current_user->get_first_day_of_week() ? $current_user->get_first_day_of_week() : '0';
 
         $javascriptend = <<<EOQ
 		 
@@ -1337,6 +1337,7 @@ EOQ;
 			button : "{$varname}_trigger",
 			singleClick : true,
 			step : 1,
+			startWeekday: $cal_fdow,
 			weekNumbers:false
 			});
 

--- a/include/SugarFields/Fields/Datetimecombo/RangeSearchForm.tpl
+++ b/include/SugarFields/Fields/Datetimecombo/RangeSearchForm.tpl
@@ -101,6 +101,7 @@ button : "start_range_{$id}_trigger",
 singleClick : true,
 dateStr : "{$date_value}",
 step : 1,
+startWeekday: {$CALENDAR_FDOW|default:'0'},
 weekNumbers:false
 {rdelim}
 );
@@ -126,6 +127,7 @@ button : "end_range_{$id}_trigger",
 singleClick : true,
 dateStr : "{$date_value}",
 step : 1,
+startWeekday: {$CALENDAR_FDOW|default:'0'},
 weekNumbers:false
 {rdelim}
 );


### PR DESCRIPTION
Closes #9470

## Description
As described in the issue, the calendar popup doesn't display the user defined first day of the week for the Massupdate date selector fields and range search.

This PR adds the logic to return the user fdow defined parameter and set it in the Calendar setup of the affected templates.

## Motivation and Context
With this change, the calendar will always display the user defined fdow.

## How To Test This
1. Set Monday as First day of the Week
2. Go to Contact Mass update view
3. Open the Calendar of the date field
4. Check that the first day of the week is Sunday

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
