### PR TITLE
Fix #9473 - Missing item "Survey" in campainglog_activity_type_dom

### DIFF
--- a/include/language/en_us.lang.php
+++ b/include/language/en_us.lang.php
@@ -906,6 +906,7 @@ $app_list_strings = array(
         'lead' => 'Leads Created',
         'contact' => 'Contacts Created',
         'blocked' => 'Suppressed by address or domain',
+        'Survey' => 'Survey answered',
     ),
 
     'campainglog_target_type_dom' => array(


### PR DESCRIPTION
Closes #9473

## Description
As described in the Issue, there is missing an item in the campainglog_activity_type_dom list.

This PR adds the missing item to the language file.

## Motivation and Context
With this change, the item will appear correctly

## How To Test This
1. Create a Survey
2. Create a Campaign Survey Type
3. Send the campaign
4. Answer the Survey
5. Check the Campaign log for the activity Type.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
