### PR TITLE
Fix #9061 - Priority to label changes from Studio

### DIFF
--- a/include/SugarObjects/LanguageManager.php
+++ b/include/SugarObjects/LanguageManager.php
@@ -198,8 +198,8 @@ class LanguageManager
         $lang_paths = array(
             'modules/' . $module . '/language/' . $lang . '.lang.php',
             'modules/' . $module . '/language/' . $lang . '.lang.override.php',
-            'custom/modules/' . $module . '/language/' . $lang . '.lang.php',
             'custom/modules/' . $module . '/Ext/Language/' . $lang . '.lang.ext.php',
+            'custom/modules/' . $module . '/language/' . $lang . '.lang.php',
         );
 
         #27023, if this module template language file was not attached , get the template from this module vardef cache file if exsits and load the template language files.


### PR DESCRIPTION
Solves part of #9061 

## Description
As mentioned in the issue, if some labels are defined using the Extension framework, a user can't override them in Studio. This is because the Extension Framework changes have more priority that the front-end changes.

This PR changes the priority that the system access the available language files, so the user Studio changes are the most priority ones.

We have been testing it since SugarCRM and it works just fine.

As a suggestion for another PR,  there could be included one extra priority label for those cases where the code-written labels can't be override. Perhaps there could be here: 'custom/modules/' . $module . '/language/' . $lang . '.lang**.override.**php',

## Motivation and Context
User's must be able to defined their own labels in any case.

## How To Test This
1. Create a custom field via code with label and save in Extension directory
2. Update label in studio

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change):
**User's that previously tried to make changes in Studio, will then see those changes appearing after merging this PR**

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
