### PR TITLE
Fixed #2857 - No dynamic refreshing in dashboard

### DIFF
--- a/themes/SuiteP/include/Dashlets/DashletHeader.tpl
+++ b/themes/SuiteP/include/Dashlets/DashletHeader.tpl
@@ -14,7 +14,7 @@
                         <a href="javascript:void(0)" title="{$DASHLET_BUTTON_ARIA_EDIT}" aria-label="{$DASHLET_BUTTON_ARIA_EDIT}" onclick="SUGAR.mySugar.configureDashlet('{$DASHLET_ID}'); return false;">
                             <span class="suitepicon suitepicon-action-edit"></span>
                         </a>
-    <a href="javascript:void(0)" title="{$DASHLET_BUTTON_ARIA_REFRESH}" aria-label="{$DASHLET_BUTTON_ARIA_REFRESH}" onclick="SUGAR.mySugar.retrieveCurrentPage(); return false;">
+    <a href="javascript:void(0)" title="{$DASHLET_BUTTON_ARIA_REFRESH}" aria-label="{$DASHLET_BUTTON_ARIA_REFRESH}" onclick="SUGAR.mySugar.retrieveDashlet('{$DASHLET_ID}'); return false;">
         <span class="suitepicon suitepicon-action-reload"></span>
     </a>
 <a href="javascript:void(0)" title="{$DASHLET_BUTTON_ARIA_DELETE}" aria-label="{$DASHLET_BUTTON_ARIA_DELETE}" onclick="SUGAR.mySugar.deleteDashlet('{$DASHLET_ID}'); return false;">


### PR DESCRIPTION
The reload icon in every dashlet was reloading all the dashboard.

With my fix it reloads just the dashlet requested as in previous versions of suiteCRM.

<!--- Provide a general summary of your changes in the Title above -->

## Description
My code just replace the onclick function in the themes/SuiteP/include/Dashlets/DashletHeader.tpl

## Motivation and Context
User use to have a lot of dashlets in their dashboards and performance in big databeses is penalized. By other hand users has no way to understand which of their dashlets are slow. Reloading dinamicaly just the targeted dashlet they can experiment to remove slow and not so useful dashlets. 

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->