### PR TITLE
fix#9480 slow to get imap mailboxex with a million records in emails …

### DIFF
--- a/modules/Emails/vardefs.php
+++ b/modules/Emails/vardefs.php
@@ -754,6 +754,11 @@ $dictionary['Email'] = array(
             'type' => 'index',
             'fields' => array('category_id')
         ),
+        array(
+            'name' => 'idx_email_uid',
+            'type' => 'index',
+            'fields' => array('uid')
+        ),
     ) // end indices
 );
 


### PR DESCRIPTION
Adds indice idx_email_uid to the emails table in order to improve performance when listing imap mail boxes in environments with a million of records in the email table.
