### PR TITLE
Fixed #9485 - Added default empty value for where clause

### DIFF
--- a/include/export_utils.php
+++ b/include/export_utils.php
@@ -546,6 +546,8 @@ function generateSearchWhere($module, $query)
     }
     $searchForm->populateFromArray(json_decode(html_entity_decode($query), true));
     $where_clauses = $searchForm->generateSearchWhere(true, $module);
+
+    $where = "";
     if (count($where_clauses) > 0) {
         $where = '('. implode(' ) AND ( ', $where_clauses) . ')';
     }


### PR DESCRIPTION
## Description
The fix helps to eliminate the number of warn logs because of "Undefined variable"

## How To Test This
It can be tested with using the export functionality.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.