### PR TITLE
Fixed #9486 - Introduced new variable instead of direct use of the function

### DIFF
--- a/include/export_utils.php
+++ b/include/export_utils.php
@@ -544,7 +544,8 @@ function generateSearchWhere($module, $query)
         $searchForm = new SearchForm($seed, $module);
         $searchForm->setup($searchdefs, $searchFields, 'SearchFormGeneric.tpl');
     }
-    $searchForm->populateFromArray(json_decode(html_entity_decode($query), true));
+    $decodedQuery = json_decode(html_entity_decode($query), true);
+    $searchForm->populateFromArray($decodedQuery);
     $where_clauses = $searchForm->generateSearchWhere(true, $module);
     if (count($where_clauses) > 0) {
         $where = '('. implode(' ) AND ( ', $where_clauses) . ')';


### PR DESCRIPTION
## Description
The fix helps to eliminate the number of warn logs because of "`array_keys()` expects parameter 1 to be array"
`SearchForm.populateFromArray` expects the parameter to be passed by reference.

## How To Test This
It can be tested with using the export functionality.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.