### PR TITLE
Fixed #9489 - Remove cookies from $_REQUEST super global variable

### DIFF
--- a/include/ListView/ListViewDisplay.php
+++ b/include/ListView/ListViewDisplay.php
@@ -589,7 +589,7 @@ class ListViewDisplay
         global $app_strings;
         unset($_REQUEST[session_name()]);
         unset($_REQUEST['PHPSESSID']);
-        $current_query_by_page = htmlentities(json_encode($_REQUEST));
+        $current_query_by_page = htmlentities(json_encode(array_diff_key($_REQUEST, $_COOKIE)));
 
         $js = <<<EOF
             if(sugarListView.get_checks_count() < 1) {

--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -111,7 +111,7 @@ class MassUpdate
         unset($_REQUEST['current_query_by_page']);
         unset($_REQUEST[session_name()]);
         unset($_REQUEST['PHPSESSID']);
-        $query = json_encode($_REQUEST);
+        $query = json_encode(array_diff_key($_REQUEST, $_COOKIE));
 
         if (!isset($_REQUEST['module'])) {
             LoggerManager::getLogger()->warn('Undefined index: module');

--- a/modules/Accounts/AccountsListViewSmarty.php
+++ b/modules/Accounts/AccountsListViewSmarty.php
@@ -16,7 +16,7 @@ class AccountsListViewSmarty extends ListViewSmarty
         global $app_strings;
         unset($_REQUEST[session_name()]);
         unset($_REQUEST['PHPSESSID']);
-        $current_query_by_page = htmlentities(json_encode($_REQUEST));
+        $current_query_by_page = htmlentities(json_encode(array_diff_key($_REQUEST, $_COOKIE)));
 
         $js = <<<EOF
              if(sugarListView.get_checks_count() < 1) {


### PR DESCRIPTION
## Description
If request_order contains cookies as well, like for example "GPC" then the cookie values end up in $current_query_by_page and hence allowing other cookies from the same domain to break SuiteCRM with their json content during json decoding.

see: https://github.com/salesagility/SuiteCRM/issues/9489

## How To Test This

1. Create a filter on Contacts
2. Select all the filtered elements and export them -> you should get the proper export
3. Introduce a cookie to the domain via the browser for example with the value: {"cm":true,"all1st":true,"closed":false}
4. Select all the filtered elements again and export them -> you should get the full list in the export instead of the filtered elements

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->