### PR TITLE
Fix #9496 - Cannot save dropdown values

### DIFF
--- a/modules/Studio/DropDowns/DropDownHelper.php
+++ b/modules/Studio/DropDowns/DropDownHelper.php
@@ -148,16 +148,16 @@ class DropDownHelper
                 //only if the value has changed or does not exist do we want to add it this way
                 if (!isset($my_list_strings[$dropdown_name][$key]) || strcmp($my_list_strings[$dropdown_name][$key], $value) != 0) {
                     //clear out the old value
-                    $contents = preg_replace($this->getPatternMatchGlobal($dropdown_name), "\n", $contents);
-                    $contents = preg_replace($this->getPatternMatch($dropdown_name), "\n", $contents);
+                    $contents = preg_replace(self::getPatternMatchGlobal($dropdown_name), "\n", $contents);
+                    $contents = preg_replace(self::getPatternMatch($dropdown_name), "\n", $contents);
                     //add the new ones
                     $contents .= "\n\$app_list_strings['$dropdown_name']['$key']=" . var_export_helper($value) . ";";
                 }
             }
         } else {
             //clear out the old value
-            $contents = preg_replace($this->getPatternMatchGlobal($dropdown_name), "\n", $contents);
-            $contents = preg_replace($this->getPatternMatch($dropdown_name), "\n", $contents);
+            $contents = preg_replace(self::getPatternMatchGlobal($dropdown_name), "\n", $contents);
+            $contents = preg_replace(self::getPatternMatch($dropdown_name), "\n", $contents);
             //add the new ones
             $contents .= "\n\$app_list_strings['$dropdown_name']=" . var_export_helper($dropdown) . ";";
         }
@@ -175,13 +175,13 @@ class DropDownHelper
         // ~~~~~~~~
     }
 
-    public function getPatternMatchGlobal($dropdown_name)
+    public static function getPatternMatchGlobal($dropdown_name)
     {
         return '/\s*\$GLOBALS\s*\[\s*\'app_list_strings\s*\'\s*\]\[\s*\''
             . $dropdown_name.'\'\s*\]\s*=\s*array\s*\([^\)]*\)\s*;\s*/ism';
     }
 
-    public function getPatternMatch($dropdown_name)
+    public static function getPatternMatch($dropdown_name)
     {
         return '/\s*\$app_list_strings\s*\[\s*\''.$dropdown_name.'\'\s*\]\s*=\s*array\s*\([^\)]*\)\s*;\s*/ism';
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This address a issue where the statically called saveDropDown function, used not static references and therefore caused a 500 error when called and affect thing like renaming modules

## How To Test This
See you can now save dropdowns and change modules name without an error

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->