### PR TITLE
Fix #9499 - Add View Survey Responses Menu item

### DIFF
--- a/modules/Surveys/Menu.php
+++ b/modules/Surveys/Menu.php
@@ -61,3 +61,12 @@ if (ACLController::checkAccess('Surveys', 'list', true)) {
             'Surveys'
         );
 }
+if (ACLController::checkAccess('SurveyResponses', 'list', true)) {
+    $module_menu[] =
+        array(
+            "index.php?module=SurveyResponses&action=index&return_module=Surveys&return_action=index",
+            translate('LNK_LIST', 'SurveyResponses'),
+            "List",
+            'SurveyResponses'
+        );
+} 


### PR DESCRIPTION
Resolve #9499 

## Description
In this PR, the menu item "View Survey Responses" is added to the Surveys module

## Motivation and Context
In this way users will be able to access the Survey Responses ListView easily.

## How To Test This
1- Go to Surveys module
2- Check that the Menu item "View Survey Responses" appears

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->