### PR TITLE
Fixed #9514 - require echoes a whitespace

### DIFF
--- a/include/DetailView/DetailView2.php
+++ b/include/DetailView/DetailView2.php
@@ -95,7 +95,12 @@ class DetailView2 extends EditView
             $this->showVCRControl = !$GLOBALS['sugar_config']['disable_vcr'];
         }
         if (!empty($this->metadataFile) && file_exists($this->metadataFile)) {
+            // issue_9514 ( require echoes a whitespace, so we will discard that whitespace )
+            ob_start();
             require($this->metadataFile);
+            $discardableContent = ob_get_contents();
+            ob_end_clean();
+            unset( $discardableContent );
         } else {
             //If file doesn't exist we create a best guess
             if (!file_exists("modules/$this->module/metadata/$metadataFileName.php") &&


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Under an ob_start block apparently require echoes a whitespace or CRLF or 0xFEFF string, this bugfix solves that problem

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Go to any module's detail view, sometimes the main Title of the detail shifts down (bringing the whole page down), but after this bugfix it remains consistent

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->