### PR TITLE
Fix #4075 - No way to add email signature after adding email template

### DIFF
--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -349,7 +349,7 @@
     };
 
 
-    self.updateSignature = function () {
+    $.fn.EmailsComposeView.updateSignature = self.updateSignature = function () {
       var inboundId = $('#from_addr_name').find('option:selected').attr('inboundId');
       if (inboundId === undefined) {
         console.warn('Unable to retrieve selected inbound id in the "From" field.');
@@ -1340,6 +1340,7 @@
         $.fn.EmailsComposeView.loadAttachmentDataFromAjaxResponse(response);
         $(form).find('[name="name"]').val(response.data.subject);
         tinymce.activeEditor.setContent(response.data.body_from_html, {format: 'html'});
+        $.fn.EmailsComposeView.updateSignature();
       });
       set_return(args);
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Populates `self.updateSignature = function ()` in a superior scope in order to be called in `$.fn.EmailsComposeView.onTemplateSelect`

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Steps to reproduce and test are in issue #4075

## Motivation and Context
The signature should stay after adding the template

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->