### PR TITLE
Fix #9326 - Adding decimal and float case option for export to use user-defined…

### DIFF
--- a/include/export_utils.php
+++ b/include/export_utils.php
@@ -273,6 +273,13 @@ function export($type, $records = null, $members = false, $sample=false)
                         require_once('modules/Currencies/Currency.php');
                         $value = currency_format_number($value);
                         break;
+                    // Fix Issue 9326 - Adding Decimal and Float case to retrieve user-defined decimal separator
+                    case 'decimal':
+                    case 'float':
+                        $user_dec_sep = (!empty($current_user->id) ? $current_user->getPreference('dec_sep') : null);
+                        $dec_sep = empty($user_dec_sep) ? $sugar_config['default_decimal_seperator'] : $user_dec_sep;
+                        $value = str_replace('.', $dec_sep, $value);
+                        break;
 
                     //if our value is a datetime field, then apply the users locale
                     case 'datetime':


### PR DESCRIPTION
Rebased branch to hotfix from #9327

Closes #9326 

When exporting a record for any module that contains a Decimal field, the content isn't exported properly if the decimal separator is different than the global separator

## Description
When using the function export of a record of any module that contains a Decimal field, it exports the value using the decimal separator defined globally, instead of using the user-defined decimal separator

## Motivation and Context
I feel this is an important functionality for any user working with export.

## How To Test This
1. Add a Decimal field in a EditView of any module
2. Create a record in that module filling the Decimal field
3. Change the user-defined Decimal separator to something else (like "|" )
4. Export the created record and see that the value of the field doesn't contained the user-defined decimal separator

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.