### PR TITLE
Fix #9427 - Adding missing help popup help strings in Studio

### DIFF
--- a/modules/ModuleBuilder/language/en_us.lang.php
+++ b/modules/ModuleBuilder/language/en_us.lang.php
@@ -615,6 +615,10 @@ $mod_strings = array(
 
 //POPUP HELP
     'LBL_POPHELP_FIELD_DATA_TYPE' => 'Select the appropriate data type based on the type of data that will be entered into the field.',
+    'LBL_POPHELP_IMPORTABLE' => '<b>Yes</b>: The field will be included in an import operation.<br><b>No</b>: The field will not be included in an import.<br><b>Required</b>: A value for the field must be provided in any import.',
+    'LBL_POPHELP_IMAGE_WIDTH' => 'Enter a number for Width, as measured in pixels.<br> The uploaded image will be scaled to this Width.',
+    'LBL_POPHELP_IMAGE_HEIGHT' => 'Enter a number for the Height, as measured in pixels.<br> The uploaded image will be scaled to this Height.',
+    'LBL_POPHELP_DUPLICATE_MERGE' => '<b>Enabled</b>: The field will appear in the Merge Duplicates feature, but will not be available to use for the filter conditions in the Find Duplicates feature.<br><b>Disabled</b>: The field will not appear in the Merge Duplicates feature, and will not be available to use for the filter conditions in the Find Duplicates feature.',
 
 //Revert Module labels
     'LBL_RESET' => 'Reset',


### PR DESCRIPTION
Rebased branch to hotfix from #9428

Closes #9427 

## Description
As described in the Issue, some popup help strings are missing. 

This PR adds the missing help strings.

## Motivation and Context
The popup help should contain some info

## How To Test This
Pull the PR, delete cache, edit a field in Studio and check that the Info points display the strings
![Selection_396](https://user-images.githubusercontent.com/61022311/149808903-96b1938d-d41a-4855-88ce-4bda4d662dda.png)



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.