### PR TITLE
Fix #9435 - Dropdown doesn't return empty selected value

### DIFF
--- a/modules/AOW_WorkFlow/aow_utils.php
+++ b/modules/AOW_WorkFlow/aow_utils.php
@@ -530,11 +530,12 @@ function getModuleField(
         if (isset($fieldlist[$name]['options']) && is_array($fieldlist[$name]['options']) && !isset($fieldlist[$name]['options'][''])) {
             $fieldlist[$name]['options'][''] = '';
         }
-
+	    // Fix #9435 - The editview of a workflow is built using a Smarty template. When editing an existing workflow with an action
+        // that sets to blank an enum field which has a not blank default value, the template does not show the blank value (as expected)
+        // but the default value. In order to properly show the expected blank value, we hack the vardef definition overriding default value 
+        // with blank value when the stored workflow value (now in $value) is blank.
         if ($fieldlist[$name]['type'] == 'enum' || $fieldlist[$name]['type'] == 'multienum' || $fieldlist[$name]['type'] == 'dynamicenum') {
-            if (($params['value_set'] ?? '') === true && $value === "") {
-                $fieldlist[$name]['default'] = $value;
-            }
+            $fieldlist[$name]['default'] = $value === "" ? $value : $fieldlist[$name]['default'];
         }
     }
 


### PR DESCRIPTION
Rebased branch to hotfix from #9436

Closes #9435 

## Description
As described in the issue, the editview of a workflow is built using a Smarty template. When editing an existing workflow with an action that sets to blank an enum field which has a not blank default value, the template does not show the blank value (as expected) but the default value. 

In order to properly show the expected blank value, we hack the vardef definition overriding default value with blank value when the stored workflow value (now in $value) is blank.

## Motivation and Context
This can be confusing for the users and it needs to be fixed.

## How To Test This
1. Set any item as a default value for the dropdown Category in Documents
2. Create a Workflow based in Documents
3. Add condition of the field Category selecting the empty value
4. Save and open the workflow, check that the value displayed in the condition is the empty one.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.