### PR TITLE
Fix #9438 - Adding Action keyword to fieldname exception

### DIFF
--- a/modules/ModuleBuilder/views/view.modulefield.php
+++ b/modules/ModuleBuilder/views/view.modulefield.php
@@ -133,7 +133,7 @@ class ViewModulefield extends SugarView
             'DATE','VARCHAR','VARCHAR2','NVARCHAR2','CHAR','NCHAR','NUMBER','PLS_INTEGER','BINARY_INTEGER','LONG','TIMESTAMP',
             'INTERVAL','RAW','ROWID','UROWID','MLSLABEL','CLOB','NCLOB','BLOB','BFILE','XMLTYPE',
             //SugarCRM reserved
-            'ID', 'ID_C', 'PARENT_NAME', 'PARENT_ID',
+            'ID', 'ID_C', 'PARENT_NAME', 'PARENT_ID', 'ACTION',
             );
 
 


### PR DESCRIPTION
Rebased branch to hotfix from #9439 

Closes #9438 

## Description
As described in the issue, the keyword 'action' shouldn't be allowed for field name creation.

## Motivation and Context
This can cause problem to users that aren't aware.

## How To Test This
1- Go to Module builder
2- Try adding a field called "action" to any module

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.