### PR TITLE
Fix #9440 - Forcing default null value for numeric core fields.

### DIFF
--- a/include/database/DBManager.php
+++ b/include/database/DBManager.php
@@ -2209,7 +2209,7 @@ abstract class DBManager
                         return 0;
                     }
 
-                    return (int)$val;
+                    return $val === '' ? 'NULL' : (int)$val; // Fix #9440 - Forcing default null value for numeric fields.
                 case 'bigint':
                     $val = (float)$val;
                     if (!empty($fieldDef['required']) && $val == false) {
@@ -2230,7 +2230,7 @@ abstract class DBManager
                         return 0;
                     }
 
-                    return (float)$val;
+                    return $val === '' ? 'NULL' : (float)$val; // Fix #9440 - Forcing default null value for numeric fields.
                 case 'time':
                 case 'date':
                     // empty date can't be '', so convert it to either NULL or empty date value


### PR DESCRIPTION
Rebased branch to hotfix from #9441 

Closes #9440 

## Description
As described in the issue, non-custom/core non-required numeric fields aren't saving properly a default empty value in newly created modules.

## Motivation and Context
(int) and (float) summoning always return 0 if the value is empty. Therefore we add a condition to return "null" if it's empty.

## How To Test This
1. Create a new module in Module Builder
2. Add an Integer or Decimal field
3. Add the field to Edit and Detail View
4. Deploy module
5. Create a new record to the module, filling only the required name
6. Check that the numeric field has an empty value

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.