### PR TITLE
Fix #9468 - Adding Security Suite subpanels to new custom modules

### DIFF
--- a/include/SugarObjects/templates/basic/metadata/metafiles.php
+++ b/include/SugarObjects/templates/basic/metadata/metafiles.php
@@ -46,4 +46,5 @@ $metafiles[$module_name] = array(
     'searchdefs' => 'modules/' . $module_name . '/metadata/searchdefs.php',
     'popupdefs' => 'modules/' . $module_name . '/metadata/popupdefs.php',
     'searchfields' => 'modules/' . $module_name . '/metadata/SearchFields.php',
+    'subpaneldefs' => 'modules/' . $module_name . '/metadata/subpaneldefs.php',
 );

--- a/include/SugarObjects/templates/basic/metadata/subpaneldefs.php
+++ b/include/SugarObjects/templates/basic/metadata/subpaneldefs.php
@@ -1,0 +1,14 @@
+<?php
+$module_name = '<module_name>';
+$layout_defs[$module_name]['subpanel_setup']['securitygroups'] = array(
+    'top_buttons' => array(array('widget_class' => 'SubPanelTopSelectButton', 'popup_module' => 'SecurityGroups', 'mode' => 'MultiSelect')),
+    'order' => 900,
+    'sort_by' => 'name',
+    'sort_order' => 'asc',
+    'module' => 'SecurityGroups',
+    'refresh_page' => 1,
+    'subpanel_name' => 'default',
+    'get_subpanel_data' => 'SecurityGroups',
+    'add_subpanel_data' => 'securitygroup_id',
+    'title_key' => 'LBL_SECURITYGROUPS_SUBPANEL_TITLE',
+);

--- a/include/SugarObjects/templates/company/metadata/metafiles.php
+++ b/include/SugarObjects/templates/company/metadata/metafiles.php
@@ -46,4 +46,5 @@ $metafiles[$module_name] = array(
     'searchdefs' => 'modules/' . $module_name . '/metadata/searchdefs.php',
     'popupdefs' => 'modules/' . $module_name . '/metadata/popupdefs.php',
     'searchfields' => 'modules/' . $module_name . '/metadata/SearchFields.php',
+    'subpaneldefs' => 'modules/' . $module_name . '/metadata/subpaneldefs.php',
 );

--- a/include/SugarObjects/templates/company/metadata/subpaneldefs.php
+++ b/include/SugarObjects/templates/company/metadata/subpaneldefs.php
@@ -1,0 +1,14 @@
+<?php
+$module_name = '<module_name>';
+$layout_defs[$module_name]['subpanel_setup']['securitygroups'] = array(
+    'top_buttons' => array(array('widget_class' => 'SubPanelTopSelectButton', 'popup_module' => 'SecurityGroups', 'mode' => 'MultiSelect'),),
+    'order' => 900,
+    'sort_by' => 'name',
+    'sort_order' => 'asc',
+    'module' => 'SecurityGroups',
+    'refresh_page' => 1,
+    'subpanel_name' => 'default',
+    'get_subpanel_data' => 'SecurityGroups',
+    'add_subpanel_data' => 'securitygroup_id',
+    'title_key' => 'LBL_SECURITYGROUPS_SUBPANEL_TITLE',
+);

--- a/include/SugarObjects/templates/file/metadata/metafiles.php
+++ b/include/SugarObjects/templates/file/metadata/metafiles.php
@@ -50,4 +50,5 @@ $metafiles[$module_name] = array(
     'searchdefs' => 'modules/' . $module_name . '/metadata/searchdefs.php',
     'popupdefs' => 'modules/' . $module_name . '/metadata/popupdefs.php',
     'searchfields' => 'modules/' . $module_name . '/metadata/SearchFields.php',
+    'subpaneldefs' => 'modules/' . $module_name . '/metadata/subpaneldefs.php',
 );

--- a/include/SugarObjects/templates/file/metadata/subpaneldefs.php
+++ b/include/SugarObjects/templates/file/metadata/subpaneldefs.php
@@ -1,0 +1,14 @@
+<?php
+$module_name = '<module_name>';
+$layout_defs[$module_name]['subpanel_setup']['securitygroups'] = array(
+    'top_buttons' => array(array('widget_class' => 'SubPanelTopSelectButton', 'popup_module' => 'SecurityGroups', 'mode' => 'MultiSelect')),
+    'order' => 900,
+    'sort_by' => 'name',
+    'sort_order' => 'asc',
+    'module' => 'SecurityGroups',
+    'refresh_page' => 1,
+    'subpanel_name' => 'default',
+    'get_subpanel_data' => 'SecurityGroups',
+    'add_subpanel_data' => 'securitygroup_id',
+    'title_key' => 'LBL_SECURITYGROUPS_SUBPANEL_TITLE',
+);

--- a/include/SugarObjects/templates/issue/metadata/metafiles.php
+++ b/include/SugarObjects/templates/issue/metadata/metafiles.php
@@ -46,4 +46,5 @@ $metafiles[$module_name] = array(
     'searchdefs' => 'modules/' . $module_name . '/metadata/searchdefs.php',
     'popupdefs' => 'modules/' . $module_name . '/metadata/popupdefs.php',
     'searchfields' => 'modules/' . $module_name . '/metadata/SearchFields.php',
+    'subpaneldefs' => 'modules/' . $module_name . '/metadata/subpaneldefs.php',
 );

--- a/include/SugarObjects/templates/issue/metadata/subpaneldefs.php
+++ b/include/SugarObjects/templates/issue/metadata/subpaneldefs.php
@@ -1,0 +1,14 @@
+<?php
+$module_name = '<module_name>';
+$layout_defs[$module_name]['subpanel_setup']['securitygroups'] = array(
+    'top_buttons' => array(array('widget_class' => 'SubPanelTopSelectButton', 'popup_module' => 'SecurityGroups', 'mode' => 'MultiSelect')),
+    'order' => 900,
+    'sort_by' => 'name',
+    'sort_order' => 'asc',
+    'module' => 'SecurityGroups',
+    'refresh_page' => 1,
+    'subpanel_name' => 'default',
+    'get_subpanel_data' => 'SecurityGroups',
+    'add_subpanel_data' => 'securitygroup_id',
+    'title_key' => 'LBL_SECURITYGROUPS_SUBPANEL_TITLE',
+);

--- a/include/SugarObjects/templates/person/metadata/metafiles.php
+++ b/include/SugarObjects/templates/person/metadata/metafiles.php
@@ -46,4 +46,5 @@ $metafiles[$module_name] = array(
     'searchdefs' => 'modules/' . $module_name . '/metadata/searchdefs.php',
     'popupdefs' => 'modules/' . $module_name . '/metadata/popupdefs.php',
     'searchfields' => 'modules/' . $module_name . '/metadata/SearchFields.php',
+    'subpaneldefs' => 'modules/' . $module_name . '/metadata/subpaneldefs.php',
 );

--- a/include/SugarObjects/templates/person/metadata/subpaneldefs.php
+++ b/include/SugarObjects/templates/person/metadata/subpaneldefs.php
@@ -1,0 +1,14 @@
+<?php
+$module_name = '<module_name>';
+$layout_defs[$module_name]['subpanel_setup']['securitygroups'] = array(
+    'top_buttons' => array(array('widget_class' => 'SubPanelTopSelectButton', 'popup_module' => 'SecurityGroups', 'mode' => 'MultiSelect')),
+    'order' => 900,
+    'sort_by' => 'name',
+    'sort_order' => 'asc',
+    'module' => 'SecurityGroups',
+    'refresh_page' => 1,
+    'subpanel_name' => 'default',
+    'get_subpanel_data' => 'SecurityGroups',
+    'add_subpanel_data' => 'securitygroup_id',
+    'title_key' => 'LBL_SECURITYGROUPS_SUBPANEL_TITLE',
+);

--- a/include/SugarObjects/templates/sale/metadata/metafiles.php
+++ b/include/SugarObjects/templates/sale/metadata/metafiles.php
@@ -50,5 +50,5 @@ $metafiles[$module_name] = array(
     'searchdefs' => 'modules/' . $module_name . '/metadata/searchdefs.php',
     'popupdefs' => 'modules/' . $module_name . '/metadata/popupdefs.php',
     'searchfields' => 'modules/' . $module_name . '/metadata/SearchFields.php',
-
+    'subpaneldefs' => 'modules/' . $module_name . '/metadata/subpaneldefs.php',
 );

--- a/include/SugarObjects/templates/sale/metadata/subpaneldefs.php
+++ b/include/SugarObjects/templates/sale/metadata/subpaneldefs.php
@@ -1,0 +1,14 @@
+<?php
+$module_name = '<module_name>';
+$layout_defs[$module_name]['subpanel_setup']['securitygroups'] = array(
+    'top_buttons' => array(array('widget_class' => 'SubPanelTopSelectButton', 'popup_module' => 'SecurityGroups', 'mode' => 'MultiSelect')),
+    'order' => 900,
+    'sort_by' => 'name',
+    'sort_order' => 'asc',
+    'module' => 'SecurityGroups',
+    'refresh_page' => 1,
+    'subpanel_name' => 'default',
+    'get_subpanel_data' => 'SecurityGroups',
+    'add_subpanel_data' => 'securitygroup_id',
+    'title_key' => 'LBL_SECURITYGROUPS_SUBPANEL_TITLE',
+);


### PR DESCRIPTION
Rebased branch to hotfix from #9469 

Closes #9468

## Description
As the Issue describes, newly created custom modules don't have the Security Suite subpanels by default, they need to be added manually in their modules' code.

This PR adds the necessary code to the SugarObjects templates for the different module types that will be later used by the ModuleBuilder when creating the modules. Basically, it adds the definition of the Security Suite subpanels in the same way that the rest of the metadata definition is added.

## Motivation and Context
With this change, newly created modules will have the Security Suite subpanel by default

## How To Test This
1. Create a module in the ModuleBuilder
2. Deploy the module
3. Create a record and check that the SS subpanel appear in their DetailView.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
