### PR TITLE
Fixed #7160 - Can't disable notifications

### DIFF
--- a/modules/Users/tpls/EditViewFooter.tpl
+++ b/modules/Users/tpls/EditViewFooter.tpl
@@ -235,8 +235,9 @@
                     </slot>&nbsp;{sugar_help text=$MOD.LBL_RECEIVE_NOTIFICATIONS_TEXT}
                 </td>
                 <td width="33%">
-                    <slot><input name='receive_notifications' class="checkbox" tabindex='12' type="checkbox"
-                                 value="12" {$RECEIVE_NOTIFICATIONS}></slot>
+                    <slot><input type='hidden' value='0' name='receive_notifications'>
+                          <input name='receive_notifications' class="checkbox" tabindex='12' type="checkbox" value="1" {$RECEIVE_NOTIFICATIONS}>
+                    </slot>
                 </td>
             </tr>
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
The checkbox "Notify on Assignment" in the "Profile > Advanced (tab)" is never saved.

## How To Test This

1. Profile > Advanced (tab)
2. uncheck the "Notify on Assignment" and save
3. Profile > Advanced (tab)
4. the "Notify on Assignment" is still checked and in database no changes happen.

This fix was previously proposed by SinergiaTIC https://github.com/SinergiaTIC/SuiteCRM/commit/dea5163593e19ffc5340586872a02d46081fff32 but no PR was found.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.