### PR TITLE
Fix #9543 - parent type saves when not using flex relate field

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -2397,6 +2397,10 @@ class SugarBean
             $this->custom_fields->save($isUpdate);
         }
 
+        if(empty($this->parent_id)) {
+            $this->parent_type = "";
+        }
+
         $this->_sendNotifications($check_notify);
 
         if ($isUpdate) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
When saving a flex relate field without saving the parent id it will save the parent type in DB

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This has been Assessed internally and has been push live for a client with no issues.
## How To Test This
<!--- Please describe in detail how to test your changes. -->
Example using Notes Module
1. Got to Notes Module.
2. Create a Note and do not relate it to anything and Save.
3. Got to Notes table in the DB and see that the parent_type has not been saved.
4. Do the same again but relate it to a record this time around.
5. Go to Notes table in the DB and see that parent_type has a module and parent_id has a record ID.

For historic data that is effected you will need to run the following SQL Query to fix the data.
`UPDATE moduleName SET parent_type = '' WHERE parent_id = ''`
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->