### PR TITLE
Fixed #8336 - bug: Compose Email Page Lacks "FROM NAME" in HTML value…

### DIFF
--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -4421,15 +4421,15 @@ eoq;
         $useDefaultFromAddressName = false;
         $useDefaultFromAddressEmail = false;
 
-        // is from address in the request?
+        // is from address name in the request?
 
         if (!isset($request['from_addr_name']) || !$request['from_addr_name']) {
             $useDefaultFromAddressName = true;
         }
 
-        // is from name in the request?
+        // is from adrress email in the request?
 
-        if (!isset($request['from_addr_email']) || !$request['from_addr_email']) {
+        if (!isset($request['from_addr']) || !$request['from_addr']) {
             $useDefaultFromAddressEmail = true;
         }
 
@@ -4454,7 +4454,7 @@ eoq;
 
                 // use the default one
 
-                $request['from_addr_email'] = $defaultEmail['email'];
+                $request['from_addr'] = $defaultEmail['email'];
             }
 
             // do we have to use the default name?
@@ -4473,12 +4473,14 @@ eoq;
             }
         }
 
-        if (isset($request['from_addr']) && $request['from_addr'] != $request['from_addr_name'] . ' &lt;' . $request['from_addr_email'] . '&gt;') {
+        if (isset($request['from_addr']) && $request['from_addr'] != $request['from_addr_name'] . ' &lt;' . $request['from_addr'] . '&gt;') {
             if (false === strpos($request['from_addr'], '&lt;')) { // we have an email only?
                 $bean->from_addr = $request['from_addr'];
                 isValidEmailAddress($bean->from_addr);
-                $bean->from_name = '';
-                $bean->reply_to_addr = $bean->from_addr;
+                $bean->from_name = $bean->from_addr_name;
+                if (!isset($bean->reply_to_addr) || !$bean->reply_to_addr) {
+                    $bean->reply_to_addr = $bean->from_addr;
+                }
                 $bean->reply_to_name = $bean->from_name;
             } else { // we have a compound string
                 $newFromAddr = str_replace($old, $new, $request['from_addr']);
@@ -4492,8 +4494,8 @@ eoq;
                 $bean->reply_to_addr = $bean->from_addr;
                 $bean->reply_to_name = $bean->from_name;
             }
-        } elseif (!empty($request['from_addr_email']) && isset($request['from_addr_email'])) {
-            $bean->from_addr = $request['from_addr_email'];
+        } elseif (!empty($request['from_addr']) && isset($request['from_addr'])) {
+            $bean->from_addr = $request['from_addr'];
             isValidEmailAddress($bean->from_addr);
             $bean->from_name = $request['from_addr_name'];
         } else {

--- a/modules/Emails/include/ComposeView/ComposeView.tpl
+++ b/modules/Emails/include/ComposeView/ComposeView.tpl
@@ -48,6 +48,8 @@
     <input type="hidden" name="record" value="{$RECORD}">
     <input type="hidden" name="type" value="out">
     <input type="hidden" name="send" value="1">
+    <input type="hidden" name="from_addr_name" value="">
+    <input type="hidden" name="reply_to_addr" value="">
     <input type="hidden" name="return_module" value="{$RETURN_MODULE}">
     <input type="hidden" name="return_action" value="{$RETURN_ACTION}">
     <input type="hidden" name="return_id" value="{$RETURN_ID}">

--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -1079,6 +1079,8 @@
               selectOption.attr('value', v.attributes.from);
               selectOption.attr('inboundId', v.id);
               selectOption.attr('infos', '(<b>Reply-to:</b> ' + v.attributes.reply_to + ', <b>From:</b> ' + v.attributes.from + ')');
+              selectOption.attr('reply_to_addr', v.attributes.reply_to);
+              selectOption.attr('from_name', v.attributes.name);
               selectOption.html(v.attributes.name);
               selectOption.appendTo(selectFrom);
 
@@ -1111,8 +1113,13 @@
               $(selectFrom).val(selectInboundEmailOption.val());
             }
 
+            $(self).find('[name=from_addr_name]').val(selectFrom.find('option:selected').attr('from_name'));
+            $(self).find('[name=reply_to_addr]').val(selectFrom.find('option:selected').attr('reply_to_addr'));
+
             $(selectFrom).change(function (e) {
               $(self).find('[name=inbound_email_id]').val($(this).find('option:selected').attr('inboundId'));
+              $(self).find('[name=from_addr_name]').val($(this).find('option:selected').attr('from_name'));
+              $(self).find('[name=reply_to_addr]').val($(this).find('option:selected').attr('reply_to_addr'));
               self.updateSignature();
               self.updateFromInfos();
             });


### PR DESCRIPTION
## Description

Fix issue #8336 and probably #9023 and #8959 could be closed.

## Motivation and Context

"From name" set up in "User Profile > Settings > Mail Accounts" in Outgoing mail accounts is not populated when sending emails from Emails ComposeView. The same happens with the " Reply to Address" users set up in the mail accounts (inbound) related with Outgoing mail accounts (see red boxed filed in screen capture below).

![imagen](https://user-images.githubusercontent.com/5545390/159945621-835f5424-2c04-4529-8c92-6dc3f4b33775.png)

so when the mails arrive to destination clients see this in the mail heads:

> From: "sinesio.profe@udima.es" <sinesio.profe@udima.es>
> Reply-To: sinesio.profe@udima.es

mail heads should be.

> From: "SINESIA Sánchez" <sinesio.profe@udima.es>
> Reply-To: "SINESIA Sánchez" <sinesio.profe+reply@udima.es>

## How To Test This

- Set up at less two mails accounts in a regular user with two different outgoing mail accounts with something like above screen capture.
- Send mails from the "Email > Compose"
- "Reply" received emails from the DisplayDetailView "Email".
- Send mails from a "Lead" detail view using "Create Task > Compose mail"
- In all your test... review mail heads received in destination.
- If you want you can try to launch a mail "Campaign" in order to verify that nothing is broken there.
- Compose mails in the Emails module and save them as "Drafts", and sent them later.

## Changes explanation

Basically "from_addr_email" was replaced by "from_addr" in populateBeanFromRequest because "from_addr" is how it is named in the email bean when populating from $request.

In the mails ComposeView.tpl was required to add these fields in order to be sent in $_REQUEST:

```
    <input type="hidden" name="from_addr_name" value="">
    <input type="hidden" name="reply_to_addr" value="">
```

Finally some fix was made in EmailsComposeView.js in order to populate this fields with the selected mail account user selects or change in the "From:" select.

No extra DB queries are required with this approach.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist

- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
