### PR TITLE
fix escapeField where $cell string is empty

### DIFF
--- a/include/CleanCSV.php
+++ b/include/CleanCSV.php
@@ -93,7 +93,7 @@ class CleanCSV
      */
     public function escapeField($cell)
     {
-        if (!is_string($cell)) {
+        if (!is_string($cell) || empty($cell)) {
             return $cell;
         }
 


### PR DESCRIPTION
If a cell is empty then there is no need to escape the cell, so just return the empty string

## Description
Description of Issue in  #9556 (https://github.com/salesagility/SuiteCRM/issues/9556)

## Motivation and Context
As above

## How To Test This
As above

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
