### PR TITLE
Turn privates to protecteds to fix Emailtemplate overrides

### DIFF
--- a/modules/EmailTemplates/EmailTemplate.php
+++ b/modules/EmailTemplates/EmailTemplate.php
@@ -108,7 +108,7 @@ class EmailTemplate extends SugarBean
      */
     protected $storedVariables = array();
 
-    private $imageLinkReplaced = false;
+    protected $imageLinkReplaced = false;
 
     public function __construct()
     {
@@ -165,9 +165,9 @@ class EmailTemplate extends SugarBean
                     ) {
                         continue;
                     }
-                    if (!isset($field_def['vname'])) {
-                        //echo $key;
-                    }
+                    /* if (!isset($field_def['vname'])) {
+                        echo $key;
+                    } */
                     // valid def found, process
                     $optionKey = strtolower("{$prefixes[$collectionKey]}{$key}");
                     if (!isset($field_def['vname'])) {
@@ -293,7 +293,7 @@ class EmailTemplate extends SugarBean
 
             $bodyCleanup = html_entity_decode($bodyCleanup, ENT_COMPAT, $sugar_config['default_charset']);
 
-            // Template contents should contains at least one
+            // Template contents should contain at least one
             // white space character at after the variable names
             // to recognise it when parsing and replacing variables
             $bodyCleanup = preg_replace('/(\$\w+\b)([^\s\/&"\'])/', '$1 $2', $bodyCleanup);
@@ -315,7 +315,7 @@ class EmailTemplate extends SugarBean
     //function all string that match the pattern {.} , also catches the list of found strings.
     //the cache will get refreshed when the template bean instance changes.
     //The found url key patterns are replaced with name value pairs provided as function parameter. $tracked_urls.
-    //$url_template is used to construct the url for the email message. the template should have place holder for 1 variable parameter, represented by %1
+    //$url_template is used to construct the url for the email message. The template should have placeholder for 1 variable parameter, represented by %1
     //$template_text_array is a list of text strings that need to be searched. usually the subject, html body and text body of the email message.
     //$removeme_url_template, if the url has is_optout property checked then use this template.
     public function parse_tracker_urls($template_text_array, $url_template, $tracked_urls, $removeme_url_template)
@@ -376,7 +376,7 @@ class EmailTemplate extends SugarBean
      * @param $text string String in which we need to search all string that match the pattern {.}
      * @return array result of search
      */
-    private function _preg_match_tracker_url($text)
+    protected function _preg_match_tracker_url($text)
     {
         $result = array();
         $ind = 0;
@@ -895,7 +895,7 @@ class EmailTemplate extends SugarBean
         return $ret;
     }
 
-    private function repairMozaikClears()
+    protected function repairMozaikClears()
     {
         // repair tinymce auto correction in mozaik clears
         $this->body_html = str_replace('&lt;div class=&quot;mozaik-clear&quot;&gt;&nbsp;&lt;br&gt;&lt;/div&gt;', '&lt;div class=&quot;mozaik-clear&quot;&gt;&lt;/div&gt;', $this->body_html);
@@ -903,7 +903,7 @@ class EmailTemplate extends SugarBean
 
 
 
-    private function repairEntryPointImages()
+    protected function repairEntryPointImages()
     {
         global $sugar_config, $log;
 
@@ -933,7 +933,7 @@ class EmailTemplate extends SugarBean
         }
     }
 
-    private function makePublicImage($id, $ext = 'jpg')
+    protected function makePublicImage($id, $ext = 'jpg')
     {
         $toFile = 'public/' . $id . '.' . $ext;
         if (file_exists($toFile)) {


### PR DESCRIPTION
## Description
Problems customizing EmailTemplate class with a custom class.

## How To Test This
Create custom class in `custom/modules/EmailTemplates/CustomEmailTemplate.php`with something like this...

```php
<?php

if (!defined('sugarEntry') || !sugarEntry) {
    die('Not A Valid Entry Point');
}

require_once 'modules/EmailTemplates/EmailTemplate.php';

class CustomEmailTemplate extends EmailTemplate
{
    public function retrieve($id = -1, $encode = true, $deleted = true)
    {
  [... code copied from original function, using function $this->repairMozaikClears() and  $this->repairEntryPointImages....]
    }
```

You get a PHP error: `Uncaught Error: Call to private method`

This is wrong because this class is meant to be overridable, so these functions should be either `public` or `protected`.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
