### PR TITLE
Turn private to protected to fix SendMail AOW_Action overrides

### DIFF
--- a/modules/AOW_Actions/actions/actionSendEmail.php
+++ b/modules/AOW_Actions/actions/actionSendEmail.php
@@ -150,7 +150,7 @@ class actionSendEmail extends actionBase
         return $html;
     }
 
-    private function getEmailsFromParams(SugarBean $bean, $params)
+    protected function getEmailsFromParams(SugarBean $bean, $params)
     {
         $emails = array();
         //backward compatible


### PR DESCRIPTION
## Description
Problems creating custom AOW_Action by subclassing it from **actionSendMail** which calls this private function...

## How To Test This
Create custom AOW_Action with something like this...

```php
class actionSendMyCustomEmail extends actionSendEmail
{
    public function run_action(SugarBean $bean, $params = array(), $in_save = false)
    {
         [... code copied from original function, using function $this->getEmailsFromParams() ....]
    }
}
```

You get a PHP error: `Uncaught Error: Call to private method getEmailsFromParams() `

This is wrong because this class is meant to be overridable, so these functions should be either `public` or `protected`.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
