### PR TITLE
Fix #3157 - Add default option to enable session_gc

### DIFF
--- a/include/entryPoint.php
+++ b/include/entryPoint.php
@@ -161,6 +161,15 @@ if (empty($GLOBALS['installing'])) {
         }
     }
 
+    $sessionGCConfig = $sugar_config['session_gc'] ?? [];
+    if (!isset($sessionGCConfig['enable']) || isTrue($sessionGCConfig['enable'])) {
+        $gcProbability = $sessionGCConfig['gc_probability'] ?? 1;
+        $gcDivisor = $sessionGCConfig['gc_divisor'] ?? 100;
+
+        ini_set('session.gc_probability', $gcProbability);
+        ini_set('session.gc_divisor', $gcDivisor);
+    }
+
     if (!empty($sugar_config['session_dir'])) {
         session_save_path($sugar_config['session_dir']);
     }

--- a/include/utils.php
+++ b/include/utils.php
@@ -547,6 +547,11 @@ function get_sugar_config_defaults(): array
             'min_cron_interval' => 30, // minimal interval between cron jobs
         ],
         'strict_id_validation' => false,
+        'session_gc' => [
+            'enable' => true,
+            'gc_probability' => 1,
+            'gc_divisor' => 100,
+        ]
     ];
 
     if (!is_object($locale)) {
@@ -5947,4 +5952,22 @@ function has_valid_extension($fieldName, $name, $validExtensions)
     }
 
     return true;
+}
+
+/**
+ * Check if value is one of the accepted true representations
+ * @param $value
+ * @return bool
+ */
+function isTrue($value): bool {
+    return $value === true || $value === 'true' || $value === 1;
+}
+
+/**
+ * Check if value is one of the accepted false representations
+ * @param $value
+ * @return bool
+ */
+function isFalse($value): bool {
+    return $value === false || $value === 'false' || $value === 0;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
- Enable php session_gc by default
- Add config to not enable it
- Add config to set values for gc_probability and gc_divisor


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- When using custom `session_dir`, the session files aren't cleaned up.
- see #3157 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
- on config.php, change `session_dir` to something different from the default
- Login in the app
- Check that session files were added to the directory defined in `session_dir`
- logout from the session
- check if some of the session files were removed. You may need to refresh the page some times. (the session garbage collector is done randomly with a probability of 1/100)
- In config.php, change the value of `enable_session_gc` to false.
- Check that after login in and logging out the session files aren't removed 

- see #3157 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->