### PR TITLE
Fix missing pagination on Elasticsearch results page

### DIFF
--- a/lib/Search/UI/SearchResultsController.php
+++ b/lib/Search/UI/SearchResultsController.php
@@ -106,7 +106,7 @@ class SearchResultsController extends Controller
             LoggerManager::getLogger()->warn('Failed to fetch list-view headers: ' . $e->getMessage());
         }
 
-        $total = count($this->results->getHits());
+        $total = $this->results->getTotal();
         if ($total > 1) {
             $size = $this->query->getSize();
             if ($size) {
@@ -132,10 +132,9 @@ class SearchResultsController extends Controller
                 throw new SearchException('Search Size can not be Zero.', SearchException::ZERO_SIZE);
             }
         }
-        $totalResults = $this->results->getTotal();
 
         $smarty = $this->view->getTemplate();
-        $smarty->assign('total', $totalResults);
+        $smarty->assign('total', $total);
         $smarty->assign('headers', $headers);
         $smarty->assign('results', $this->results);
         try {


### PR DESCRIPTION
## Description
Pagination total was previously determined using a count on the hits returned.

Basic and advanced search return all results from a query, making the count an effective solution. Elasticsearch results are limited by the query size parameter rendering this previous solution unsuitable.

This change uses the getTotal value from the SearchResults class which contains the true total.

Tested for backwards compatibility with all three search types.

## Motivation and Context
Pagination is missing on the search results page when using Elasticsearch engine

## How To Test This
Perform a search which returns a multi page result and ensure pagination is available. 
It may be worth testing with Basic, Advanced and Elasticsearch.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.