### PR TITLE
Change the logger level in setStream and getStream functions to prevent excessive log errors

### DIFF
--- a/include/Imap/ImapHandler.php
+++ b/include/Imap/ImapHandler.php
@@ -107,7 +107,7 @@ class ImapHandler implements ImapHandlerInterface
     protected function setStream($stream, $validate = true)
     {
         if ($validate && !is_resource($stream)) {
-            $this->logger->error('ImapHandler trying to set a non valid resource az stream.');
+            $this->logger->warn('ImapHandler trying to set a non valid resource az stream.');
         }
         $this->stream = $stream;
     }
@@ -120,7 +120,7 @@ class ImapHandler implements ImapHandlerInterface
     protected function getStream($validate = true)
     {
         if ($validate && !is_resource($this->stream)) {
-            $this->logger->error('ImapHandler trying to use a non valid resource stream.');
+            $this->logger->warn('ImapHandler trying to use a non valid resource stream.');
         }
 
         return $this->stream;


### PR DESCRIPTION
## Description
The test functionality of InboundEmail cycles through multiple imap connection stings to find the optimum. See InboundEmail.php findOptimumSettings() In doing so, it triggers multiple errors, which may be better represented as warnings. As this is by design, changing the level of these errors to warn will prevent unnecessary errors being logged.

## Motivation and Context
Minimises logged errors

## How To Test This
From Admin -> Email -> Inbound Email , run the test functionality on an IMAP mailbox. Multiple errors should now be suppressed such as:

* ImapHandler trying to use a non valid resource stream.
* ImapHandler trying to set a non valid resource az stream.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.