### PR TITLE
AOW Conditions do not work on_save action

### DIFF
--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -864,9 +864,9 @@ class AOW_WorkFlow extends Basic
             case "Less_Than":  return $var1 <  $var2;
             case "Greater_Than_or_Equal_To": return $var1 >= $var2;
             case "Less_Than_or_Equal_To": return $var1 <= $var2;
-            case "Contains": return strpos($var1, $var2);
-            case "Starts_With": return strrpos($var1, $var2, -strlen($var1));
-            case "Ends_With": return strpos($var1, $var2, strlen($var1) - strlen($var2));
+            case "Contains": return false!==strpos($var1, $var2);
+            case "Starts_With": return false!==strrpos($var1, $var2, -strlen($var1));
+            case "Ends_With": return false!==strpos($var1, $var2, strlen($var1) - strlen($var2));
             case "is_null": return $var1 == '';
             case "One_of":
                 if (is_array($var1)) {

--- a/tests/unit/phpunit/modules/AOW_WorkFlow/AOW_WorkFlowTest.php
+++ b/tests/unit/phpunit/modules/AOW_WorkFlow/AOW_WorkFlowTest.php
@@ -277,16 +277,9 @@ class AOW_WorkFlowTest extends SuitePHPUnitFrameworkTestCase
         self::assertTrue($aowWorkFlow->compare_condition('', '', 'is_null'));
         self::assertTrue($aowWorkFlow->compare_condition('test2', array('test1', 'test2'), 'One_of'));
         self::assertTrue($aowWorkFlow->compare_condition('test', array('test1', 'test2'), 'Not_One_of'));
-
-        //These do not return bool but 'strpos' result
-        //$this->assertNotFalse($aowWorkFlow->compare_condition('test1', 'test', 'Contains'));
-        self::assertEquals(0, $aowWorkFlow->compare_condition('test1', 'test', 'Contains'));
-
-        //$this->assertNotFalse($aowWorkFlow->compare_condition('test1', 'test', 'Starts_With'));
-        self::assertEquals(0, $aowWorkFlow->compare_condition('test1', 'test', 'Starts_With'));
-
-        //$this->assertNotFalse($aowWorkFlow->compare_condition('test1', '1', 'Ends_With'));
-        self::assertEquals(4, $aowWorkFlow->compare_condition('test1', '1', 'Ends_With'));
+        self::assertTrue($aowWorkFlow->compare_condition('test1', 'test', 'Contains'));
+        self::assertTrue($aowWorkFlow->compare_condition('test1', 'test', 'Starts_With'));
+        self::assertTrue($aowWorkFlow->compare_condition('test1', '1', 'Ends_With'));
     }
 
     public function testcheck_in_group(): void


### PR DESCRIPTION
When saving a record AOW does call check_valid_bean in the logic hook. So the bug does not show in the scheduler.
In line 828 following line does not compare to "false" and as of that if compare_condition returns "0" it interprets it as "false"
 if (!($this->compare_condition($field, $value, $condition->operator))) {

In compare_conditions we give back the result of strpos. This is "0" if the comparision is true, but for the first char.
Example:
Fieldvalue: Myspecialfieldname
Condition: Starts_With "M"
Should be true, Record should run the Workflow, but does not run because strpos gives back "0" interpreted as false.

On a side note: I do not get on first sight why Starts_with uses strrpos and not strpos.