### PR TITLE
Fix #9354 - Advance range filter isn't displayed in Popup views

### DIFF
--- a/include/Popups/PopupSmarty.php
+++ b/include/Popups/PopupSmarty.php
@@ -337,7 +337,9 @@ class PopupSmarty extends ListViewSmarty
             require('modules/'.$this->module.'/metadata/metafiles.php');
         }
 
-        if (!empty($metafiles[$this->module]['searchfields'])) {
+        if(file_exists('custom/modules/'.$this->module.'/metadata/SearchFields.php')) { 
+            require('custom/modules/'.$this->module.'/metadata/SearchFields.php'); 
+        } elseif (!empty($metafiles[$this->module]['searchfields'])) {
             require($metafiles[$this->module]['searchfields']);
         } elseif (file_exists('modules/'.$this->module.'/metadata/SearchFields.php')) {
             require('modules/'.$this->module.'/metadata/SearchFields.php');

--- a/include/SugarFields/Fields/Base/SugarFieldBase.php
+++ b/include/SugarFields/Fields/Base/SugarFieldBase.php
@@ -639,7 +639,7 @@ class SugarFieldBase
      */
     protected function isRangeSearchView($vardef)
     {
-        return !empty($vardef['enable_range_search']) && !empty($_REQUEST['action']) && $_REQUEST['action'] != 'Popup';
+        return !empty($vardef['enable_range_search']) && !empty($_REQUEST['action']);
     }
 
     /**


### PR DESCRIPTION
- Closes #9354 

The advance range options for filters in popup view isn't load properly

## Description
This issue add this fix https://sugarclub.sugarcrm.com/dev-club/f/questions-answers/400/custom-date-field-range-search-does-not-show-in-popup-search that allows advance filter to display in popup views.

Note:
There needs to be apply some CSS for the filters to display properly. I didn't know where to fit it in the code. I leave a suggestion here in case you guys can apply it in this or in other PR:
```css
/* Fix range search in popup view */
form#popup_query_form { 
  .dateTimeRangeChoice select{
    display: block;
    width: 190px;
    margin-right: 60%;
  }
  .dateRangeInput {
    width: 30%;
  }
} 
```
## Motivation and Context
Advance filters are important in any view

## How To Test This
- Activate the Advance range filter for birthdate field in Contacts and add it in the Popup Search view
- Create a Call and select a Contact
- In the popup for selecting Contacts check that the range filter appears in the birthdate datefield

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->