### PR TITLE
Fix #7030 - Contains, Startwith and End with fixes Workflow

### DIFF
--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -863,9 +863,9 @@ class AOW_WorkFlow extends Basic
             case "Less_Than":  return $var1 <  $var2;
             case "Greater_Than_or_Equal_To": return $var1 >= $var2;
             case "Less_Than_or_Equal_To": return $var1 <= $var2;
-            case "Contains": return strpos($var1, $var2);
-            case "Starts_With": return strrpos($var1, $var2, -strlen($var1));
-            case "Ends_With": return strpos($var1, $var2, strlen($var1) - strlen($var2));
+            case "Contains": return strpos(strtolower($var1), strtolower($var2)) !== false;
+            case "Starts_With": return substr(strtolower($var1), 0, strlen($var2) ) === strtolower($var2);
+            case "Ends_With": return substr(strtolower($var1), -strlen($var2) ) === strtolower($var2);
             case "is_null": return $var1 == '';
             case "One_of":
                 if (is_array($var1)) {


### PR DESCRIPTION
- Closes #7030

This PR is an alternative to solution suggested in #7042 . There is a discussion and several proposals. With this PR we try to summarized and close the Issue.

## Description
As the Issue mentions, Workflow module - contains , start with and end with operator not working in all versions.

In this PR we change the conditions so it works with case insensitive strings (as suggested by @DJUserkent ). We don't use stripos() php function because it won't work with diacritical signs.

## Motivation and Context
Important Condition for workflows

## How To Test This
- Create new workflow with any module.
- Add condition with contains, start or end with operator.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->