### PR TITLE
Fix #9616 - Assign Date or Decimal fields in a Workflow action doesn't work

### DIFF
--- a/modules/AOW_Actions/AOW_Action.php
+++ b/modules/AOW_Actions/AOW_Action.php
@@ -106,7 +106,7 @@ class AOW_Action extends Basic
                             } else {
                                 if ($post_data[$key . 'param'][$i]['value_type'][$p_id] == 'Value' && is_array($p_value)) {
                                     $param_value[$p_id] = encodeMultienumValue($p_value);
-                                }else{
+                                } elseif ($post_data[$key . 'param'][$i]['value_type'][$p_id] != 'Field' && $post_data[$key . 'param'][$i]['value_type'][$p_id] != 'Date'){
                                     $param_value[$p_id] = fixUpFormatting($params["record_type"], $post_data[$key . 'param'][$i]["field"][$p_id], $p_value);
                                 }
                             }


### PR DESCRIPTION
- Closes #9616 

As the issue mentions, saving a workflow with date or decimal fields, doesn't work.

This use to work in previous version of the file.

## Description

This PR adds the condition that skips the function fixUpFormatting if the field type is "Field", it isn't a value.

## Motivation and Context
This is basic functionality

## How To Test This
1. Create a workflow and add many fields/values in the Conditions and Actions panels
2. Save the workflow
3. Edit the workflow and check that not all the fields/values are loaded
4. Save the workflow and check that after opening again, the workflow is corrupted

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->