### PR TITLE
Fix #9626 - Single quotes in datetime fields label

### DIFF
--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -1297,6 +1297,7 @@ EOQ;
     public function addDatetime($displayname, $varname)
     {
         global $timedate;
+        $displayname = addslashes($displayname);
         $userformat = $timedate->get_user_time_format();
         $cal_dateformat = $timedate->get_cal_date_format();
         global $app_strings, $app_list_strings, $theme;

--- a/include/javascript/javascript.php
+++ b/include/javascript/javascript.php
@@ -82,10 +82,14 @@ class javascript
         }
     }
 
-    public function addSpecialField($dispField, $realField, $type, $required, $prefix = '')
+    public function addSpecialField($dispField, $realField, $type, $required, $prefix = '', $translate = false)
     {
         if (isset($this->sugarbean->field_name_map[$realField]['vname'])) {
-            $this->addFieldGeneric($dispField, 'date', $this->sugarbean->field_name_map[$realField]['vname'], $required, $prefix);
+            $vname = $this->sugarbean->field_name_map[$realField]['vname'];
+            if ($translate) {
+                $vname = $this->buildStringToTranslateInSmarty($this->sugarbean->field_name_map[$realField]['vname']);
+            }
+            $this->addFieldGeneric($dispField, 'date', $vname, $required, $prefix);
         }
     }
 
@@ -280,7 +284,7 @@ class javascript
             if (!isset($skip_fields[$field])) {
                 if (isset($value['type']) && ($value['type'] == 'datetimecombo' || $value['type'] == 'datetime')) {
                     $isRequired = (isset($value['required']) && $value['required']) ? 'true' : 'false';
-                    $this->addSpecialField($value['name'] . '_date', $value['name'], 'datetime', $isRequired);
+                    $this->addSpecialField($value['name'] . '_date', $value['name'], 'datetime', $isRequired, $prefix, $translate);
                     if ($value['type'] != 'link'  && isset($this->sugarbean->field_name_map[$field]['validation'])) {
                         //datetime should also support the isbefore or other type of validate
                         $this->addField($field, '', $prefix, '', $translate);


### PR DESCRIPTION
- Closes #9626

## Description
As mentioned the proposed changes in the issue. Adding two fixes here:
1- For the ListView: Add slashes to datetime field labels, same as with date fields.
2- For the EditView: Translating Datetime string to smarty for avoiding single quote sintax errors. Replicating solution as in addField() function.

## Motivation and Context
This fieldtype labels should work as any other.

## How To Test This
1. Create a datetime field in Contacts module
2. Add the field to Contacts EditView
3. Modify the Label manually in the code and add a single quote
4. Go to Contacts Editview and check there is no error

(Cache needs to be deleted for the changes to apply)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->