### PR TITLE
Fix #9627 - Studio changes not picked up by CRM when opcache.validate_timestamps=0

### DIFF
--- a/include/Sugar_Smarty.php
+++ b/include/Sugar_Smarty.php
@@ -169,6 +169,22 @@ class Sugar_Smarty extends Smarty
     }
 
     /**
+     * compile the template and clear opcache
+     *
+     * @param string $resource_name
+     * @param string $compile_path
+     * @return boolean
+     */
+    function _compile_resource($resource_name, $compile_path)
+    {
+        if(parent::_compile_resource($resource_name, $compile_path)) {
+            SugarCache::cleanFile($compile_path);
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Log smarty error out to default log location
      * @param string $error_msg
      * @param integer $error_type


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Fix for https://github.com/salesagility/SuiteCRM/issues/9627
Has been an issue since https://github.com/salesagility/SuiteCRM/pull/8514
Studio changes such as changes to a field or layout are not getting picked up by the CRM until a server restart under certain conditions.
When opcache.validate_timestamps is set to 0 on the server, the smarty template cache does not get cleared from opcache, this causes old templates to load.

## Motivation and Context
Studio changes require a server restart to show up when validate_timestamps is set to 0 on a server

## How To Test This

  1.  Ensure xdebug isn't active on the container/server
  2.  Set opcache.validate_timestamps to 0 in server's php.ini
  3.  Perform a server restart to clear cache
  4.  Load the cases detail view to load it into cache/opcache
  5.  Go to Studio and make a change to the layout
  6.  Go back to cases detail view and see the old layout.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->