### PR TITLE
Update aow_utils.php

### DIFF
--- a/modules/AOR_Reports/AOR_Report.js
+++ b/modules/AOR_Reports/AOR_Report.js
@@ -22,14 +22,16 @@
  */
 
 $(document).ready(function () {
+  $("#download_pdf_button_old").click(function () {
+    var _form = addParametersToForm("DownloadPDF");
 
-  $('#download_pdf_button_old').click(function () {
-
-    var _form = addParametersToForm('DownloadPDF');
-
-    var rGraphs = document.getElementsByClassName('resizableCanvas');
+    var rGraphs = document.getElementsByClassName("resizableCanvas");
     for (var i = 0; i < rGraphs.length; i++) {
-      _form.append('<input type="hidden" id="graphsForPDF" name="graphsForPDF[]" value=' + rGraphs[i].toDataURL() + '>');
+      _form.append(
+        '<input type="hidden" id="graphsForPDF" name="graphsForPDF[]" value=' +
+          rGraphs[i].toDataURL() +
+          ">"
+      );
     }
 
     _form.submit();
@@ -37,90 +39,109 @@ $(document).ready(function () {
     $("#formDetailView #graphsForPDF").remove();
   });
 
-  $('#download_csv_button_old').click(function () {
-
-    var _form = addParametersToForm('Export');
+  $("#download_csv_button_old").click(function () {
+    var _form = addParametersToForm("Export");
 
     _form.submit();
   });
 
-  $('#updateParametersButton').click(function(){
-
-    var _form = addParametersToForm('DetailView');
+  $("#updateParametersButton").click(function () {
+    var _form = addParametersToForm("DetailView");
 
     _form.submit();
   });
 });
 
-
 function updateTimeDateFields(fieldInput, ln) {
-  // datetime combo fields
-  if (typeof fieldInput === 'undefined'
-    && $("[name='aor_conditions_value\\[" + ln + "\\]").val()
-    && $("[name='aor_conditions_value\\[" + ln + "\\]").hasClass('DateTimeCombo')) {
-    var datetime = $("[name='aor_conditions_value\\[" + ln + "\\]']").val();
-    var date = datetime.substr(0, 10);
-    var formatDate = $.datepicker.formatDate('yy-mm-dd', new Date(date));
-    fieldInput = datetime.replace(date, formatDate) + ':00';
-  }
-  return fieldInput;
-}
+  // Fix 22_07_12 datetime combo fields
+  if (
+    $("[name='aor_conditions_value\\[" + ln + "\\]").hasClass("DateTimeCombo")
+  ) {
+    //Get the dateFormat now embedded in the DOM
+    var dateFormat = $("#user_dateFormat").val();
+    //Get the separator
+    var dateSeparator = dateFormat.match(/[^a-zA-Z\d\s:]/)[0];
 
-function updateHiddenReportFields(ln, _form) {
-// Fix for issue #1272 - AOR_Report module cannot update Date type parameter.
-  if ($("#aor_conditions_value\\["+ln+"\\]\\[0\\]").length) {
-      var fieldValue = $("#aor_conditions_value\\["+ln+"\\]\\[0\\]").val();
-      var fieldSign = $("#aor_conditions_value\\["+ln+"\\]\\[1\\]").val();
-      var fieldNumber = $("#aor_conditions_value\\["+ln+"\\]\\[2\\]").val();
-      var fieldTime = $("#aor_conditions_value\\["+ln+"\\]\\[3\\]").val();
+    //Get the entered date from the hidden field (time removed)
+    var dateTime = fieldInput.substr(0, 10);
+    var dateParts = dateTime.split(dateSeparator);
 
-      _form.append('<input type="hidden" name="parameter_date_value['+ ln + ']" value="' + fieldValue + '">');
-      _form.append('<input type="hidden" name="parameter_date_sign['+ ln + ']" value="' + fieldSign + '">');
-      _form.append('<input type="hidden" name="parameter_date_number['+ ln + ']" value="' + fieldNumber + '">');
-      _form.append('<input type="hidden" name="parameter_date_time['+ ln + ']" value="' + fieldTime + '">');
-  }
-}
-
-function localToDbFormat(index, ln, fieldInput) {
-// Fix for issue #1082 - change local date format to db date format
-  if ($('#aor_conditions_value' + index + '').hasClass('date_input')) { // only change to DB format if its a date
-    if ($('#aor_conditions_value' + ln + '').hasClass('date_input')) {
-      fieldInput = $.datepicker.formatDate('yy-mm-dd', new Date(fieldInput));
+    //Use the dateFormat to create the date
+    var dateFormatParts = dateFormat.split(dateSeparator);
+    var newDate = new Date();
+    for (let i = 0; i < dateFormatParts.length; i++) {
+      if (dateFormatParts[i] == "dd") {
+        newDate.setDate(dateParts[i]);
+      }
+      if (dateFormatParts[i] == "mm") {
+        newDate.setMonth(dateParts[i] - 1);
+      }
+      if (dateFormatParts[i] == "yy" || dateFormatParts[i] == "yyyy") {
+        newDate.setYear(dateParts[i]);
+      }
     }
+    var fieldInput = $.datepicker.formatDate("yy-mm-dd", newDate);
   }
   return fieldInput;
 }
 
 function appendHiddenFields(_form, ln, id) {
-    _form.append('<input type="hidden" name="parameter_id\[' + ln + '\]" value="' + id + '">');
-    var operator = $("#aor_conditions_operator\\[" + ln + "\\]").val();
-    _form.append('<input type="hidden" name="parameter_operator\[' + ln + '\]" value="' + operator + '">');
-    var fieldType = $("#aor_conditions_value_type\\[" + ln + "\\]").val();
-    _form.append('<input type="hidden" name="parameter_type[' + ln + ']" value="' + fieldType + '">');
+  _form.append(
+    '<input type="hidden" name="parameter_id[' + ln + ']" value="' + id + '">'
+  );
+  var operator = $("#aor_conditions_operator\\[" + ln + "\\]").val();
+  _form.append(
+    '<input type="hidden" name="parameter_operator[' +
+      ln +
+      ']" value="' +
+      operator +
+      '">'
+  );
+  var fieldType = $("#aor_conditions_value_type\\[" + ln + "\\]").val();
+  _form.append(
+    '<input type="hidden" name="parameter_type[' +
+      ln +
+      ']" value="' +
+      fieldType +
+      '">'
+  );
 
-    // values can be #aor_conditions_value3 or #aor_conditions_value[3]
-    var fieldInput = '';
-    if ($("#aor_conditions_value\\["+ln+"\\]\\[0\\]").length > 0) {
-        fieldInput = $("#aor_conditions_value\\["+ln+"\\]\\[0\\]").val();
-    } else if ($("#aor_conditions_value\\["+ln+"\\]").length > 0) {
-        fieldInput = $("#aor_conditions_value\\["+ln+"\\]").val();
-    } else if ($("[name='aor_conditions_value\\[" + ln + "\\]']").length > 0) {
-    	fieldInput = $("[name='aor_conditions_value\\[" + ln + "\\]']").val();
-    }
+  // Fix 22_07_12 - Updates hidden date fields with date and time
+  if (
+    $("[name='aor_conditions_value\\[" + ln + "\\]").hasClass("DateTimeCombo")
+  ) {
+    //Appends hidden date and time
+    var fieldInput = $("#aor_conditions_value" + ln).val();
+    var fieldInputTime = fieldInput.substr(11, 16);
+    debugger;
+    fieldInput = updateTimeDateFields(fieldInput, ln);
+    _form.append(
+      '<input type="hidden" name="parameter_value[' +
+        ln +
+        ']" value="' +
+        fieldInput +
+        '">'
+    );
 
     fieldInput = updateTimeDateFields(fieldInput, ln);
-    _form.append('<input type="hidden" name="parameter_value[' + ln + ']" value="' + fieldInput + '">');
-	
-    updateHiddenReportFields(ln, _form);
+    _form.append(
+      '<input type="hidden" name="parameter_date_time[' +
+        ln +
+        ']" value="' +
+        fieldInputTime +
+        ":00" +
+        '">'
+    );
+  }
 }
 
 function addParametersToForm(action) {
-  var _form = $('#formDetailView');
-  _form.find('input[name=action]').val(action);
+  var _form = $("#formDetailView");
+  _form.find("input[name=action]").val(action);
 
-  $('.aor_conditions_id').each(function(index, elem) {
+  $(".aor_conditions_id").each(function (index, elem) {
     $elem = $(elem);
-    var ln = $elem.attr('id').substr(17);
+    var ln = $elem.attr("id").substr(17);
     var id = $elem.val();
     appendHiddenFields(_form, ln, id);
   });
@@ -128,21 +149,18 @@ function addParametersToForm(action) {
 }
 
 function openProspectPopup() {
-
   var popupRequestData = {
-    "call_back_function": "setProspectReturn",
-    "form_name": "EditView",
-    "field_to_name_array": {
-      "id": "prospect_id"
-    }
+    call_back_function: "setProspectReturn",
+    form_name: "EditView",
+    field_to_name_array: {
+      id: "prospect_id",
+    },
   };
 
-  open_popup('ProspectLists', '600', '400', '', true, false, popupRequestData);
-
+  open_popup("ProspectLists", "600", "400", "", true, false, popupRequestData);
 }
 
 function setProspectReturn(popup_reply_data) {
-
   var callback = {
     success: function (result) {
       //report_rel_modules = result.responseText;
@@ -150,51 +168,61 @@ function setProspectReturn(popup_reply_data) {
     },
     failure: function (result) {
       //alert('fail '+result.responseText);
-    }
-  }
+    },
+  };
 
   var prospect_id = popup_reply_data.name_to_value_array.prospect_id;
-  var record = document.getElementsByName('record')[0].value;
+  var record = document.getElementsByName("record")[0].value;
 
   var form = addParametersToForm("addToProspectList");
   var query = form.serialize();
-  YAHOO.util.Connect.asyncRequest("GET", "index.php?" + query + "&prospect_id=" + prospect_id, callback);
+  YAHOO.util.Connect.asyncRequest(
+    "GET",
+    "index.php?" + query + "&prospect_id=" + prospect_id,
+    callback
+  );
 }
 
 function changeReportPage(record, offset, group_value, table_id) {
   var paginationButtonCaller = $(this);
-  var query = "?module=AOR_Reports&action=changeReportPage&record=" + record + "&offset=" + offset + "&group=" + group_value;
-  $('.aor_conditions_id').each(function (index, elem) {
+  var query =
+    "?module=AOR_Reports&action=changeReportPage&record=" +
+    record +
+    "&offset=" +
+    offset +
+    "&group=" +
+    group_value;
+  $(".aor_conditions_id").each(function (index, elem) {
     $elem = $(elem);
-    var ln = $elem.attr('id').substr(17);
+    var ln = $elem.attr("id").substr(17);
     var id = $elem.val();
     query += "&parameter_id[]=" + id;
     var operator = $("#aor_conditions_operator\\[" + ln + "\\]").val();
     query += "&parameter_operator[]=" + operator;
-    var fieldType = $('#aor_conditions_value_type\\[' + ln + '\\]').val();
+    var fieldType = $("#aor_conditions_value_type\\[" + ln + "\\]").val();
     query += "&parameter_type[]=" + fieldType;
-    var fieldInput = '';
-    if ($("#aor_conditions_value\\["+ln+"\\]\\[0\\]").length > 0) {
-		var fieldValue = $("#aor_conditions_value\\["+ln+"\\]\\[0\\]").val();
-        query += "&parameter_date_value[]=" + fieldValue;
-        var fieldSign = $("#aor_conditions_value\\["+ln+"\\]\\[1\\]").val();
-        query += "&parameter_date_sign[]=" + fieldSign;
-        var fieldNumber = $("#aor_conditions_value\\["+ln+"\\]\\[2\\]").val();
-        query += "&parameter_date_number[]=" + fieldNumber;
-        var fieldTime = $("#aor_conditions_value\\["+ln+"\\]\\[3\\]").val();
-        query += "&parameter_date_time[]=" + fieldTime;
-        fieldInput = $("#aor_conditions_value\\["+ln+"\\]\\[0\\]").val();
-        fieldInput = updateTimeDateFields(fieldInput, ln);
+    var fieldInput = "";
+
+    // FIX 22_07_12 - checks for DateTimeCombo condition
+    if (
+      $("[name='aor_conditions_value\\[" + ln + "\\]").hasClass("DateTimeCombo")
+    ) {
+      // Condition is a date
+      var hiddenDateTime = $("#aor_conditions_value" + ln).val();
+
+      // fieldValueTime parameter addded to the query. Referenced in aor_utils.php to add time to date
+      var fieldValueTime = hiddenDateTime.substr(11, 5) + ":00";
+      query += "&parameter_date_time[]=" + fieldValueTime;
+
+      fieldInput = $("#aor_conditions_value" + ln).val();
+      fieldInput = updateTimeDateFields(fieldInput, ln);
     } else {
-        fieldInput = $('#aor_conditions_value\\[' + ln + '\\]').val();
-        fieldInput = updateTimeDateFields(fieldInput, ln);
+      fieldInput = $("#aor_conditions_value\\[" + ln + "\\]").val();
     }
     query += "&parameter_value[]=" + fieldInput;
   });
 
-  $.get(query).done(
-    function (data) {
-      $('#report_table_' + table_id + group_value).replaceWith(data);
-    }
-  );
+  $.get(query).done(function (data) {
+    $("#report_table_" + table_id + group_value).replaceWith(data);
+  });
 }

--- a/modules/AOR_Reports/tpls/report.tpl
+++ b/modules/AOR_Reports/tpls/report.tpl
@@ -60,6 +60,8 @@
             <script>
               document.getElementById('detailpanel_parameters').className += ' expanded';
             </script>
+            {* Fix 22_07_11 Embeds the user date format into the conditions panel *}
+            <input type="hidden" value="{$USER_DATEFORMAT}" id="user_dateFormat" />
         </h4>
         <div id="aor_conditionLines" class="panelContainer" style="min-height: 50px;">
         </div>
@@ -82,9 +84,6 @@
                   var ln = $elem.attr('id').substr(17);
                   var id = $elem.val();
                   appendHiddenFields(_form, ln, id);
-                  updateTimeDateFields(fieldInput, ln);
-                  // Fix for issue #1272 - AOR_Report module cannot update Date type parameter.
-                  updateHiddenReportFields(ln, _form);
                 });
                 _form.submit();
               });


### PR DESCRIPTION
CRM Report Condition on Related Table Date Fails

**Problem**:

A Report Date Condition based on a date in a related module fails. The date does not save and the report results are incorrect.

**Reason**:
The issue lies with the line below in function fixUpFormatting($module, $field, $value)

$bean->field_defs[$field]

It seems that this will always fail when a report condition is based on a field related to the Report Module the report is based on. 

**Steps to replicate**

1. Create a new report based in Cases.
2. Add Task - Due date as Date condition. 
3. Set a date value and check parameter
4. Save / Update

![image](https://user-images.githubusercontent.com/108534276/178345673-0a5b1b4f-a49f-4126-8d22-8580a888d066.png)



Here the report is based on the module **Cases** and the condition is **Cases:Tasks - Due Date.** Because **Task**’s **Due Date** will not feature in the **$bean->field_defs** array it will fail and a correctly formatted date is not returned.

The result on Save or Update:

![image](https://user-images.githubusercontent.com/108534276/178346394-2c8d4389-ed14-4307-9e78-4c0edd953099.png)


The date entered in the condition is not saved and the condition fails.

Note that choosing **Date Created** or **Date Modified** in the related module will bypass this error and looks like it is working due to the fact these field_defs do appear in the **$field_defs** array. However these defs are actually from Cases, not Tasks.
 
 
Solution:

The code change to function **fixUpFormatting** checks to see if **$field** is in **$bean->field_defs** and if not it will check to see if it is in a date format. If it is, it will continue on to **_convert** the date.

Note the subsequent preg_matches have been removed as it has already been checked for a date format:



 

