### PR TITLE
Fix #9646 - Display TinyMCE in step 4 of the campaigns form wizard

### DIFF
--- a/include/SugarTinyMCE.php
+++ b/include/SugarTinyMCE.php
@@ -147,13 +147,13 @@ class SugarTinyMCE
 <script type="text/javascript">
 <!--
 $(document).ready(function(){
-  if (!SUGAR.ajaxUI.hist_loaded){
-	load_mce_{$unique}();
-	}
-});
-if (SUGAR.ajaxUI && SUGAR.ajaxUI.hist_loaded){
-    setTimeout(function(){ load_mce_{$unique}();},40);
-}
+    if (!SUGAR.ajaxUI.hist_loaded){
+      load_mce_{$unique}();
+    }
+    if (SUGAR.ajaxUI && SUGAR.ajaxUI.hist_loaded){
+      setTimeout(function(){ load_mce_{$unique}();},40);
+    }
+  });
 function load_mce_{$unique}(){
     if (!SUGAR.util.isTouchScreen()) {
         if(tinyMCE.editors.length === 0 ){


### PR DESCRIPTION
Closes #9646 

## Description
As described in the issue, this PR will display the TinyMCE editor in step 4 of the form generation process

## Motivation and Context
Retrieve a feature that the CRM had to be able to edit the form from the TinyMCE editor

## How To Test This
1. Go to the campaign menu and create a Person form
2. Skip ahead to step 4 and check that the TinyMCE editor is displayed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->