### PR TITLE
Fix #9650 - Deprecated constructor method is being called in Calendar

### DIFF
--- a/modules/Calendar/views/view.savesettings.php
+++ b/modules/Calendar/views/view.savesettings.php
@@ -44,7 +44,7 @@ class CalendarViewSaveSettings extends SugarView
 {
     public function CalendarViewSettings()
     {
-        parent::SugarView();
+        parent::__construct();
     }
     
     public function process()


### PR DESCRIPTION
Closes #9650 

## Description
As described in the issue, this PR update the call to the deprecated constructor method.

## Motivation and Context
Update the call to the deprecated constructor method.

## How To Test This
It is a very simple change and it can see it by reviewing the code

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->