### PR TITLE
Fix #9653 - Display relationship labels correctly in workflows

### DIFF
--- a/modules/AOW_WorkFlow/aow_utils.php
+++ b/modules/AOW_WorkFlow/aow_utils.php
@@ -251,11 +251,9 @@ function getModuleRelationships($module, $view='EditView', $value = '')
                     } else {
                         $sort_fields[$name] = $relModuleName.' : '. $name;
                     }
-                    if ($arr['type'] == 'relate' && isset($arr['id_name']) && $arr['id_name'] != '') {
-                        if (isset($fields[$arr['id_name']])) {
-                            unset($fields[$arr['id_name']]);
-                        }
-                    }
+                    if ($arr['type'] == 'link' && (strpos($arr['name'], '_ida') || strpos($arr['name'], '_idb'))  && isset($sort_fields[$arr['name']])) {
+                        unset($sort_fields[$arr['name']]);
+                    }  
                 }
             } //End loop.
             array_multisort($sort_fields, SORT_ASC, $sort_fields);


### PR DESCRIPTION
Solves: #9653

## Description
This PR replaces part of the code that selects which module names are listed in the Module field of workflow conditions and actions to filter out duplicate labels that were displayed incorrectly

## Motivation and Context
Filter out duplicate tags as they can confuse the user

## How To Test This
1. Go to the contacts module and add a relationship of type 1 to N with any module, for example Projects or Locations
2. Create a workflow and select Projects or Locations as the base module
3. Add a condition and click on the Module field.
4. Check that the names of these two modules are displayed once for each relationship they have to the base module of the workflow

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->