### PR TITLE
Fix #9658 - SuiteCRM add duplicate dashlet when filter is used

### DIFF
--- a/include/MySugar/tpls/dashletsSearchResults.tpl
+++ b/include/MySugar/tpls/dashletsSearchResults.tpl
@@ -51,7 +51,7 @@
 	{/if}
 		<td width="50%" align="left"><a id="{$module.id}_icon" href="javascript:void(0)" onclick="{$module.onclick}" style="text-decoration:none">
 				<span class="suitepicon suitepicon-module-{$module.module_name|lower|replace:'_':'-'}"></span>&nbsp;
-				<span class="mbLBLL" href="#" onclick="{$module.onclick}">{$module.title}</a><br /></td>
+				<span id="mbLBLL" class="mbLBLL">{$module.title}</span></a><br /></td>
 	{if $rowCounter % 2 == 1}
 	</tr>
 	{/if}


### PR DESCRIPTION
Solves #9658

## Description
The PR modifies the properties of the HTML element returned by the dashlet filter to be the same as the element that is displayed when no filter is applied, so that only one dashlet is added.

## Motivation and Context
Avoid having to remove a dashlet when the dashlet filter has been used

## How To Test This
1. Access the Home view
2. Filter to add a dashlet from any module
3. Check that only one dashlet are added.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->