### PR TITLE
Fix #9660 - Imported Customizations cause issues with Studio views

### DIFF
--- a/modules/ModuleBuilder/MB/MBPackage.php
+++ b/modules/ModuleBuilder/MB/MBPackage.php
@@ -561,18 +561,18 @@ class MBPackage
     private function getCustomMetadataManifestForModule($module, &$installdefs)
     {
         $meta_path = 'custom/modules/' . $module . '/metadata';
+        $working_array = [
+            'editviewdefs.php',
+            'detailviewdefs.php',
+            'quickcreatedefs.php'
+        ];
         foreach (scandir($meta_path) as $meta_file) {
             if (substr($meta_file, 0, 1) !== '.' && is_file($meta_path . '/' . $meta_file)) {
-                if ($meta_file === 'listviewdefs.php') {
-                    $installdefs['copy'][] = array(
-                        'from' => '<basepath>/SugarModules/modules/' . $module . '/metadata/' . $meta_file,
-                        'to' => 'custom/modules/' . $module . '/metadata/' . $meta_file,
-                    );
-                } else {
-                    $installdefs['copy'][] = array(
-                        'from' => '<basepath>/SugarModules/modules/' . $module . '/metadata/' . $meta_file,
-                        'to' => 'custom/modules/' . $module . '/metadata/' . $meta_file,
-                    );
+                $installdefs['copy'][] = array(
+                    'from' => '<basepath>/SugarModules/modules/' . $module . '/metadata/' . $meta_file,
+                    'to' => 'custom/modules/' . $module . '/metadata/' . $meta_file,
+                );
+                if (in_array($meta_file, $working_array, true)) {
                     $installdefs['copy'][] = array(
                         'from' => '<basepath>/SugarModules/modules/' . $module . '/metadata/' . $meta_file,
                         'to' => 'custom/working/modules/' . $module . '/metadata/' . $meta_file,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
From issue https://github.com/salesagility/SuiteCRM/issues/9660

Imported module customizations via the module loader copy files to the "custom/working" directory. This directory is used to store studio changes that have been saved but not deployed.

All metadata is copied to this directory, except for listviewdefs.php, regardless if it is in the custom/working directory of the exported module.

This causes an issue where Studio loads in this working metadata file for dashletviewdefs and never overwrites or deletes it because the working directory is only used for detail view, edit view and quickcreate view.

## Motivation and Context
Imported customizations cause Studio to load the wrong dashlet views.

## How To Test This
1. Go to Studio and make a customization to cases->layouts->defaults->SuiteCRM Dashlet->SuiteCRM Dashlet Search to create a custom/modules/Cases/metadata/dashletviewdefs.php file.
2. Go back to Studio homepage and click "Export Customizations"
3. Name the export file and choose the cases module and click export
4. Use module loader to install the customizations from step 3
5. Try to make a change to cases->layouts->default->SuiteCRM Dashlet->SuiteCRM Dashlet Search
6. The change made will not update in Studio.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->