### PR TITLE
Fix #9447 - The year in a Calendar popup from a date field in a Search of a ListView can't be edit 

### DIFF
--- a/include/SearchForm/tpls/headerPopup.tpl
+++ b/include/SearchForm/tpls/headerPopup.tpl
@@ -38,7 +38,7 @@
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 *}
-<div id="searchDialog" class="modal fade modal-search" tabindex="-1" role="dialog">
+<div id="searchDialog" class="modal fade modal-search" role="dialog">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">


### PR DESCRIPTION
Closes #9447 

This PR is a copy of PR #9526, closed by mistake

## Description
As describes in the issue, this PR fix the issue and allows the user to change manually the year in a Calendar selector of a Date field of a Search inside a ListView.

## Motivation and Context
This is required to select past dates.

## How To Test This
1. Add the Birthdate field in the Basic Search of Contacts
2. Go to the Contacts ListView and Search
3. Click on the Calendar of the Birthdate field
4. Change the Year value manually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.