### PR TITLE
Fix #9674 - Error when importing (creating and updating) a record with ID already deleted in the database

### DIFF
--- a/modules/Import/Importer.php
+++ b/modules/Import/Importer.php
@@ -363,7 +363,7 @@ class Importer
 
             if (isset($dbrow['id']) && $dbrow['id'] != -1) {
                 // if it exists but was deleted, just remove it
-                if (isset($dbrow['deleted']) && $dbrow['deleted'] == 1 && $this->isUpdateOnly ==false) {
+                if (isset($dbrow['deleted']) && $dbrow['deleted'] == 1) {
                     $this->removeDeletedBean($focus);
                     $focus->new_with_id = true;
                 } else {


### PR DESCRIPTION
Solves https://github.com/salesagility/SuiteCRM/issues/9674


## Description
The PR deletes the condition indicated in the issue.

## Motivation and Context
The PR deletes the condition indicated in the issue to be able to import, with the create and update option, files with record IDs deleted at the database level

## How To Test This
1. Create a contact, opportunity, or other record and export it
2. Delete the record from the CRM interface
3. Import the file exported in step 1 through the Update and Create option.
4. Check that the import was successful

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->