### PR TITLE
Fix #8279 - ProjectTask - no Task ID

### DIFF
--- a/modules/ProjectTask/ProjectTask.php
+++ b/modules/ProjectTask/ProjectTask.php
@@ -120,7 +120,7 @@ class ProjectTask extends SugarBean
     {
         //Bug 46012.  When saving new Project Tasks instance in a workflow, make sure we set a project_task_id value
         //associated with the Project if there is no project_task_id specified.
-        if ($this->in_workflow && empty($this->id) && empty($this->project_task_id) && !empty($this->project_id)) {
+        if (empty($this->id) && empty($this->project_task_id) && !empty($this->project_id)) {
             $this->project_task_id = $this->getNumberOfTasksInProject($this->project_id) + 1;
         }
 


### PR DESCRIPTION
Solves #8279
Replaces https://github.com/salesagility/SuiteCRM/pull/8342

## Description
Changed a condition in the process of creating a project task from the Project Tasks subpanel so that the task id is generated

## Motivation and Context
Task ID is useful for Gantt view

## How To Test This
1. Create a project
2. In detailview scroll to subpanel project task
3. Create a new project task
4. Check the new task has Task ID


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->