### PR TITLE
Fix #9680 - The related record selected from subpanel edit view is not updated

### DIFF
--- a/include/EditView/header.tpl
+++ b/include/EditView/header.tpl
@@ -70,7 +70,7 @@
 <input type="hidden" name="contact_role">
 {if (!empty($smarty.request.return_module) || !empty($smarty.request.relate_to)) && !(isset($smarty.request.isDuplicate) && $smarty.request.isDuplicate eq "true")}
 <input type="hidden" name="relate_to" value="{if $smarty.request.return_relationship}{$smarty.request.return_relationship}{elseif $smarty.request.relate_to && empty($smarty.request.from_dcmenu)}{$smarty.request.relate_to}{elseif empty($isDCForm) && empty($smarty.request.from_dcmenu)}{$smarty.request.return_module}{/if}">
-<input type="hidden" name="relate_id" value="{$smarty.request.return_id}">
+<input type="hidden" name="relate_id" value="{$fields.id.value}">
 {/if}
 <input type="hidden" name="offset" value="{$offset}">
 {assign var='place' value="_HEADER"} <!-- to be used for id for buttons with custom code in def files-->

--- a/themes/SuiteP/include/EditView/header.tpl
+++ b/themes/SuiteP/include/EditView/header.tpl
@@ -81,7 +81,7 @@
 <input type="hidden" name="contact_role">
 {if (!empty($smarty.request.return_module) || !empty($smarty.request.relate_to)) && !(isset($smarty.request.isDuplicate) && $smarty.request.isDuplicate eq "true")}
 <input type="hidden" name="relate_to" value="{if $smarty.request.return_relationship}{$smarty.request.return_relationship}{elseif $smarty.request.relate_to && empty($smarty.request.from_dcmenu)}{$smarty.request.relate_to}{elseif empty($isDCForm) && empty($smarty.request.from_dcmenu)}{$smarty.request.return_module}{/if}">
-<input type="hidden" name="relate_id" value="{$smarty.request.return_id}">
+<input type="hidden" name="relate_id" value="{$fields.id.value}">
 {/if}
 <input type="hidden" name="offset" value="{$offset}">
 {assign var='place' value="_HEADER"} <!-- to be used for id for buttons with custom code in def files-->


### PR DESCRIPTION
Solves #9680 

## Description
The TPLs that represent the editing view of a record when it is edited or created from a subpanel are modified so that the hidden field _relate_id_ is assigned the id of the record that is being modified instead of the id of the record that contained the subpanel

## Motivation and Context
Failure to update related field causes data inconsistencies

## How To Test This
1. Create two contacts.
2. Go to the detail view of one of them, create a new project from the subpanel and change the related contact. 
3. Check that the contact has been updated with the contact indicated in the edit form
4. Edit the newly created project from the subpanel and change the related contact.
5. Check that the contact has been updated with the contact indicated in the edit form.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->