### PR TITLE
Fix #9693 - Expand a campaign's status view sub-panels by default to …

### DIFF
--- a/include/SubPanel/SubPanelTiles.php
+++ b/include/SubPanel/SubPanelTiles.php
@@ -307,6 +307,10 @@ class SubPanelTiles
                 $div_display = $div_cookies[$cookie_name] === 'false' ? 'none' : '';
             }
 
+            if ($_REQUEST['action'] == "TrackDetailView") {
+                $div_display = 'inline';
+            }
+
             if ($div_display == 'none') {
                 $opp_display = 'inline';
                 $tabs_properties[$t]['expanded_subpanels'] = false;


### PR DESCRIPTION
solves #9693

## Description
The PR solves the problem by expanding all the sub-panels every time you load the status view of a campaign, so that it applies the marketing email filter.

## Motivation and Context
That the marketing email filter applies and the information displayed is not wrong

## How To Test This
1. Create a campaign with two marketing emails and send them.
2. Access the campaign status view and verify that all sub-panels are expanded
3. In the field called _Filter chart by_ select the None option.
4. Verify that the _Message Sent/Attempted_ sub-panel displays two Sent records, one for each marketing email.
5. Collapse the subpanel, select a marketing email in the filter, and verify that you're applying the filter.
7. Do the same test with other subpanels

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->