### PR TITLE
Fix #9696 - Show marketing emails reversely sorted by modified date in test send view

### DIFF
--- a/modules/Campaigns/Schedule.php
+++ b/modules/Campaigns/Schedule.php
@@ -172,6 +172,7 @@ if ($campaign_id && isset($campaign) && $campaign->status == 'Inactive') {
         $query.=" WHERE email_marketing.campaign_id='$campaign_id'";
         $query.=" and email_marketing.deleted=0 ";
         $query.=" and email_marketing.all_prospect_lists=1 ";
+        $query.=" ORDER BY date_modified desc";
 
         $result=$focus->db->query($query);
         while (($row=$focus->db->fetchByAssoc($result)) != null) {


### PR DESCRIPTION
solves #9696

## Description
A condition is added in the query that retrieves the marketing emails of the campaign so that it orders them in reverse order to the date of modification of the record

## Motivation and Context
Sort marketing emails in the test sends view the same as the actual sends view

## How To Test This
1. Create an Email campaign.
2. Create multiple marketing emails.
3. Modify the first email marketing created.
4. Click Send Emails and check that the email marketing modified in the previous step appears first.
5. Check Send Test and verify that the email marketing modified in the previous step also appear first.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->