### PR TITLE
Fix #9700 - Field editing view is displayed after editing a field from Studio

### DIFF
--- a/modules/ModuleBuilder/javascript/ModuleBuilder.js
+++ b/modules/ModuleBuilder/javascript/ModuleBuilder.js
@@ -694,13 +694,11 @@ if (typeof('console') == 'undefined') {
           }
 
           // check where we are and do it if we are in field editor in module builder
-          if (
-            formname != "dropdown_form" && formname != "popup_form" &&
-            // user came from studio/fields layout by ajax urls
-            ((urlVars.module == 'ModuleBuilder' && urlVars.action == 'modulefields' && urlVars.view_package == 'studio') ||
-              // user refresh the page or came from direct url
-              (urlVars.module == 'ModuleBuilder' && urlVars.action == 'modulefield' && urlVars.view_package == ''))
-          ) {
+          if (formname != "dropdown_form" && formname != "popup_form" &&
+              // user came from studio/fields layout by ajax urls
+              ((urlVars.module == 'ModuleBuilder' && urlVars.action == 'modulefields' && urlVars.view_package == 'studio'))
+             ) 
+          {
             if(!(document.popup_form.action.value == 'CloneField')) {
               // switch on the preloader message
               ModuleBuilder.preloader.on();


### PR DESCRIPTION
solves #9700 

## Description
The PR deletes a condition so that the behavior of the CRM after editing a field in Studio or in the Builder Module is the same

## Motivation and Context
That Studio and the module builder have the same behavior after editing a field.
Automatically closing a view as having to do it manually is of no value to the user.

## How To Test This
1. Access Studio and create a field in any module
2. Save the creation of the field and check that the editing view of the field is closed.
3. Edit the field and check that after saving the changes the field editing screen also closes.
4. Check that in the module buider the editing view of the field is closed, both after a creation and an edition

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->