### PR TITLE
Fix #9706 - ModuleBuilder doesn't save language files in the correct …

### DIFF
--- a/modules/ModuleBuilder/parsers/parser.label.php
+++ b/modules/ModuleBuilder/parsers/parser.label.php
@@ -215,7 +215,11 @@ class ParserLabel
             }
         }
 
-        $filename = "$basepath/_override_$language.lang.php";
+        if (!$deployedModule) {
+            $filename = "$basepath/$language.lang.php";
+        } else {
+            $filename = "$basepath/_override_$language.lang.php";
+        }
         $dir_exists = is_dir($basepath);
 
         $mod_strings = array();


### PR DESCRIPTION
- Closes #9706 

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
This PR adds a condition to assign the correct path to place the language label modifications when editing a undeployed module in ModuleBuilder

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This should be fix to place the labels in the correct path

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create a new module in ModuleBuilder
2. Edit a label of the module
3. Check that the modifications of the label are placed properly in `custom/modulebuilder/packages/test/modules/test/language/en_us.lang.php`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->