### PR TITLE
Fix #9715 - Email address field isn't available in Calculate Fields Workflow action

### DIFF
--- a/modules/AOW_Actions/actions/actionComputeField.php
+++ b/modules/AOW_Actions/actions/actionComputeField.php
@@ -610,7 +610,7 @@ class actionComputeField extends actionBase
         $oneRelations = array();
 
         foreach ($linkedFields as $key => $value) {
-            if (!isset($value['link_type']) || $value['link_type'] != "one") {
+            if ((!isset($value['link_type']) || $value['link_type'] != "one") && $key != 'email_addresses') {
                 continue;
             }
 


### PR DESCRIPTION
- Closes #9715 

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->

## Description
In this PR we add a condition when calculating the relationships that will be displayed in the Action. With this condition, the email_addresses relationship won't be filtered, and therefore treated as any other relationship.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, the Email address value can be used in a "Calculate Fields" Workflow action.

## How To Test This
1. Create a WF record based in Contacts
2. Add an action of type Calculate Fields
3. Check that the Email Address is available in the relationship list:
![Selection_623](https://user-images.githubusercontent.com/61022311/182183416-e56fdcc7-50af-43a3-96dd-abdf66d2a421.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->