### PR TITLE
Fix #9728 - cron.php fails with "must be compatible" error

### DIFF
--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -3607,7 +3607,7 @@ class InboundEmail extends SugarBean
         return ($this->mailbox_type == 'createcase' && !empty($this->groupfolder_id));
     } // fn
 
-    public function handleCreateCase($email, $userId)
+    public function handleCreateCase(Email $email, $userId)
     {
         global $current_user, $mod_strings, $current_language;
         $mod_strings = return_module_language($current_language, "Emails");

--- a/modules/Schedulers/_AddJobsHere.php
+++ b/modules/Schedulers/_AddJobsHere.php
@@ -665,6 +665,9 @@ function pollMonitoredInboxesAOP()
                                             throw new Exception('Email retrieving error to handle case create, email id was: ' . $emailId);
                                         }
                                     }
+                                    if (empty($aopInboundEmailX->email)) {
+                                        throw new Exception('Invalid type for email id ' . $emailId);
+                                    }
                                     $aopInboundEmailX->handleCreateCase($aopInboundEmailX->email, $userId);
                                 } // if
                             } // if


### PR DESCRIPTION
… from AOPInboundEmail.php

## Description

Trying to run cron.php with PHP 8 fails with a fatal error (see [issue salesagility/SuiteCRM-Core#143](https://github.com/salesagility/SuiteCRM-Core/issues/143)):

    PHP Fatal error:  Declaration of AOPInboundEmail::handleCreateCase(Email $email, $userId) must be compatible with InboundEmail::handleCreateCase($email, $userId)

## Motivation and Context

This allows cron.php to succeed on a system with PHP 8.

The fix was suggested by pgr on forum team: "it’s a known issue that was aggravated in PHP 8 because it used to be a warning, now it’s FATAL"

## How To Test This
Run cron.php with PHP 8

(Note: for the script to fully succeed, PR salesagility/SuiteCRM#9731 for Issue salesagility/SuiteCRM#9730 must also be applied)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.