### PR TITLE
Fix #9730 - cron.php fails with fatal TypeError using PHP 8

### DIFF
--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -6173,7 +6173,8 @@ class InboundEmail extends SugarBean
             $ret = $this->getImap()->search('UNDELETED UNSEEN');
         }
 
-        LoggerManager::getLogger()->debug('-----> getNewMessageIds() got ' . count($ret) . ' new Messages');
+        $nmessages = is_countable($ret)? count($ret) : 0;
+        LoggerManager::getLogger()->debug('-----> getNewMessageIds() got ' . $nmessages . ' new Messages');
 
         return $ret;
     }


### PR DESCRIPTION
## Description
Trying to run cron.php with PHP 8 fails with a fatal error (see [issue #9730](https://github.com/salesagility/SuiteCRM/issues/9730)):

## Motivation and Context
This allows cron.php to succeed on a system with PHP 8.

## How To Test This
Run cron.php with RHEL 8

(Note: for the script to fully succeed, PR #9729 for Issue #9728 must also be applied)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.