### PR TITLE
Closing count bracket before relational operator PHP 8.0 count throwing TypeError

### DIFF
--- a/include/ListView/ListViewData.php
+++ b/include/ListView/ListViewData.php
@@ -512,7 +512,7 @@ class ListViewData
         $queryString = '';
 
         if (isset($_REQUEST["searchFormTab"]) && $_REQUEST["searchFormTab"] == "advanced_search" ||
-            isset($_REQUEST["type_basic"]) && (count($_REQUEST["type_basic"] > 1) || $_REQUEST["type_basic"][0] != "") ||
+            isset($_REQUEST["type_basic"]) && (count($_REQUEST["type_basic"]) > 1 || $_REQUEST["type_basic"][0] != "") ||
             isset($_REQUEST["module"]) && $_REQUEST["module"] == "MergeRecords") {
             $queryString = "-advanced_search";
         } else {


### PR DESCRIPTION
Corrected typo mistake 

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
Count bracket is closed after relational operator it must be typo mistake done years ago
before PHP 8.0 count() use to yield a warning but after PHP 8.0 count() will throw TypeError if countable types parameter is not passed, in this case Boolean value was feeding to count so it was throwing TypeError in PHP 8.0+

## Motivation and Context
This issue will throw TypeError in PHP 8.0 and may stop execution on all listing page

## How To Test This
Use PHP 8.0 + version and search on any listing page with some conditions selected in dropdown in basic search
Click on Campaigns -> View Email Template -> click on filter -> in Quick filter enter some name and select type as email -> click on search you will see following error

```
Fatal error: Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, bool given in C:\xampp80\htdocs\SuiteCRM-7.12.7\include\ListView\ListViewData.php:514 Stack trace: #0 C:\xampp80\htdocs\SuiteCRM-

7.12.7\include\ListView\ListViewDisplay.php(158): ListViewData->getListViewData(Object(EmailTemplate), '(email_template...', 0, 20, Array, Array, 'id', true, NULL) #1 C:\xampp80\htdocs\SuiteCRM-7.12.7\include\MVC\View\views\view.list.php(283): ListViewDisplay->setup(Object(EmailTemplate), 'include/ListVie...', '(email_template...', Array) #2 C:\xampp80\htdocs\SuiteCRM-
7.12.7\include\MVC\View\views\view.list.php(391): ViewList->listViewProcess() #3 C:\xampp80\htdocs\SuiteCRM-
7.12.7\include\MVC\View\SugarView.php(210): ViewList->display() #4 C:\xampp80\htdocs\SuiteCRM-
7.12.7\include\MVC\Controller\SugarController.php(432): SugarView->process() #5 C:\xampp80\htdocs\SuiteCRM-
7.12.7\include\MVC\Controller\SugarController.php(363): SugarController->processView() #6 C:\xampp80\htdocs\SuiteCRM-
7.12.7\include\MVC\SugarApplication.php(101): SugarController->execute() #7 C:\xampp80\htdocs\SuiteCRM-
7.12.7\index.php(52): SugarApplication->execute() #8 {main} thrown in C:\xampp80\htdocs\SuiteCRM-
7.12.7\include\ListView\ListViewData.php on line 514
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->