### PR TITLE
Fix  #9756 - Show emails in list view

### DIFF
--- a/modules/Emails/metadata/listviewdefs.php
+++ b/modules/Emails/metadata/listviewdefs.php
@@ -122,11 +122,6 @@ $viewdefs['Emails']['ListView'] = array(
 );
 
 $listViewDefs['Emails'] = array(
-    'FROM_ADDR_NAME' => array(
-        'width' => '32',
-        'label' => 'LBL_LIST_FROM_ADDR',
-        'default' => true,
-    ),
     'INDICATOR' => array(
         'width' => '32',
         'label' => 'LBL_INDICATOR',
@@ -134,27 +129,22 @@ $listViewDefs['Emails'] = array(
         'sortable' => false,
         'hide_header_label' => true,
     ),
-    'SUBJECT' => array(
-        // Uses function field
-        'width' => '32',
-        'label' => 'LBL_LIST_SUBJECT',
+    'NAME' => array (
+        'type' => 'name',
+        'link' => true,
+        'label' => 'LBL_SUBJECT',
+        'width' => '10%',
         'default' => true,
-        'link' => false,
-        'customCode' => ''
     ),
-    'HAS_ATTACHMENT' => array(
+    'FROM_ADDR_NAME' => array(
         'width' => '32',
-        'label' => 'LBL_HAS_ATTACHMENT_INDICATOR',
-        'default' => false,
-        'sortable' => false,
-        'hide_header_label' => true,
+        'label' => 'LBL_LIST_FROM_ADDR',
+        'default' => true,
     ),
-    'ASSIGNED_USER_NAME' => array(
-        'width' => '9',
-        'label' => 'LBL_ASSIGNED_TO_NAME',
-        'module' => 'Employees',
-        'id' => 'ASSIGNED_USER_ID',
-        'default' => false
+    'TO_ADDRS_NAMES' => array(
+        'width' => '32',
+        'label' => 'LBL_LIST_TO_ADDR',
+        'default' => true,
     ),
     'DATE_ENTERED' => array(
         'width' => '32',
@@ -166,15 +156,31 @@ $listViewDefs['Emails'] = array(
         'label' => 'LBL_LIST_DATE_SENT_RECEIVED',
         'default' => true,
     ),
-    'TO_ADDRS_NAMES' => array(
-        'width' => '32',
-        'label' => 'LBL_LIST_TO_ADDR',
-        'default' => false,
+    'CATEGORY_ID' => array(
+        'width' => '10%',
+        'label' => 'LBL_LIST_CATEGORY',
+        'default' => true,
     ),
-    'CATEGORY_ID' =>
-        array(
-            'width' => '10%',
-            'label' => 'LBL_LIST_CATEGORY',
-            'default' => true,
-        ),
+    'ASSIGNED_USER_NAME' => array(
+        'width' => '9',
+        'label' => 'LBL_ASSIGNED_TO_NAME',
+        'module' => 'Employees',
+        'id' => 'ASSIGNED_USER_ID',
+        'default' => true
+    ),    
+    'SUBJECT' => array(
+        // Uses function field
+        'width' => '32',
+        'label' => 'LBL_LIST_SUBJECT',
+        'default' => false,
+        'link' => false,
+        'customCode' => ''
+    ),
+    'HAS_ATTACHMENT' => array(
+        'width' => '32',
+        'label' => 'LBL_HAS_ATTACHMENT_INDICATOR',
+        'default' => false,
+        'sortable' => false,
+        'hide_header_label' => true,
+    ),
 );

--- a/modules/Emails/views/view.list.php
+++ b/modules/Emails/views/view.list.php
@@ -58,5 +58,6 @@ class EmailsViewList extends ViewList
     public function preDisplay()
     {
         $this->lv = new ListViewSmartyEmails();
+        parent::preDisplay();
     }
 }


### PR DESCRIPTION
## Description
Solves #9756

As described in the issue, the PR add the call to the parent method preDisplay in modules/Emails/views/view.list.php file and modifies the list layoutdef. 

## Motivation and Context
Being able to see the emails in the list view of the module

## How To Test This
1. Configure SMTP data
2. Send one or more emails
3. Check that they are shown in the list view

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->