### PR TITLE
Option to mark emails as read on the mail server while importing to CRM

### DIFF
--- a/modules/InboundEmail/DetailView.html
+++ b/modules/InboundEmail/DetailView.html
@@ -246,6 +246,17 @@
 			<span>&nbsp;</span>&nbsp;
 		</td>
 	</tr>
+	<tr style="{LEAVEMESSAGESONMAILSERVER_STYLE}">
+		<td valign="top" width='20%' scope='row'>
+			<span>{MOD.LBL_MARK_AS_READ}:</span></td>
+		<td valign="top" width='30%'>
+			<span>{MARKASREADONMAILSERVER}&nbsp;</span></td>
+		<td valign="top" width='20%' scope='row'>
+			<span>&nbsp;</span>&nbsp;</td>
+		<td valign="top" width='30%'>
+			<span>&nbsp;</span>&nbsp;
+		</td>
+	</tr>
 	</table>
 </div>
 

--- a/modules/InboundEmail/DetailView.php
+++ b/modules/InboundEmail/DetailView.php
@@ -173,11 +173,13 @@ if (!empty($focus->stored_options)) {
     } else {
         $leaveMessagesOnMailServer = $app_strings['LBL_EMAIL_NO'];
     } // else
-    if (!isset($storedOptions['leaveMessagesOnMailServer']) || $storedOptions['leaveMessagesOnMailServer'] == 1) {
-        $leaveMessagesOnMailServer = $app_strings['LBL_EMAIL_YES'];
+
+    if (!isset($storedOptions['markAsReadOnMailServer']) || $storedOptions['markAsReadOnMailServer'] == 1) {
+        $markAsReadOnMailServer = $app_strings['LBL_EMAIL_YES'];
     } else {
-        $leaveMessagesOnMailServer = $app_strings['LBL_EMAIL_NO'];
-    } // else
+        $markAsReadOnMailServer = $app_strings['LBL_EMAIL_NO'];
+    }
+
     $distrib_method = (isset($storedOptions['distrib_method'])) ? $storedOptions['distrib_method'] : "";
     $create_case_email_template = (isset($storedOptions['create_case_email_template'])) ? $storedOptions['create_case_email_template'] : "";
     $email_num_autoreplies_24_hours = (isset($storedOptions['email_num_autoreplies_24_hours'])) ? $storedOptions['email_num_autoreplies_24_hours'] : $focus->defaultEmailNumAutoreplies24Hours;

--- a/modules/InboundEmail/EditView.html
+++ b/modules/InboundEmail/EditView.html
@@ -337,6 +337,16 @@
 			<td valign="top"  width="35%"><span>
 				&nbsp;</span></td>
 		</tr>
+		<tr id = "markAsReadOnMailServerRow" style="{LEAVEMESSAGESONMAILSERVER_STYLE}">
+			<td valign="top" scope="row" width='20%'>
+				<span>{MOD.LBL_MARK_AS_READ}:</span></td>
+			<td valign="top"  width='30%'>
+				<select name='markAsReadOnMailServer' tabindex='253'>{MARKASREADONMAILSERVER}</select></td>
+			<td valign="top" scope="row">
+				<span>&nbsp;</span></td>
+			<td valign="top"  width="35%"><span>
+				&nbsp;</span></td>
+		</tr>
 	</table>
 	</div>
 

--- a/modules/InboundEmail/EditView.php
+++ b/modules/InboundEmail/EditView.php
@@ -180,6 +180,13 @@ if (!empty($focus->stored_options)) {
     } else {
         $leaveMessagesOnMailServer = 0;
     } // else
+
+    if (!isset($storedOptions['markAsReadOnMailServer']) || $storedOptions['markAsReadOnMailServer'] == 1) {
+        $markAsReadOnMailServer = 1;
+    } else {
+        $markAsReadOnMailServer = 0;
+    }
+
 } else { // initialize empty vars for template
     $from_name = $current_user->name;
     $from_addr = $current_user->email1;
@@ -358,6 +365,7 @@ if ($focus->is_personal) {
 $xtpl->assign('hasGrpFld', $focus->groupfolder_id == null ? '' : 'checked="1"');
 $xtpl->assign('LEAVEMESSAGESONMAILSERVER_STYLE', $leaveMessagesOnMailServerStyle);
 $xtpl->assign('LEAVEMESSAGESONMAILSERVER', get_select_options_with_id($app_list_strings['dom_int_bool'], $leaveMessagesOnMailServer));
+$xtpl->assign('MARKASREADONMAILSERVER', get_select_options_with_id($app_list_strings['dom_int_bool'], $markAsReadOnMailServer));
 
 $distributionMethod = get_select_options_with_id($app_list_strings['dom_email_distribution_for_auto_create'], $distrib_method);
 $xtpl->assign('DISTRIBUTION_METHOD', $distributionMethod);

--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -6918,6 +6918,16 @@ class InboundEmail extends SugarBean
     }
 
     /**
+     * marks emails as read on server
+     * @param string $uid UID(s), comma delimited, of email(s) on server
+     * @return bool true on success
+     */
+    public function markEmailsAsReadOnMailServer($uid)
+    {
+        return $this->getImap()->setFlagFull($uid, '\\SEEN', ST_UID);
+    }
+
+    /**
      * deletes and expunges emails on server
      * @param string $uid UID(s), comma delimited, of email(s) on server
      * @return bool true on success

--- a/modules/InboundEmail/Save.php
+++ b/modules/InboundEmail/Save.php
@@ -198,6 +198,11 @@ if (!empty($focus->groupfolder_id)) {
     } else {
         $stored_options['leaveMessagesOnMailServer'] = 0;
     }
+    if ($_REQUEST['markAsReadOnMailServer'] == "1") {
+        $stored_options['markAsReadOnMailServer'] = 1;
+    } else {
+        $stored_options['markAsReadOnMailServer'] = 0;
+    }
 }
 
 $focus->stored_options = base64_encode(serialize($stored_options));

--- a/modules/InboundEmail/language/en_us.lang.php
+++ b/modules/InboundEmail/language/en_us.lang.php
@@ -94,6 +94,7 @@ $mod_strings = array(
     'LBL_MARK_READ_NO' => 'Email marked deleted after import',
     'LBL_MARK_READ_YES' => 'Email left on server after import',
     'LBL_MARK_READ' => 'Leave Messages On Server',
+    'LBL_MARK_AS_READ' => 'Mark As Read On Mail Server',
     'LBL_MAX_AUTO_REPLIES' => 'Number of Auto-responses',
     'LBL_MAX_AUTO_REPLIES_DESC' => 'Set the maximum number of auto-responses to send to a unique email address during a period of 24 hours.',
     'LBL_PERSONAL_MODULE_NAME' => 'Personal Mail Account',

--- a/modules/Schedulers/_AddJobsHere.php
+++ b/modules/Schedulers/_AddJobsHere.php
@@ -245,6 +245,12 @@ function pollMonitoredInboxes()
                     } // if
                 } // if
                 if ($isGroupFolderExists) {
+                    $markAsReadOnMailServer = $ieX->get_stored_options("markAsReadOnMailServer", 0);
+                    if ($markAsReadOnMailServer) {
+                        if (!$ieX->markEmailsAsReadOnMailServer(implode(',', $messagesToDelete))) {
+                            $GLOBALS['log']->error("Failed to mark all emails as read when importing");
+                        }
+                    }
                     $leaveMessagesOnMailServer = $ieX->get_stored_options("leaveMessagesOnMailServer", 0);
                     if (!$leaveMessagesOnMailServer) {
                         if ($ieX->isPop3Protocol()) {
@@ -692,6 +698,13 @@ function pollMonitoredInboxesAOP()
                 } // if
 
                 if (!empty($isGroupFolderExists)) {
+                    $markAsReadOnMailServer = $aopInboundEmailX->get_stored_options("markAsReadOnMailServer", 0);
+                    if ($markAsReadOnMailServer) {
+                        if (!$aopInboundEmailX->markEmailsAsReadOnMailServer(implode(',', $messagesToDelete))) {
+                            $GLOBALS['log']->error("Failed to mark all emails as read when importing");
+                        }
+                    }
+
                     $leaveMessagesOnMailServer = $aopInboundEmailX->get_stored_options("leaveMessagesOnMailServer", 0);
                     if (!$leaveMessagesOnMailServer) {
                         if ($aopInboundEmailX->isPop3Protocol()) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->

## Description
Provide an option to mark emails as read on an inbound email group account when importing them to the CRM via the scheduled tasks. This will be in the Inbound Email record in the Admin menu

## Motivation and Context
By default, when importing emails from a group account, the emails remain marked as 'unread'. This will provide the option to mark the email as read once it has been imported.

## How To Test This
1. Set up a group inbound email account via the admin menu.
2. Ensure that "Mark As Read On Mail Server" is set to "Yes"
3. Make sure the email server has unread emails.
4. Run the scheduled task "Check Inbound Mailboxes".
5. See that the email has been marked as read once the scheduled task has completed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->