### PR TITLE
Fix #9768 - Disable relative URLs in TinyMCE

### DIFF
--- a/include/SuiteEditor/SuiteEditorConnector.php
+++ b/include/SuiteEditor/SuiteEditorConnector.php
@@ -78,6 +78,8 @@ class SuiteEditorConnector
                 height : '480',
                 plugins: ['code', 'table', 'link', 'image'],
                 toolbar: ['fontselect | fontsizeselect | bold italic underline | forecolor backcolor | styleselect | outdent indent | link image'],
+                relative_urls: false,
+                remove_script_host : false,
             }"
         );
     }

--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -1387,7 +1387,8 @@
   $.fn.EmailsComposeView.defaults = {
     "tinyMceOptions": {
       menubar: false,
-      toolbar: ['fontselect | fontsizeselect | bold italic underline | forecolor backcolor | styleselect | outdent indent'],
+      plugins: ['link'],
+      toolbar: ['fontselect | fontsizeselect | bold italic underline | forecolor backcolor | styleselect | outdent indent | link'],
       formats: {
         bold: {inline: 'b'},
         italic: {inline: 'i'},
@@ -1396,6 +1397,8 @@
       convert_urls: true,
       relative_urls: false,
       remove_script_host: false,
+      relative_urls: false,
+      remove_script_host : false,      
     }
   };
 }(jQuery));


### PR DESCRIPTION
## Description
Solves #9768 

As described in the issue, the PR adds the necessary configuration in TinyMCE to disable relative URLs and not remove the scheme and domain from the URL when creating a link.

## Motivation and Context
Being able to link to CRM content in emails.

## How To Test This
1. Create a campaign and go to the Templates step.
2. Open the popup view and insert a link to the site's URL in the body of the email.
3. Open the popup view of the newly created link and verify that the scheme and domain have not been removed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->