### PR TITLE
Fix salesagility#9680 - The related record selected from subpanel edit view is not updated

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -2841,6 +2841,18 @@ class SugarBean
             }
         }
 
+        // Assign the record indicated in the subpanel form instead of 
+        // the parent record (record from which the subpanel was opened) since they might be different
+        if (!empty($new_rel_id) 
+            && ( // Relationships with an ID in the _ida field of the relationship different from the parent record
+                 (!empty($this->{$new_rel_link}) && is_string($this->{$new_rel_link}) && $new_rel_id != $this->{$new_rel_link})
+                 // Special relationships like member_accounts where the parent_id is not equal to the ID of the parent record
+                 || (empty($this->{$new_rel_link}) && !empty($this->parent_id) && $new_rel_id !=$this->parent_id)
+                )
+        ) {
+            $new_rel_id = ''; // Assign the empty value to this variable, in the same way as when creating the record from the edit view
+        }
+
         return array($new_rel_id, $new_rel_link);
     }
 


### PR DESCRIPTION
Solves #9680 

## Description
Assign the record indicated in the subpanel form instead of the main record (record from which the subpanel was opened) as they may be different.

We handle the two types of relationships that we have identified as failing so far:
- Relationships with ID in the _ida field of the relationship different from the parent record
- Special relationships like member_accounts where parent_id is not equal to parent record ID

We have created this code at the end of the function `set_relationship_info()`, although due to the fact that we are not experts in the core of SuiteCRM and the existing complexity in relationship management, we have the doubt if the proposed code can be more efficient in another part of the function or of SuiteCRM code

## Motivation and Context
Failure to update related field causes data inconsistencies

## How To Test This
1. Create two accounts.
2. Go to the detail view of one of them, create a new contact or a new opportunity from the subpanel and change the related contact. 
3. Check that the contact has been updated with the contact indicated in the edit form
4. Edit the newly created contact or opportunnity from the subpanel and change the related contact.
5. Check that the contact or opportunnity has been updated with the account indicated in the edit form.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->