### PR TITLE
fix #9802 - Diagnostic checkboxes

### DIFF
--- a/modules/Administration/Diagnostic.tpl
+++ b/modules/Administration/Diagnostic.tpl
@@ -59,44 +59,44 @@
 <table id="maintable" width="430" border="0" cellspacing="0" cellpadding="0" class="edit view">
 <tr>
 	<td scope="row"><span>{$MOD.LBL_DIAGNOSTIC_CONFIGPHP}</span></td>
-	<td ><span><input name='configphp' class="checkbox" type="checkbox" tabindex='1' checked></span></td>
+	<td ><span><input name='configphp' class="checkbox" type="checkbox" tabindex='1'></span></td>
 	</tr><tr>
 	<td scope="row"><span>{$MOD.LBL_DIAGNOSTIC_CUSTOMDIR}</span></td>
-	<td ><span><input name='custom_dir' class="checkbox" type="checkbox" tabindex='2' checked></span></td>
+	<td ><span><input name='custom_dir' class="checkbox" type="checkbox" tabindex='2'></span></td>
 	</tr><tr>
 
 	<td scope="row"><span>{$MOD.LBL_DIAGNOSTIC_PHPINFO}</span></td>
-	<td ><span><input name='phpinfo' class="checkbox" type="checkbox" tabindex='3' checked></span></td>
+	<td ><span><input name='phpinfo' class="checkbox" type="checkbox" tabindex='3'></span></td>
 	</tr><tr>
 	<td scope="row"><span>{$DB_NAME} - {$MOD.LBL_DIAGNOSTIC_MYSQLDUMPS}</span></td>
-	<td ><span><input name='mysql_dumps' class="checkbox" type="checkbox" tabindex='4' checked></span></td>
+	<td ><span><input name='mysql_dumps' class="checkbox" type="checkbox" tabindex='4'></span></td>
 	</tr><tr>
 	<td scope="row"><span>{$DB_NAME} - {$MOD.LBL_DIAGNOSTIC_MYSQLSCHEMA}</span></td>
 
-	<td ><span><input name='mysql_schema' class="checkbox" type="checkbox" tabindex='5' checked></span></td>
+	<td ><span><input name='mysql_schema' class="checkbox" type="checkbox" tabindex='5'></span></td>
 	</tr><tr>
 	<td scope="row"><span>{$DB_NAME} - {$MOD.LBL_DIAGNOSTIC_MYSQLINFO}</span></td>
-	<td ><span><input name='mysql_info' class="checkbox" type="checkbox" tabindex='6' checked></span></td>
+	<td ><span><input name='mysql_info' class="checkbox" type="checkbox" tabindex='6'></span></td>
 	</tr><tr>
 	<td scope="row"><span>{$MOD.LBL_DIAGNOSTIC_MD5}</span></td>
-	<td ><span><input name='md5' class="checkbox" type="checkbox" tabindex='7' onclick="md5checkboxes()" checked></span></td>
+	<td ><span><input name='md5' class="checkbox" type="checkbox" tabindex='7' onclick="md5checkboxes()"></span></td>
 	</tr><tr>
 
 	<td scope="row"><span>{$MOD.LBL_DIAGNOSTIC_FILESMD5}</span></td>
-	<td ><span><input name='md5filesmd5' class="checkbox" type="checkbox" tabindex='8' ></span></td>
+	<td ><span><input name='md5filesmd5' class="checkbox" type="checkbox" tabindex='8'></span></td>
 	</tr><tr>
 	<td scope="row"><span>{$MOD.LBL_DIAGNOSTIC_CALCMD5}</span></td>
-	<td ><span><input name='md5calculated' class="checkbox" type="checkbox" tabindex='9' ></span></td>
+	<td ><span><input name='md5calculated' class="checkbox" type="checkbox" tabindex='9'></span></td>
 	</tr><tr>
 	<td scope="row"><span>{$MOD.LBL_DIAGNOSTIC_BLBF}</span></td>
 
-	<td ><span><input name='beanlistbeanfiles' class="checkbox" type="checkbox" tabindex='10' checked></span></td>
+	<td ><span><input name='beanlistbeanfiles' class="checkbox" type="checkbox" tabindex='10'></span></td>
 	</tr><tr>
 	<td scope="row"><span>{$MOD.LBL_DIAGNOSTIC_SUITELOG}</span></td>
-	<td ><span><input name='sugarlog' class="checkbox" type="checkbox" tabindex='11' checked></span></td>
+	<td ><span><input name='sugarlog' class="checkbox" type="checkbox" tabindex='11'></span></td>
 	</tr><tr>
 	<td scope="row"><span>{$MOD.LBL_DIAGNOSTIC_VARDEFS}</span></td>
-	<td ><span><input name='vardefs' class="checkbox" type="checkbox" tabindex='11' checked></span></td>
+	<td ><span><input name='vardefs' class="checkbox" type="checkbox" tabindex='11'></span></td>
 	</tr>
 </table>
 </div>


### PR DESCRIPTION
## Description
Checkboxes are automatically checked in the diagnostic tools section in admin. Having them unchecked is quicker and easier for users just checking what they want as it is rare that users need all of them. 

## How To Test This
1. go to adamin->diagnostic tools
2. see that all checkboxes are not checked

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->