### PR TITLE
Fix #9805 - Use timezone offset for datetime only

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -1729,7 +1729,7 @@ class AOR_Report extends Basic
                             } else {
                                 $params = base64_decode($condition->value);
                             }
-                            $value = '"' . getPeriodDate($params)->format('Y-m-d H:i:s') . '"';
+                            $value = '"' . getPeriodDate($params, $data['type'])->format('Y-m-d H:i:s') . '"';
                             break;
                         case "CurrentUserID":
                             global $current_user;
@@ -1885,8 +1885,8 @@ class AOR_Report extends Basic
                             } else {
                                 $params = base64_decode($condition->value);
                             }
-                            $date = getPeriodEndDate($params)->format('Y-m-d H:i:s');
-                            $value = "'" . $this->db->quote(getPeriodDate($params)->format('Y-m-d H:i:s')) . "'";
+                            $date = getPeriodEndDate($params, $data['type'])->format('Y-m-d H:i:s');
+                            $value = "'" . $this->db->quote(getPeriodDate($params, $data['type'])->format('Y-m-d H:i:s')) . "'";
 
                             $query['where'][] = ($tiltLogicOp ? '' : ($condition->logic_op ? $condition->logic_op . ' ' : 'AND '));
                             $tiltLogicOp = false;

--- a/modules/AOR_Reports/aor_utils.php
+++ b/modules/AOR_Reports/aor_utils.php
@@ -226,7 +226,7 @@ function getConditionsAsParameters($report, $override = array())
  * @param $date_time_period_list_selected
  * @return DateTime
  */
-function getPeriodDate($date_time_period_list_selected)
+function getPeriodDate($date_time_period_list_selected, $type = '')
 {
     global $sugar_config, $timedate;
     $datetime_period = new DateTime();
@@ -324,7 +324,9 @@ function getPeriodDate($date_time_period_list_selected)
     // set time to 00:00:00
     $datetime_period = $datetime_period->setTime(0, 0, 0);
 
-    $datetime_period->sub(DateInterval::createFromDateString($timedate->getUserUTCOffset().' minutes'));
+    if($type === 'datetime') {
+        $datetime_period->sub(DateInterval::createFromDateString($timedate->getUserUTCOffset() . ' minutes'));
+    }
 
     return $datetime_period;
 }
@@ -334,7 +336,7 @@ function getPeriodDate($date_time_period_list_selected)
  * @param $date_time_period_list_selected
  * @return DateTime
  */
-function getPeriodEndDate($dateTimePeriodListSelected)
+function getPeriodEndDate($dateTimePeriodListSelected, $type = '')
 {
     global $timedate;
     switch ($dateTimePeriodListSelected) {
@@ -412,7 +414,11 @@ function getPeriodEndDate($dateTimePeriodListSelected)
             $datetimePeriod->setTime(0, 0, 0);
             break;
     }
-    $datetimePeriod->sub(DateInterval::createFromDateString($timedate->getUserUTCOffset().' minutes'));
+
+    if($type === 'datetime') {
+        $datetimePeriod->sub(DateInterval::createFromDateString($timedate->getUserUTCOffset() . ' minutes'));
+    }
+
     return $datetimePeriod;
 }
 

--- a/modules/AOR_Reports/aor_utils.php
+++ b/modules/AOR_Reports/aor_utils.php
@@ -345,43 +345,61 @@ function getPeriodEndDate($dateTimePeriodListSelected, $type = '')
             break;
         case 'yesterday':
             $datetimePeriod = new DateTime("yesterday");
-            $datetimePeriod->setTime(23, 59, 59);
+            if($type === 'datetime') {
+                $datetimePeriod->setTime(23, 59, 59);
+            }
             break;
         case 'this_week':
-            $datetimePeriod = new DateTime("next week monday");
-            $datetimePeriod->setTime(0, 0, 0);
+            $datetimePeriod = new DateTime("this week sunday");
+            if($type === 'datetime') {
+                $datetimePeriod->setTime(23, 59, 59);
+            }
             break;
         case 'last_week':
-            $datetimePeriod = new DateTime("this week monday");
-            $datetimePeriod->setTime(0, 0, 0);
+            $datetimePeriod = new DateTime("last week sunday");
+            if($type === 'datetime') {
+                $datetimePeriod->setTime(23, 59, 59);
+            }
             break;
         case 'this_month':
-            $datetimePeriod = new DateTime('first day of next month');
-            $datetimePeriod->setTime(0, 0, 0);
+            $datetimePeriod = new DateTime('last day of this month');
+            if($type === 'datetime') {
+                $datetimePeriod->setTime(23, 59, 59);
+            }
             break;
         case 'last_month':
-            $datetimePeriod = new DateTime("first day of this month");
-            $datetimePeriod->setTime(0, 0, 0);
+            $datetimePeriod = new DateTime("last day of last month");
+            if($type === 'datetime') {
+                $datetimePeriod->setTime(23, 59, 59);
+            }
             break;
         case 'this_quarter':
             $thisMonth = new DateTime('first day of this month');
             $thisMonth = $thisMonth->format('n');
             if ($thisMonth < 4) {
                 // quarter 1
-                $datetimePeriod = new DateTime('first day of april');
-                $datetimePeriod->setTime(0, 0, 0);
+                $datetimePeriod = new DateTime('last day of march');
+                if($type === 'datetime') {
+                    $datetimePeriod->setTime(23, 59, 59);
+                }
             } elseif ($thisMonth > 3 && $thisMonth < 7) {
                 // quarter 2
-                $datetimePeriod = new DateTime('first day of july');
-                $datetimePeriod->setTime(0, 0, 0);
+                $datetimePeriod = new DateTime('last day of june');
+                if($type === 'datetime') {
+                    $datetimePeriod->setTime(23, 59, 59);
+                }
             } elseif ($thisMonth > 6 && $thisMonth < 10) {
                 // quarter 3
-                $datetimePeriod = new DateTime('first day of october');
-                $datetimePeriod->setTime(0, 0, 0);
+                $datetimePeriod = new DateTime('last day of september');
+                if($type === 'datetime') {
+                    $datetimePeriod->setTime(23, 59, 59);
+                }
             } elseif ($thisMonth > 9) {
                 // quarter 4
-                $datetimePeriod = new DateTime('next year first day of january');
-                $datetimePeriod->setTime(0, 0, 0);
+                $datetimePeriod = new DateTime('this year last day of december');
+                if($type === 'datetime') {
+                    $datetimePeriod->setTime(23, 59, 59);
+                }
             }
             break;
         case 'last_quarter':
@@ -389,29 +407,41 @@ function getPeriodEndDate($dateTimePeriodListSelected, $type = '')
             $thisMonth = $thisMonth->format('n');
             if ($thisMonth < 4) {
                 // previous quarter 1
-                $datetimePeriod = new DateTime('this year first day of january');
-                $datetimePeriod->setTime(0, 0, 0);
+                $datetimePeriod = new DateTime('this year last day of december');
+                if($type === 'datetime') {
+                    $datetimePeriod->setTime(23, 59, 59);
+                }
             } elseif ($thisMonth > 3 && $thisMonth < 7) {
                 // previous quarter 2
-                $datetimePeriod = new DateTime('first day of april');
-                $datetimePeriod->setTime(0, 0, 0);
+                $datetimePeriod = new DateTime('last day of march');
+                if($type === 'datetime') {
+                    $datetimePeriod->setTime(23, 59, 59);
+                }
             } elseif ($thisMonth > 6 && $thisMonth < 10) {
                 // previous quarter 3
-                $datetimePeriod = new DateTime('first day of july');
-                $datetimePeriod->setTime(0, 0, 0);
+                $datetimePeriod = new DateTime('last day of june');
+                if($type === 'datetime') {
+                    $datetimePeriod->setTime(23, 59, 59);
+                }
             } elseif ($thisMonth > 9) {
                 // previous quarter 4
-                $datetimePeriod = new DateTime('first day of october');
-                $datetimePeriod->setTime(0, 0, 0);
+                $datetimePeriod = new DateTime('last day of september');
+                if($type === 'datetime') {
+                    $datetimePeriod->setTime(23, 59, 59);
+                }
             }
             break;
         case 'this_year':
-            $datetimePeriod = new DateTime('next year first day of january');
-            $datetimePeriod->setTime(0, 0, 0);
+            $datetimePeriod = new DateTime('this year last day of december');
+            if($type === 'datetime') {
+                $datetimePeriod->setTime(23, 59, 59);
+            }
             break;
         case 'last_year':
-            $datetimePeriod = new DateTime("this year first day of january");
-            $datetimePeriod->setTime(0, 0, 0);
+            $datetimePeriod = new DateTime("last year last day of december");
+            if($type === 'datetime') {
+                $datetimePeriod->setTime(23, 59, 59);
+            }
             break;
     }
 

--- a/modules/AOW_WorkFlow/aow_utils.php
+++ b/modules/AOW_WorkFlow/aow_utils.php
@@ -615,7 +615,7 @@ function getModuleField(
             $fieldlist[$fieldname]['value'] = $timedate->to_display($value, $convert_format, $params['date_format']);
         } else {
             if ($fieldlist[$fieldname]['type'] == 'date') {
-                $fieldlist[$fieldname]['value'] = $timedate->to_display_date($value, true, true);
+                $fieldlist[$fieldname]['value'] = $timedate->to_display_date($value, false);
             } else {
                 $fieldlist[$fieldname]['value'] = $timedate->to_display_date_time($value, true, true);
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
See https://github.com/salesagility/SuiteCRM/issues/9805

When a User has set a different timezone and they attempt to report on Date fields, the CRM queries the database using a datetime value with an offset for the timezone. This provides incorrect results as the query will assume a date type has a midnight timestamp.

## Motivation and Context
Users with custom timezones may have incorrect report results.

## How To Test This
1. Set your timezone to America/Chicago in your profile.
2. Create a date field in Contacts
3. Create a Contacts record with the newly created date field set to today.
4. Create a Report on Contacts with a condition on the newly created date field equal to the period "Today"
5. The Contacts record will not be returned in the report

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->