### PR TITLE
FIX #9344 Error in Browsers console after adding tabs to Quickcreate: function selectTabOnError

### DIFF
--- a/themes/SuiteP/include/DetailView/DetailView.tpl
+++ b/themes/SuiteP/include/DetailView/DetailView.tpl
@@ -333,7 +333,7 @@
                         $('#content div.panel-content div.panel.tab-panel-' + tab).show();
                     };
 
-                    let selectTabOnError = function(tab) {
+                    var selectTabOnError = function(tab) {
                         selectTabDetailView(tab);
                         $('#content ul.nav.nav-tabs > li').removeClass('active');
                         $('#content ul.nav.nav-tabs > li a').css('color', '');


### PR DESCRIPTION
FIX #9344 

Found that the name of the function selectTabOnError has been declared twice at the theme SuiteP

If I change the definition of the function from let to var it does not throws the error on the javascript console.

# Motivation and Context

When create a new record with quickcreate view form subpanel it throws an error console of javascript. 

# How To Test This

1. Add a panel in the QuickCreate view of the Accounts module
2. After saving the view, change the "Panel" to "Tab" configuration
3. Go to the Quickcreateview of Accounts (Inside an Account, the Member Organization subpanel)
4. Open the browser console and see the error

![140304087-7036bd05-be6a-43aa-8532-1ed8caf11706](https://user-images.githubusercontent.com/776682/201053699-66d5b258-3fc8-49f8-b3bc-ceffc03e4c46.png)

# Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Final checklist

- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [How to Contribute](https://docs.suitecrm.com/community/contributing-code/) guidelines.