### PR TITLE
Fix #9823 - Wrong link to related objects in search result

### DIFF
--- a/lib/Search/SearchResults.php
+++ b/lib/Search/SearchResults.php
@@ -209,7 +209,12 @@ class SearchResults
     {
         $relField = $idName;
         if (isset($obj->$link)) {
-            $relId = $obj->$link->getFocus()->$relField;
+            $linkedbeans=$obj->$link->getBeans();
+            if(count($linkedbeans)==1){
+                $relId = array_keys($linkedbeans)[0];
+            }else{
+                $relId = $obj->$link->getFocus()->$relField;
+            }
             if (is_object($relId)) {
                 if (method_exists($relId, "getFocus")) {
                     $relId = $relId->getFocus()->id;


### PR DESCRIPTION
In search result some related objects get the same id in the link as the found object. As example you find object of type custom type 
mmm_mymodule id 12345678
related to mmm_realtedmodule 87654321

Search results gives two links if related module is in listview

index.php?module=mmm_mymodule &id=12345678
index.php?module=mmm_realtedmodule &id=12345678

So the second link will lead to an unexistent object. I do not know exactly why this happens only in some cases. Maybe the relation is defined in the mmm_relatedmodule. Maybe it is because it is custom module.

The search result page anyways is totally butchered by someone. Checkboxes in listview get displayed as "0" and "1" etc.
