### PR TITLE
When defining buttons as empty array do not display them

### DIFF
--- a/themes/SuiteP/include/EditView/actions_buttons.tpl
+++ b/themes/SuiteP/include/EditView/actions_buttons.tpl
@@ -1,5 +1,5 @@
 <div class="buttons">
-    {{if !empty($form) && !empty($form.buttons)}}
+    {{if !empty($form) && isset($form.buttons)}}
         {{foreach from=$form.buttons key=val item=button}}
         {{sugar_button module="$module" id="$button" form_id="$form_id" view="$view"}}
         {{/foreach}}


### PR DESCRIPTION
If defining buttons in editviewdefs to get rid of the buttons as empty array they still get displayed because empty logic differs from isset logic. Define like:
$viewdefs[$module]['EditView']['templateMeta']['form']['buttons']=array();

SAVE and CANCEL buttons still will get displayed.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->