### PR TITLE
Fix salesagility#9788 - Database Failures in Subpanels throughout SuiteCRM (MySQL Error)

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -873,7 +873,7 @@ class SugarBean
                     $final_query .= ' UNION ALL ( ' . $tmp_final_query . ' )';
                 } else {
                     $final_query_rows = '(' . $parentbean->create_list_count_query($tmp_final_query, $parameters) . ')';
-                    $final_query = '(' . $tmp_final_query . ')';
+                    $final_query = $tmp_final_query;
                     $first = false;
                 }
             }
@@ -927,7 +927,6 @@ class SugarBean
                     $query = ' UNION ALL ( ' . $query . ' )';
                     $final_query_rows .= " UNION ALL ";
                 } else {
-                    $query = '(' . $query . ')';
                     $first = false;
                 }
                 $query_array = $subquery['query_array'];
@@ -3511,7 +3510,7 @@ class SugarBean
         if (isset($_SESSION['show_deleted'])) {
             $show_deleted = 1;
         }
-        
+
         $query = $this->create_new_list_query(
             $order_by,
             $where,
@@ -4472,7 +4471,7 @@ class SugarBean
         if (isset($_SESSION['show_deleted'])) {
             $show_deleted = 1;
         }
-        
+
         $query = $this->create_new_list_query($order_by, $where, array(), array(), $show_deleted, $offset);
 
         return $this->process_detail_query($query, $row_offset, $limit, $max, $where, $offset);
@@ -6159,10 +6158,10 @@ class SugarBean
 
         return $args->access
             && ACLController::checkAccess(
-                $this->module_dir, 
-                $args->view, 
-                $args->is_owner, 
-                $this->acltype, 
+                $this->module_dir,
+                $args->view,
+                $args->is_owner,
+                $this->acltype,
                 $args->in_group
             );
     }


### PR DESCRIPTION
Fix Issue https://github.com/salesagility/SuiteCRM/issues/9788

Description
Changes implemented in MySQL 8.0.31 cause SQL queries that pull data for subpannels to fail. If the outer ( ) is removed from the query, it will complete normally.

The code that adds the outer ( ) to the query is located on lines 876 and 930 of Suite CRM/data/SugarBean.php. By removing these lines the query if fixed.

876: $final_query = '(' . $tmp_final_query . ')';
930: $query = '(' . $query . ')'; '''

Motivation and Context
If the MySQL environment is updated to MySQL 8.0.31 the subpannels that depend on these SQL queries will fail.

How To Test
Update MySQL to 8.0.31 on host server
Create Account with linked subpanel data (contacts, opportunities, leads, ect)
Subpanels must have data for the error to occur.
Open Account detail page & suitecrm.log to see error.
Remove specified lines and test

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.