### PR TITLE
ElasticSearch Indexing batch error handling

### DIFF
--- a/lib/Search/ElasticSearch/ElasticSearchIndexer.php
+++ b/lib/Search/ElasticSearch/ElasticSearchIndexer.php
@@ -500,16 +500,18 @@ class ElasticSearchIndexer extends AbstractIndexer
             // logs the errors
             foreach ($responses['items'] as $item) {
                 $action = array_keys($item)[0];
-                $type = $item[$action]['error']['type'];
-                $reason = $item[$action]['error']['reason'];
-                $this->logger->error("[$action] [$type] $reason");
+                if(isset($item[$action]['error'])) {
+                    $type = $item[$action]['error']['type'];
+                    $reason = $item[$action]['error']['reason'];
+                    $this->logger->error("[$action] [$type] $reason");
+                    
+                    if ($action === 'index') {
+                        $this->indexedRecordsCount--;
+                    }
 
-                if ($action === 'index') {
-                    $this->indexedRecordsCount--;
-                }
-
-                if ($action === 'delete') {
-                    $this->removedRecordsCount--;
+                    if ($action === 'delete') {
+                        $this->removedRecordsCount--;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description
Previously, the ElasticSearch Indexing would assume that if there were errors in a batch that all items in the batch had an error.  This fix only logs errors when an item actually has an error present.

## Motivation and Context
Previously, the sendBatch() function did not check if $item[$action]['error']) was set before trying to access indices within.  This would cause errors when indexing if there was a batch that included an item that had an error but others items within the batch did not.

## How To Test This
My database previously included some items that had some errors.  I've since fixed those errors so I can't immediately reproduce the issue currently.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.