### PR TITLE
Feature - Add ACL Access Logic Hooks

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -3506,22 +3506,7 @@ class SugarBean
         if (isset($_SESSION['show_deleted'])) {
             $show_deleted = 1;
         }
-
-        if ($this->bean_implements('ACL') && ACLController::requireOwner($this->module_dir, 'list')) {
-            global $current_user;
-            $owner_where = $this->getOwnerWhere($current_user->id);
-
-            //rrs - because $this->getOwnerWhere() can return '' we need to be sure to check for it and
-            //handle it properly else you could get into a situation where you are create a where stmt like
-            //WHERE .. AND ''
-            if (!empty($owner_where)) {
-                if (empty($where)) {
-                    $where = $owner_where;
-                } else {
-                    $where .= ' AND ' . $owner_where;
-                }
-            }
-        }
+        
         $query = $this->create_new_list_query(
             $order_by,
             $where,
@@ -3551,6 +3536,49 @@ class SugarBean
             return " $this->table_name.created_by ='$user_id' ";
         }
         return '';
+    }
+
+
+    /**
+     * @param string $view
+     * @param User $user
+     * @return string
+     */
+    public function buildAccessWhere($view, $user = null)
+    {
+        global $current_user, $sugar_config;
+
+        $conditions = [];
+        $user = $user === null ? $current_user : $user;
+
+        if ($this->bean_implements('ACL') && ACLController::requireOwner($this->module_dir, $view)) {
+            $ownerWhere = $this->getOwnerWhere($user->id);
+            if (!empty($ownerWhere)) {
+                $conditions['owner'] = $ownerWhere;
+            }
+        }
+
+        /* BEGIN - SECURITY GROUPS */
+        $SecurityGroupFile = BeanFactory::getBeanFile('SecurityGroups');
+        require_once $SecurityGroupFile;
+        if ($view === 'list' && $this->module_dir === 'Users' && !is_admin($user)
+            && isset($sugar_config['securitysuite_filter_user_list'])
+            && $sugar_config['securitysuite_filter_user_list']
+        ) {
+            $groupWhere = SecurityGroup::getGroupUsersWhere($user->id);
+            $conditions['group'] = $groupWhere;
+        } elseif ($this->bean_implements('ACL') && ACLController::requireSecurityGroup($this->module_dir, $view)) {
+            $ownerWhere = $this->getOwnerWhere($user->id);
+            $groupWhere = SecurityGroup::getGroupWhere($this->table_name, $this->module_dir, $user->id);
+            if (!empty($ownerWhere)) {
+                $conditions['group'] = " (" . $ownerWhere . " or " . $groupWhere . ") ";
+            } else {
+                $conditions['group'] = $groupWhere;
+            }
+        }
+        /* END - SECURITY GROUPS */
+
+        return implode(' AND ', $conditions);
     }
 
     /**
@@ -3587,45 +3615,12 @@ class SugarBean
         $secondarySelectedFields = array();
         $ret_array = array();
         $distinct = '';
-        if ($this->bean_implements('ACL') && ACLController::requireOwner($this->module_dir, 'list')) {
-            global $current_user;
-            $owner_where = $this->getOwnerWhere($current_user->id);
-            if (empty($where)) {
-                $where = $owner_where;
-            } else {
-                $where .= ' AND ' . $owner_where;
-            }
+
+        $accessWhere = $this->buildAccessWhere('list');
+        if (!empty($accessWhere)) {
+            $where .= empty($where) ? $accessWhere : ' AND ' . $accessWhere;
         }
-        /* BEGIN - SECURITY GROUPS */
-        global $current_user, $sugar_config;
-        if ($this->module_dir == 'Users' && !is_admin($current_user)
-            && isset($sugar_config['securitysuite_filter_user_list'])
-            && $sugar_config['securitysuite_filter_user_list']
-        ) {
-            require_once('modules/SecurityGroups/SecurityGroup.php');
-            global $current_user;
-            $group_where = SecurityGroup::getGroupUsersWhere($current_user->id);
-            if (empty($where)) {
-                $where = " (" . $group_where . ") ";
-            } else {
-                $where .= " AND (" . $group_where . ") ";
-            }
-        } elseif ($this->bean_implements('ACL') && ACLController::requireSecurityGroup($this->module_dir, 'list')) {
-            require_once('modules/SecurityGroups/SecurityGroup.php');
-            global $current_user;
-            $owner_where = $this->getOwnerWhere($current_user->id);
-            $group_where = SecurityGroup::getGroupWhere($this->table_name, $this->module_dir, $current_user->id);
-            if (!empty($owner_where)) {
-                if (empty($where)) {
-                    $where = " (" . $owner_where . " or " . $group_where . ") ";
-                } else {
-                    $where .= " AND (" . $owner_where . " or " . $group_where . ") ";
-                }
-            } else {
-                $where .= ' AND ' . $group_where;
-            }
-        }
-        /* END - SECURITY GROUPS */
+
         if (!empty($params['distinct'])) {
             $distinct = ' DISTINCT ';
         }
@@ -4465,35 +4460,7 @@ class SugarBean
         if (isset($_SESSION['show_deleted'])) {
             $show_deleted = 1;
         }
-
-        if ($this->bean_implements('ACL') && ACLController::requireOwner($this->module_dir, 'list')) {
-            global $current_user;
-            $owner_where = $this->getOwnerWhere($current_user->id);
-
-            if (empty($where)) {
-                $where = $owner_where;
-            } else {
-                $where .= ' AND ' . $owner_where;
-            }
-        }
-
-        /* BEGIN - SECURITY GROUPS */
-        if ($this->bean_implements('ACL') && ACLController::requireSecurityGroup($this->module_dir, 'list')) {
-            require_once('modules/SecurityGroups/SecurityGroup.php');
-            global $current_user;
-            $owner_where = $this->getOwnerWhere($current_user->id);
-            $group_where = SecurityGroup::getGroupWhere($this->table_name, $this->module_dir, $current_user->id);
-            if (!empty($owner_where)) {
-                if (empty($where)) {
-                    $where = " (" . $owner_where . " or " . $group_where . ") ";
-                } else {
-                    $where .= " AND (" . $owner_where . " or " . $group_where . ") ";
-                }
-            } else {
-                $where .= ' AND ' . $group_where;
-            }
-        }
-        /* END - SECURITY GROUPS */
+        
         $query = $this->create_new_list_query($order_by, $where, array(), array(), $show_deleted, $offset);
 
         return $this->process_detail_query($query, $row_offset, $limit, $max, $where, $offset);

--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -3142,10 +3142,10 @@ class SugarBean
      * function NAME(&$bean, $event, $arguments)
      *        $bean - $this bean passed in by reference.
      *        $event - The string for the current event (i.e. before_save)
-     *        $arguments - An array of arguments that are specific to the event.
+     *        $arguments - An object or array of arguments that are specific to the event.
      *
      * @param string $event
-     * @param array $arguments
+     * @param object|array $arguments
      */
     public function call_custom_logic($event, $arguments = null)
     {
@@ -3578,7 +3578,14 @@ class SugarBean
         }
         /* END - SECURITY GROUPS */
 
-        return implode(' AND ', $conditions);
+        $args = new stdClass();
+        $args->view = $view;
+        $args->user = $user;
+        $args->conditions = $conditions;
+
+        $this->call_custom_logic('before_acl_query', $args);
+
+        return implode(' AND ', $args->conditions);
     }
 
     /**
@@ -6131,7 +6138,28 @@ class SugarBean
             require_once("modules/SecurityGroups/SecurityGroup.php");
             $in_group = SecurityGroup::groupHasAccess($this->module_dir, $this->id, $view);
         }
-        return ACLController::checkAccess($this->module_dir, $view, $is_owner, $this->acltype, $in_group);
+
+        $args = new stdClass();
+        $args->view = $view;
+        $args->is_owner = $is_owner;
+        $args->in_group = $in_group;
+        $args->access = true;
+        $args->override_acl_check = false;
+
+        $this->call_custom_logic('before_acl_check', $args);
+
+        if ($args->override_acl_check) {
+            return $args->access;
+        }
+
+        return $args->access
+            && ACLController::checkAccess(
+                $this->module_dir, 
+                $args->view, 
+                $args->is_owner, 
+                $this->acltype, 
+                $args->in_group
+            );
     }
 
     /**

--- a/include/export_utils.php
+++ b/include/export_utils.php
@@ -168,32 +168,11 @@ function export($type, $records = null, $members = false, $sample=false)
             ACLController::displayNoAccess();
             sugar_die('');
         }
-        if (ACLController::requireOwner($focus->module_dir, 'export')) {
-            if (!empty($where)) {
-                $where .= ' AND ';
-            }
-            $where .= $focus->getOwnerWhere($current_user->id);
+
+        $accessWhere = $focus->buildAccessWhere('export');
+        if (!empty($accessWhere)) {
+            $where .= empty($where) ? $accessWhere : ' AND ' . $accessWhere;
         }
-        /* BEGIN - SECURITY GROUPS */
-        if (ACLController::requireSecurityGroup($focus->module_dir, 'export')) {
-            require_once('modules/SecurityGroups/SecurityGroup.php');
-            global $current_user;
-            $owner_where = $focus->getOwnerWhere($current_user->id);
-            $group_where = SecurityGroup::getGroupWhere($focus->table_name, $focus->module_dir, $current_user->id);
-            if (!empty($owner_where)) {
-                if (empty($where)) {
-                    $where = " (".  $owner_where." or ".$group_where.")";
-                } else {
-                    $where .= " AND (".  $owner_where." or ".$group_where.")";
-                }
-            } else {
-                if (!empty($where)) {
-                    $where .= ' AND ';
-                }
-                $where .= $group_where;
-            }
-        }
-        /* END - SECURITY GROUPS */
     }
     // Export entire list was broken because the where clause already has "where" in it
     // and when the query is built, it has a "where" as well, so the query was ill-formed.

--- a/include/utils.php
+++ b/include/utils.php
@@ -3132,26 +3132,12 @@ function get_bean_select_array(
         }
 
         $query .= " {$focus->table_name}.deleted=0";
-
-        /* BEGIN - SECURITY GROUPS */
-        global $current_user, $sugar_config;
-        if ($focus->module_dir == 'Users' && !is_admin($current_user) && isset($sugar_config['securitysuite_filter_user_list']) && $sugar_config['securitysuite_filter_user_list'] == true
-        ) {
-            require_once 'modules/SecurityGroups/SecurityGroup.php';
-            $group_where = SecurityGroup::getGroupUsersWhere($current_user->id);
-            $query .= ' AND (' . $group_where . ') ';
-        } elseif ($focus->bean_implements('ACL') && ACLController::requireSecurityGroup($focus->module_dir, 'list')) {
-            require_once 'modules/SecurityGroups/SecurityGroup.php';
-            $owner_where = $focus->getOwnerWhere($current_user->id);
-            $group_where = SecurityGroup::getGroupWhere($focus->table_name, $focus->module_dir, $current_user->id);
-            if (!empty($owner_where)) {
-                $query .= ' AND (' . $owner_where . ' or ' . $group_where . ') ';
-            } else {
-                $query .= ' AND ' . $group_where;
-            }
+        
+        $accessWhere = $focus->buildAccessWhere('list');
+        if (!empty($accessWhere)) {
+            $query .= ' AND ' . $accessWhere;
         }
-        /* END - SECURITY GROUPS */
-
+        
         if ($order_by != '') {
             $query .= " order by {$focus->table_name}.{$order_by}";
         }

--- a/include/utils/LogicHook.php
+++ b/include/utils/LogicHook.php
@@ -179,7 +179,7 @@ class LogicHook
      *
      * @param string $module_dir
      * @param string $event
-     * @param array $arguments
+     * @param object|array $arguments
      * @param SugarBean $bean
      */
     public function call_custom_logic($module_dir, $event, $arguments = null)
@@ -209,7 +209,7 @@ class LogicHook
      *
      * @param array $hook_array
      * @param string $event
-     * @param array $arguments
+     * @param object|array $arguments
      * @param SugarBean $bean
      */
     public function process_hooks($hook_array, $event, $arguments)

--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -1427,29 +1427,10 @@ class AOR_Report extends Basic
     {
         $tempTableName = $module->table_name;
         $module->table_name = $alias;
-        $where = '';
-        if ($module->bean_implements('ACL') && ACLController::requireOwner($module->module_dir, 'list')) {
-            global $current_user;
-            $owner_where = $module->getOwnerWhere($current_user->id);
-            $where = ' AND ' . $owner_where;
+        $where = $module->buildAccessWhere('list');
+        if (!empty($where)) {
+            $where = ' AND ' . $where;
         }
-
-        if (file_exists('modules/SecurityGroups/SecurityGroup.php')) {
-            /* BEGIN - SECURITY GROUPS */
-            if ($module->bean_implements('ACL') && ACLController::requireSecurityGroup($module->module_dir, 'list')) {
-                require_once('modules/SecurityGroups/SecurityGroup.php');
-                global $current_user;
-                $owner_where = $module->getOwnerWhere($current_user->id);
-                $group_where = SecurityGroup::getGroupWhere($alias, $module->module_dir, $current_user->id);
-                if (!empty($owner_where)) {
-                    $where .= " AND (" . $owner_where . " or " . $group_where . ") ";
-                } else {
-                    $where .= ' AND ' . $group_where;
-                }
-            }
-            /* END - SECURITY GROUPS */
-        }
-
         $module->table_name = $tempTableName;
 
         return $where;

--- a/modules/Campaigns/utils.php
+++ b/modules/Campaigns/utils.php
@@ -413,16 +413,13 @@ function get_subscription_lists_query($focus, $additional_fields = null)
     $all_news_type_pl_query .= "and c.campaign_type = 'NewsLetter'  and pl.deleted = 0 and c.deleted=0 and plc.deleted=0 ";
     $all_news_type_pl_query .= "and (pl.list_type like 'exempt%' or pl.list_type ='default') ";
 
-    /* BEGIN - SECURITY GROUPS */
-    if ($focus->bean_implements('ACL') && ACLController::requireSecurityGroup('Campaigns', 'list')) {
-        require_once('modules/SecurityGroups/SecurityGroup.php');
-        global $current_user;
-        $owner_where = $focus->getOwnerWhere($current_user->id);
-        $group_where = SecurityGroup::getGroupWhere('c', 'Campaigns', $current_user->id);
-        $all_news_type_pl_query .= " AND ( c.assigned_user_id ='".$current_user->id."' or ".$group_where.") ";
+    $campaign = BeanFactory::newBean('Campaigns');
+    $campaign->table_name = 'c';
+    $accessWhere = $campaign->buildAccessWhere('list');
+    if (!empty($accessWhere)) {
+        $all_news_type_pl_query .= ' AND ' . $accessWhere;
     }
-    /* END - SECURITY GROUPS */
-
+    
     $all_news_type_list =$focus->db->query($all_news_type_pl_query);
 
     //build array of all newsletter campaigns

--- a/modules/MergeRecords/MergeRecord.php
+++ b/modules/MergeRecords/MergeRecord.php
@@ -383,9 +383,9 @@ class MergeRecord extends SugarBean
             }
         }
         // Add ACL Check
-        if ($this->merge_bean->bean_implements('ACL') && ACLController::requireOwner($this->merge_bean->module_dir, 'delete')) {
-            global $current_user;
-            $where_clauses[] = $this->merge_bean->getOwnerWhere($current_user->id);
+        $accessWhere = $this->merge_bean->buildAccessWhere('delete');
+        if (!empty($accessWhere)) {
+            $where_clauses[] = $accessWhere;
         }
         array_push($where_clauses, $this->merge_bean->table_name.".id !='".DBManagerFactory::getInstance()->quote($this->merge_bean->id)."'");
 

--- a/modules/Spots/controller.php
+++ b/modules/Spots/controller.php
@@ -93,29 +93,8 @@ class SpotsController extends SugarController
     public function buildSpotsAccessQuery(SugarBean $module, $alias)
     {
         $module->table_name = $alias;
-        $where = '';
-        if ($module->bean_implements('ACL') && ACLController::requireOwner($module->module_dir, 'list')) {
-            global $current_user;
-            $owner_where = $module->getOwnerWhere($current_user->id);
-            $where = ' AND '.$owner_where;
-        }
 
-        if (file_exists('modules/SecurityGroups/SecurityGroup.php')) {
-            /* BEGIN - SECURITY GROUPS */
-            if ($module->bean_implements('ACL') && ACLController::requireSecurityGroup($module->module_dir, 'list')) {
-                require_once 'modules/SecurityGroups/SecurityGroup.php';
-                global $current_user;
-                $owner_where = $module->getOwnerWhere($current_user->id);
-                $group_where = SecurityGroup::getGroupWhere($alias, $module->module_dir, $current_user->id);
-                if (!empty($owner_where)) {
-                    $where .= ' AND ('.$owner_where.' or '.$group_where.') ';
-                } else {
-                    $where .= ' AND '.$group_where;
-                }
-            }
-        }
-
-        return $where;
+        return $module->buildAccessWhere('list');
     }
 
     /**

--- a/service/v3_1/SugarWebServiceUtilv3_1.php
+++ b/service/v3_1/SugarWebServiceUtilv3_1.php
@@ -401,18 +401,7 @@ class SugarWebServiceUtilv3_1 extends SugarWebServiceUtilv3
             $show_deleted = 1;
         }
         $order_by=$seed->process_order_by($order_by, null);
-
-        if ($seed->bean_implements('ACL') && ACLController::requireOwner($seed->module_dir, 'list')) {
-            global $current_user;
-            $owner_where = $seed->getOwnerWhere($current_user->id);
-            if (!empty($owner_where)) {
-                if (empty($where)) {
-                    $where = $owner_where;
-                } else {
-                    $where .= ' AND '.  $owner_where;
-                }
-            }
-        }
+        
         $params = array();
         if ($favorites) {
             $params['favorites'] = true;

--- a/soap/SoapSugarUsers.php
+++ b/soap/SoapSugarUsers.php
@@ -1358,22 +1358,11 @@ function get_relationships($session, $module_name, $module_id, $related_module, 
         $sql .= " AND ( {$related_module_query} )";
     }
 
-	/* BEGIN - SECURITY GROUPS */
-	global $current_user;
-	if($mod->bean_implements('ACL') && ACLController::requireSecurityGroup($mod->module_dir, 'list') )
-	{
-		require_once('modules/SecurityGroups/SecurityGroup.php');
-		global $current_user;
-		$owner_where = $mod->getOwnerWhere($current_user->id);
-		$group_where = SecurityGroup::getGroupWhere($mod->table_name,$mod->module_dir,$current_user->id);
-    	if(!empty($owner_where)){
-    		$sql .= " AND (".  $owner_where." or ".$group_where.") ";
-		} else {
-			$sql .= ' AND '.  $group_where;
-		}
-	}
-	/* END - SECURITY GROUPS */
-
+    $accessWhere = $mod->buildAccessWhere('list');
+    if (!empty($accessWhere)) {
+        $sql .= ' AND ' . $accessWhere;
+    }
+    
     $result = $related_mod->db->query($sql);
     while ($row = $related_mod->db->fetchByAssoc($result)) {
         $list[] = $row['id'];


### PR DESCRIPTION
## Description
This PR add 2 new Logic Hooks:-

- before_acl_query
- before_acl_check

That allow you to extend and override access rights. To achieve this there was slight extension to the logic hook logic to allow it too return a value which was require in both cases, along side the general use of access logic being simplified through the CRM so it consistent and easily extendable via the new hooks.

The change should fully backward compatible and documentation to follow

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->