### PR TITLE
Fix #9859 - Improper reapplication of assigned user inheritance in security groups

### DIFF
--- a/modules/SecurityGroups/SecurityGroup.php
+++ b/modules/SecurityGroups/SecurityGroup.php
@@ -190,7 +190,7 @@ class SecurityGroup extends SecurityGroup_sugar
         global $sugar_config;
         self::assign_default_groups($focus, $isUpdate); //this must be first because it does not check for dups
 
-        self::inherit_assigned($focus);
+        self::inherit_assigned($focus,$isUpdate);
         self::inherit_parent($focus, $isUpdate);
 
         //don't do creator inheritance if popup selector method is chosen and a user is making the request...
@@ -297,10 +297,10 @@ class SecurityGroup extends SecurityGroup_sugar
     /**
      * @param SugarBean $focus
      */
-    public static function inherit_assigned($focus)
+    public static function inherit_assigned($focus, $isUpdate)
     {
         global $sugar_config;
-        if (isset($sugar_config['securitysuite_inherit_assigned']) && $sugar_config['securitysuite_inherit_assigned'] == true) {
+        if (isset($sugar_config['securitysuite_inherit_assigned']) && $sugar_config['securitysuite_inherit_assigned'] == true && $isUpdate == false) {
             if (!empty($focus->assigned_user_id)) {
                 $assigned_user_id = $focus->db->quote($focus->assigned_user_id);
                 //inherit only for those that support Security Groups


### PR DESCRIPTION
- resolve #9859
## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
A small modification is made in the code of the main file of the security groups so that the inheritance of the assigned user applies exclusively at the moment of creating a record, and not when modifying it later



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As explained in issue #9859, assignee inheritance should only be applied at record creation time, as is now the case with the creator user and parent record.
## How To Test This
<!--- Please describe in detail how to test your changes. -->
Assign a user two or more security groups.
In the security group settings, set exclusively assigned user inheritance (and disable the rest)
Create a record in any module and verify that it has acquired the assigned user's security groups.
Delete any of the security groups from the registry using the security groups subpanel in the details view.
Save the registry again (even without making any changes) and verify that no other security groups have been added.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [X] My change requires a change to the documentation.
(It would be nice to specify in the documentation that the inheritance of security groups is applied exclusively at record creation time.)
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->

