### PR TITLE
Fix #9861 - Error calculating the end date and time of a call

### DIFF
--- a/modules/Calls/Call.php
+++ b/modules/Calls/Call.php
@@ -174,7 +174,7 @@ class Call extends SugarBean
         global $timedate;
 
         if (!empty($this->date_start)) {
-            if (!empty($this->duration_hours) && !empty($this->duration_minutes)) {
+            if (!empty($this->duration_hours + $this->duration_minutes)) {
                 $td = $timedate->fromDb($this->date_start);
                 if ($td) {
                     $this->date_end = $td->modify(


### PR DESCRIPTION
- resolve #9861
## Description
When a Call is saved, the value of the _end_date_ field is not calculated correctly if any of the values of the _duration_ field is 0 (hours or minutes), since in this case, the code flow does not enter the if that performs the calculation .
In this PR, the conditions are modified to evaluate correctly whether or not to calculate _end_date_


## Motivation and Context

It is important to correctly calculate the end time of the call correctly

## How To Test This

1. In the Calls module, add the end_date field to the edit view or detail view.
2. Create a record indicating in the duration field 0 in hours or minutes.
3. Check that the value of the end_date field has been correctly calculated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
(It would be nice to specify in the documentation that the inheritance of security groups is applied exclusively at record creation time.)
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->

