### PR TITLE
Fix #9871 -  Javascript message error when bulk updating all user records

### DIFF
--- a/modules/Users/language/en_us.lang.php
+++ b/modules/Users/language/en_us.lang.php
@@ -96,6 +96,7 @@ $mod_strings = array(
     'LBL_REGULAR_DESC' => 'User can access modules and records based on roles.',
     'LBL_PHOTO' => 'Photo',
     'LBL_ADMIN' => 'System Administrator',
+    'LBL_LAST_ADMIN_NOTICE' => 'Current selection could include yourself. You cannot change your own type of user or status.',    
     'LBL_ADVANCED' => 'Advanced',
     'LBL_ANY_ADDRESS' => 'Any Address:',
     'LBL_ANY_EMAIL' => 'Any Email',


### PR DESCRIPTION
- resolve #9871
## Description
This PR adds the `LBL_LAST_ADMIN_NOTICE` label that must be displayed when trying to update all users massively, if you try to modify the _is_admin_ or _status_ fields.

This prevents the message with the text undefined from being displayed

## Motivation and Context
An erroneous message that does not offer any information to the user is avoided

## How To Test
1) In the list view of the users module, select all the records (not the current page, but all the records)
2) By mass update, try to modify the _is_admin_ or _status_ fields and check how the correct message is displayed


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
(It would be nice to specify in the documentation that the inheritance of security groups is applied exclusively at record creation time.)
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->

