### PR TITLE
Fix #9873 - Plesk php.ini disable_functions = opcache_get_status

### DIFF
--- a/include/SugarCache/SugarCache.php
+++ b/include/SugarCache/SugarCache.php
@@ -141,11 +141,7 @@ class SugarCache
             }
         }
         // Zend OPcache
-        if (
-            extension_loaded('Zend OPcache') &&
-            ($opcache_status = opcache_get_status(false)) !== false &&
-            $opcache_status['opcache_enabled'] && $full_reset
-        ) {
+        if ($full_reset && SugarCache::isOPcacheEnabled()) {
             if (!opcache_reset()) {
                 LoggerManager::getLogger()->error("OPCache - could not reset");
             }
@@ -163,11 +159,7 @@ class SugarCache
         }
 
         // Zend OPcache
-        if (
-            extension_loaded('Zend OPcache') &&
-            ($opcache_status = opcache_get_status(false)) !== false &&
-            $opcache_status['opcache_enabled']
-        ) {
+        if (SugarCache::isOPcacheEnabled()) {
             // three attempts incase concurrent opcache operations pose a lock
             for ($i = 3; $i && !opcache_invalidate($file, true); --$i) {
                 sleep(0.2);
@@ -192,6 +184,24 @@ class SugarCache
             if ((new SplFileInfo($file))->getExtension() == 'php') {
                 sugarCache::cleanFile($file);
             }
+        }
+    }
+
+    /**
+     * Check if OPcache is enabled
+     *
+     */
+    public static function isOPcacheEnabled()
+    {
+        if (extension_loaded('Zend OPcache')) {
+            if (function_exists('opcache_get_status')) {
+                $opcache_status = opcache_get_status(false);
+                return $opcache_status !== false && ($opcache_status['opcache_enabled'] ?? false);
+            } else {
+                return ini_get('opcache.enable');
+            }
+        } else {
+            return false;
         }
     }
 }

--- a/include/utils/file_utils.php
+++ b/include/utils/file_utils.php
@@ -142,12 +142,7 @@ function write_override_label_to_file($the_name, $the_array, $the_file, $mode = 
         $the_string .= '$' . "{$the_name}['{$labelName}'] = '{$labelValue}';\n";
     }
 
-    $result = sugar_file_put_contents($the_file, $the_string, LOCK_EX) !== false;
-
-    if (function_exists('opcache_invalidate')) {
-        opcache_invalidate($the_file, true);
-    }
-    return $result;
+    return sugar_file_put_contents($the_file, $the_string, LOCK_EX) !== false;
 }
 
 function write_encoded_file($soap_result, $write_to_dir, $write_to_file="")


### PR DESCRIPTION
Fixes compatibility with PHP 8.0 for Plesk users

## Description
PHP configurations which have the following configured in php.ini
`disable_functions = opcache_get_status`

will not be able to install or use SuiteCRM from 8.0 as disabled functions now trigger a fatal error
https://php.watch/versions/8.0/disable_functions-redeclare

The code for SugarCache uses a check which uses the function opcache_get_status to retrieve detailed information on the current opcache configuration

## Motivation and Context
Plesk users have the above php.ini configuration as default are are not able to install SuiteCRM with the default configuration with php 8.0

This change provides a graceful degradation for installations which have opcache_get_status disabled by checking the opcache configuration using the more archaic function "ini_get" to retrieve its status.

Besides an opcache_invalidate call was removed from the method "write_override_label_to_file" as this is already taken care of in "sugar_file_put_contents"

## How To Test This
See https://github.com/salesagility/SuiteCRM/issues/9873

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->