### PR TITLE
Fix #9875 SugarFeed shows 0 seconds ago and negative interval for cer…

### DIFF
--- a/modules/SugarFeed/SugarFeed.php
+++ b/modules/SugarFeed/SugarFeed.php
@@ -476,9 +476,26 @@ class SugarFeed extends Basic
 
         $timedate->getInstance()->userTimezone();
         $currentTime = $timedate->now();
-
-        $first = strtotime($currentTime);
-        $second = strtotime($startDate);
+        //Fix #9875 SugarFeed shows 0 seconds ago and negative interval for certain datetime formats
+        //Use proper user datetime format to convert datetime string to timestamp
+        $user_format=$timedate->get_date_time_format();
+		$first=date_create_from_format($user_format,$currentTime);
+        if(empty($first)){
+            LoggerManager::getLogger()->warn('SugarFeed getTimeLapse: Could not fetch currentTime ');
+            $first=0;
+        }
+        else{
+            $first=$first->getTimestamp();
+        }
+		
+        $second=date_create_from_format($user_format,$startDate);
+        if(empty($second)){
+            LoggerManager::getLogger()->warn('SugarFeed getTimeLapse: Could not fetch startDate ');
+            $second=0;
+        }
+        else{
+            $second=$second->getTimestamp();
+        }
 
         $seconds = $first - $second;
         $minutes = $seconds / 60;


### PR DESCRIPTION
…tain datetime formats

Use proper user datetime format to convert datetime string to timestamp in SugarFeed.php

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
use date_create_from_format with current user datetime format instead of strtotime because strtotime to time does lots of assumtions e.g  if the separator is a slash (/), then the American m/d/y is assumed. If the separator is a dash (-) or a dot (.), then the European d-m-y format is assumed
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
SugarFeeds shows correctly for all users with different datetime format settings
## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->