### PR TITLE
Fix #9883 -  Security Groups do not work with modules whose name exceeds 36 characters.

### DIFF
--- a/metadata/securitygroups_recordsMetaData.php
+++ b/metadata/securitygroups_recordsMetaData.php
@@ -5,7 +5,7 @@ $dictionary['securitygroups_records'] = array(
         array('name' =>'id', 'type' =>'char', 'len'=>'36', 'required'=>true, 'default'=>'')
       , array('name' =>'securitygroup_id', 'type' =>'char', 'len'=>'36')
       , array('name' =>'record_id', 'type' =>'char', 'len'=>'36')
-      , array('name' =>'module', 'type' =>'char', 'len'=>'36')
+      , array('name' =>'module', 'type' =>'varchar', 'len'=>'100')
       , array('name' =>'date_modified','type' => 'datetime')
       , array('name' =>'modified_user_id', 'type' =>'char', 'len'=>'36')
       , array('name' =>'created_by', 'type' =>'char', 'len'=>'36')


### PR DESCRIPTION
resolve #9883
## Description
It has been found that the problem is caused by the _module_ field in the _securitygroups_records_ table being defined as _char(36)_, so the name of the module will be truncated in the database when a record is created in this table, that is, when any Security group is assigned to a record of the same. In this PR, the type of the module field is changed to _varchar(100)_ in the _securitygroups_records_ table, so that longer module names are stored correctly. It has been considered that setting the limit of the field at 100 is sufficient for any reasonable module name.

## Motivation and Context
It is common to use module names that, along with the prefix, exceed 36 characters and this must be corrected.

## How To Test

1. Remove or rename the securitygroups_record table and quick repair. The table should be created with the module field set to varchar(100).
2. Verify that the assignment of security groups to records of a module whose name exceeds 36 characters works correctly, specifically that the name of the module is not truncated in the database.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
(It would be nice to specify in the documentation that the inheritance of security groups is applied exclusively at record creation time.)
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->

