### PR TITLE
Fix #9900 - Conditions doesn't recognize some of the characters set

### DIFF
--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -823,6 +823,10 @@ class AOW_WorkFlow extends Basic
                         } elseif ($data['type'] == 'bool' && (!(bool)$value || strtolower($value) == 'false')) {
                             $value = 0;
                         }
+                        $type = $data['dbType'] ?? $data['type'];
+                        if ((strpos($type, 'char') !== false || strpos($type, 'text') !== false) && !empty($field)) {
+                            $field = from_html($field);
+                        }
                         break;
                 }
 


### PR DESCRIPTION
- Closes #9900 


## Description
This PR adds the code that decode the HTML value of a text field in a Workflow condition. Therefore any character set can be used in condition

## Motivation and Context
Condition should work with any special character.

## How To Test This
1. Create a workflow that compares "aña" with last_name of a Contact
2. Add any action
3. Create a Contact with last_name "aña" and check the the Workflow run successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->