### PR TITLE
Fix #9909 - Default empty item when creating a new Dropdown field

### DIFF
--- a/modules/DynamicFields/templates/Fields/Forms/dynamicenum.php
+++ b/modules/DynamicFields/templates/Fields/Forms/dynamicenum.php
@@ -88,6 +88,8 @@ function get_body(&$ss, $vardef)
         }
     }
     $dropdowns = array_keys($my_list_strings);
+    // Adding a default empty list
+    $dropdowns[] = '';
     sort($dropdowns);
     $default_dropdowns = array();
     if (!empty($vardef['options']) && !empty($my_list_strings[$vardef['options']])) {

--- a/modules/DynamicFields/templates/Fields/Forms/enum2.php
+++ b/modules/DynamicFields/templates/Fields/Forms/enum2.php
@@ -90,6 +90,8 @@
          }
      }
      $dropdowns = array_keys($my_list_strings);
+    //  Adding a default empty list
+     $dropdowns[] = '';
      sort($dropdowns);
      $default_dropdowns = array();
      if (!empty($vardef['options']) && !empty($my_list_strings[$vardef['options']])) {


### PR DESCRIPTION
- Closes #9909 

## Description
This PR adds a default empty item to the list of Drop Down lists available. Therefore, if the user doesn't choose or select a list, no list will be assigned.

## Motivation and Context
No list should be chosen by default

## How To Test This
- Create a Dropdown field
- Check an empty option item appears in the Dropdown List field.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->