### PR TITLE
Fix #9937 - Resolve high memory usage when performing bulk relationship changes

### DIFF
--- a/data/Link2.php
+++ b/data/Link2.php
@@ -552,6 +552,11 @@ class Link2
             if ($success == false) {
                 $failures[] = $key->id;
             }
+
+            // remove temporary beans to prevent runaway memory usage
+            if(isset($this->tempBeans[$key->id])) {
+                unset($this->tempBeans[$key->id]);
+            }
         }
 
         if (!empty($failures)) {
@@ -600,6 +605,11 @@ class Link2
 
             if ($success == false) {
                 $failures[] = $keyBean->id;
+            }
+
+            // remove temporary beans to prevent runaway memory usage
+            if(isset($this->tempBeans[$keyBean->id])) {
+                unset($this->tempBeans[$keyBean->id]);
             }
         }
 


### PR DESCRIPTION
## Description
When adding or removing multiple relationships the beans are loaded and stored within the tempBeans array in data/Link2.php file.

When performing lots of changes at once, for example when performing bulk actions or updating target lists this leads to runaway memory usage.

This fix unsets the bean from the temporary array as it is no longer necessary to remain in storage.

## Motivation and Context
Has potentially wide ranging impacts when record numbers and bulk actions increase.

## How To Test This

1. Prepare demo data with a reasonably large number of account records (e.g. 2000)
2. Create an empty Target List
3. Attempt to bulk assign all 2000 accounts to the target list
4. Monitor the php memory usage, it should now remain at very low levels.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.