### PR TITLE
Fix #9939 - Consistent Null/Empty handling on Reports and Workflows

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -1859,6 +1859,19 @@ class AOR_Report extends Basic
                         $field = "(" . $field;
                     }
 
+                    if ($condition->value_type == 'Value' && !$condition->value && $condition->operator == 'Not_Equal_To') {
+                        if (!isset($value)) {
+                            $GLOBALS['log']->warn(
+                                $condition->field
+                                . ' value is not set, assuming empty string value'
+                            );
+                            $value = '';
+                        }
+
+                        $value = "{$value} OR {$field} IS NOT NULL)";
+                        $field = "(" . $field;
+                    }
+
                     if (!$where_set) {
                         if ($condition->value_type == "Period") {
                             if (array_key_exists($condition->value, $app_list_strings['date_time_period_list'])) {

--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -591,6 +591,16 @@ class AOW_WorkFlow extends Basic
                     $where_set = true;
                     break;
                 case 'Value':
+                    if(empty($condition->value) && $condition->operator === 'Equal_To') {
+                        $value = "'' OR {$field} IS NULL)";
+                        $field = "(" . $field;
+                        break;
+                    }
+                    if(empty($condition->value) && $condition->operator === 'Not_Equal_To') {
+                        $value = "'' OR {$field} IS NOT NULL)";
+                        $field = "(" . $field;
+                        break;
+                    }
                 default:
                     $value = "'".$condition->value."'";
                     break;


### PR DESCRIPTION
## Description
When comparing empty and null strings, the current handling of this is inconsistent between Reports and AOW_Workflows

Reports:

- Checks if a value is empty or null during an "equal to" empty string value.
- Checks if a value is empty during a "not equal to" empty string value.

Workflows:

- Checks if a value is empty during an "equal to" empty string value.
- Checks if a value is empty during a "not equal to" empty string value.

This change will:

- Check for null or empty strings on an "equal to"
- Check for not null or empty strings on an "not equal to"

As null will now be considered empty where it was not previously, this may lead to different (hopefully more accurate?) report / workflow results depending upon the data set. Still something to consider.

Null values can still be checked with the null, not null condition parameters and are unaffected by this change.

## Motivation and Context
Records returned between these two modules are different with the same conditions

## How To Test This

1. Create a report which checks against a null-able field with empty values
2. Behaviour will be consistent between "equal to" and "not equal to" across the two modules discussed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.