### PR TITLE
Fix #8980 - Check beanFiles for class path

### DIFF
--- a/download.php
+++ b/download.php
@@ -75,7 +75,8 @@ if ((!isset($_REQUEST['isProfile']) && empty($_REQUEST['id'])) || empty($_REQUES
         if ($bean_name == 'aCase') {
             $bean_name = 'Case';
         }
-        if (!file_exists('modules/' . $module . '/' . $bean_name . '.php')) {
+        global $beanFiles;
+        if (!file_exists($beanFiles[$bean_name])){
             die($app_strings['ERROR_TYPE_NOT_VALID']);
         }
 


### PR DESCRIPTION
BeanFiles global provides the path to the overwritten class for customizations.

## Description
See #8980 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Cannot download files if extending Documents Bean.
## How To Test This
<!--- Please describe in detail how to test your changes. -->
See how to reproduce in #8980 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->