### PR TITLE
Fix Email OAuth Saving with no type

### DIFF
--- a/modules/ExternalOAuthConnection/controller.php
+++ b/modules/ExternalOAuthConnection/controller.php
@@ -45,11 +45,16 @@ class ExternalOAuthConnectionController extends SugarController
 {
     public function action_EditView() {
         $this->view = 'edit';
-        if (!empty($this->bean) && !empty($_REQUEST['type'])) {
+
+        if (empty($_REQUEST['type'])){
+            $_REQUEST['type'] = 'personal';
+        }
+
+        if (!empty($this->bean)) {
             $this->bean->type = $_REQUEST['type'];
         }
 
-        if (empty($_REQUEST['record']) && !empty($_REQUEST['type']) && $_REQUEST['type'] === 'personal') {
+        if (empty($_REQUEST['record']) && $_REQUEST['type'] === 'personal') {
             $this->hasAccess = true;
             return;
         }

--- a/modules/ExternalOAuthProvider/controller.php
+++ b/modules/ExternalOAuthProvider/controller.php
@@ -45,11 +45,17 @@ class ExternalOAuthProviderController extends SugarController
 {
     public function action_EditView() {
         $this->view = 'edit';
-        if (!empty($this->bean) && !empty($_REQUEST['type'])) {
+
+        if (empty($_REQUEST['type'])){
+            $_REQUEST['type'] = 'personal';
+        }
+
+
+        if (!empty($this->bean)) {
             $this->bean->type = $_REQUEST['type'];
         }
 
-        if (empty($_REQUEST['record']) && !empty($_REQUEST['type']) && $_REQUEST['type'] === 'personal') {
+        if (empty($_REQUEST['record']) && $_REQUEST['type'] === 'personal') {
             $this->hasAccess = true;
             return;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->

Fix OAuth External Provider and OAuth External Connection saving with no type.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. When creating a OAuth External Provider record remove the `type=xxx` from the url.
2. Fill in required fields and save
3. See that it defaults to personal.
4. Do the same with a OAuth External Connection record and see the same result

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->