### PR TITLE
Fix issue #9516

### DIFF
--- a/lib/Search/SearchResults.php
+++ b/lib/Search/SearchResults.php
@@ -224,6 +224,9 @@ class SearchResults
             LoggerManager::getLogger()->warn('Unresolved related ID for field: ' . $relField);
         }
 
+        if (!$relId) {
+            $relId = '';
+        }
         return $relId;
     }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
getRelatedId is supposed to return a string but returns null in some conditions. Return an empty string instead
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Fix issue #9516 
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Global Search can fail with an error message:
An unknown error has occurred while performing the search. Contact an administrator if the problem persists. More information available in the logs.
Return value of SuiteCRM\Search\SearchResults::getRelatedId() must be of the type string, null returned in /var/www/crm/sractivities/lib/Search/SearchResults.php:227
## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->