### PR TITLE
Fix issue #9985

### DIFF
--- a/modules/Calls/Call.php
+++ b/modules/Calls/Call.php
@@ -174,7 +174,7 @@ class Call extends SugarBean
         global $timedate;
 
         if (!empty($this->date_start)) {
-            if (!empty($this->duration_hours) && !empty($this->duration_minutes)) {
+            if (!empty($this->duration_hours) || !empty($this->duration_minutes)) {
                 $td = $timedate->fromDb($this->date_start);
                 if ($td) {
                     $this->date_end = $td->modify(


### PR DESCRIPTION
date_end of calls is stored equals to date_start in the database if duration_hours is 0 or duration_minutes is 0

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Fix issue #9985 
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
if the duration is, for example 0 hours 15minutes or 1 hour 0 minute, it is not taken into account to compute date_end when saving
Create a call with duration = 15mn
Look at that call in the database
date_end is equal to date_start

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Create a call with duration = 15mn
Look at that call in the database
date_end is now date_start + 15 minute

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->