### PR TITLE
Fix duration displayed in edit view

### DIFF
--- a/modules/Calls/CallHelper.php
+++ b/modules/Calls/CallHelper.php
@@ -77,7 +77,7 @@ function getDurationMinutesOptions($focus, $field, $value, $view)
         }
 
         $html .=  'name="duration_minutes">';
-        $html .= get_select_options_with_id($focus->minutes_values, $focus->duration_minutes);
+        $html .= get_select_options_with_id($focus->minutes_values, (int)$focus->duration_minutes);
         $html .= '</select>';
         return $html;
     }


### PR DESCRIPTION
Fix #9986

<!--- Provide a general summary of your changes in the Title above -->

<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Create a call with a 15 mn duration
Save that call
Edit that call again
The duration is displayed as 0

This is due to get_select_options_with_id in SuiteCRM 7.12 being more strict when comparing keys to select current value.

Replaced
$html .= get_select_options_with_id($focus->minutes_values, $focus->duration_minutes);
by
$html .= get_select_options_with_id($focus->minutes_values, (int)$focus->duration_minutes);


<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Duration is lost when editing an existing call

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->