### PR TITLE
Fix #8939 - Fix Static call to non-static method in AOW_WorkFlow

### DIFF
--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -185,7 +185,7 @@ class AOW_WorkFlow extends Basic
      */
     public function run_flows()
     {
-        $flows = AOW_WorkFlow::get_full_list('', " aow_workflow.status = 'Active'  AND (aow_workflow.run_when = 'Always' OR aow_workflow.run_when = 'In_Scheduler' OR aow_workflow.run_when = 'Create') ");
+        $flows = $this->get_full_list('', " aow_workflow.status = 'Active'  AND (aow_workflow.run_when = 'Always' OR aow_workflow.run_when = 'In_Scheduler' OR aow_workflow.run_when = 'Create') ");
 
         if (empty($flows)) {
             LoggerManager::getLogger()->warn('There is no any workflow to run');


### PR DESCRIPTION
Code correction.
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->

## Description
There is no such static method present (AOW_Workflow -> Basic -> SugarBean).
Issue: https://github.com/salesagility/SuiteCRM/issues/8939

## Motivation and Context
-

## How To Test This
-

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->