### PR TITLE
Fix #8359 - Fix Contract renewal reminder title is hardcoded.

### DIFF
--- a/modules/AOS_Contracts/AOS_Contracts.php
+++ b/modules/AOS_Contracts/AOS_Contracts.php
@@ -98,6 +98,7 @@ class AOS_Contracts extends AOS_Contracts_sugar
 
     public function createReminder()
     {
+        global $mod_strings;
         require_once('modules/Calls/Call.php');
         $call = new call();
 
@@ -111,7 +112,7 @@ class AOS_Contracts extends AOS_Contracts_sugar
             $call->parent_id = $this->id;
             $call->parent_type = 'AOS_Contracts';
             $call->date_start = $this->renewal_reminder_date;
-            $call->name = $this->name . ' Contract Renewal Reminder';
+            $call->name = $this->name . $mod_strings['LBL_RENEWAL_REMINDER'];
             $call->assigned_user_id = $this->assigned_user_id;
             $call->status = 'Planned';
             $call->direction = 'Outbound';

--- a/modules/AOS_Contracts/language/en_us.lang.php
+++ b/modules/AOS_Contracts/language/en_us.lang.php
@@ -76,6 +76,7 @@ $mod_strings = array(
     'LBL_STATUS' => 'Status',
     'LBL_CUSTOMER_SIGNED_DATE' => 'Customer Signed Date',
     'LBL_COMPANY_SIGNED_DATE' => 'Company Signed Date',
+    'LBL_RENEWAL_REMINDER' => ' Contract Renewal Reminder',
     'LBL_RENEWAL_REMINDER_DATE' => 'Renewal Reminder Date',
     'LBL_CONTRACT_TYPE' => 'Contract Type',
     'LBL_CONTACT' => 'Contact',


### PR DESCRIPTION
Additional label added for language pack purposes ('LBL_RENEWAL_REMINDER'). 

## Description
Function createReminder() slightly changed to use label instead plain string.
The link to an actual issue:
https://github.com/salesagility/SuiteCRM/issues/8359

## Motivation and Context
For language packs purposes.

## How To Test This
Issue has a brief description.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->