### PR TITLE
Fix #9021 - User Preferences Wrong Label.

### DIFF
--- a/themes/SuiteP/modules/Users/tpls/DetailView-advanced-tab-content.tpl
+++ b/themes/SuiteP/modules/Users/tpls/DetailView-advanced-tab-content.tpl
@@ -181,7 +181,7 @@ advanced tab content goes here
             <!-- DIV inside - colspan != 3 -->
             <div class="col-xs-12 col-sm-4 label col-1-label">
                 <!-- LABEL -->
-                {$MOD.LBL_TIME_FORMAT|strip_semicolon}
+                {$MOD.LBL_TIMEZONE|strip_semicolon}
             </div>
             <!-- /DIV inside  -->
             <!-- phone (version 1) -->


### PR DESCRIPTION
Changes to .tpl file for Users module

## Description
Same label is used for different fields in one of DetailView templates: 
![image](https://user-images.githubusercontent.com/116086008/228243784-5c78cae3-3dfb-48e0-9f80-5fc3857c2ec5.png)
 
To see the issue:
1) Go to Users list view;
2) Choose user -> Detail view -> Tab Advanced
3) Check that labels are the same for different fields: 

![image](https://user-images.githubusercontent.com/116086008/228243433-e5cf987d-d3a5-4706-9237-b0b1ee2b9584.png)

Fixes the issue: 
https://github.com/salesagility/SuiteCRM/issues/9021

## Motivation and Context
To use correct labels in the application.

## How To Test This
Check that correct label is in use.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->