### PR TITLE
Fix #9574 - Avoid calling method in a static way

### DIFF
--- a/modules/Studio/SaveTabs.php
+++ b/modules/Studio/SaveTabs.php
@@ -45,7 +45,8 @@ if (!defined('sugarEntry') || !sugarEntry) {
 
 
 require_once('modules/Studio/TabGroups/TabGroupHelper.php');
-TabGroupHelper::saveTabGroups($_POST);
+$tg = new TabGroupHelper();
+$tg->saveTabGroups($_POST);
 ob_clean();
 if (!empty($_POST['grouptab_lang'])) {
     header('Location: index.php?module=Studio&action=TabGroups&lang='.$_POST['grouptab_lang']);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
With Php 8 static calls require static methods.

When pressing save in the Configure Module Menu Filters editor the following fatal error has shown up:

```
[30-Mar-2023 07:54:05 UTC] PHP Fatal error:  Uncaught Error: Non-static method TabGroupHelper::saveTabGroups() cannot be called statically in /bitnami/suitecrm/modules/Studio/SaveTabs.php:48
Stack trace:
#0 /bitnami/suitecrm/include/MVC/View/SugarView.php(824): include_once()
#1 /bitnami/suitecrm/include/MVC/View/views/view.classic.php(72): SugarView->includeClassicFile()
#2 /bitnami/suitecrm/include/MVC/View/SugarView.php(210): ViewClassic->display()
#3 /bitnami/suitecrm/include/MVC/Controller/SugarController.php(432): SugarView->process()
#4 /bitnami/suitecrm/include/MVC/Controller/SugarController.php(363): SugarController->processView()
#5 /bitnami/suitecrm/include/MVC/SugarApplication.php(101): SugarController->execute()
#6 /bitnami/suitecrm/index.php(52): SugarApplication->execute()
#7 {main}
  thrown in /bitnami/suitecrm/modules/Studio/SaveTabs.php on line 48
```

This PR fixes part of #9574 by enabling saving module edits.


## Motivation and Context
It allows to save edits in the Module Filter running on Php 8

## How To Test This
Open the Administration page via the menu. Click on "Configure Module Menu Filters", perform and changes and press "Save & Deploy". The application will not show that fatal error on Php 8 any more

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->