### PR TITLE
Fix #10009 - Cannot configure Module Menu Filters on PHP8+

### DIFF
--- a/modules/Studio/SaveTabs.php
+++ b/modules/Studio/SaveTabs.php
@@ -45,7 +45,8 @@ if (!defined('sugarEntry') || !sugarEntry) {
 
 
 require_once('modules/Studio/TabGroups/TabGroupHelper.php');
-TabGroupHelper::saveTabGroups($_POST);
+$tg = new TabGroupHelper();
+$tg->saveTabGroups($_POST);
 ob_clean();
 if (!empty($_POST['grouptab_lang'])) {
     header('Location: index.php?module=Studio&action=TabGroups&lang='.$_POST['grouptab_lang']);


### PR DESCRIPTION
Make object instead of calling function statically

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
Make object instead of calling function statically

<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
Fixes issue with menu not being configurable on php8+
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
Go to admin->Configure Module Menu Filters
Re-order menu
Press save
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->