### PR TITLE
Fix #5712 - Alerts in the menu bar are not displayed with Night theme…

### DIFF
--- a/themes/SuiteP/css/Night/variables.scss
+++ b/themes/SuiteP/css/Night/variables.scss
@@ -1004,7 +1004,7 @@ $navbar-alert-body-bg: $main-bg;
 $navbar-alert-title-bg: $color-9;
 $navbar-alert-title-color: $main-font-color;
 $navbar-alert-separator: $navbar-menu-separator;
-$navbar-alert-count-bg: $color-81;
+$navbar-alert-count-bg: $color-46;
 
 $navbar-user-color: $navbar-link-color;
 $navbar-user-color-hover: $navbar-link-color-hover;


### PR DESCRIPTION
## Description
Visual issue with alert counter on the icon (theme Night):
![image](https://user-images.githubusercontent.com/116086008/231499220-a28c1884-6eb1-46ff-b687-6c5832b4a350.png)

https://github.com/salesagility/SuiteCRM/issues/5712

## Motivation and Context
The element should have right colour to show the number of messages waiting to be read. 

## How To Test This
Change a theme in user preferences to Night and watch the notification icon after some alerts have arrived.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->