### PR TITLE
Fix #9601 - Fix bug where report conditions parenthesis pairs would not save correctly.

### DIFF
--- a/modules/AOR_Conditions/AOR_Condition.php
+++ b/modules/AOR_Conditions/AOR_Condition.php
@@ -122,11 +122,11 @@ class AOR_Condition extends Basic
                                 }
                             }
                         }
-                        if ($field_name == 'parenthesis' && $post_data[$key . $field_name][$i] == 'END') {
-                            if (!isset($lastParenthesisStartConditionId)) {
+                        if ($field_name === 'parenthesis' && $post_data[$key . $field_name][$i] !== 'START') {
+                            if (!isset($lastParenthesisStartConditionIds)) {
                                 throw new Exception('a closure parenthesis has no starter pair');
                             }
-                            $condition->parenthesis = $lastParenthesisStartConditionId;
+                            $condition->parenthesis = array_pop($lastParenthesisStartConditionIds);
                         } else {
                             $condition->$field_name = $post_data[$key . $field_name][$i];
                         }
@@ -149,8 +149,8 @@ class AOR_Condition extends Basic
                     }
                     $condition->aor_report_id = $parent->id;
                     $conditionId = $condition->save();
-                    if ($condition->parenthesis == 'START') {
-                        $lastParenthesisStartConditionId = $conditionId;
+                    if ($condition->parenthesis === 'START') {
+                        $lastParenthesisStartConditionIds[] = $conditionId;
                     }
                 }
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Fix for issue #9601 where parenthesis pairs in Report Conditions would not save the pairing data correctly. 
As part of the deployment, if admins have pre-existing reports with parentheses that they do not wish to recreate, they can run the following SQL in order to reset the necessary information on parentheses:
```
UPDATE aor_conditions SET parenthesis = 'END'
WHERE parenthesis != 'START' AND parenthesis IS NOT NULL
```
Once the above has been run, re-saving the reports with parentheses will update the conditions with the correct data. If the above SQL is not run, then the incorrect data will still be there after saving. This fix will only affect new conditions otherwise.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This solves a bug when deleting parentheses from the report conditions, where if the pairs do not match up, then the user can make a report with an orphaned parenthesis, causing errors and the report to be unfix-able. 

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Add nested parentheses to a report. Once the report has been saved, go back to the Edit view and confirm that any pairs of parentheses can be removed correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->