### PR TITLE
Fix #10033 PHP Fatal error Uncaught TypeError PHP8

### DIFF
--- a/modules/AOW_Actions/actions/actionSendEmail.php
+++ b/modules/AOW_Actions/actions/actionSendEmail.php
@@ -484,7 +484,7 @@ class actionSendEmail extends actionBase
         $mail->handleAttachments($attachments);
         $mail->prepForOutbound();
 
-        if (empty($emailTo)) {
+        if ((empty($emailTo)) || (!is_array($emailTo))) {
             return false;
         }
         foreach ($emailTo as $to) {
@@ -499,6 +499,13 @@ class actionSendEmail extends actionBase
             foreach ($emailBcc as $email) {
                 $mail->AddBCC($email);
             }
+        }
+        if (!is_array($emailCc)) {
+            $emailCc = [];
+        }
+
+        if (!is_array($emailBcc)) {
+            $emailBcc = [];
         }
 
         //now create email


### PR DESCRIPTION
The `$array` parameter passed to `implode($separator, $array)` was `null`. 
Previously in PHP 7 and less, this gave only a `Notice` or `Warning` error.
In PHP 8+ passing a null array parameter to implode now gives a `FATAL` error and PHP exits because the call matches a different overloaded function signature, expecting an `array` in first position, but it gets the `separator` which is a `string`.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Fixes bug #10033 when running on PHP 8+

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
PHP 7 and below only emitted a `Notice` or `Warning` to the log when you call `implode` with a `NULL` for the `$array`.
PHP 8 and above now will throw an `Exception` and exit PHP because the call signature matches a different overload and the `$separator` is passed in where it expects the `$array`.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
See issue.
Basic code example proving this is `FATAL` on PHP 8+
```
<?php
$emailsArray = null;
$emailsToLine = implode (',' , $emailsArray);
?>
// When run on PHP 7, this will exit without `Exception`.
// On PHP 8, this will throw a PHP `Fatal uncaught TypeError` Exception
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->