### PR TITLE
Codeception testing compatibility changes

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -11,7 +11,6 @@
 # For more information, see the Automated Testing Documentation.
 # https://docs.suitecrm.com/developer/automatedtesting/
 
-
 #== Install Test Suite:
 
 # MYSQL or MSSQL
@@ -29,7 +28,6 @@ DATABASE_USER=automated_tests
 # Database password
 DATABASE_PASSWORD=automated_tests
 
-
 #== Acceptance, API, and Install Test Suites:
 
 # URL of the SuiteCRM instance which the tester needs to access
@@ -41,7 +39,6 @@ INSTANCE_ADMIN_USER=admin
 # Admin password for SuiteCRM instance
 INSTANCE_ADMIN_PASSWORD=password
 
-
 #== API Test Suite:
 
 # API Client ID
@@ -50,3 +47,11 @@ INSTANCE_CLIENT_ID=suitecrm_client
 # API Client Secret
 INSTANCE_CLIENT_SECRET=secret
 
+# Default web browser for acceptance and install tests
+BROWSER=chrome
+
+# Webdriver hostname (Selenium, Local or Cloud Testing)
+WEBDRIVER_HOST=127.0.0.1
+
+# Webdriver port (Selenium, Local or Cloud Testing)
+WEBDRIVER_PORT=4444

--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -50,3 +50,4 @@ coverage:
     - modules/AOR_Charts/lib/*
 params:
   - env
+  - .env.test

--- a/tests/SuiteCRM/Test/Driver/WebDriver.php
+++ b/tests/SuiteCRM/Test/Driver/WebDriver.php
@@ -47,15 +47,6 @@ use Exception;
  */
 class WebDriver extends \Codeception\Module\WebDriver
 {
-    public function _initialize()
-    {
-        $config = $this->_getConfig();
-        $this->config['host'] = $config['host'];
-        $this->config['port'] = $config['port'];
-
-        parent::_initialize();
-    }
-
     protected function initialWindowSize()
     {
         $config = $this->_getConfig();

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -14,5 +14,23 @@ modules:
         - \SuiteCRM\Test\Driver\WebDriver
     config:
         \SuiteCRM\Test\Driver\WebDriver:
-            url: "https://demo.suiteondemand.com"
-            browser: chrome
+            url: '%INSTANCE_URL%'
+            browser: '%BROWSER%'
+            host: '%WEBDRIVER_HOST%'
+            port: '%WEBDRIVER_PORT%'
+env:
+    chrome:
+        modules:
+            config:
+                \SuiteCRM\Test\Driver\WebDriver:
+                    browser: chrome
+    firefox:
+        modules:
+            config:
+                \SuiteCRM\Test\Driver\WebDriver:
+                    browser: firefox
+    edge:
+        modules:
+            config:
+                \SuiteCRM\Test\Driver\WebDriver:
+                    browser: MicrosoftEdge

--- a/tests/acceptance/_bootstrap.php
+++ b/tests/acceptance/_bootstrap.php
@@ -2,6 +2,7 @@
 // Here you can initialize variables that will be available to your tests
 
 /* bootstrap composer's autoloader */
+chdir(__DIR__.'/../../');
 require_once __DIR__ . '/../../vendor/autoload.php';
 global $sugar_config, $db;
 

--- a/tests/api/_bootstrap.php
+++ b/tests/api/_bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 /* bootstrap composer's autoloader */
+chdir(__DIR__.'/../../');
 require_once __DIR__.'/../../vendor/autoload.php';
 global $sugar_config, $db;
 require_once __DIR__ .'/../../include/utils.php';

--- a/tests/install.suite.yml
+++ b/tests/install.suite.yml
@@ -7,8 +7,24 @@ modules:
         - \SuiteCRM\Test\Driver\WebDriver
         - Filesystem
     config:
-      \SuiteCRM\Test\Driver\WebDriver:
-        url: "https://demo.suiteondemand.com/"
-        browser: chrome
-        restart: true
-        wait: 1
+        \SuiteCRM\Test\Driver\WebDriver:
+            url: '%INSTANCE_URL%'
+            browser: '%BROWSER%'
+            restart: true
+            wait: 1
+env:
+    chrome:
+        modules:
+            config:
+                \SuiteCRM\Test\Driver\WebDriver:
+                    browser: chrome
+    firefox:
+        modules:
+            config:
+                \SuiteCRM\Test\Driver\WebDriver:
+                    browser: firefox
+    edge:
+        modules:
+            config:
+                \SuiteCRM\Test\Driver\WebDriver:
+                    browser: MicrosoftEdge

--- a/tests/unit.suite.yml
+++ b/tests/unit.suite.yml
@@ -1,0 +1,4 @@
+bootstrap: _bootstrap.php
+modules:
+  enabled:
+    - Asserts

--- a/tests/unit/_bootstrap.php
+++ b/tests/unit/_bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 // Here you can initialize variables that will be available to your test
 //echo "CWD:" . getcwd() . "\n";
-chdir('../');
+chdir(__DIR__.'/../../');
 if (!defined('sugarEntry')) {
     define('sugarEntry', true);
     define('SUITE_PHPUNIT_RUNNER', true);


### PR DESCRIPTION
## Description
The current implementation of Codeception will load environment variables from your operating system as described here: https://docs.suitecrm.com/developer/automatedtesting/

This PR includes changes to the codeception yaml files to also attempt to load environment variables from the `.env.test` file, if it exists.

Doing so simplifies the testing setup process, removing the need to run `./vendor/bin/robo configure:tests` and change the environment itself. Most common configuration can be applied in the `.env.test` file

In addition the browser and webdriver can now be fully configured using environment variables and some unused code is removed from test/driver/WebDriver.php

Finally the bootstrap files for each test module have been adjusted to use the appropriate working directory. This change ensures the tests run in a containerised environment.
 

## Motivation and Context
Testing currently requires changes to the local environment, using robo commands or manually.
Tests fail within PHPStorm, possibly other IDE's are affected by currently untested.

## How To Test This
Copy .env.dist to .env.test, adjust the variables in .env.test to suit your test environment and run the tests either directly your IDE or using Robo

The changes should not affect those who already have their environment configured in a similar way to the official documentation, although if anyone else can test this it would be appreciated.

If merged, the documentation could be simplified to make it easier for people who are new to the project to begin testing.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.