### PR TITLE
Update EmailUI.css

### DIFF
--- a/modules/Emails/EmailUI.css
+++ b/modules/Emails/EmailUI.css
@@ -138,7 +138,7 @@
 }
 
 .emailUILabel button {
-    width: 50px;
+    width: 80px;
     text-align: right;
 }
 


### PR DESCRIPTION
Make button "To" larger for others languages

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
With Portuguese language, "To" is "Para" and the button is small for that text.

On
modules\Emails\EmailUI.css

where is:

.emailUILabel button {
width: 50px;
text-align: right;
}

should be:

.emailUILabel button {
width: 80px;
text-align: right;
}

## Motivation and Context
SuiteCRM 7.13.3 with lang package pt_PT

## How To Test This
Install lang package pt_PT and try to compose a mail.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->