### PR TITLE
Update Delete.php to mark group folders as deleted RE:#9028 #10059

### DIFF
--- a/modules/InboundEmail/Delete.php
+++ b/modules/InboundEmail/Delete.php
@@ -53,4 +53,21 @@ if (empty($_REQUEST['record'])) {
     $focus->retrieve($_REQUEST['record']);
     $focus->mark_deleted($_REQUEST['record']);
     header("Location: index.php?module=".$_REQUEST['return_module']."&action=".$_REQUEST['return_action']."&record=".$_REQUEST['return_id']);
+    //delete related folders by calling delete() in SugarFolders.php
+    // Retrieve the ID of the inbound email account being deleted
+    // Create an instance of the SugarFolders class to call the delete() function
+    require_once('include/SugarFolders/SugarFolders.php');
+    $inboundEmailId = $focus->id;
+    $sugarFolder = new SugarFolder();
+    if (!empty($inboundEmailId)) {
+        if ($sugarFolder->retrieve($inboundEmailId)) {
+            $sugarFolder->delete();
+        } else {
+            // Write a fatal error to the log indicating retrieval failure
+            error_log('Failed to retrieve the sugar folder for inbound email ID: ' . $inboundEmailId);
+        }
+    } else {
+        // Write a fatal error to the log indicating null inbound email ID
+        error_log('Inbound email ID is null. Cannot proceed.');
+    }
 }


### PR DESCRIPTION
When group email accounts are deleted the associated folders don't get marked as deleted=1 in the folders table.  This means they show up for users in folder selection because is shows all folder not equal to deleted=1 (among a few other conditions).  They should be marked as deleted when the inbound group email account is deleted.  There is in fact, functionality to do this in SugarFolders.php but is is not called when an inbound group email is deleted.  This additional code just calls the existing function delete() when an inbound email account is deleted.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
This is an addtion to delete.php file simply to get the ID of the folder that is being deleted and then to call and pass it along to SugarFolders.php.  There are two functions that then get processed:  delete() which also then calls deleteChildrenCascade($id) to delete the child folders.
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
This is related to the general issue #9028 there are various problems related to group emails.  This is one.
<!--- Please link to the issue here unless your commit contains the issue number -->
#9028 #10059 
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required so that the delete function gets called properly and the folders from the folders table are marked deleted as they should be.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Create a group inbound email account. Ensure you have subscribed the user to folders so they are created.
Delete the inbound group email account, after application of this change, the INBOX (parent folder) and the children folders of the inbound email account should now be updated such that deleted="1" in the folders table.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->