### PR TITLE
Fix parameter userTime method in class TimeDate

### DIFF
--- a/include/TimeDate.php
+++ b/include/TimeDate.php
@@ -617,7 +617,7 @@ class TimeDate
                 return $this->asUserDate($date, true, $user);
                 break;
             case 'time':
-                return $this->asUserTime($date, true, $user);
+                return $this->asUserTime($date, $user);
                 break;
             case 'datetime':
             case 'datetimecombo':


### PR DESCRIPTION
Another alternative would be to change this function
```
    /**
     * Format DateTime object as user time
     * Note: by default does not convert TZ!
     *
     * @param DateTime $date
     * @param boolean $tz Perform TZ conversion?
     * @param User $user
     * @return string
     */
    public function asUserTime(DateTime $date, $tz = false, User $user = null)
    {
        if ($tz) {
            $this->tzUser($date, $user);
        }

        return $date->format($this->get_time_format($user));
    }
``Σ