### PR TITLE
Fix #10139 - HTML Text Field tinyMCE version

### DIFF
--- a/include/SugarFields/Fields/Text/SugarFieldText.php
+++ b/include/SugarFields/Fields/Text/SugarFieldText.php
@@ -92,20 +92,32 @@ class SugarFieldText extends SugarFieldBase
     public function setup($parentFieldArray, $vardef, $displayParams, $tabindex, $twopass = true)
     {
         parent::setup($parentFieldArray, $vardef, $displayParams, $tabindex, $twopass);
-        $editor = "";
+        $initiate = "";
 
-        if (isset($vardef['editor']) && $vardef['editor'] == "html") {
+        if (isset($vardef['editor']) && $vardef['editor'] === "html") {
             if (!isset($displayParams['htmlescape'])) {
                 $displayParams['htmlescape'] = false;
             }
 
-            if ($_REQUEST['action'] == "EditView") {
-                require_once(__DIR__ . "/../../../../include/SugarTinyMCE.php");
-                $tiny = new SugarTinyMCE();
-                $editor = $tiny->getInstance($vardef['name'], 'email_compose_light');
+            if ($_REQUEST['action'] === "EditView") {
+                $form_name = '';
+
+                if (!empty($this->ss->_tpl_vars['displayParams']['formName'])) {
+                    $form_name = $this->ss->_tpl_vars['displayParams']['formName'];
+                }
+
+                $config = [];
+                $config['height'] = 250;
+                $config['menubar'] = false;
+                $config['plugins'] = 'code, table, link, image, wordcount';
+                $config['selector'] = "#{$form_name} " . "#" . $vardef['name'];
+                $config['toolbar1'] = 'fontselect | fontsizeselect | bold italic underline | forecolor backcolor | styleselect | outdent indent | link image | code table';
+
+                $jsConfig = json_encode($config);
+                $initiate = '<script type="text/javascript"> tinyMCE.init(' . $jsConfig . ')</script>';
             }
         }
 
-        $this->ss->assign("tinymce", $editor);
+        $this->ss->assign("tinymce", $initiate);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
Fix for bug https://github.com/salesagility/SuiteCRM/issues/10139

## Motivation and Context
Text fields using html editors are loading an older version of tinyMCE, this can prevent new WYSIWIG fields from displaying due to conflicts.

This is most notable on the Cases description field that is set to use an html editor by default

## How To Test This
1. In Studio, create a WYSIWIG field for the Cases module.
2. Add the WYSIWIG field to the edit view.
3. Go to a Cases edit view.
4. The WYSIWIG field will fail to load the editor.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->