### PR TITLE
Fix #10141 - Orphaned Case Attachments bug

### DIFF
--- a/modules/AOP_Case_Updates/Case_Updates.php
+++ b/modules/AOP_Case_Updates/Case_Updates.php
@@ -299,6 +299,9 @@ function display_single_update(AOP_Case_Updates $update)
 function display_case_attachments($case)
 {
     $html = '';
+    if(empty($case->id)){
+        return '';
+    }
     $notes = $case->get_linked_beans('notes', 'Notes');
     if ($notes) {
         foreach ($notes as $note) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->

## Description
Fix for issue https://github.com/salesagility/SuiteCRM/issues/10141
When a Cases record with Notes related to it is deleted, the orphaned notes will be loaded into the Case Attachements field when creating a new Cases record.

## Motivation and Context
This causes a display bug when creating a Case

## How To Test This
1. Create a Cases record
2. Add/relate a Notes record to the Cases record
3. Delete the Case
4. Click on Create Case
5. The Case Attachments field will contain the orphaned Note

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->