### PR TITLE
Fix #9950 editing Email settings drops TLS SSL selection

### DIFF
--- a/include/utils.php
+++ b/include/utils.php
@@ -1888,7 +1888,7 @@ function get_select_options_with_id_separate_key($label_list, $key_list, $select
         // the system is evaluating $selected_key == 0 || '' to true.  Be very careful when changing this.  Test all cases.
         // The bug was only happening with one of the users in the drop down.  It was being replaced by none.
         if (
-                ($option_key !== '' && $selected_key === $option_key) || (
+                ($option_key !== '' && $selected_key == $option_key) || (
                     $option_key === '' && (($selected_key === '' && !$massupdate) || $selected_key === '__SugarMassUpdateClearField__')
                 ) || (is_array($selected_key) && in_array($option_key, $selected_key))
         ) {


### PR DESCRIPTION
## Motivation

After all the recent work done to make email configuration in SuiteCRM less of a problem, this bug is totally killing the experience. Again. A fix has been around for months, but people keep stumbling on this, comes up in the forums every week.

## Description
Please see Issue #9950 for details.

## How To Test This

To see the bug happening, before the fix:
1. In **Admin / Email settings**, set up an SMTP account that uses TLS.
2. Check DB, value is saved in `outbound_email`, system account, field `mail_smtpssl` with value 2.
3. Open the **Admin / Email settings** screen again. Note that the dropdown changed to `None`.
4. Click Save.
5. Check DB, field is now 0.

With the fix, the dropdown should show the saved value, and saving should keep that value every time.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

