### PR TITLE
Fix #10199 - PHP Fatal error: Uncaught Error: Non-static method Sug…

### DIFF
--- a/include/generic/SugarWidgets/SugarWidgetFieldname.php
+++ b/include/generic/SugarWidgets/SugarWidgetFieldname.php
@@ -55,6 +55,7 @@ class SugarWidgetFieldName extends SugarWidgetFieldVarchar
     {
         parent::__construct($layout_manager);
         $this->reporter = $this->layout_manager->getAttribute('reporter');
+        $this->sugarWidgetFieldId = new SugarWidgetFieldId($layout_manager);
     }
 
     public function displayList(&$layout_def)
@@ -186,7 +187,7 @@ class SugarWidgetFieldName extends SugarWidgetFieldVarchar
             $input_name0 = $current_user->id;
         }
 
-        return SugarWidgetFieldid::_get_column_select($layout_def)."="
+        return $this->sugarWidgetFieldId->_get_column_select($layout_def)."="
             .$this->reporter->db->quoted($input_name0)."\n";
     }
 
@@ -204,7 +205,7 @@ class SugarWidgetFieldName extends SugarWidgetFieldVarchar
             $input_name0 = $current_user->id;
         }
 
-        return SugarWidgetFieldid::_get_column_select($layout_def)."<>"
+        return $this->sugarWidgetFieldId->_get_column_select($layout_def)."<>"
             .$this->reporter->db->quoted($input_name0)."\n";
     }
 
@@ -228,7 +229,7 @@ class SugarWidgetFieldName extends SugarWidgetFieldVarchar
 
         $str = implode(",", $arr);
 
-        return SugarWidgetFieldid::_get_column_select($layout_def)." IN (".$str.")\n";
+        return $this->sugarWidgetFieldId->_get_column_select($layout_def)." IN (".$str.")\n";
     }
     // $rename_columns, if true then you're coming from reports
     public function queryFilternot_one_of($layout_def, $rename_columns = true)
@@ -250,7 +251,7 @@ class SugarWidgetFieldName extends SugarWidgetFieldVarchar
 
         $str = implode(",", $arr);
 
-        return SugarWidgetFieldid::_get_column_select($layout_def)." NOT IN (".$str.")\n";
+        return $this->sugarWidgetFieldId->_get_column_select($layout_def)." NOT IN (".$str.")\n";
     }
 
     public function &queryGroupBy($layout_def)
@@ -259,7 +260,7 @@ class SugarWidgetFieldName extends SugarWidgetFieldVarchar
             $layout_def['name'] = 'id';
             $layout_def['type'] = 'id';
 
-            $group_by =  SugarWidgetFieldid::_get_column_select($layout_def)."\n";
+            $group_by =  $this->sugarWidgetFieldId->_get_column_select($layout_def)."\n";
         } else {
             // group by clause for user name passes through here.
             $group_by = $this->_get_column_select($layout_def)."\n";

--- a/include/generic/SugarWidgets/SugarWidgetFieldname.php
+++ b/include/generic/SugarWidgets/SugarWidgetFieldname.php
@@ -50,6 +50,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
 class SugarWidgetFieldName extends SugarWidgetFieldVarchar
 {
     protected static $moduleSavePermissions = array();
+    protected $sugarWidgetFieldId;
 
     public function __construct(&$layout_manager)
     {


### PR DESCRIPTION
…arWidgetReportField::_get_column_select()

PHP version 8 seems to have deprecated the non-static method calling. In this fix the class SugarWidgetFieldid is being instantiated and set as a property for reusability throughout the class.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Solving this issue: #10199

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->
The bug occurs when having a widget on your dashboard (e.g. "My Top Open Opportunities : Options") and adding the following filter: disable "only my items" checkbox and add a "assigned To". This will cause the dashboard to crash.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->