### PR TITLE
Fix #10222 - Workflow Conditions table styling

### DIFF
--- a/modules/AOW_WorkFlow/metadata/editviewdefs.php
+++ b/modules/AOW_WorkFlow/metadata/editviewdefs.php
@@ -123,14 +123,20 @@ $viewdefs ['AOW_WorkFlow'] =
                 array(
                     0 =>
                     array(
-                        0 => 'condition_lines',
+                        0 => array(
+                            'name' => 'condition_lines',
+                            'hideLabel' => true,
+                        ),
                     ),
                 ),
                 'LBL_ACTION_LINES' =>
                 array(
                     0 =>
                     array(
-                        0 => 'action_lines',
+                        0 => array(
+                            'name' => 'action_lines',
+                            'hideLabel' => true,
+                        ),
                     ),
                 ),
             ),

--- a/themes/SuiteP/css/suitep-base/aow.scss
+++ b/themes/SuiteP/css/suitep-base/aow.scss
@@ -96,7 +96,11 @@
 
 #aow_conditionLines td:first-of-type button {
   margin-top: 6px;
-  line-height: 30px;
+  line-height: 1px;
+  margin-right: 18px;
+  padding: 0;
+  width: 32px;
+  height: 32px;
 }
 
 #aow_conditionLines input {

--- a/themes/SuiteP/css/suitep-base/editview.scss
+++ b/themes/SuiteP/css/suitep-base/editview.scss
@@ -2698,6 +2698,11 @@ input#btn_ActionLine.button[type="button"] {
 
 #conditionLines_head{
   background: none;
+  text-align: center;
+}
+
+#aow_conditionLines tbody {
+  text-align: center;
 }
 
 #fieldLines_head {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Styling changes to WF conditions table.
Before: 

![image](https://github.com/salesagility/SuiteCRM/assets/116086008/8ff83430-4b09-4349-8db6-f3d955136723)

After: 

![image](https://github.com/salesagility/SuiteCRM/assets/116086008/1f852d84-d264-4f33-b13b-bf4b5cab0356)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Cleaner UI

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Workflows -> Create WF -> Add condition -> check condition's table


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->