### PR TITLE
Fixed #8583 Side panel - view full names of favorites and recent records instead of module names

### DIFF
--- a/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -111,7 +111,8 @@
                                                 {foreach from=$recentRecords item=item name=lastViewed }
                                                     {if $smarty.foreach.lastViewed.iteration < 4} {* limit to 3 results *}
                                                         <li class="recentlinks" role="presentation">
-                                                            <a title="{sugar_translate module=$item.module_name label=LBL_MODULE_NAME}"
+                                                            {* #8583 Add the summary on title *}
+                                                            <a title="{sugar_translate module=$item.module_name label="LBL_MODULE_NAME"} : {$item.item_summary}"
                                                                accessKey="{$smarty.foreach.lastViewed.iteration}"
                                                                href="{sugar_link module=$item.module_name action='DetailView' record=$item.item_id link_only=1}" class="recent-links-detail">
                                                                 <span class="suitepicon suitepicon-module-{$item.module_name|lower|replace:'_':'-'}"></span>
@@ -137,7 +138,8 @@
                                                 {foreach from=$favoriteRecords item=item name=lastViewed}
                                                     {if $smarty.foreach.lastViewed.iteration < 4} {* limit to 3 results *}
                                                         <li class="favoritelinks" role="presentation">
-                                                            <a title="{$item.module_name}"
+                                                            {* #8583 Add the summary on title *}
+                                                            <a title="{sugar_translate module=$item.module_name label="LBL_MODULE_NAME"} : {$item.item_summary}"
                                                                accessKey="{$smarty.foreach.lastViewed.iteration}"
                                                                href="{sugar_link module=$item.module_name action='DetailView' record=$item.id link_only=1}"  class="favorite-links-detail">
                                                                 <span class="suitepicon suitepicon-module-{$item.module_name|lower|replace:'_':'-'}"></span>
@@ -224,7 +226,8 @@
                                                         {foreach from=$recentRecords item=item name=lastViewed}
                                                             {if $item.module_name == $name and $submoduleRecentRecords < 3}
                                                                 <li class="recentlinks" role="presentation">
-                                                                    <a title="{sugar_translate module=$item.module_name label=LBL_MODULE_NAME}"
+                                                                    {* #8583 Add the summary on title *}
+                                                                    <a title="{sugar_translate module=$item.module_name label="LBL_MODULE_NAME"} : {$item.item_summary}"
                                                                        accessKey="{$smarty.foreach.lastViewed.iteration}"
                                                                        href="{sugar_link module=$item.module_name action='DetailView' record=$item.item_id link_only=1}" class="recent-links-detail">
 
@@ -259,7 +262,8 @@
                                                     {foreach from=$favoriteRecords item=item name=lastViewed}
                                                         {if $item.module_name == $name and $submoduleFavoriteRecords < 3}
                                                             <li class="favoritelinks" role="presentation">
-                                                                <a title="{$item.module_name}"
+                                                                {* #8583 Add the summary on title *}
+                                                                <a title="{sugar_translate module=$item.module_name label="LBL_MODULE_NAME"} : {$item.item_summary}"
                                                                    accessKey="{$smarty.foreach.lastViewed.iteration}"
                                                                    href="{sugar_link module=$item.module_name action='DetailView' record=$item.id link_only=1}" class="favorite-links-detail">
                                                                     <span class="suitepicon suitepicon-module-{$item.module_name|lower|replace:'_':'-'}"></span>
@@ -376,7 +380,8 @@
                                             {foreach from=$recentRecords item=item name=lastViewed}
                                                 {if $item.module_name == $submodule and $submoduleRecentRecords < 3}
                                                     <li class="recentlinks" role="presentation">
-                                                        <a title="{sugar_translate module=$item.module_name label=LBL_MODULE_NAME}"
+                                                        {* #8583 Add the summary on title *}
+                                                        <a title="{sugar_translate module=$item.module_name label="LBL_MODULE_NAME"} : {$item.item_summary}"
                                                            accessKey="{$smarty.foreach.lastViewed.iteration}"
                                                            href="{sugar_link module=$item.module_name action='DetailView' record=$item.item_id link_only=1}" class="recent-links-detail">
                                                             <span aria-hidden="true">{$item.item_summary_short}</span>
@@ -406,7 +411,8 @@
                                         {foreach from=$favoriteRecords item=item name=lastViewed}
                                             {if $item.module_name == $submodule and $submoduleFavoriteRecords < 3}
                                                 <li class="favoritelinks" role="presentation">
-                                                    <a title="{$item.module_name}"
+                                                    {* #8583 Add the summary on title *}
+                                                    <a title="{sugar_translate module=$item.module_name label="LBL_MODULE_NAME"} : {$item.item_summary}"
                                                        accessKey="{$smarty.foreach.lastViewed.iteration}"
                                                        href="{sugar_link module=$item.module_name action='DetailView' record=$item.id link_only=1}" class="favorite-links-detail">
                                                         <span aria-hidden="true">{$item.item_summary_short}</span>
@@ -807,7 +813,8 @@
                                 {if $smarty.foreach.lastViewed.index < 5}
                                     <div class="recently_viewed_link_container_sidebar">
                                         <li class="recentlinks" role="presentation">
-                                            <a title="{sugar_translate module=$item.module_name label=LBL_MODULE_NAME}"
+                                            {* #8583 Add the summary on title *}
+                                            <a title="{sugar_translate module=$item.module_name label="LBL_MODULE_NAME"} : {$item.item_summary}"
                                                accessKey="{$smarty.foreach.lastViewed.iteration}"
                                                href="{sugar_link module=$item.module_name action='DetailView' record=$item.item_id link_only=1}"
                                                class="recent-links-detail">
@@ -834,7 +841,9 @@
                             {if $smarty.foreach.lastViewed.index < 5}
                             <div class="recently_viewed_link_container_sidebar">
                                 <li class="recentlinks" role="presentation">
-                                    <a title="{$item.module_name}" accessKey="{$smarty.foreach.lastViewed.iteration}" href="{sugar_link module=$item.module_name action='DetailView' record=$item.id link_only=1}" class="favorite-links-detail">
+                                    {* #8583 Add the summary on title *}
+                                    <a title="{sugar_translate module=$item.module_name label="LBL_MODULE_NAME"} : {$item.item_summary}"
+                                        accessKey="{$smarty.foreach.lastViewed.iteration}" href="{sugar_link module=$item.module_name action='DetailView' record=$item.id link_only=1}" class="favorite-links-detail">
                                         <span class="suitepicon suitepicon-module-{$item.module_name|lower|replace:'_':'-'}"></span>
                                         <span aria-hidden="true">{$item.item_summary_short}</span>
                                     </a>


### PR DESCRIPTION
## Description
Solve  #8583

## Motivation and Context
As stated on issue #8583, the names of the instances of modules might not be clearly readable on side panel (recent records and favorites).
Just add the item_summary to the html link title.

## How To Test This
1. Make sure the side panel is opened.
2. Navigate to a record or create one with a long enough name
3. Refresh
4. Hover on the recent record, you will see in the title tooltip the module name and the record name

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
