### PR TITLE
Fix non-countable error when importing CSV

### DIFF
--- a/modules/Import/views/ImportListView.php
+++ b/modules/Import/views/ImportListView.php
@@ -128,7 +128,7 @@ class ImportListView
         $this->ss->assign('navStrings', $navStrings);
         $this->ss->assign('pageData', $this->generatePaginationData());
         $this->ss->assign('tableID', $this->tableID);
-        $this->ss->assign('colCount', count($this->headerColumns));
+        $this->ss->assign('colCount', is_countable($this->headerColumns) ? count($this->headerColumns) : 0);
         $this->ss->assign('APP', $app_strings);
         $this->ss->assign('rowColor', array('oddListRow', 'evenListRow'));
         $this->ss->assign('displayColumns', $this->headerColumns);


### PR DESCRIPTION
## Description
Not my issue, see this forum thread for details:
https://community.suitecrm.com/t/php-fatal-error-uncaught-typeerror-count-argument-1-value-must-be-of-type-countable-after-upgrade-to-suite-7-14/91224

```php
[Thu Dec 14 19:43:01.002817 2023] [php:error] [pid 35371] [client 127.0.0.1:45634] 
PHP Fatal error:  Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, bool given in modules/Import/views/ImportListView.php:131

Stack trace:
#0 modules/Import/views/view.last.php(189): ImportListView->display()
#1 modules/Import/views/view.last.php(141): ImportViewLast->getListViewTableFromFile()
#2 include/MVC/View/SugarView.php(210): ImportViewLast->display()
#3 include/MVC/Controller/SugarController.php(432): SugarView->process()
#4 include/MVC/Controller/SugarController.php(363): SugarController->processView()
#5 include/MVC/SugarApplication.php(101): SugarController->execute()
#6 index.php(52): SugarApplication->execute()
#7 {main} thrown in modules/Import/views/ImportListView.php on line 131, referer: index.php
```

Problem only happens with PHP v8, not with v7.4.

## How To Test This
Import CSV?

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.


