### PR TITLE
More logical code structure, don't need to fill variable if gets over…

### DIFF
--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -6323,18 +6323,16 @@ class InboundEmail extends SugarBean
      */
     public function getConnectString($service = '', $mbox = '', $includeMbox = true)
     {
-        $service = empty($service) ? $this->getServiceString() : $service;
-        $mbox = empty($mbox) ? $this->mailbox : $mbox;
-
-        $protocol = $this->protocol ?? 'imap';
-        $port = $this->port ?? '143';
-
-        $connectString = '{' . $this->server_url . ':' . $port . '/service=' . $protocol . $service . '}';
-
         if (!empty($this->connection_string)){
             $connectString = '{' . $this->connection_string . '}';
+        } else {
+            $service = empty($service) ? $this->getServiceString() : $service;
+            $protocol = $this->protocol ?? 'imap';
+            $port = $this->port ?? '143';
+            $connectString = '{' . $this->server_url . ':' . $port . '/service=' . $protocol . $service . '}';
         }
-
+        
+        $mbox = empty($mbox) ? $this->mailbox : $mbox;
         $connectString .= ($includeMbox) ? $mbox : "";
 
         return $connectString;


### PR DESCRIPTION
## Description
More logical code structure, don't need to fill variable if gets overwritten later

## Motivation and Context
It is just a code cleanup.
IF $this->connection_string is filled, most of the code that ran before was useless. So run this code after the condition in else makes more sense to me. May safe some nanoseconds, too.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->