### PR TITLE
Fix #10172 Emails don't show subject  MIME headers #10269 Email sync …

### DIFF
--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -4866,7 +4866,7 @@ class InboundEmail extends SugarBean
             $subjectDecoded = $this->getImap()->MimeHeaderDecode($subject); // returns array or string.
         } else {
             // imap_mime_header_decode() is not installed on bitnami docker container! Fall back to iconv_mime_decode().
-            if function_exists('iconv_mime_decode') {
+            if (function_exists('iconv_mime_decode')) {
                 $subjectDecoded = iconv_mime_decode($subject, 0, 'UTF-8');  // returns string or false.
                 if ($subjectDecoded == false) { // error occurred in iconv_mime_decode().
                     $subjectDecoded = $subject;  // possibly still mime encoded.
@@ -4874,10 +4874,6 @@ class InboundEmail extends SugarBean
             } else {  // iconv module not installed or enabled!
                 $subjectDecoded = $subject;
             }
-        }
-
-        if (is_string($subjectDecoded)) {  //should be plain US-ASCII, compatible with UTF-8.
-            return $subjetDecoded;
         }
 
         if (is_array($subjectDecoded)) {
@@ -4889,8 +4885,10 @@ class InboundEmail extends SugarBean
                     $ret .= $object->text;
                 }
             }
-            return $ret;
+            $subjectDecoded = $ret;
         }
+
+        return $subjectDecoded;  //should be plain US-ASCII, compatible with UTF-8.
     }
 
     /**

--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -4861,18 +4861,36 @@ class InboundEmail extends SugarBean
      */
     public function handleMimeHeaderDecode($subject)
     {
-        $subjectDecoded = $this->getImap()->MimeHeaderDecode($subject);
-
-        $ret = '';
-        foreach ($subjectDecoded as $object) {
-            if ($object->charset != 'default') {
-                $ret .= $this->handleCharsetTranslation($object->text, $object->charset);
-            } else {
-                $ret .= $object->text;
+        $subjectDecoded = '';
+        if (function_exists('imap_mime_header_decode')) {   // function_exists() should be moved to MimeHeaderDecode().
+            $subjectDecoded = $this->getImap()->MimeHeaderDecode($subject); // returns array or string.
+        } else {
+            // imap_mime_header_decode() is not installed on bitnami docker container! Fall back to iconv_mime_decode().
+            if function_exists('iconv_mime_decode') {
+                $subjectDecoded = iconv_mime_decode($subject, 0, 'UTF-8');  // returns string or false.
+                if ($subjectDecoded == false) { // error occurred in iconv_mime_decode().
+                    $subjectDecoded = $subject;  // possibly still mime encoded.
+                }
+            } else {  // iconv module not installed or enabled!
+                $subjectDecoded = $subject;
             }
         }
 
-        return $ret;
+        if (is_string($subjectDecoded)) {  //should be plain US-ASCII, compatible with UTF-8.
+            return $subjetDecoded;
+        }
+
+        if (is_array($subjectDecoded)) {
+            $ret = '';
+            foreach ($subjectDecoded as $object) {
+                if ($object->charset != 'default') {
+                    $ret .= $this->handleCharsetTranslation($object->text, $object->charset);
+                } else {
+                    $ret .= $object->text;
+                }
+            }
+            return $ret;
+        }
     }
 
     /**

--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -4862,7 +4862,7 @@ class InboundEmail extends SugarBean
     public function handleMimeHeaderDecode($subject)
     {
         $subjectDecoded = '';
-        if (function_exists('imap_mime_header_decode')) {   // function_exists() should be moved to MimeHeaderDecode().
+        if (function_exists('imap_mime_header_decode') && in_array('imap', get_loaded_extensions(), true)) {   // function_exists() should be moved to MimeHeaderDecode().
             $subjectDecoded = $this->getImap()->MimeHeaderDecode($subject); // returns array or string.
         } else {
             // imap_mime_header_decode() is not installed on bitnami docker container! Fall back to iconv_mime_decode().


### PR DESCRIPTION
…breaking on MIME decoding.  
A commonly reported bug report on the forum: https://community.suitecrm.com/t/subject-line-missing-from-inbound-emails/88059 
Also fixes this issue https://github.com/salesagility/SuiteCRM-Core/issues/363
..and fixes https://github.com/salesagility/SuiteCRM-Core/issues/420
..all similar reports about the same bug - a lack of resilience in decoding the MIME headers, resulting in broken inbox emails.
Credit also to @DBRenny for putting together a first version of this: https://github.com/salesagility/SuiteCRM-Core/pull/366

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Inbound email was broken on Bitnami containers, and on any installation that is missing the `php-imap` extension.  [Bitnami intentionally leaves out the `php-imap` extension, because of the long time since it last received security fixes](https://github.com/bitnami/containers/issues/51877).


## How To Test This
<!--- Please describe in detail how to test your changes. -->
Try inbound email on a bitnami container.  There should be no subjects, for servers that return MIME encoded headers (languages with accented characters outside of US-ASCII character set, e.g. French, German, etc).
Then from inside the container, get the patch with `wget` and apply the patch `git apply`, try inbound email again, and it should show email Subjects in the inbox.  Other MIME encoded headers may also display properly as `UTF-8`, such as `From`, `To`, `CC`, `Bcc`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->