### PR TITLE
Fix #10339 - Inconsistent application of trim function on name & varchar fields

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -2520,6 +2520,11 @@ class SugarBean
                     $type .= $def['dbType'];
                 }
 
+                // Trim name & varchar type values on save when the value is not null
+                if (isset($def['type']) && in_array($def['type'], ['name', 'varchar']) && !is_null($this->$key)) {
+                    $this->$key = trim($this->$key);
+                }
+
                 if (isset($def['type']) && ($def['type'] == 'html' || $def['type'] == 'longhtml')) {
                     $this->$key = purify_html($this->$key);
                 } elseif (


### PR DESCRIPTION
- Closes #10339 
## Description
<!--- Describe your changes in detail -->
This Pull Request addresses issue [#10339](https://github.com/salesagility/SuiteCRM/issues) by implementing improvements in the `cleanBean()` function in `data/SugarBean.php`. It now executes `trim` on all "name" and "varchar" type fields during save operations. A check has been added to avoid using `trim` when the field value is `null` to prevent errors in PHP.

## Motivation and Context
<!--- Why is this change necessary? What problem does it solve? -->
This change is necessary to improve data consistency and cleanliness in text fields where unnecessary spaces can impact data quality and search efficiency.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create or edit a record in SuiteCRM with additional spaces in "name" or "varchar" type fields in various modules, including modules created using the Module Builder and through Web forms.
2. Save these records and verify that the additional spaces have been automatically removed.
3. Ensure that this functionality works consistently across standard modules, custom modules created via Module Builder, and records entered through web forms to ensure comprehensive testing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-disruptive change that solves an issue)
- [ ] New feature (non-disruptive change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final Checklist
<!--- Go over all the following points and make sure they apply. --->
- [x] My code follows the coding style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change in the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
