### PR TITLE
Fix #10345 Microsoft Azure OAuth Redirect URL cannot have query string.

### DIFF
--- a/install/install_utils.php
+++ b/install/install_utils.php
@@ -1030,6 +1030,9 @@ EOQ;
     RewriteRule ^cache/jsLanguage/(.._..).js$ index.php?entryPoint=jslang&modulename=app_strings&lang=$1 [L,QSA]
     RewriteRule ^cache/jsLanguage/(\w*)/(.._..).js$ index.php?entryPoint=jslang&modulename=$1&lang=$2 [L,QSA]
 
+    #Fix #10345 Microsoft Azure OAuth Redirect URL cannot have query string.
+    RewriteRule "^entryPoint/setExternalOAuthToken" "index.php?entryPoint=setExternalOAuthToken" [PT,L]
+
     # --------- DEPRECATED --------
     RewriteRule ^api/(.*)$ - [env=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
     RewriteRule ^api/(.*?)$ lib/API/public/index.php/$1 [L]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Setting up MS Azure OAuth for email accounts was failing because Suite docs say use a Redirect URL containing a query string, and Azure forbids Redirect URLs with query strings.
My fix involves adding a line to the `.htaccess` to rewrite the incoming Redirect URL compatible with Microsoft Azure OAuth, to the query-string type of Redirect URL expected by Suite.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Microsoft Azure OAuth does not allow Redirect URL to have query strings, which is the exact type of URL Suite uses.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Try creating an application in Azure according to the documentation.
At one point, it will have you paste the Suite Redirect URL into Microsoft Azure application.
Paste the URL with query strings from the docs.  
Azure will refuse to save it because query strings are not allowed.
![Azure OAuth Redirect URL may not coontain a query string](https://github.com/salesagility/SuiteCRM/assets/259416/7554f2a7-a307-401b-9488-afe522417907)
Try again with the URL like this instead: `https://suite.mysite.tld/entryPoint/setExternalOAuthToken`
Azure will save this Redirect URL.
And Suite will accept the Redirect URL during the OAuth email account login, because Suite will internally rewrite the incoming Redirect URL from Azure, to the expected URL `https://suite.mysite.tld/index.php?entryPoint=setExternalOAuthToken`, Suite will receive the token back from Azure OAuth, making OAuth login to the MS Azure email account work.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->