### PR TITLE
Fix #10365: Custom subpanels not loading data until the page is reloaded

### DIFF
--- a/include/SubPanel/SubPanelViewer.php
+++ b/include/SubPanel/SubPanelViewer.php
@@ -83,7 +83,7 @@ if (!empty($_REQUEST['layout_def_key'])) {
 }
 require_once 'include/SubPanel/SubPanelDefinitions.php';
 // retrieve the definitions for all the available subpanels for this module from the subpanel
-$bean = BeanFactory::getBean($module);
+$bean = BeanFactory::getBean($module , $record);
 $spd = new SubPanelDefinitions($bean);
 $aSubPanelObject = $spd->load_subpanel($subpanel, false, false, '', $collection);
 


### PR DESCRIPTION
This fixes a bug that makes custom subpanels that uses $this->_focus->id as a function parameter not load correctly

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
By adding the record Id to the getBean call the data for the current record is retrieved which allows the layout_def custom function to acceed the bean data for building a custom query correctly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This reduces the error margin when creating custom subpanels for modules. Also prevents the user need to reload the page everytime a custom subpanel is opened.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Create a custom layout_def subpanel for any module that uses a custom subpanel to build a query with $this->_focus->id as a function parameter.
2. Use this parameter in your query
3. This will make the subpanel not load when opening it for the first time or when trying to order the subpanel by some column from the view.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->