### PR TITLE
Fix #10372 - Product import fails with fatal error

### DIFF
--- a/include/SugarFields/Fields/Currency/SugarFieldCurrency.php
+++ b/include/SugarFields/Fields/Currency/SugarFieldCurrency.php
@@ -99,7 +99,8 @@ class SugarFieldCurrency extends SugarFieldFloat
 
         if (isset($vardef['len'])) {
             // check for field length
-            $value = sugar_substr($value, $vardef['len']);
+            $length = explode(',', $vardef['len']);
+            $value = sugar_substr($value, $length[0]);
         }
 
         return $value;


### PR DESCRIPTION
## Description
When importing products via CSV file on a server running PHP 8.2 the following error is thrown when reaching the product prices within the import.

`PHP Fatal error:  Uncaught TypeError: mb_substr(): Argument #3 ($length) must be of type ?int, string given in /var/www/include/utils.php:5149`

This is caused by the price vardefs which are in the format 26,4 with 26 representing the overall length and 4 representing the potential decimals.

In PHP8.2 this throws a fatal error and prevents the import from completing.

Issue: https://github.com/salesagility/SuiteCRM/issues/10372

## Motivation and Context
When importing products, the import fails with no errors displayed through the UI, just an empty warning box.

## How To Test This

- Prepare an import CSV with the required fields and at least one price
- Import the CSV
- The import will fail and the 500 fatal error logged

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.