### PR TITLE
Fix #10375 - Upgradewizard double commit

### DIFF
--- a/modules/UpgradeWizard/index.php
+++ b/modules/UpgradeWizard/index.php
@@ -294,6 +294,7 @@ if ($upgradeStepFile == 'end') {
     //}
 }
 
+$additionalStep = $_REQUEST['additional_step'] ?? false;
 if (!isset($additionalStep) || !$additionalStep) {
     require('modules/UpgradeWizard/' . $upgradeStepFile . '.php');
 }
@@ -506,7 +507,6 @@ function getSelectedModulesForLayoutMerge()
 eoq;
 
 // If we are on step  4 then force a redirect to run again to pick up changes to smarty before setting the template.
-$additionalStep = $_REQUEST['additional_step'] ?? false;
 if ($_REQUEST['step'] === '4' && !$additionalStep) {
     // Set session variables
     $_SESSION['UW_MAIN'] = $uwMain;


### PR DESCRIPTION
This PR fixes an issue that "commit" is called twice when runing the upgradewizard caused by changes in:
https://github.com/salesagility/SuiteCRM/commit/890e5997a02666b925623cd53b99a81609fa481d#diff-7c5c0ada659df5cc72d508d4b597f1882ede2ee19a4a243010a84b9a3a8b4213

## Description
The changes in the said commit introduce the variable $additionalStep in modules/Upgradewizard/index.php
This variable is initalized in line 509, but already used before in line 297 without initialization. This causes the commit.php to be executed twice.

## Motivation and Context
As commit.php is secured to not run its logic twice, this bug does not have any implications for now, however future changes might cause an issue here.

## How To Test This
 - install SuiteCRM 7.14.2
 - upgrade to SuiteCRM 7.14.3

**Expected result**
commit.php is only called once

**Observed behaviour**
the file `upgradewizard.log` shows two entries of the line "[At commit.php]"
This can also be verified by debugger.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->