### PR TITLE
Correctly find the id of related objects in search results

### DIFF
--- a/lib/Search/SearchResults.php
+++ b/lib/Search/SearchResults.php
@@ -210,7 +210,12 @@ class SearchResults
     {
         $relField = $idName;
         if (isset($obj->$link)) {
-            $relId = $obj->$link->getFocus()->$relField;
+            $linkedBeans = $obj->$link->getBeans();
+            if(count($linkedBeans) === 1){
+                $relId = array_keys($linkedBeans)[0];
+            } else {
+                $relId = $obj->$link->getFocus()->$relField;
+            }
             if (is_object($relId)) {
                 if (method_exists($relId, "getFocus")) {
                     $relId = $relId->getFocus()->id;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->
When a search results contain records which have related links in them; the link to the related record does not contain the correct related record id. This causes the link to go to a page with an error message of `Error retrieving record. This record may be deleted or you may not be authorized to view it.`

*NOTE* This bug is documented in Pull Request #9823 which seems to only have not been merged due to the formatting of the Pull Request itself.

This issue affects all previous versions of 7.12.x - 7.14.x

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
* Spin up a new SuiteCrm installation
* Go to Administration > Module Builder
* Create a new Package and Module
* Add a One-to-Many relation of your new module to Accounts
* Deploy the package
* Go to Administration > Search Settings and add your new module
* Go to the new module
* Create a new record with a related Account
* Search for your new record in the global search
* Click the record link and the account name
* on master, the record link will go to the record and account name link will 404 when going to the Account module with the record id

![search-result-bad-link](https://github.com/salesagility/SuiteCRM/assets/361586/03a86c58-4465-4082-a683-8997c2515313)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When searching for a record which has a related record, a user may want to click on the related record. Currently, the user will be shown a link to the related record; however, it will 404 when clicking on it.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

* Spin up a new SuiteCrm installation
* Go to Administration > Module Builder
* Create a new Package and Module
* Add a One-to-Many relation of your new module to Accounts
* Deploy the package
* Go to Administration > Search Settings and add your new module
* Go to the new module
* Create a new record with a related Account
* Search for your new record in the global search
* Click the record link and the account name
* on master, the record link will go to the record and account name link will 404 when going to the Account module with the record id
* after this fix, the record link will continue to go to the record and the account name link will go to the Account module using the Account id

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->