### PR TITLE
Fix #8209 - Compare parentenum_value more precisely

### DIFF
--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -394,11 +394,8 @@ eoq;
                                     $parentenum_value = $newbean->$parentenum_name;
 
                                     $dynamic_field_name = $field_name['name'];
-                                    // Dynamic field set value.
-                                    list($dynamic_field_value) = explode('_', $newbean->$dynamic_field_name);
 
-                                    if ($parentenum_value != $dynamic_field_value) {
-
+                                    if (strpos($newbean->$dynamic_field_name, $parentenum_value) !== 0) {
                                         // Change to the default value of the correct value set.
                                         $defaultValue = '';
                                         foreach ($app_list_strings[$field_name['options']] as $key => $value) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
If a Mass Update is performed on a module containing dynamic fields with underscores in parent field keys, the child field's default value is always set, regardless if a change has been made to the dynamic parent field. This issue is closely related to https://github.com/salesagility/SuiteCRM/issues/8209 however the proposed fix in https://github.com/salesagility/SuiteCRM/pull/10340 does not fix this issue if a custom dynamic dropdown is still in the Cases module and this can happen with no change to the dynamic dropdowns.

examples of dynamic dropdown options that would be affected:
```
parent dropdown keys: 
health_and_safety

child option keys:
health_and_safety_fire
health_and_safety_power_cut
health_and_safety_volcano
```

## Motivation and Context
Mass Update on many records can cause many unwanted changes to dynamic dropdowns

## How To Test This
1. Add a dynamic dropdown with keys containing underscores to a module
2. Create a record and set the child value to non-default(not the first value)
3. Perform a mass update on the record, with no changes to the dynamic dropdowns
4. The dynamic dropdown child field will be set to the default value.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->