### PR TITLE
Fix #10410  - Check report has been loaded before setting user params

### DIFF
--- a/modules/AOR_Reports/Dashlets/AORReportsDashlet/AORReportsDashlet.php
+++ b/modules/AOR_Reports/Dashlets/AORReportsDashlet/AORReportsDashlet.php
@@ -41,7 +41,9 @@ class AORReportsDashlet extends Dashlet
         }
         if (!empty($def['aor_report_id'])) {
             $this->report = BeanFactory::getBean('AOR_Reports', $def['aor_report_id']);
-            $this->report->user_parameters = $this->params;
+            if($this->report !== false) {
+                $this->report->user_parameters = $this->params;
+            }
         }
         $this->onlyCharts = !empty($def['onlyCharts']);
         $this->charts = !empty($def['charts']) ? $def['charts'] : array();


### PR DESCRIPTION
## Description
The reports dashlet allows you to add reports to your homescreen.
If you delete a report which is used in a reports dashlet, the home screen fails to load and throws a 500 error.

Uncaught Error: Attempt to assign property "user_parameters" on bool in /var/www/modules/AOR_Reports/Dashlets/AORReportsDashlet/AORReportsDashlet.php:44

## Motivation and Context
When this happens, the main workarounds are to clear user preferences or restore the deleted report.
This fix prevents the unrecoverable error and allows the user to interact with the dashlet as normal.

## How To Test This
1. Create a test report
2. Add a reports dashlet to your dashboard
3. Assign the test report to your new reports dashlet
4. Confirm the home screen loads
5. Delete the report
6. Confirm the home screen fails to load, with the error shown above in the logs

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.