### PR TITLE
Fix #10438 Depreciation warning on usort on the Dashboard Page

### DIFF
--- a/modules/SugarFeed/Dashlets/SugarFeedDashlet/SugarFeedDashlet.php
+++ b/modules/SugarFeed/Dashlets/SugarFeedDashlet/SugarFeedDashlet.php
@@ -417,7 +417,7 @@ class SugarFeedDashlet extends DashletGeneric
         }
 
         $function = function ($a, $b) {
-            return $a["sort_key"] < $b["sort_key"];
+            return $b["sort_key"] <=> $a["sort_key"];
         };
 
         usort($resortQueue, $function);


### PR DESCRIPTION
## Description
See the issue 10438
#10438 

## Motivation and Context
Just solves one of the php 8.2 depreciation warnings. 

## How To Test This
Simply reloading on the home page should be enough for the error to go away.

## Types of changes
Simply changed the < operator to the <=> operator as well as exchanged a with b to give earliest to last order.

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.