### PR TITLE
Fix # - VAT Values display incorrectly on Quotes->Service Line Items, if Significant Figures = 0

### DIFF
--- a/modules/AOS_Products_Quotes/Line_Items.php
+++ b/modules/AOS_Products_Quotes/Line_Items.php
@@ -176,11 +176,7 @@ function display_lines($focus, $field, $value, $view)
                 $product .= "<td class='tabDetailViewDF' style='text-align: right; padding:2px;'>".get_discount_string($line_item->discount, $line_item->product_discount, $params, $locale, $sep)."</td>";
 
                 $product .= "<td class='tabDetailViewDF' style='text-align: right; padding:2px;'>".currency_format_number($line_item->product_unit_price, $params)."</td>";
-                if ($locale->getPrecision()) {
-                    $product .= "<td class='tabDetailViewDF' style='text-align: right; padding:2px;'>".rtrim(rtrim(format_number($line_item->vat), '0'), $sep[1])."%</td>";
-                } else {
-                    $product .= "<td class='tabDetailViewDF' style='text-align: right; padding:2px;'>".format_number($line_item->vat)."%</td>";
-                }
+                $product .= "<td class='tabDetailViewDF' style='text-align: right; padding:2px;'>".display_tax_detail_view($locale, $line_item->vat, $sep)."</td>";
                 $product .= "<td class='tabDetailViewDF' style='text-align: right; padding:2px;'>".currency_format_number($line_item->vat_amt, $params)."</td>";
                 $product .= "<td class='tabDetailViewDF' style='text-align: right; padding:2px;'>".currency_format_number($line_item->product_total_price, $params)."</td>";
                 $product .= "</tr>";
@@ -204,10 +200,8 @@ function display_lines($focus, $field, $value, $view)
                 $service .= "<td class='tabDetailViewDF' style='text-align: right; padding:2px;'>".currency_format_number($line_item->product_list_price, $params)."</td>";
 
                 $service .= "<td class='tabDetailViewDF' style='text-align: right; padding:2px;'>".get_discount_string($line_item->discount, $line_item->product_discount, $params, $locale, $sep)."</td>";
-
-
                 $service .= "<td class='tabDetailViewDF' style='text-align: right; padding:2px;'>".currency_format_number($line_item->product_unit_price, $params)."</td>";
-                $service .= "<td class='tabDetailViewDF' style='text-align: right; padding:2px;'>".rtrim(rtrim(format_number($line_item->vat), '0'), $sep[1])."%</td>";
+                $service .= "<td class='tabDetailViewDF' style='text-align: right; padding:2px;'>".display_tax_detail_view($locale, $line_item->vat, $sep)."</td>";
                 $service .= "<td class='tabDetailViewDF' style='text-align: right; padding:2px;'>".currency_format_number($line_item->vat_amt, $params)."</td>";
                 $service .= "<td class='tabDetailViewDF' style='text-align: right; padding:2px;'>".currency_format_number($line_item->product_total_price, $params)."</td>";
                 $service .= "</tr>";
@@ -258,4 +252,24 @@ function display_shipping_vat($focus, $field, $value, $view)
         return $html;
     }
     return format_number($value);
+}
+
+/**
+ * Returns formatted value for the tax field;
+ * @param $locale
+ * @param $value
+ * @param $sep
+ * @return string
+ */
+function display_tax_detail_view($locale, $value, $sep): string
+{
+    global $app_strings;
+
+    if ($locale->getPrecision()) {
+        $value = rtrim(rtrim(format_number($value), '0'), $sep[1]) . $app_strings['LBL_PERCENTAGE_SYMBOL'];
+    } else {
+        $value = format_number($value) . $app_strings['LBL_PERCENTAGE_SYMBOL'];
+    }
+
+    return $value;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
When the user sets their Significant Digits to 0 (via their Profile)

When viewing the Quotes detailview, any "0" values are stripped, leading to displaying errors

ie:
"0%" becomes "%"
"20%" becomes "2%"


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Set sign digits to 0 in settings: Profile -> Advanced Tab -> . 
2. Go to Quotes module -> Create quote -> add service line
3. Check tax column on DetailView: 
![image](https://github.com/salesagility/SuiteCRM/assets/116086008/aae688c7-1f04-409b-87cf-63b7c2cfbf67)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->