### PR TITLE
Fix #10443 - Incorrect lengths in emails_text vardefs

### DIFF
--- a/metadata/emails_beansMetaData.php
+++ b/metadata/emails_beansMetaData.php
@@ -304,14 +304,14 @@ $dictionary['emails_text'] = array(
             'name'			=> 'from_addr',
             'vname'			=> 'LBL_FROM',
             'type'			=> 'varchar',
-            'len'			=> 250,
+            'len'			=> 255,
             'comment'		=> 'Email address of person who send the email',
         ),
         'reply_to_addr' => array(
             'name'			=> 'reply_to_addr',
             'vname'			=> 'LBL_REPLY_TO',
             'type'			=> 'varchar',
-            'len'			=> 250,
+            'len'			=> 255,
             'comment'		=> 'reply to email address',
         ),
         'to_addrs' => array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
The fromaddr and reply_to_addr fields in emails_text vardefs are set to 250 when they should be 255. This has caused an issue where repair and rebuild keeps trying to recreate the index on the fromaddr field in some situations.
https://github.com/salesagility/SuiteCRM/issues/10443

## Motivation and Context
This looks to have been unintentionally changed in a previous MR:
https://github.com/salesagility/SuiteCRM/pull/7798

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->