### PR TITLE
Fix #10446 - Resolve issue preventing link creation in Security Groups sub-panels

### DIFF
--- a/data/Relationships/M2MRelationship.php
+++ b/data/Relationships/M2MRelationship.php
@@ -146,6 +146,9 @@ class M2MRelationship extends SugarRelationship
         //due to the way the module works. Plus it would remove the relative ease of adding custom module support
 
         if (get_class($rhs) != 'User' && get_class($rhs) != 'ACLRole' && get_class($lhs) == 'SecurityGroup') {
+            if (!($this->loadLink($rhs, $rhsLinkName, REL_RHS))) {
+                return false;
+            }
             $rhs->$rhsLinkName->addBean($lhs);
             $this->callBeforeAdd($rhs, $lhs, $rhsLinkName);
 
@@ -154,6 +157,9 @@ class M2MRelationship extends SugarRelationship
             $rhs->$rhsLinkName->addBean($lhs);
             $this->callAfterAdd($lhs, $rhs, $lhsLinkName);
         } elseif (get_class($lhs) != 'User' && get_class($lhs) != 'ACLRole' && get_class($rhs) == 'SecurityGroup') {
+            if (!($this->loadLink($lhs, $lhsLinkName, REL_LHS))) {
+                return false;
+            }
             $lhs->$lhsLinkName->addBean($rhs);
             $this->callBeforeAdd($lhs, $rhs, $lhsLinkName);
 
@@ -164,17 +170,12 @@ class M2MRelationship extends SugarRelationship
         } else {
             /* END - SECURITY GROUPS */
 
-            if (empty($lhs->$lhsLinkName) && !$lhs->load_relationship($lhsLinkName)) {
-                $lhsClass = get_class($lhs);
-                $GLOBALS['log']->fatal("could not load LHS $lhsLinkName in $lhsClass");
+            if (!($this->loadLink($lhs, $lhsLinkName, REL_LHS))) {
                 return false;
             }
-            if (empty($rhs->$rhsLinkName) && !$rhs->load_relationship($rhsLinkName)) {
-                $rhsClass = get_class($rhs);
-                $GLOBALS['log']->fatal("could not load RHS $rhsLinkName in $rhsClass");
+            if (!($this->loadLink($rhs, $rhsLinkName, REL_RHS))) {
                 return false;
             }
-
             $lhs->$lhsLinkName->addBean($rhs);
             $rhs->$rhsLinkName->addBean($lhs);
 

--- a/data/Relationships/SugarRelationship.php
+++ b/data/Relationships/SugarRelationship.php
@@ -539,4 +539,25 @@ abstract class SugarRelationship
 
         return '';
     }
+
+    /**
+     * Ensure that the specified property on the given bean is set to an instance of Link2
+     * by attempting to load the relationship. Logs a fatal error if the relationship cannot be loaded.
+     *
+     * @param SugarBean $relationshipBean The bean containing the link property.
+     * @param string $linkName The name of the link property to check.
+     * @param string $relationshipSide The side of the relationship being checked.
+     *
+     * @return bool Returns true if the relationship is successfully loaded, false otherwise.
+     */
+    public function loadLink(SugarBean $relationshipBean, string $linkName, string $relationshipSide): bool
+    {
+        if (!$relationshipBean->load_relationship($linkName)) {
+            $GLOBALS['log']->fatal("could not load $relationshipSide $linkName in" . get_class($relationshipBean));
+
+            return false;
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
## Description
This commit addresses an issue where related custom module items couldn't be selected via sub-panels. The problem occurred when the bean with the relationship link property was empty and not an instance of Link2.

The root cause was identified within the Link2 class's add() function, specifically when the getSide() method returns 'RHS'. This situation arose when either the 'RHS' or 'LHS' was set to 'SecurityGroup' in the M2MRelationship add() function.

## Motivation and Context
This will fix a bug where you are unable to make selections using Security Groups sub-panels.

## How To Test This
1.Open the Security groups module ui
2.Use the 'Create' button's 'Select' option on any custom module
3.In the pop-up window select a single or multiple options using the checkbox
4.Click 'Select'

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.