### PR TITLE
Fix #10459 - Resolve not being able to clear template cache

### DIFF
--- a/include/TemplateHandler/TemplateHandler.php
+++ b/include/TemplateHandler/TemplateHandler.php
@@ -105,8 +105,10 @@ class TemplateHandler
         $cacheDir = create_cache_directory('modules/' . $module . '/');
         $d = dir($cacheDir);
         while ($e = $d->read()) {
-            if (!empty($view) && $e !== $view) {
-                continue;
+            if (!empty($view) && $e !== $view . '.tpl') {
+                if (isset($_SESSION['groupLayout']) && $e !== $_SESSION['groupLayout']) {
+                    continue;
+                }
             }
 
             $end = strlen($e) - 4;
@@ -131,8 +133,10 @@ class TemplateHandler
             }
             $d = dir($tplDir);
             while ($e = $d->read()) {
-                if (!empty($view) && $e !== $view) {
-                    continue;
+                if ((!empty($view) && $e !== $view . '.tpl')) {
+                    if (isset($_SESSION['groupLayout']) && $e !== $_SESSION['groupLayout']) {
+                        continue;
+                    }
                 }
 
                 $end = strlen($e) - 4;


### PR DESCRIPTION
When optional $view value does not contain file extension '.tpl'. When DetailView cache template directory was built using $_SESSION['groupLayout'] in TemplateHandler::buildTemplate().

In include/TemplateHandler/TemplateHandler::clearCache I have upated the IF statements to add the '.tpl' extension to $view and to check for '$_SESSION['groupLayout']'.

## Motivation and Context
This is fixing a bug

## How To Test This
Refer to the Issue for testing steps.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->