### PR TITLE
Fix #10475 - Rename the History subpanel by changing the label

### DIFF
--- a/modules/ModuleBuilder/parsers/relationships/ActivitiesRelationship.php
+++ b/modules/ModuleBuilder/parsers/relationships/ActivitiesRelationship.php
@@ -262,7 +262,7 @@ class ActivitiesRelationship extends OneToManyRelationship
             'order' => 20 ,
             'sort_order' => 'desc' ,
             'sort_by' => 'date_modified' ,
-            'title_key' => 'LBL_HISTORY' ,
+            'title_key' => 'LBL_HISTORY_SUBPANEL_TITLE' ,
             'type' => 'collection' ,
             'subpanel_name' => 'history' , //this values is not associated with a physical file.
             'module' => 'History' ,


### PR DESCRIPTION
## Description
In this PR, the label assigned in the _title_key_ property (LBL_HISTORY) is replaced in the definition of the properties that will be used in the automation that generates the History subpanel during the process of creating the relationship between a module and the Activities metamodule (LBL_HISTORY_SUBPANEL_TITLE)

## Motivation and Context
The LBL_HISTORY tag does not appear in the module's tag list and cannot be changed, while the LBL_HISTORY_SUBPANEL_TITLE tag is available, whose name corresponds to what we want to be able to modify.

## How To Test This
1. Create a new module, publish it and upload it to the CRM.
2. From Studio, create a relationship between this module and the Activities metamodule.
3. Access the labels section, select **All labels** from the drop-down menu in the upper right corner and change the value of the labels: **LBL_HISTORY_SUBPANEL_TITLE**
4. Create a record in the new module and access its detail view.
5. Check that the History subpanel name has been updated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->