### PR TITLE
Fix #10479 - Call LoggerManager's warn() method instead of warning()

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -57,7 +57,7 @@ if (!is_windows()) {
     $cronUser = getRunningUser();
  
     if ($cronUser == '') {
-        $GLOBALS['log']->warning('cron.php: can\'t determine running user. No cron user checks will occur.');
+        $GLOBALS['log']->warn('cron.php: can\'t determine running user. No cron user checks will occur.');
     } elseif (array_key_exists('cron', $sugar_config) && array_key_exists('allowed_cron_users', $sugar_config['cron'])) {
         if (!in_array($cronUser, $sugar_config['cron']['allowed_cron_users'])) {
             $GLOBALS['log']->fatal("cron.php: running as $cronUser is not allowed in allowed_cron_users ".
@@ -70,7 +70,7 @@ if (!is_windows()) {
             sugar_die('cron.php running with user that is not in allowed_cron_users in config.php');
         }
     } else {
-        $GLOBALS['log']->warning('cron.php: missing expected allowed_cron_users entry in config.php. ' .
+        $GLOBALS['log']->warn('cron.php: missing expected allowed_cron_users entry in config.php. ' .
                                  'No cron user checks will occur.');
     }
 }

--- a/modules/ModuleBuilder/parsers/views/AbstractMetaDataImplementation.php
+++ b/modules/ModuleBuilder/parsers/views/AbstractMetaDataImplementation.php
@@ -463,7 +463,7 @@ abstract class AbstractMetaDataImplementation
         // BEGIN ASSERTIONS
         if ($type != MB_BASEMETADATALOCATION && $type != MB_HISTORYMETADATALOCATION) {
             // just warn rather than die
-            $GLOBALS ['log']->warning(
+            $GLOBALS ['log']->warn(
                 "UndeployedMetaDataImplementation->getFileName(): view type $type is not recognized"
             );
         }


### PR DESCRIPTION
## Description
In this PR all calls to the warning() method of the LoggerManager are located and changed to call the warn method

## How To Test This
1. Comment out the following code to be able to call cron.php from the URL (https://github.com/salesagility/SuiteCRM/blob/hotfix/cron.php#L50C1-L53C2) 

```bash
$sapi_type = php_sapi_name();
if (substr($sapi_type, 0, 3) != 'cli') {
sugar_die("cron.php is CLI only.");
}
```

and change the following line to cause it to enter the logger:

`$cronUser = getRunningUser(); `   -->    `$cronUser = '';`


2. Set warn as log level
3. Call _cron.php_ from the browser and check that the error message is displayed in suitecrm.log

> [WARN] cron.php: can't determine running user is displayed. No cron user checks will occur

4. Configure fatal, error or other log level more restricted than _warn_

5.  Call _cron.php_ from the browser and check that the error message is not displayed in suitecrm.log 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->