### PR TITLE
Fix #10848 - Update importable property when republishing module in constructor

### DIFF
--- a/modules/ModuleBuilder/MB/MBPackage.php
+++ b/modules/ModuleBuilder/MB/MBPackage.php
@@ -306,6 +306,10 @@ class MBPackage
     {
         $this->loadModules();
         require_once 'include/utils/php_zip_utils.php';
+        $folder = $this->getBuildDir();
+        if (file_exists($folder) && !rmdir_recursive($folder)){
+            $GLOBALS['log']->error('Line '.__LINE__.': '.__METHOD__.':  Could not delete folder: ' . $folder);
+        };
         $path = $this->getBuildDir() . '/SugarModules';
         if ($clean && file_exists($path)) {
             rmdir_recursive($path);


### PR DESCRIPTION
## Description
This PR removes the custom/modulebuilder/builds/<Package> folder when the user proceeds to deploy or publish an existing module in the module builder, so that the different properties are updated.
## Motivation and Context

## How To Test This
1. Go to Module Builder and generate a module without selecting Import
2. Publish the module
3. Go to the module loader and select the generated module
4. Try to modify the module status in the module builder by selecting checking Import.
5. Publish the module with the changes and upload it to the loader.
6. Verify that now the module allow the import. To check it click on the menu option of the module Import and verify that it is working

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->