### PR TITLE
Fix #10486 - Fix filtering in Email queue list view

### DIFF
--- a/modules/EmailMan/metadata/SearchFields.php
+++ b/modules/EmailMan/metadata/SearchFields.php
@@ -44,7 +44,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
 $searchFields['EmailMan'] =
     array(
         'campaign_name' => array( 'query_type'=>'default','db_field'=>array('campaigns.name')),
-        'to_name'=> array('query_type'=>'default','db_field'=>array('contacts.first_name','contacts.last_name','leads.first_name','leads.last_name','prospects.first_name','prospects.last_name')),
-        'to_email'=> array('query_type'=>'default','db_field'=>array('contacts.email1','leads.email1','prospects.email1')),
+        'to_name'=> array('query_type'=>'default','db_field'=>array('contacts.first_name','contacts.last_name','accounts.name','leads.first_name','leads.last_name','prospects.first_name','prospects.last_name', 'users.user_name')),
+        'to_email'=> array('query_type'=>'default','operator' => 'subquery','subquery' => 'SELECT eabr.bean_id FROM email_addr_bean_rel eabr JOIN email_addresses ea ON (ea.id = eabr.email_address_id) WHERE eabr.deleted=0 AND eabr.primary_address = 1 AND eabr.deleted=0 AND ea.email_address LIKE','db_field'=>array(0 => 'related_id',),),
         'current_user_only'=> array('query_type'=>'default','db_field'=>array('assigned_user_id'),'my_items'=>true, 'vname' => 'LBL_CURRENT_USER_FILTER', 'type' => 'bool'),
     );


### PR DESCRIPTION
## Description
This PR adds the name of the organizations in the filter by Recipient Name and modifies the query that is executed when querying by Recipient Email.

## How To Test This
1. Create a campaign with contacts, accounts, leads and users.
2. Send one or more marketing emails.
3. Access the message queue view and check:
- The message related to the account recipient is returned when filtering by Recipient Name
- The corresponding messages are returned when using the Recipient Email filter

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->