### PR TITLE
Fix #9261 - Use decimal symbol configured in system and user

### DIFF
--- a/include/utils.php
+++ b/include/utils.php
@@ -6339,3 +6339,20 @@ function isWebToLeadAllowedRedirectHost(string $url): bool {
 
     return false;
 }
+
+/**
+ * Set the proper decimal separator according to the user/system configuration
+ *
+ * @param Decimal $decimalValue
+ * @param Boolean $userSetting. Indicates whether to choose user or system configuration
+ * @return Decimal
+ */
+function formatDecimalInConfigSettings($decimalValue, $userSetting = false) {
+    global $current_user, $sugar_config;
+    if ($userSetting) {
+        $user_dec_sep = (!empty($current_user->id) ? $current_user->getPreference('dec_sep') : null);
+    }
+    $dec_sep = empty($user_dec_sep) ? $sugar_config['default_decimal_seperator'] : $user_dec_sep;
+    return str_replace('.', $dec_sep, $decimalValue);
+}
+

--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -116,6 +116,13 @@ class templateParser
                         ENT_COMPAT, 'UTF-8');
                     $repl_arr[$key . "_" . $fieldName] = html_entity_decode((string) $focus->{$fieldName},
                         ENT_COMPAT, 'UTF-8');
+                } elseif ($field_def['type'] == 'decimal' || $field_def['type'] == 'float') {
+                    if ($_REQUEST['entryPoint'] == 'formLetter') {
+                        $value = formatDecimalInConfigSettings($focus->$fieldName, true);
+                    } else {
+                        $value = formatDecimalInConfigSettings($focus->$fieldName, false);
+                    }
+                    $repl_arr[$key . "_" . $fieldName] = $value;
                 } else {
                     $repl_arr[$key . "_" . $fieldName] = $focus->{$fieldName};
                 }

--- a/modules/EmailTemplates/EmailTemplateParser.php
+++ b/modules/EmailTemplates/EmailTemplateParser.php
@@ -197,6 +197,9 @@ class EmailTemplateParser
                 if (isset($app_list_strings[$enum][$this->module->$attribute])) {
                     $this->module->$attribute = $app_list_strings[$enum][$this->module->$attribute];
                 }
+            } else if (($this->module->field_name_map[$attribute]['type']) && (($this->module->field_name_map[$attribute]['type']) === 'decimal' || ($this->module->field_name_map[$attribute]['type']) === 'float')) {
+                $value = formatDecimalInConfigSettings($this->module->$attribute, false);
+                return $value;
             }
             return $this->module->$attribute;
         }


### PR DESCRIPTION
## Description

This PR fixes the decimal separator symbol for a decimal or float value obtained from a database not being parsed correctly when incorporated into an email template or PDF template.

To do this, a generic function is created in the PR with a parameter where you can indicate which configuration to use: the system configuration (configured by default) or the user configuration. This function will be used in the operation of parsing the PDF template or the email template.

Our proposal is to use the system configuration for sending emails and the user configuration for using the PDF template.


## Motivation and Context
- #9261
- We have found that this also happens when sending an email from a workflow. Here is a video with the three use cases of incorrect behavior.

![DecimalSymbolParser](https://github.com/user-attachments/assets/ce10490d-bd44-4fc0-ba23-ada141b655da)


## How To Test This
1. Create a decimal and a float fields in a contact module
2. Set a symbol to separate decimals in user profile and system configuration.
3. Create a contact-based email template that contains the decimal and float fields.
4. Create a campaign and use the previous template.
5. Send a email and check that in the sent email, the decimal and float values is being parsed with the configured system decimal symbol

6. Create a workflow based on Contacts and edit a Contact that has a value in the decimal and float fields for the workflow to send the email with the previous template
7. Check that in the sent email, the decimal and float value is being parsed with the configured system decimal symbol

8. Create a PDF template based on Contact and include the decimal and float fields
9. Generate a PDF file of a contact that has a value in the decimal field and
check that the decimal symbol is applied in the generated PDF template

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->