### PR TITLE
Fix #10496 - Prevent password autofill when setting up emails

### DIFF
--- a/include/SugarFields/Fields/Password/EditView.tpl
+++ b/include/SugarFields/Fields/Password/EditView.tpl
@@ -48,4 +48,5 @@
        value='{{if isset($vardef.display) && $vardef.display == 'writeonly'}}{{else}}{{sugarvar key='value'}}{{/if}}'
        title='{{$vardef.help}}'
        tabindex='{{$tabindex}}'
+       autocomplete='{{$vardef.autocomplete}}'
        {{if !empty($displayParams.accesskey)}} accesskey='{{$displayParams.accesskey}}' {{/if}}>

--- a/modules/EmailMan/tpls/config.tpl
+++ b/modules/EmailMan/tpls/config.tpl
@@ -181,7 +181,7 @@ function change_state(radiobutton) {
 										<tr id="smtp_auth2">
 											<td width="20%" scope="row"><span id="mail_smtppass_label">{$MOD.LBL_MAIL_SMTPPASS}</span> <span class="required">{$APP.LBL_REQUIRED_SYMBOL}</span></td>
 											<td width="30%" >
-												<input type="password" id="mail_smtppass" name="mail_smtppass" size="25" maxlength="255" tabindex='1'>
+												<input type="password" id="mail_smtppass" name="mail_smtppass" size="25" maxlength="255" tabindex='1' autocomplete="new-password">
 												<a href="javascript:void(0)" id='mail_smtppass_link' onClick="SUGAR.util.setEmailPasswordEdit('mail_smtppass')" style="display: none">{$APP.LBL_CHANGE_PASSWORD}</a>
 											</td>
 											<td width="20%">&nbsp;</td>

--- a/modules/OutboundEmailAccounts/vardefs.php
+++ b/modules/OutboundEmailAccounts/vardefs.php
@@ -283,6 +283,7 @@ $dictionary["OutboundEmailAccounts"] = [
             'importable' => false,
             'exportable' => false,
             'unified_search' => false,
+            'autocomplete' => 'new-password',            
         ],
         'mail_smtpauth_req' => [
             'name' => 'mail_smtpauth_req',


### PR DESCRIPTION
## Description
This PR resolves this issue by preventing autocompletion by adding the `autocomplete='new-password'` property to the password type field.

## Motivation and Context
#10496 

## How To Test This
1. Access the **Email Settings** and save a first configuration with a password. At the same time, save the password in the browser (After clicking on save the record, a dialog box is usually displayed to save the user and password in the browser)
2. Acces again in **Email Settings**, click en "Change Password" and check that password stored in the browser is not recovered in password field. Check that the send test email runs correctly
3. Go to the **Outbound Email** module and access the editing view of the **system** record. Check that the password stored in the browser is not recovered in the password field. Check that the send test email runs correctly

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->