### PR TITLE
Fix #10505 Rebuild and repair can lead to malformed grouped JS files

### DIFF
--- a/jssource/minify_utils.php
+++ b/jssource/minify_utils.php
@@ -166,6 +166,9 @@ if (!defined('sugarEntry') || !sugarEntry) {
 
                     //make sure we have handles to both source and target file
                     if ($trgt_handle) {
+                        // Acquire exclusive lock on the target file.
+                        flock($trgt_handle, LOCK_EX);
+
                         if ($already_minified || isset($excludedFiles[dirname((string) $loc)])) {
                             $buffer = file_get_contents($loc);
                         } else {
@@ -179,6 +182,8 @@ if (!defined('sugarEntry') || !sugarEntry) {
                             //log error, file did not get appended
                             echo "Error while concatenating file $loc to target file $trgt \n";
                         }
+                        // Release the lock on the target file.
+                        flock($trgt_handle, LOCK_UN);
                         //close file opened.
                         fclose($trgt_handle);
                     }


### PR DESCRIPTION
Make other processes (web users) wait to read the grouped JS files until AFTER they're completely concatenated and written out to disk.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
The function `ConcatenateFiles()` now prevents users from accessing the combined grouped JS files, until after they're added together and saved to disk.  How does it accomplish this?  It locks for exclusive access each grouped JS file, writes all its contents, then unlocks the file for any user's web browser to download and run.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There is a race condition on the  grouped (combined) JS files, resulting in malformed JS files which fail run.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Test original code: bug:
Admin, Quick Repair Rebuild, and to be sure, Clear JS cache.
Have two or more users go to the login screen and try to login at the same time.
The result will be a race condition, as each user's Suite will try to build the grouped JS files at the same time, and some of the JS files could be malformed and fail to run, because each Suite is allowed to write to the same grouped JS file at the same time, resulting in a Frankenstein JS file that fails.

Test fixed code:
Same procedure as above.
No matter how hard you try, no matter how many simultaneous users logging into a Suite with QRR and cleared JS cache, you will only be able to get Suite to build well formed grouped JS files.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->