### PR TITLE
Fix #10539 - Indexes lacking in securitygroups_acl_roles

### DIFF
--- a/metadata/securitygroups_acl_rolesMetaData.php
+++ b/metadata/securitygroups_acl_rolesMetaData.php
@@ -9,7 +9,8 @@ $dictionary['securitygroups_acl_roles'] = array(
       , array('name' =>'deleted', 'type' =>'bool', 'len'=>'1', 'required'=>true, 'default'=>'0')
     ),
     'indices' => array(
-       array('name' =>'securitygroups_acl_rolespk', 'type' =>'primary', 'fields'=>array('id'))
+       array('name' =>'securitygroups_acl_rolespk', 'type' =>'primary', 'fields'=>array('id')),
+       array('name' => 'idx_SG_roles', 'type' => 'index', 'fields' => array('securitygroup_id', 'role_id')),
     ),
     'relationships' => array(
     


### PR DESCRIPTION

## Description
Index added to table securitygroups_acl_roles to speed up queries by security group id.
Fixing bug: #10539 

## Motivation and Context
Queries generated during login can take too much time if many securitygroups with roles exist.

## How To Test This
The easiest way is to inspect the database after a repair and check that the index exists.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->