### PR TITLE
Fix #10541 - Relation M2M between Security Groups and Security Groups raises an error

### DIFF
--- a/data/Relationships/M2MRelationship.php
+++ b/data/Relationships/M2MRelationship.php
@@ -145,7 +145,7 @@ class M2MRelationship extends SugarRelationship
         //Need to hijack this as security groups will not contain a link on the module side
         //due to the way the module works. Plus it would remove the relative ease of adding custom module support
 
-        if (get_class($rhs) != 'User' && get_class($rhs) != 'ACLRole' && get_class($lhs) == 'SecurityGroup') {
+        if (get_class($rhs) != 'User' && get_class($rhs) != 'ACLRole' && get_class($lhs) == 'SecurityGroup' && get_class($rhs) != 'SecurityGroup') {
             $rhs->$rhsLinkName->addBean($lhs);
             $this->callBeforeAdd($rhs, $lhs, $rhsLinkName);
 
@@ -153,7 +153,7 @@ class M2MRelationship extends SugarRelationship
             $this->addRow($dataToInsert);
             $rhs->$rhsLinkName->addBean($lhs);
             $this->callAfterAdd($lhs, $rhs, $lhsLinkName);
-        } elseif (get_class($lhs) != 'User' && get_class($lhs) != 'ACLRole' && get_class($rhs) == 'SecurityGroup') {
+        } elseif (get_class($lhs) != 'User' && get_class($lhs) != 'ACLRole' && get_class($rhs) == 'SecurityGroup' && get_class($lhs) != 'SecurityGroup') {            
             $lhs->$lhsLinkName->addBean($rhs);
             $this->callBeforeAdd($lhs, $rhs, $lhsLinkName);
 


### PR DESCRIPTION
## Description
On class M2MRelationship, the function add has a special if when on side of the relationship is with Security Groups. When a relation between SGs and SGs is created, the execution flow follows this special IF, but that's wrong: normal flow should be followed.
This PR corrects the IF condition.

## Motivation and Context
When a M2M relations between SGs and SGs exists, and anyone tries to select a SG from SG subpanel on SG detail view an error occurs.

## How To Test This
1.Create a M2M relation between Security Groups and Security Groups
2.Create a new Security group
3.From the "Security Suite Management" subpanel select another existing security group

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

