### PR TITLE
Fix #10543 - Remove Security Groups button on subpanelsbased on EditView

### DIFF
--- a/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelRemoveButton.php
@@ -115,8 +115,7 @@ class SugarWidgetSubPanelRemoveButton extends SugarWidgetField
             $hideremove = true;
         }
 
-        //based on listview since that lets you select records
-        if ($layout_def['ListView'] && !$hideremove) {
+        if ($layout_def['EditView'] && !$hideremove) {
             $retStr = "<a href=\"javascript:sub_p_rem('$subpanel', '$linked_field'"
                 . ", '$record', $refresh_page);\""
                 . ' class="listViewTdToolsS1"'


### PR DESCRIPTION
## Description
Fixing bug #10543 
Remove Security Group button was being displayed or hidden depending on permission on list and not edit.

## Motivation and Context
The behavior between the remove button in the subpanel and removing groups from list view was not consistent.

## How To Test This
1.Create a user U1
2.Create a security group SG1
3.Create a Role R1 and assign group permission on every action of every module
4.Assign SG1 and R1 to U1
5.Login with user U1 and check that it can not see the remove button on the subpanels
6. Change permission for R1 on Edit Security Groups and check that now the button is shown.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
