### PR TITLE
Fix 10545 - Current user groups are used instead of "created by" groups when they differ

### DIFF
--- a/modules/SecurityGroups/SecurityGroup.php
+++ b/modules/SecurityGroups/SecurityGroup.php
@@ -281,7 +281,11 @@ class SecurityGroup extends SecurityGroup_sugar
                 } elseif ($focus->db->dbType == 'mssql') {
                     $query .= ' lower(newid()) ';
                 }
-                $currentUserId = isset($current_user->id) ? $focus->db->quote($current_user->id) : null;
+                if (isset($focus->created_by) && $focus->created_by!= '') {
+                    $currentUserId = $focus->db->quote($focus->created_by);
+                } else {
+                    $currentUserId = isset($current_user->id) ? $focus->db->quote($current_user->id) : null;
+                }    
                 $recordId =  $focus->db->quote($focus->id);
                 $query .= ",u.securitygroup_id,'$recordId','$focus->module_dir',"
                     . $focus->db->convert('', 'today') . ',0 '


### PR DESCRIPTION
## Description
Fixing #10545 
When creating a record from an entrypoint and setting the set_created_by to false, security groups from current user were used instead of security groups from the specified user.
A change to SecurityGroups bean has been made to use the created_by user if it is filled instead of using always the current user.

## Motivation and Context
If an entry points set a creator user different from the current user, the groups from the specified should be used. Usually generic users used on some entrypoints does not have security groups at all.

## How To Test This
Using the same steps specified to reproduce the issue, check that groups from the specified user are used.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
