### PR TITLE
Fix 10547 - Incorrect visualization of task due date on subpanels

### DIFF
--- a/include/ListView/ListViewSubPanel.php
+++ b/include/ListView/ListViewSubPanel.php
@@ -418,7 +418,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
                                 $alias_field_def['name'] = $list_field['alias'];
                                 // Add alias field def into bean to can render field in subpanel
                                 $aItem->field_defs[$list_field['alias']] = $alias_field_def;
-                                if (!isset($fields[strtoupper($list_field['alias'])]) || empty($fields[strtoupper($list_field['alias'])])) {
+                                if (!isset($fields[strtoupper($list_field['alias'])]) || empty($fields[strtoupper($list_field['alias'])]) || !isset($aitem->field_name_map[$list_field['alias']])) {
                                     global $timedate;
                                     $fields[strtoupper($list_field['alias'])] = (!empty($aItem->$field_name)) ? $aItem->$field_name : $timedate->to_display_date_time($aItem->{$list_field['alias']});
                                 }


### PR DESCRIPTION
## Description
Fixing #10547 
When visualizing more than one task row on the activities subpanel (of Contact for instance), the second row had the due date incorrectly formatted.
The problem was that on second record, for alias fields, $aItem->field_defs contains the field definition, but field_name_map does not have the type information.
The solution has been to apply to second and following rows the same treatment as the first row

## Motivation and Context
Motivation: Due date was being incorrectly formatted on some records

## How To Test This
1. Create more than one task with due date informed from the activities subpanel of any contact
2. Check that all due dates are formatted consistently

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

