### PR TITLE
Modify compare function for sort to avoid deprecation alert

### DIFF
--- a/modules/SugarFeed/Dashlets/SugarFeedDashlet/SugarFeedDashlet.php
+++ b/modules/SugarFeed/Dashlets/SugarFeedDashlet/SugarFeedDashlet.php
@@ -417,7 +417,7 @@ class SugarFeedDashlet extends DashletGeneric
         }
 
         $function = function ($a, $b) {
-            return $a["sort_key"] < $b["sort_key"];
+            return $a["sort_key"] <=> $b["sort_key"];
         };
 
         usort($resortQueue, $function);


### PR DESCRIPTION
## Description
Modify compare function for sort to avoid deprecation alert.

## Motivation and Context
From Php 8 the usort method produce a deprecation alert is the callback function in usort doesn't return an int. Refers to https://wiki.php.net/rfc/stable_sorting

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
