### PR TITLE
Fix salesagility#10562 - Include start date in the Activities subpanel

### DIFF
--- a/modules/Calls/metadata/subpanels/ForActivities.php
+++ b/modules/Calls/metadata/subpanels/ForActivities.php
@@ -81,6 +81,10 @@ $subpanel_layout = [
         'contact_id' => [
             'usage' => 'query_only',
         ],
+        'date_start' => [
+            'vname' => 'LBL_LIST_DATE',
+            'width' => '10%',
+        ],
         'date_end' => [
             'vname' => 'LBL_LIST_DUE_DATE',
             'width' => '10%',

--- a/modules/Meetings/metadata/subpanels/ForActivities.php
+++ b/modules/Meetings/metadata/subpanels/ForActivities.php
@@ -83,6 +83,10 @@ $subpanel_layout = [
             'usage' => 'query_only',
             'force_exists' => true
         ],
+        'date_start' => [
+            'vname' => 'LBL_LIST_DATE',
+            'width' => '10%',
+        ],
         'date_end' => [
             'vname' => 'LBL_LIST_DUE_DATE',
             'width' => '10%',

--- a/modules/Tasks/Task.php
+++ b/modules/Tasks/Task.php
@@ -255,6 +255,10 @@ class Task extends SugarBean
                 $taskClass = 'todaysTask';
             }
         }
+        
+        // Correct date start of Tasks on subpanel
+        $date_due = $timedate->to_display_date_time($dbtime);
+
         $task_fields['DATE_DUE']= "<font class='$taskClass'>$date_due</font>";
         if ($override_date_for_subpanel) {
             $task_fields['DATE_START']= "<font class='$taskClass'>$date_due</font>";

--- a/modules/Tasks/metadata/subpanels/ForActivities.php
+++ b/modules/Tasks/metadata/subpanels/ForActivities.php
@@ -69,6 +69,10 @@ $subpanel_layout = [
             'vname' => 'LBL_LIST_CONTACT',
             'width' => '11%',
         ],
+        'date_start' => [
+            'vname' => 'LBL_LIST_START_DATE',
+            'width' => '10%',
+        ],
         'date_due' => [
             'vname' => 'LBL_LIST_DUE_DATE',
             'width' => '10%',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Fixing https://github.com/salesagility/SuiteCRM/issues/10562

It is proposed to include the start date in the Activities subpanel.
From the studio it is not possible to modify the subpanel of the Activities module and include new fields, so this change should be made at the code level.

Solution: The “Start date” field has been added to the Activities subpanel, in addition to the fields already displayed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Motivation: The Activities subpanel does not show the start date of the records.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to any module with the Activities subpanel.
2. Quick create a task, meeting or call with the date start.
3. Check that the subpanel shows the start date.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->