### PR TITLE
Fix #10564 - Thank you message in Surveys only in English

### DIFF
--- a/modules/Surveys/Entry/Thanks.php
+++ b/modules/Surveys/Entry/Thanks.php
@@ -2,6 +2,7 @@
 
 $surveyName = !empty($_REQUEST['name']) ? $_REQUEST['name'] : 'Survey';
 
+$surveyThanks = translate('LBL_SURVEY_THANKS', 'Surveys');
 ?>
 
 <!DOCTYPE html>
@@ -23,7 +24,7 @@ $surveyName = !empty($_REQUEST['name']) ? $_REQUEST['name'] : 'Survey';
     <div class="row well">
         <div class="col-md-offset-2 col-md-8">
             <h1><?= $surveyName; ?></h1>
-            <p>Thanks for completing this survey.</p>
+            <p><?= $surveyThanks; ?></p>
         </div>
     </div>
 </div>

--- a/modules/Surveys/language/en_us.lang.php
+++ b/modules/Surveys/language/en_us.lang.php
@@ -105,4 +105,5 @@ $mod_strings = array(
     'LBL_SUBMIT' => 'Submit',
     'LBL_STARS' => 'Stars',
     'LBL_SURVEY_CLOSE_RESPONSE' => 'Thanks for your interest but this survey is now closed.',
+    'LBL_SURVEY_THANKS' => 'Thanks for completing this survey.',
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Fixing https://github.com/salesagility/SuiteCRM/issues/10564

Completing a survey redirects to a page where the message is only in English “Thanks for completing this survey”. The message should be displayed in the default language of the CRM.

Solution implemented:
The string have been implemented with the message that appeared at the beginning in English, therefore a variable has been created with the translate() function to collect these strings according to the language selected in the login.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Motivation: The message should be displayed in the default language of the instance.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to Surveys and create a survey with a question.
2. Send the survey and check that the message appears in the language selected in the login or the default language of the CRM.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->