### PR TITLE
Fix #10574  - Display TinyMCE in PDF templates after adding a wysiwyg field

### DIFF
--- a/include/SugarFields/Fields/Wysiwyg/SugarFieldWysiwyg.php
+++ b/include/SugarFields/Fields/Wysiwyg/SugarFieldWysiwyg.php
@@ -63,7 +63,9 @@ class SugarFieldWysiwyg extends SugarFieldBase {
         $config = [];
         $config['height'] = 250;
         $config['menubar'] = false;
-        $config['plugins']  = 'code, table, link, image, wordcount';
+        if ($vardef["custom_module"] != "AOS_PDF_Templates") {
+            $config['plugins']  = 'code, table, link, image, wordcount';
+        }
         if ($form_name !== '') {
             $config['selector'] = "#{$form_name} " . "#" . $vardef['name'];
         } else {


### PR DESCRIPTION
## Description
In this PR the TinyMCE plugin configuration in the include/SugarFields/Fields/Wysiwyg/SugarFieldWysiwyg.php file is overridden if the module is AOS_PDF_Templates as it seems that the error occurs because another TinyMCE configuration is already preloaded


## How To Test This
1. Go to Administration -> Studio -> PDF Templates
2. Create a WYSIWYG field
3. Edit the Edit View and add the new WYSIWYG field
4. Go to PDF Templates -> Create PDF Template
5. Check that the TinyMCE editor for the new wysiwyg type field is displayed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->