### PR TITLE
Fix #10580 - Import float values ​​with correct decimal separator

### DIFF
--- a/include/SugarFields/Fields/Float/SugarFieldFloat.php
+++ b/include/SugarFields/Fields/Float/SugarFieldFloat.php
@@ -76,15 +76,10 @@ class SugarFieldFloat extends SugarFieldInt
         $focus,
         ImportFieldSanitize $settings
         ) {
-        $value = str_replace($settings->num_grp_sep, "", $value);
-        $dec_sep = $settings->dec_sep;
-        if ($dec_sep != '.') {
-            $value = str_replace($dec_sep, ".", $value);
+        if (isset($vardef['len'])) {
+            // check for field length
+            $value = sugar_substr($value, $vardef['len']);
         }
-        if (!is_numeric($value)) {
-            return false;
-        }
-        
         return $value;
     }
 }


### PR DESCRIPTION

## Description
This PR modifies the importSanitize function in the include/SugarFields/Fields/Float/SugarFieldFloat.php file to treat Float fields the same as Decimal fields so that float values ​​are imported with the correct decimal separator.

## How To Test This
1. Set the decimal comma separator (,) in the user profile
2. Create a Float type field in the Contacts module
3. Create a record and assign a value to the previous field
4. Export the Contact and edit the generated file to leave only the last name column (required field) and the Float field column. 
5. Import the file and check that the value of the Float field is the same and that it uses the decimal symbol configured in the logged in user profile

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->