### PR TITLE
Fix #10586 - Unable to send marketing emails from the wizard for an inactive campaign

### DIFF
--- a/modules/Campaigns/WizardMarketing.html
+++ b/modules/Campaigns/WizardMarketing.html
@@ -1349,18 +1349,22 @@
 		</div>
 		<div class="template-panel-container panel-toolbar ">
 			<div class="template-container-full">
-				<div class="button-group">
-					<input type="hidden" name="wiz_home_next_step" value="1" />
+				{if $CAMPAIGN_STATUS != 'Inactive'}	
+					<div class="button-group">
+						<input type="hidden" name="wiz_home_next_step" value="1" />
 
-					<a class="btn {if $PL_DISABLED}btn-default{else}btn-primary{/if} btn-sm" style="border-radius: 0px;" {if $PL_DISABLED} {else}href="javascript:;" onclick="onScheduleClick(this, '{$CAMPAIGN_ID}', $('#marketing_select').val());"{/if}>
-						<span class="suitepicon suitepicon-action-schedule"></span> {$MOD.LBL_SEND_EMAIL}
-					</a>
+						<a class="btn {if $PL_DISABLED}btn-default{else}btn-primary{/if} btn-sm" style="border-radius: 0px;" {if $PL_DISABLED} {else}href="javascript:;" onclick="onScheduleClick(this, '{$CAMPAIGN_ID}', $('#marketing_select').val());"{/if}>
+							<span class="suitepicon suitepicon-action-schedule"></span> {$MOD.LBL_SEND_EMAIL}
+						</a>
 
-					<a class="btn {if $PL_DISABLED_TEST}btn-default{else}btn-primary{/if} btn-sm" style="border-radius: 0px;" {if $PL_DISABLED_TEST} {else}href="javascript:;"  onclick="onSendAsTestClick(this, '{$CAMPAIGN_ID}', $('#marketing_select').val());"{/if}>
-					<span class="suitepicon suitepicon-module-emails"></span> {$MOD.LBL_SEND_AS_TEST}
-					</a>
-				</div>
-				<div class="button-group-separator"></div>
+						<a class="btn {if $PL_DISABLED_TEST}btn-default{else}btn-primary{/if} btn-sm" style="border-radius: 0px;" {if $PL_DISABLED_TEST} {else}href="javascript:;"  onclick="onSendAsTestClick(this, '{$CAMPAIGN_ID}', $('#marketing_select').val());"{/if}>
+						<span class="suitepicon suitepicon-module-emails"></span> {$MOD.LBL_SEND_AS_TEST}
+						</a>
+					</div>
+					<div class="button-group-separator"></div>
+				{else}
+					<div  class="button-group"> {$MOD.LBL_CAMPAIGN_INACTIVE_WIZARD} </div>
+				{/if}					
 				<div class="button-group">
 					<a class="btn btn-primary btn-sm" href="index.php?module=Campaigns&action=DetailView&record={$CAMPAIGN_ID}" style="border-radius: 0px;">{$MOD.LBL_TODETAIL_BUTTON_TITLE}</a>
 				</div>

--- a/modules/Campaigns/WizardMarketing.php
+++ b/modules/Campaigns/WizardMarketing.php
@@ -93,6 +93,7 @@ if (isset($_REQUEST['return_id'])) {
 }
 // handle Create $module then Cancel
 $ss->assign('CAMPAIGN_ID', $campaign_focus->id);
+$ss->assign('CAMPAIGN_STATUS', $campaign_focus->status);
 
 $seps = get_number_separators();
 $ss->assign("NUM_GRP_SEP", $seps[0]);

--- a/modules/Campaigns/language/en_us.lang.php
+++ b/modules/Campaigns/language/en_us.lang.php
@@ -139,6 +139,7 @@ $mod_strings = array(
     //error messages.
     'ERR_SENDING_NOW' => 'Messages are being delivered , please try this later.',
 
+    'LBL_CAMPAIGN_INACTIVE_WIZARD' => 'Sending buttons will not show on inactive campaigns.',
     'LBL_TRACK_ROI_BUTTON_LABEL' => 'View ROI',
     'LBL_TRACK_DELETE_BUTTON_TITLE' => 'Delete Test Entries',
     'LBL_TRACK_DELETE_BUTTON_LABEL' => 'Delete Test Entries',


### PR DESCRIPTION
## Description
This PR addresses the related issue by hiding the send buttons in the 'Send Email and Summary' view of the wizard and displaying a message to the user that the campaign is inactive.

## How To Test This
1. Create a campaign with a marketing email.
2. Deactivate the campaign and verify that the send buttons are not displayed in the 'Send Email and Summary' view of the wizard and instead of the buttons, a message is displayed indicating that the campaign is inactive


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->