### PR TITLE
Fix #10596 - No display of user preferences in a decimal type field in PDF templates

### DIFF
--- a/include/utils.php
+++ b/include/utils.php
@@ -6343,7 +6343,7 @@ function isWebToLeadAllowedRedirectHost(string $url): bool {
 }
 
 /**
- * Set the proper decimal separator according to the user/system configuration
+ * Set value with appropriate separators according to user/system configuration
  *
  * @param Decimal $decimalValue
  * @param Boolean $userSetting. Indicates whether to choose user or system configuration
@@ -6351,10 +6351,24 @@ function isWebToLeadAllowedRedirectHost(string $url): bool {
  */
 function formatDecimalInConfigSettings($decimalValue, $userSetting = false) {
     global $current_user, $sugar_config;
+
+    // Get the user preferences for the thousands and decimal separator and the number of decimal places 
     if ($userSetting) {
+        // User decimal separator
         $user_dec_sep = (!empty($current_user->id) ? $current_user->getPreference('dec_sep') : null);
+        // User thousands separator
+        $user_grp_sep = (!empty($current_user->id) ? $current_user->getPreference('num_grp_sep') : null);
+        // User number of decimal places
+        $user_sig_digits = (!empty($current_user->id) ? $current_user->getPreference('default_currency_significant_digits') : null);
     }
+
+    // Set the user preferences or the default preferences
     $dec_sep = empty($user_dec_sep) ? $sugar_config['default_decimal_seperator'] : $user_dec_sep;
-    return str_replace('.', $dec_sep, $decimalValue);
+    $grp_sep = empty($user_grp_sep) ? $sugar_config['default_number_grouping_seperator'] : $user_grp_sep;
+    $sig_digits = empty($user_sig_digits) ? $sugar_config['default_currency_significant_digits'] : $user_sig_digits;
+
+    // Format the number
+    $value = number_format($decimalValue, $sig_digits, $dec_sep, $grp_sep);
+    return $value;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Fixing #10596 

It was found that in a decimal type field, it did not show the thousands separator and the Currency Significant Digits when generating a PDF template. It should reflect the number format as shown in the CRM, where the thousands separator and Currency Significant Digits are displayed in the views.

It has been implemented in the function that formats the decimal number with the preferences that the user has, or they are by default, of the separators and the number of decimals to be displayed with the function `number_format()`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The solution returns the value with the thousands separator and the Significant Currency Digits, in addition to the decimal separator, that the user has configured in his profile.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to Studio and in a module create a decimal type field.
2. Add that field to the edit view and add a number greater than 999 with decimal places.
3. Go to Profile-Advanced and check or change the values of Thousands Separator, Decimal Separator and Significant Digits in Currency.
4. Include the decimal field in a PDF template.
5. Check that the number is displayed with the appropriate separators and number of decimal places when generating the template.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->