### PR TITLE
Fix #10606 - Recently viewed items tooltip shows module name instead of full record name

### DIFF
--- a/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -812,7 +812,7 @@
                                                href="{sugar_link module=$item.module_name action='DetailView' record=$item.item_id link_only=1}"
                                                class="recent-links-detail">
                                                 <span class="suitepicon suitepicon-module-{$item.module_name|lower|replace:'_':'-'}"></span>
-                                                <span>{$item.item_summary_short}</span>
+                                                <span title="{$item.item_summary}">{$item.item_summary_short}</span>
                                             </a>
                                             {capture assign='access'}{suite_check_access module=$item.module_name action='edit' record=$item.item_id }{/capture}
                                             {if $access}
@@ -836,7 +836,7 @@
                                 <li class="recentlinks" role="presentation">
                                     <a title="{sugar_translate module=$item.module_name label=LBL_MODULE_NAME}" accessKey="{$smarty.foreach.lastViewed.iteration}" href="{sugar_link module=$item.module_name action='DetailView' record=$item.id link_only=1}" class="favorite-links-detail">
                                         <span class="suitepicon suitepicon-module-{$item.module_name|lower|replace:'_':'-'}"></span>
-                                        <span aria-hidden="true">{$item.item_summary_short}</span>
+                                        <span title="{$item.item_summary}" aria-hidden="true">{$item.item_summary_short}</span>
                                     </a>
                                     {capture assign='access'}{suite_check_access module=$item.module_name action='edit' record=$item.id }{/capture}
                                     {if $access}


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Previously, the tooltip would only show the module name regardless of cursor position, which made it difficult to identify specific records when their names were truncated due to space constraints. This change enhances user experience by:

1. Maintaining the ability to identify record types via module name tooltip
2. Adding the ability to see full record names when they are truncated in the display
3. Making the tooltip behavior more intuitive by showing contextually relevant information based on cursor position

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Test Recently Viewed Items:
   - Navigate through different modules to populate the Recently Viewed list
   - Verify module name tooltip appears when hovering over module icons
   - Verify full record name tooltip appears when hovering over truncated record names

2. Test Favorites:
   - Add several items with long names to Favorites
   - Verify module name tooltip appears when hovering over module icons
   - Verify full record name tooltip appears when hovering over truncated record names


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->