### PR TITLE
Fix #9778 - Dynamic dropdown fields dont work in inline edit

### DIFF
--- a/include/InlineEditing/inlineEditing.js
+++ b/include/InlineEditing/inlineEditing.js
@@ -473,6 +473,15 @@ function handleSave(field, id, module, type) {
         parent_type = $("#parent_type").val();
     }
     var output_value = saveFieldHTML(field, module, id, value, parent_type);
+    
+    // Add hidden input field in detail view for dynamicenum filters
+    if(view == 'DetailView')
+    {
+        if(type == 'enum' || type == 'multienum' || type == 'dynamicenum'){
+            output_value ='<input type="hidden" class="sugar_field" id="'+field+'" value="'+value+'">' + output_value;
+        }
+    }
+
     // If the field type is email, we don't want to handle linebreaks in the output.
     if (field === "email1") {
         setValueClose(output_value, false);

--- a/include/SugarFields/Fields/Dynamicenum/SugarFieldDynamicenum.js
+++ b/include/SugarFields/Fields/Dynamicenum/SugarFieldDynamicenum.js
@@ -55,7 +55,21 @@ function addLoadEvent(func) {
 function loadDynamicEnum(field, subfield) {
 
     if (field != '') {
-        var el = document.getElementById(field);
+        
+        // Add specific method for retrieving parent list value in view list
+        if(action_sugar_grp1 == 'index'){
+            var moduleName = module_sugar_grp1;
+            var recordId = $('input.listview-checkbox',$('form#EditView').closest('tr')).val();
+            var dynamicFieldName = $('form#EditView select').attr('id');
+            var el = $('<input></input>',{
+                id:recordId+dynamicFieldName,
+                type: 'hidden',
+                value: getParentValueFromDynamicEnum(moduleName, recordId, dynamicFieldName)
+            }).appendTo($('#'+subfield).parent());
+            updateDynamicEnum(recordId+dynamicFieldName, subfield)
+        } else {
+            var el = document.getElementById(field);
+        }
 
         if (el) {
             if (el.addEventListener) {
@@ -119,3 +133,23 @@ function updateDynamicEnum(field, subfield) {
         selector.fireEvent("onchange");
 
 }
+
+/**
+* Gets parent value from dynamic enum field
+* @param {string} moduleName - Name of the module
+* @param {string} recordId - ID of the record
+* @param {string} dynamicFieldName - Name of dynamic enum field
+* @returns {string} Parent value from dynamic enum field
+*/
+function getParentValueFromDynamicEnum(moduleName, recordId, dynamicFieldName){
+    $.ajaxSetup({ async: false });
+    var result = $.getJSON("index.php", {
+        module: "Home", 
+        action: "getParentValueFromDynamicEnum",
+        dynamicFieldName: dynamicFieldName,
+        moduleName: moduleName,
+        recordId: recordId
+    });
+    $.ajaxSetup({ async: true });
+    return result.responseText;
+ }

--- a/modules/Home/controller.php
+++ b/modules/Home/controller.php
@@ -140,4 +140,30 @@ class HomeController extends SugarController
 
         echo $quicksearch_js;
     }
+
+     /**
+     * Return the field value from the parent list of current field, attending to the values of Request moduleName, recordId and dynamicFieldname
+     * It's used for retrieving value of the parent dropdown from dynamicenum fields, in view list context.
+     *
+     * @return void
+     */
+    public function action_getParentValueFromDynamicEnum(){
+        $moduleName = $_REQUEST['moduleName'];
+        $recordId = $_REQUEST['recordId'];
+        $dynamicFieldName = $_REQUEST['dynamicFieldName'];
+
+        $focusBean = BeanFactory::getBean($_REQUEST['moduleName']);
+
+        // ensure current user has access
+        if (!$focusBean->ACLAccess('view')) {
+            return false;
+        }
+
+        // recovery parent name field
+        $parentFieldName = $focusBean->field_name_map[$dynamicFieldName]['parentenum'];
+
+        echo getFieldValueFromModule($parentFieldName, $moduleName, $recordId);
+
+        die();
+    }
 }


### PR DESCRIPTION
## Description
Fixes dynamic dropdowns not filtering correctly in both list and detail views. The changes address two distinct scenarios:

1. Detail View: Restores hidden field after inline editing to maintain parent field value access
2. List View: Implements dynamic filtering using `getFieldValueFromModule` to access parent field values

Related issue: [Link to issue]

## Motivation and Context
Dynamic dropdowns were not filtering correctly:
- Detail view lost filtering after inline edits due to missing hidden field
- List view had no filtering mechanism implemented

## How To Test This
1. Detail View Testing:
   - Open any record with dynamic dropdowns
   - Edit parent field inline
   - Verify dependent field filters correctly
   - Change parent field again
   - Verify dependent field updates accordingly

2. List View Testing:
   - Navigate to list view with dynamic dropdowns
   - Edit parent field inline
   - Verify dependent field filters properly

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.