### PR TITLE
Fix - #10611 Subpanels don't show related records links when view permission is set to "group"

### DIFF
--- a/include/generic/SugarWidgets/SugarWidgetSubPanelDetailViewLink.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelDetailViewLink.php
@@ -125,10 +125,11 @@ class SugarWidgetSubPanelDetailViewLink extends SugarWidgetField
         $detailView = $layout_def['DetailView'] ?? '';
         $ownerId = $layout_def['owner_id'] ?? '';
         $ownerModule = $layout_def['owner_module'] ?? '';
+        $groupAccessView = SecurityGroup::groupHasAccess($module,$record,'view');
         if (!empty($record) &&
             ($detailView && !$layout_def['owner_module']
-            ||  $detailView && !ACLController::moduleSupportsACL($layout_def['owner_module'])
-            || ACLController::checkAccess($ownerModule, 'view', $ownerId == $current_user->id))) {
+            || $detailView && !ACLController::moduleSupportsACL($layout_def['owner_module'])
+            || ACLController::checkAccess($ownerModule, 'view', $ownerId == $current_user->id, 'module',  $groupAccessView))) {
             $link = ajaxLink("index.php?module=$module&action=$action&record={$record}{$parent}");
             if ($module == 'EAPM') {
                 $link = "index.php?module=$module&action=$action&record={$record}{$parent}";


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

This PR fixes an issue where subpanels weren't correctly displaying links to related records when the user's role had "Group" view permissions. Previously, when viewing a record's subpanel, related records would show only as plain text instead of clickable links if the user had Group-level view permissions, even when they had access to those records.

The fix adds specific user permission checking logic in the subpanel code to properly evaluate the "View" permission column value, ensuring links are displayed according to the user's actual permissions.

Related issue: #10611 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This change is required to ensure proper functionality of subpanels when working with security groups and role-based permissions. The previous behavior was inconsistent with how direct relationships were handled and made navigation more difficult for users with group-level permissions.

The fix maintains the security model while improving user experience by showing clickable links when the user actually has permission to view the related record.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. As an admin user:
   - Create a regular user (u1)
   - Create a role (r1) setting for Accounts module *List=Group* and *View=Group*
   - Create two security groups (g1 and g2)
   - Add u1 to g1
   - Add role r1 to g1
   - Create a project (p1) and assign it to g1
   - Create an account (a1) and assign it to g1
   - Create an opportunity linking p1 and a1, ensuring the opportunity is assigned to **g1**
   - Create another account (a2) and assign it to g2
   - Create another opportunity linking p1 and a2, ensuring the opportunity is assigned to **g1**
2. Login as user u1
3. Navigate to p1's detail view
4. Verify in the Opportunities subpanel:
   - The opportunity linked to a1 shows as a clickable link
   - The opportunity linked to a2 shows only the name without a link
   - This behavior correctly reflects the user's group-level view permissions
![image](https://github.com/user-attachments/assets/761d0e37-caba-42e5-a0ea-b615d414d78f)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
