### PR TITLE
Fix #10616 - Default values of DateTime always in English and value “first day of next month” gives an error

### DIFF
--- a/modules/DynamicFields/templates/Fields/TemplateDatetimecombo.php
+++ b/modules/DynamicFields/templates/Fields/TemplateDatetimecombo.php
@@ -49,21 +49,28 @@ class TemplateDatetimecombo extends TemplateRange
 {
     public $type = 'datetimecombo';
     public $len = '';
-    public $dateStrings = array(
-        '-none-' => '',
-        'today'=>'now',
-        'yesterday'=> '-1 day',
-        'tomorrow'=>'+1 day',
-        'next week'=> '+1 week',
-        'next monday'=>'next monday',
-        'next friday'=>'next friday',
-        'two weeks'=> '+2 weeks',
-        'next month'=> '+1 month',
-        'first day of next month'=> 'first of next month', // must handle this non-GNU date string in SugarBean->populateDefaultValues; if we don't this will evaluate to 1969...
-        'three months'=> '+3 months',  //kbrill Bug #17023
-        'six months'=> '+6 months',
-        'next year'=> '+1 year',
-    );
+    public $dateStrings;
+
+    public function __construct()
+    {
+        parent::__construct();
+        global $app_strings;
+        $this->dateStrings = array(
+            $app_strings['LBL_NONE']=>'',
+            $app_strings['LBL_YESTERDAY']=> '-1 day',
+            $app_strings['LBL_TODAY']=>'now',
+            $app_strings['LBL_TOMORROW']=>'+1 day',
+            $app_strings['LBL_NEXT_WEEK']=> '+1 week',
+            $app_strings['LBL_NEXT_MONDAY']=>'next monday',
+            $app_strings['LBL_NEXT_FRIDAY']=>'next friday',
+            $app_strings['LBL_TWO_WEEKS']=> '+2 weeks',
+            $app_strings['LBL_NEXT_MONTH']=> '+1 month',
+            $app_strings['LBL_FIRST_DAY_OF_NEXT_MONTH']=> 'first day of next month', // must handle this non-GNU date string in SugarBean->populateDefaultValues; if we don't this will evaluate to 1969...
+            $app_strings['LBL_THREE_MONTHS']=> '+3 months',  //kbrill Bug #17023
+            $app_strings['LBL_SIXMONTHS']=> '+6 months',
+            $app_strings['LBL_NEXT_YEAR']=> '+1 year',
+        );
+    }
     
     public $hoursStrings = array(
         '' => '',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Fixing https://github.com/salesagility/SuiteCRM/issues/10616

This PR solves two issues.

1. The first one, as described in the issue, it was detected that in the creation/edition view of Studio fields, for fields of type DateTime, the default values to be selected are not shown in the different languages, but always in English.
2. In the second one, it was detected that if the default value “first day of next month” is selected for a field of type “DateTime”, of any module, the instance gives an error that makes it unusable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
1. The constructor function has been added next to `$app_strings` where the labels of the dropdown are collected. Generating the dropdown.
2. Fixed the value “first of next month” that was generating problem, for “first day of next month”.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to Studio, to any module and add a field.
2. Create a field of type Date and time (DateTime) and check that the list of default values is displayed in the language that the user has selected in the login or has the default instance.
3. Also, check that when selecting “first day of next month”, the field can be saved and displayed correctly without generating an error that prevents access to “Administration”.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->