### PR TITLE
Fix #10618 - Order of modules in unified search results does not correspond to order in settings (Elasticsearch)

### DIFF
--- a/lib/Search/ElasticSearch/ElasticSearchEngine.php
+++ b/lib/Search/ElasticSearch/ElasticSearchEngine.php
@@ -49,6 +49,7 @@ use SuiteCRM\Search\SearchEngine;
 use SuiteCRM\Search\SearchQuery;
 use SuiteCRM\Search\SearchResults;
 use SuiteCRM\Search\SearchWrapper;
+use SuiteCRM\Search\SearchModules;
 
 /**
  * SearchEngine that use Elasticsearch index for performing almost real-time search.
@@ -182,6 +183,10 @@ class ElasticSearchEngine extends SearchEngine
 
         $searchResults = [];
 
+        $enabledModules = SearchModules::getEnabledModules();
+        foreach ($enabledModules as $enabledModule) {
+            $searchResults[$enabledModule] = [];
+        }
         foreach ($initialResults as $index => $hit) {
             $params = ['index' => $index];
             $meta = $this->client->indices()->getMapping($params);


### PR DESCRIPTION

Modified the parseHits function in /lib/Search/ElasticSearch/ElasticSearchEngine.php so that the search results are parsed based on the order given in Search Settings. 


## Description
I added a loop before the loop over initialResults which sets the keys of the array to be the enabled modules which are set in Admin->'Search Settings'
'''
    private function parseHits(array $hits): array
    {
        $hitsArray = $hits['hits']['hits'];

        $initialResults = [];

        foreach ($hitsArray as $hit) {
            $recordModule = $hit['_index'];
            $initialResults[$recordModule][] = $hit['_id'];
        }

        $searchResults = [];

        // This is my code:
        $enabledModules = SearchModules::getEnabledModules();
        foreach ($enabledModules as $enabledModule) {
            $searchResults[$enabledModule] = [];
        }
        foreach ($initialResults as $index => $hit) {
            $params = ['index' => $index];
            $meta = $this->client->indices()->getMapping($params);
            $moduleName = $meta[$index]['mappings']['_meta']['module_name'];
            $searchResults[$moduleName] = $hit;
        }

        return $searchResults;
    }
'''

## Motivation and Context
Clients have complained that the order of the results of the unified search doesn't match the order they defined in Admin->'Search Settings'.

## How To Test This
This is a bugfix for issue #10618, so to test this you can simply try to reproduce the bug as described in the bug report. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->