### PR TITLE
Fix salesagility#10621 - The values in a checkbox must be in the respective language

### DIFF
--- a/modules/AOS_PDF_Templates/language/en_us.lang.php
+++ b/modules/AOS_PDF_Templates/language/en_us.lang.php
@@ -99,4 +99,6 @@ $mod_strings = array(
     'LBL_DETAILVIEW_PANEL1' => 'Margins',
     'LBL_PAGE_SIZE' => 'Page Size',
     'LBL_ORIENTATION' => 'Orientation',
+    'LBL_CHECKBOX_TRUE' => 'True',
+    'LBL_CHECKBOX_FALSE' => 'False',
 );

--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -90,9 +90,9 @@ class templateParser
                     $repl_arr[$key . "_" . $fieldName] = (string)$focus->$fieldName;
                 } elseif ($field_def['type'] == 'bool') {
                     if ($focus->{$fieldName} == "1") {
-                        $repl_arr[$key . "_" . $fieldName] = "true";
+                        $repl_arr[$key . "_" . $fieldName] = translate('LBL_CHECKBOX_TRUE', 'AOS_PDF_Templates');
                     } else {
-                        $repl_arr[$key . "_" . $fieldName] = "false";
+                        $repl_arr[$key . "_" . $fieldName] = translate('LBL_CHECKBOX_FALSE', 'AOS_PDF_Templates');
                     }
                 } elseif ($field_def['type'] == 'image') {
                     $secureLink = $sugar_config['site_url'] . '/' . "public/" . $focus->id . '_' . $fieldName;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Fixing https://github.com/salesagility/SuiteCRM/issues/10621

As mentioned in the issue, it has been found that, when displaying checkbox type field data in a PDF Template, the values are only displayed in English. Currently, the templates display “true” or “false”.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The different strings of the values of the checkboxes that appeared at the beginning in English have been implemented, so the translate() function has been implemented to pick up these strings according to the language of the instance.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Go to Studio and, in any module, create a field of type “Checkbox”.
2. Then, create a PDF template of that module.
3. Generate the template and check that the answer of that checkbox is in the language selected in the login or the default language of the instance.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->