### PR TITLE
QuickEdit in subpanel list items

### DIFF
--- a/include/ListView/ListViewSubPanel.php
+++ b/include/ListView/ListViewSubPanel.php
@@ -489,11 +489,11 @@ if (!defined('sugarEntry') || !sugarEntry) {
                                         $widget_contents[$aVal][$field_name] = '&nbsp;';
                                     }
                                 } elseif (preg_match("/button/i", $list_field['name'])) {
-                                    if ((($list_field['name'] === 'edit_button' && $field_acl['EditView']) || ($list_field['name'] === 'close_button' && $field_acl['EditView']) || ($list_field['name'] === 'remove_button' && $field_acl['EditView'])) && '' != ($_content = $layout_manager->widgetDisplay($list_field))) {
+                                    if ((($list_field['name'] === 'edit_button' && $field_acl['EditView']) || ($list_field['name'] === 'quickedit_button' && $field_acl['EditView']) || ($list_field['name'] === 'close_button' && $field_acl['EditView']) || ($list_field['name'] === 'remove_button' && $field_acl['EditView'])) && '' != ($_content = $layout_manager->widgetDisplay($list_field))) {
                                         $button_contents[$aVal][] = $_content;
                                         unset($_content);
                                     } else {
-                                        $doNotProcessTheseActions = array("edit_button", "close_button","remove_button");
+                                        $doNotProcessTheseActions = array("edit_button", "quickedit_button", "close_button","remove_button");
                                         if (!in_array($list_field['name'], $doNotProcessTheseActions) && '' != ($_content = $layout_manager->widgetDisplay($list_field))) {
                                             $button_contents[$aVal][] = $_content;
                                             unset($_content);

--- a/include/SugarObjects/templates/basic/language/en_us.lang.php
+++ b/include/SugarObjects/templates/basic/language/en_us.lang.php
@@ -56,6 +56,7 @@ $mod_strings = array(
     'LBL_MODIFIED_USER' => 'Modified by User',
     'LBL_LIST_NAME' => 'Name',
     'LBL_EDIT_BUTTON' => 'Edit',
+    'LBL_QUICKEDIT_BUTTON' => '↙ Edit',
     'LBL_REMOVE' => 'Remove',
 
     'LBL_ASCENDING' => 'Ascending',

--- a/include/SugarObjects/templates/basic/metadata/subpanels/default.php
+++ b/include/SugarObjects/templates/basic/metadata/subpanels/default.php
@@ -67,6 +67,12 @@ $subpanel_layout = array(
             'module' => $module_name,
             'width' => '4%',
         ),
+        'quickedit_button' => array(
+            'vname' => 'LBL_QUICKEDIT_BUTTON',
+            'widget_class' => 'SubPanelQuickEditButton',
+            'module' => $module_name,
+            'width' => '4%',
+        ),
         'remove_button' => array(
             'vname' => 'LBL_REMOVE',
             'widget_class' => 'SubPanelRemoveButton',

--- a/include/SugarObjects/templates/company/language/en_us.lang.php
+++ b/include/SugarObjects/templates/company/language/en_us.lang.php
@@ -125,6 +125,7 @@ $mod_strings = array(
     'NTC_DELETE_CONFIRMATION' => 'Are you sure you want to delete this record?',
 
     'LBL_EDIT_BUTTON' => 'Edit  ',
+    'LBL_QUICKEDIT_BUTTON' => '↙ Edit',
     'LBL_REMOVE' => 'Remove',
 
 );

--- a/include/SugarObjects/templates/company/metadata/subpanels/default.php
+++ b/include/SugarObjects/templates/company/metadata/subpanels/default.php
@@ -78,6 +78,12 @@ $subpanel_layout = array(
             'module' => $module_name,
             'width' => '4%',
         ),
+        'quickedit_button' => array(
+            'vname' => 'LBL_QUICKEDIT_BUTTON',
+            'widget_class' => 'SubPanelQuickEditButton',
+            'module' => $module_name,
+            'width' => '4%',
+        ),
         'remove_button' => array(
             'vname' => 'LBL_REMOVE',
             'widget_class' => 'SubPanelRemoveButton',

--- a/include/SugarObjects/templates/file/language/en_us.lang.php
+++ b/include/SugarObjects/templates/file/language/en_us.lang.php
@@ -112,6 +112,7 @@ $mod_strings = array(
     'LBL_LIST_DOCUMENT_NAME' => 'Document Name',
 
     'LBL_EDIT_BUTTON' => 'Edit ',
+    'LBL_QUICKEDIT_BUTTON' => '↙ Edit',
     'LBL_REMOVE' => 'Remove',
 
 );

--- a/include/SugarObjects/templates/file/metadata/subpanels/default.php
+++ b/include/SugarObjects/templates/file/metadata/subpanels/default.php
@@ -82,6 +82,12 @@ $subpanel_layout = array(
             'module' => $module_name,
             'width' => '5%',
         ),
+        'quickedit_button' => array(
+            'vname' => 'LBL_QUICKEDIT_BUTTON',
+            'widget_class' => 'SubPanelQuickEditButton',
+            'module' => $module_name,
+            'width' => '4%',
+        ),
         'remove_button' => array(
             'vname' => 'LBL_REMOVE',
             'widget_class' => 'SubPanelRemoveButton',

--- a/include/SugarObjects/templates/issue/language/en_us.lang.php
+++ b/include/SugarObjects/templates/issue/language/en_us.lang.php
@@ -63,6 +63,7 @@ $mod_strings = array(
     'LBL_SUBJECT' => 'Subject:',
 
     'LBL_EDIT_BUTTON' => 'Edit',
+    'LBL_QUICKEDIT_BUTTON' => '↙ Edit',
     'LBL_REMOVE' => 'Remove',
 
 );

--- a/include/SugarObjects/templates/issue/metadata/subpanels/default.php
+++ b/include/SugarObjects/templates/issue/metadata/subpanels/default.php
@@ -82,6 +82,12 @@ $subpanel_layout = array(
             'module' => $module_name,
             'width' => '4%',
         ),
+        'quickedit_button' => array(
+            'vname' => 'LBL_QUICKEDIT_BUTTON',
+            'widget_class' => 'SubPanelQuickEditButton',
+            'module' => $module_name,
+            'width' => '4%',
+        ),
         'remove_button' => array(
             'vname' => 'LBL_REMOVE',
             'widget_class' => 'SubPanelRemoveButton',

--- a/include/SugarObjects/templates/person/language/en_us.lang.php
+++ b/include/SugarObjects/templates/person/language/en_us.lang.php
@@ -91,6 +91,7 @@ $mod_strings = array(
     'LBL_EMAIL_NON_PRIMARY' => 'Non Primary E-mails',
     'LBL_PHOTO' => 'Photo',
     'LBL_EDIT_BUTTON' => 'Edit',
+    'LBL_QUICKEDIT_BUTTON' => '↙ Edit',
     'LBL_REMOVE' => 'Remove',
 
     //Lawful Basis labels

--- a/include/SugarObjects/templates/person/metadata/subpanels/default.php
+++ b/include/SugarObjects/templates/person/metadata/subpanels/default.php
@@ -90,6 +90,12 @@ $subpanel_layout = array(
             'module' => 'Contacts',
             'width' => '5%',
         ),
+        'quickedit_button' => array(
+            'vname' => 'LBL_QUICKEDIT_BUTTON',
+            'widget_class' => 'SubPanelQuickEditButton',
+            'module' => 'Contacts',
+            'width' => '4%',
+        ),
         'remove_button' => array(
             'vname' => 'LBL_REMOVE',
             'widget_class' => 'SubPanelRemoveButton',

--- a/include/SugarObjects/templates/sale/language/en_us.lang.php
+++ b/include/SugarObjects/templates/sale/language/en_us.lang.php
@@ -88,6 +88,7 @@ $mod_strings = array(
     'LBL_CURRENCY_NAME' => 'Currency Name',
     'LBL_CURRENCY_SYMBOL' => 'Currency Symbol',
     'LBL_EDIT_BUTTON' => 'Edit',
+    'LBL_QUICKEDIT_BUTTON' => '↙ Edit',
     'LBL_REMOVE' => 'Remove',
 
 );

--- a/include/SugarObjects/templates/sale/metadata/subpanels/default.php
+++ b/include/SugarObjects/templates/sale/metadata/subpanels/default.php
@@ -85,6 +85,12 @@ $subpanel_layout = array(
             'module' => $module_name,
             'width' => '4%',
         ),
+        'quickedit_button' => array(
+            'vname' => 'LBL_QUICKEDIT_BUTTON',
+            'widget_class' => 'SubPanelQuickEditButton',
+            'module' => $module_name,
+            'width' => '4%',
+        ),
         'amount_usdollar' => array(
             'usage' => 'query_only',
         ),

--- a/include/generic/SugarWidgets/SugarWidgetSubPanelQuickEditButton.php
+++ b/include/generic/SugarWidgets/SugarWidgetSubPanelQuickEditButton.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ *
+ * SugarCRM Community Edition is a customer relationship management program developed by
+ * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2019 SalesAgility Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License version 3 as published by the
+ * Free Software Foundation with the addition of the following permission added
+ * to Section 15 as permitted in Section 7(a): FOR ANY PART OF THE COVERED WORK
+ * IN WHICH THE COPYRIGHT IS OWNED BY SUGARCRM, SUGARCRM DISCLAIMS THE WARRANTY
+ * OF NON INFRINGEMENT OF THIRD PARTY RIGHTS.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program; if not, see http://www.gnu.org/licenses or write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ *
+ * You can contact SugarCRM, Inc. headquarters at 10050 North Wolfe Road,
+ * SW2-130, Cupertino, CA 95014, USA. or at email address contact@sugarcrm.com.
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "Powered by
+ * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+/**
+ * This custom class, allows you to create a button in each record of the subpanel
+ * which open the QuickCreate View to edit the record.
+ */
+class SugarWidgetSubPanelQuickEditButton extends SugarWidgetField
+{
+    public function displayList(&$layout_def)
+	{
+		global $app_strings;
+        global $subpanel_item_count;
+		
+		$return_module = $_REQUEST['module'];
+		$return_id = $_REQUEST['record']; 
+		$module_name = $layout_def['module'];
+		$record_id = $layout_def['fields']['ID'];
+		$subpanel = $layout_def['subpanel_id'];
+        $unique_id = $layout_def['subpanel_id']."_form_".$subpanel_item_count; //bug 51512
+		
+		// @see SugarWidgetSubPanelTopButtonQuickCreate::get_subpanel_relationship_name()
+		$relationship_name = '';
+		if (!empty($layout_def['linked_field'])) {
+			$relationship_name = $layout_def['linked_field'];
+			$bean = BeanFactory::getBean($layout_def['module']);
+			if (!empty($bean->field_defs[$relationship_name]['relationship'])) {
+				$relationship_name = $bean->field_defs[$relationship_name]['relationship'];
+			}
+		}
+		
+		$subpanel = $layout_def['subpanel_id'];
+
+		$labelText = "Quick Edit";
+		$label = null;
+		if (isset($layout_def['vname'])) {
+			$label = $layout_def['vname'];
+		} elseif (isset($layout_def['label'])) {
+			$label = $layout_def['label'];
+		}
+		if ($label != null) {
+			if (isset($app_strings[$label])) {
+				$labelText = $app_strings[$label];
+			} elseif (isset($mod_strings[$label])) {
+				$labelText = $mod_strings[$label];
+			}
+		}
+
+		$html = '
+		<form onsubmit="return SUGAR.subpanelUtils.sendAndRetrieve(this.id, \'subpanel_'.$subpanel.'\', \'Loading ...\');" action="index.php" method="post" name="form" id="'.$unique_id.'">
+		<input type="hidden" name="record" value="'.$record_id.'">
+		<input type="hidden" name="target_module" value="'.$module_name.'">
+		<input type="hidden" name="tpl" value="QuickCreate.tpl">
+		<input type="hidden" name="return_module" value="'.$return_module.'">
+		<input type="hidden" name="return_action" value="SubPanelViewer">
+		<input type="hidden" name="return_id" value="'.$return_id.'">
+		<input type="hidden" name="return_relationship" value="'.$relationship_name.'">
+		<input type="hidden" name="action" value="SubpanelCreates">
+		<input type="hidden" name="module" value="Home">
+		<input type="hidden" name="target_action" value="QuickEdit">
+		<input type="hidden" name="return_name" value="XXXX">
+		<input type="hidden" name="parent_type" value="'.$return_module.'">
+		<input type="hidden" name="parent_name" value="XXXX">
+		<input type="hidden" name="parent_id" value="'.$return_id.'">
+		<input title="'.$labelText.'" accesskey="N" class="button" type="submit" name="'.$module_name.'_quickedit_button" id="'.$record_id.'_quickedit_button" value="'.$labelText.'">
+		</form>';
+				
+		return $html;
+	}
+}

--- a/include/language/en_us.lang.php
+++ b/include/language/en_us.lang.php
@@ -1534,6 +1534,7 @@ $app_strings = array(
     'LBL_DATE_ENTERED' => 'Date Created:',
     'LBL_DATE_MODIFIED' => 'Date Modified:',
     'LBL_EDIT_BUTTON' => 'Edit',
+    'LBL_QUICKEDIT_BUTTON' => '↙ Edit',
     'LBL_DUPLICATE_BUTTON' => 'Duplicate',
     'LBL_DELETE_BUTTON' => 'Delete',
     'LBL_DELETE' => 'Delete',

--- a/modules/ModuleBuilder/parsers/views/DeployedSubpanelImplementation.php
+++ b/modules/ModuleBuilder/parsers/views/DeployedSubpanelImplementation.php
@@ -127,6 +127,18 @@ class DeployedSubpanelImplementation extends AbstractMetaDataImplementation impl
                 //First load the original defs from the module folder
                 $originalSubpanel = $spd->load_subpanel($subpanelName, false, true);
                 $this->_fullFielddefs = $originalSubpanel->get_list_fields();
+
+                // Add quickedit_button if edit_button is present
+                if (array_key_exists('edit_button', $this->_fullFielddefs) && 
+                    !array_key_exists('quickedit_button', $this->_fullFielddefs)) {
+                    $this->_fullFielddefs['quickedit_button'] = array(
+                        'vname' => 'LBL_QUICKEDIT_BUTTON',
+                        'widget_class' => 'SubPanelQuickEditButton',
+                        'module' => $moduleName,
+                        'width' => '4%',
+                    );
+                }
+                
                 $this->_mergeFielddefs($this->_fielddefs, $this->_fullFielddefs);
 
                 $this->_aSubPanelObject = $spd->load_subpanel($subpanelName);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
In SuiteCRM, subpanels allow users to create related records using the "Quick Create" view, which is embedded within the subpanel itself. However, editing existing related records is only possible by navigating to the full edit view of the record, which disrupts the context of the related items.

This PR introduces a "Quick Edit" button for subpanels, which can replace the default "Edit" button. This new functionality enables users to edit related records directly within the subpanel using the "Quick Create" view, maintaining the context of the related items.

The following changes are included:

1. A new `quickedit_button` option is available for subpanels, replacing the default edit button.
2. The "Quick Edit" button can be added to subpanels via Studio.
3. Support for adding the button programmatically through subpanel metadata definitions.

This implementation is based on the idea discussed here:
https://community.suitecrm.com/t/quickedit-view-does-it-exist/80182/3.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This feature addresses the lack of a seamless way to edit related records within subpanels. By adding "Quick Edit" functionality, users can modify records directly within subpanels without leaving the main view, improving the user experience and saving time. This functionality is especially useful when working with related records that require frequent updates.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
### Testing via Studio
1. Access Studio and select a module.
2. Edit a subpanel and verify that the `quickedit_button` option is available.
![image](https://github.com/user-attachments/assets/863a48e8-aa02-4b51-9f95-b24b59bf18c0)
4. Add the `quickedit_button` to the subpanel, save, and deploy.
5. Open the detail view of a record for the module with the edited subpanel.
6. Verify the following:
     1. The "**↙ Edit**" button appears in the subpanel.    
![image](https://github.com/user-attachments/assets/2f4581f3-266a-43a4-be71-f67310801241)
     3. Clicking the "**↙ Edit**" button opens the "Quick Create" view for editing the record within the subpanel.
     4. Modified data is saved correctly.

### Testing via code:
1. Edit the metadata definition of a subpanel (e.g., `modules/[SUBPANEL_MODULE]/metadata/subpanels/default.php`).
2. Replace the `SubPanelEditButton` widget with `SubPanelQuickEditButton` as follows:
```php
'quickedit_button' => array(
    'vname' => 'LBL_QUICKEDIT_BUTTON',
    'widget_class' => 'SubPanelQuickEditButton',
    'module' => '%% MY_MODULE %%',
    'width' => '4%',
    'default' => true,
),
```
3. Quick Repair and Rebuild
4. Open the detail view of a record with the edited subpanel.
5. Verify that the "**↙ Edit**" button appears and allows editing of related records using the "Quick Create" view.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [X] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->