### PR TITLE
Fix #10627 - Workflow dates are processed in UTC+0 instead of the user's timezone

### DIFF
--- a/modules/AOW_Actions/actions/actionComputeField.php
+++ b/modules/AOW_Actions/actions/actionComputeField.php
@@ -164,7 +164,19 @@ class actionComputeField extends actionBase
                     }
                 }
             } else {
-                $resolvedParameters[$i] = ($bean->{$parameters[$i]} == null) ? "" : $bean->{$parameters[$i]};
+                $type = '';
+                if (isset($bean->field_name_map[$parameters[$i]]['type'])) {
+                    $type = $bean->field_name_map[$parameters[$i]]['type'];
+                }
+                if (isset($bean->field_name_map[$parameters[$i]]['dbType'])) {
+                    $type .= $bean->field_name_map[$parameters[$i]]['dbType'];
+                }                
+                if ($type == 'datetimecombodatetime') {
+                    global $timedate;
+                    $resolvedParameters[$i] = $timedate->to_display_date_time($bean->{$parameters[$i]});
+                } else {
+                    $resolvedParameters[$i] = ($bean->{$parameters[$i]} == null) ? "" : $bean->{$parameters[$i]};
+                }
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
This pull request fixes an issue in SuiteCRM workflows where date fields are always processed and displayed in UTC+0, regardless of the user's configured timezone. This fix ensures that dates are processed and displayed according to the user's timezone settings, aligning workflow behavior with user expectations.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Users working in timezones other than UTC+0 experience issues with date formatting and calculations in workflows. For example, when using calculated fields in workflows, the system does not respect the user's timezone

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Edit the current user's profile to set a timezone other than UTC+0 (e.g., Europe/Madrid).
2. Create a workflow on the Tasks module with the following parameters: Run: "Only on Save", Run on: "All Records"
3. Add an action to the workflow: 
    1. Action: "Calculated fields"
    2. Parameters: "Subject (P0)" and "Start Date (P1)"
    3. Formula:
```
{P0}: {P1} (Year: {date(Y;{P1})}, Month: {date(m;{P1})}, Day: {date(d;{P1})}, Hour: {date(H;{P1})}, Minutes: {date(i;{P1})}, Seconds: {date(s;{P1})})
```
4. Save a new Task with a "Start Date" and verify the following:
    1. The date displayed in the "Subject" field reflects the user's configured timezone.
    2. The calculated fields respect the user's timezone during processing.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->