### PR TITLE
Fix salesagility#10629 - Duplicating Surveys

### DIFF
--- a/modules/Surveys/Lines/Lines.php
+++ b/modules/Surveys/Lines/Lines.php
@@ -2,7 +2,12 @@
 
 function survey_questions_display(Surveys $focus, $field, $value, $view)
 {
-    $hasResponses = !empty($focus->id) && $focus->get_linked_beans('surveys_surveyresponses');
+    if ($_POST["isDuplicate"] && $_POST["isDuplicate"] == "true") {
+        $hasResponses = false;
+    } else {
+        $hasResponses = !empty($focus->id) && $focus->get_linked_beans('surveys_surveyresponses');
+    }
+
     if ($view == 'EditView' && !$hasResponses) {
         return survey_questions_display_edit($focus, $field, $value, $view);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->
Closes https://github.com/salesagility/SuiteCRM/issues/8947

As the Issue mentions, there is a problem when duplicating Surveys. Basically, what goes wrong when duplicating:
- If the base survey has questions and no answers, the duplicated survey will take all the questions, leaving the base survey without questions
- If the base survey has questions and answers, the duplicated survey won't take/keep the questions, neither the answers. Although the Editview that appears after duplicating will contain the questions and won't allow it to modify them:
![Selection_430](https://user-images.githubusercontent.com/61022311/152755020-27103130-3d28-4c47-8959-217fd51c1e73.png)


Closes https://github.com/salesagility/SuiteCRM/issues/10629

Having a WorkFlow and duplicating a survey or create also duplicated the questions, as the code was executed without any workflow verification. This was because:
- When duplicating survey X to Y or creating survey X, having WorkFlow active, the code saved the questions normally.
- But because there was no control over the workflow, when the workflow was executed:
   - The code re-executed the foreach loop that saves the questions.
   - As a result, the questions were saved twice: once during the normal save and once during the workflow execution.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
This PR fixes the Duplicate functionality for the Surveys module, as we understand it should work:
- If the base survey has questions and no answers, the duplicated survey will keep the questions, duplicating them.
- If the base survey has questions and answers, the duplicated survey ~won't~ will take/keep/duplicate the questions ~or~ but not the answers. And other new Questions can be added during the first edition after duplication.
- Fixed the workflow problem by adding a control variable `already_saved` which is used to verify that the method is not re-executed. If `already_saved` is set, it means that the method has already been executed and reprocessing of the questions is avoided.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, duplicating Surveys will be consistent.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1- Create a Survey
2- Add questions
3- Duplicate it.
4- Repeat adding answers to the survey.

**Workflow Issue**
1. WorkFlow Module: Surveys
2. Run: Only On Save
3. Run On: New Records
4. Action:
  4.1. Modify the survey itself, for example, change from draft to published status.
  4.2. Calculate fields, for example, calculate the name.
5. Duplicate the survey from step 1, checking the number of questions it has.
6. Check that the survey has been duplicated without duplicating the questions and that it has the same questions as the survey from step 1.
7. Create a survey with several questions and check that the surveys are not duplicated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->