### PR TITLE
Fix #4630 - [AOR_REPORT] Pie Chart show the ID instead the name when the field selected is related field

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -256,7 +256,12 @@ class AOR_Report extends Basic
             foreach ($fields as $name => $att) {
                 $currency_id = isset($row[$att['alias'] . '_currency_id']) ? $row[$att['alias'] . '_currency_id'] : '';
 
-                if ($att['function'] != 'COUNT' && empty($att['format']) && !is_numeric($row[$name])) {
+                $isFieldTypeRelate = isFieldTypeRelate($att['module'], $att['field']);
+                $isFunctionCount = $att['function'] === 'COUNT';
+                $isFormatSet = !empty($att['format']);
+                $isValueNumeric = isset($row[$name]) && is_numeric($row[$name]);
+
+                if ($isFieldTypeRelate || !$isFunctionCount || !$isFormatSet || !$isValueNumeric) {
                     $row[$name] = trim(strip_tags(getModuleField(
                         $att['module'],
                         $att['field'],
@@ -805,7 +810,11 @@ class AOR_Report extends Basic
 
                     $currency_id = isset($row[$att['alias'] . '_currency_id']) ? $row[$att['alias'] . '_currency_id'] : '';
 
-                    if ($att['function'] == 'COUNT' || !empty($att['format'])) {
+                    $isFieldTypeRelate = isFieldTypeRelate($att['module'], $att['field']);
+                    $isFunctionCount = $att['function'] === 'COUNT';
+                    $isFormatSet = !empty($att['format']);
+
+                    if ((!$isFieldTypeRelate && $isFunctionCount) || $isFormatSet) {
                         $html .= $row[$name];
                     } else {
                         // Make sure the `{$module}_id` key exists on $row, to prevent PHP notices.

--- a/modules/AOR_Reports/aor_utils.php
+++ b/modules/AOR_Reports/aor_utils.php
@@ -615,3 +615,22 @@ function convertToDateTime($value)
 
     return $dateTime;
 }
+
+/**
+ * Checks if the specified field in a module is of type "relate".
+ * @param string $module
+ * @param string $field
+ * @return bool
+ */
+function isFieldTypeRelate(string $module, string $field): bool
+{
+    $fieldBean = BeanFactory::getBean($module);
+
+    if (!$fieldBean) {
+        return false;
+    }
+
+    $fieldDefinition = $fieldBean->getFieldDefinition($field);
+
+    return isset($fieldDefinition['type']) &&  $fieldDefinition['type'] === 'relate';
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
See the issue: 
https://github.com/salesagility/SuiteCRM/issues/4630

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There is no getModuleField() call in the case of the COUNT aggregate function during the whole HTML generation of the report, which may be inappropriate in case of related fields.  

## How To Test This
<!--- Please describe in detail how to test your changes. -->
See the issue: 
https://github.com/salesagility/SuiteCRM/issues/4630

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->