### PR TITLE
Fix: Global Search respects module filter in UnifiedSearchAdvanced

### DIFF
--- a/lib/Search/ElasticSearch/ElasticSearchEngine.php
+++ b/lib/Search/ElasticSearch/ElasticSearchEngine.php
@@ -115,7 +115,7 @@ class ElasticSearchEngine extends SearchEngine
         // Override frontend wildcard character
         if (isset($GLOBALS['sugar_config']['search_wildcard_char'])) {
             $wildcardFe = $GLOBALS['sugar_config']['search_wildcard_char'];
-            if ($wildcardFe !== $wildcardBe && strlen($wildcardFe) === 1) {
+            if ($wildcardFe !== $wildcardBe && strlen((string) $wildcardFe) === 1) {
                 $searchStr = str_replace($wildcardFe, $wildcardBe, $searchStr);
             }
         }

--- a/lib/Search/ElasticSearch/ElasticSearchEngine.php
+++ b/lib/Search/ElasticSearch/ElasticSearchEngine.php
@@ -114,7 +114,7 @@ class ElasticSearchEngine extends SearchEngine
         // Override frontend wildcard character
         if (isset($GLOBALS['sugar_config']['search_wildcard_char'])) {
             $wildcardFe = $GLOBALS['sugar_config']['search_wildcard_char'];
-            if ($wildcardFe !== $wildcardBe && strlen((string) $wildcardFe) === 1) {
+            if ($wildcardFe !== $wildcardBe && strlen($wildcardFe) === 1) {
                 $searchStr = str_replace($wildcardFe, $wildcardBe, $searchStr);
             }
         }

--- a/lib/Search/ElasticSearch/ElasticSearchEngine.php
+++ b/lib/Search/ElasticSearch/ElasticSearchEngine.php
@@ -106,7 +106,6 @@ class ElasticSearchEngine extends SearchEngine
     {
         $searchStr = $query->getSearchString();
         $searchModules = SearchWrapper::getModules();
-
         $indexes = (empty($query->getOption('module_only'))) ? implode(',', array_map('strtolower', $searchModules)) : $query->getOption('module_only');
 
         // Wildcard character required for Elasticsearch

--- a/modules/AOR_Conditions/AOR_Condition.php
+++ b/modules/AOR_Conditions/AOR_Condition.php
@@ -122,11 +122,11 @@ class AOR_Condition extends Basic
                                 }
                             }
                         }
-                        if ($field_name == 'parenthesis' && $post_data[$key . $field_name][$i] == 'END') {
-                            if (!isset($lastParenthesisStartConditionId)) {
+                        if ($field_name === 'parenthesis' && $post_data[$key . $field_name][$i] !== 'START') {
+                            if (!isset($lastParenthesisStartConditionIds)) {
                                 throw new Exception('a closure parenthesis has no starter pair');
                             }
-                            $condition->parenthesis = $lastParenthesisStartConditionId;
+                            $condition->parenthesis = array_pop($lastParenthesisStartConditionIds);
                         } else {
                             $condition->$field_name = $post_data[$key . $field_name][$i];
                         }
@@ -149,8 +149,8 @@ class AOR_Condition extends Basic
                     }
                     $condition->aor_report_id = $parent->id;
                     $conditionId = $condition->save();
-                    if ($condition->parenthesis == 'START') {
-                        $lastParenthesisStartConditionId = $conditionId;
+                    if ($condition->parenthesis === 'START') {
+                        $lastParenthesisStartConditionIds[] = $conditionId;
                     }
                 }
             }


### PR DESCRIPTION
# Fix: Global Search respects module filter in UnifiedSearchAdvanced

## 📝 Description

This change fixes a bug in the global search where selecting a specific module (e.g., "Opportunities") does not limit the results to that module.  
Currently, results from other modules are mixed in, and relevant results appear only on later pages (e.g., page 4 or 5), which leads to confusion and the false impression that there are no matches.

The fix ensures that when a module filter is selected, the search only returns and paginates results from that module.

---

## 🎯 Motivation and Context

This improves the **usability and accuracy** of the global search. Users expect filtered search results to be immediately visible when selecting a specific module.  
Without this fix, users may **overlook important data**, believing no results were found.

---

## ✅ How To Test This

1. Log into SuiteCRM.
2. Use the **Global Search** (top-right) and search for the term:  
   `Wagner`
3. In the module filter dropdown, select only:  
   `Opportunities`
4. Click **Search**.

**Before this fix**:
- Results from Opportunities appear only on later pages (e.g., page 4/5).
- Results from other modules appear first, even if the filter is set.

**After this fix**:
- Only Opportunity records are shown, starting from **page 1**.
- Other modules are **not included** in the results.

---

## 🔧 Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## ✅ Final checklist

- [x] My code follows the code style of this project: [SuiteCRM Coding Standards](https://docs.suitecrm.com/community/contributing-code/coding-standards/)  
- [ ] My change requires a change to the documentation  
- [x] I have read the [How to Contribute](https://docs.suitecrm.com/community/contributing-code/) guidelines
