### PR TITLE
Fix #10147, #10396 - Smarty unregistered function deprecated notice

### DIFF
--- a/include/Sugar_Smarty.php
+++ b/include/Sugar_Smarty.php
@@ -75,12 +75,25 @@ class Sugar_Smarty extends Smarty
             mkdir_recursive(SUGAR_SMARTY_DIR . 'cache', true);
         }
 
-        $this->template_dir = '.';
-        $this->compile_dir = SUGAR_SMARTY_DIR . 'templates_c';
-        $this->config_dir = SUGAR_SMARTY_DIR . 'configs';
-        $this->cache_dir = SUGAR_SMARTY_DIR . 'cache';
-        //$this->request_use_auto_globals = true; // to disable Smarty from using long arrays
+        $this->setTemplateDir('.');
+        $this->setCompileDir(SUGAR_SMARTY_DIR . 'templates_c');
+        $this->setCacheDir(SUGAR_SMARTY_DIR . 'cache');
+        $this->setConfigDir(SUGAR_SMARTY_DIR . 'configs');
 
+        $this->registerPHPFunctions([
+            'count',
+            'intval',
+            'is_string',
+            'key',
+            'preg_match',
+            'substr',
+            'strpos',
+            'strstr',
+            'strtoupper',
+            'strval',
+            'url2html'
+        ]);
+        
         //TODO fix literals
         $this->auto_literal = false;
 
@@ -94,7 +107,16 @@ class Sugar_Smarty extends Smarty
         $this->assign("VERSION_MARK", getVersionedPath(''));
     }
 
-
+    public function registerPHPFunctions(array $functions): void
+    {
+        foreach ($functions as $function) {
+            try {
+                $this->registerPlugin(Smarty::PLUGIN_MODIFIER, $function, $function);
+            } catch (SmartyException $e) {
+                $GLOBALS['log']->fatal('Smarty: Failed to register PHP function' . $function . ': ' . $e->getMessage());
+            }
+        }
+    }
 
     /**
      * Override default _unlink method call to fix Bug 53010


### PR DESCRIPTION
## Description
Fixes #10147, #10396 - Smarty unregistered function deprecated notice

## Motivation and Context
Reduce unnecessary logging

## How To Test This
See that there are no longer any deprecation notices logged on PHP functions used with smarty template files

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->