### PR TITLE
Fix #10676 - Remove old query which duplicates email address in table

### DIFF
--- a/include/SugarEmailAddress/SugarEmailAddress.php
+++ b/include/SugarEmailAddress/SugarEmailAddress.php
@@ -454,31 +454,7 @@ class SugarEmailAddress extends SugarBean
             return false;
         }
 
-        // do we have to update the address?
-
-        if ($email->email_address != $address) {
-            $_address = $db->quote($address);
-            $_addressCaps = $db->quote(strtoupper($address));
-            $_id = $db->quoted($id);
-            $query =
-                "UPDATE email_addresses 
-                  SET 
-                    email_address = '$_address', 
-                    email_address_caps = '$_addressCaps' 
-                  WHERE 
-                    id = {$_id} AND
-                    deleted = 0";
-            $result = $db->query($query);
-            if (!$result) {
-                $GLOBALS['log']->warn("Undefined behavior: Missing error information about email save (1)");
-            }
-            if ($db->getAffectedRowCount($result) != 1) {
-                $GLOBALS['log']->debug("Email address has not change");
-            }
-        }
-
         // update primary and replyTo
-
         $_primary = (bool)$primary ? '1' : '0';
         $_replyTo = (bool)$replyTo ? '1' : '0';
         $_id = $db->quoted($id);
@@ -494,7 +470,7 @@ class SugarEmailAddress extends SugarBean
                 deleted = 0";
         $result = $db->query($query);
         if (!$result) {
-            $GLOBALS['log']->warn("Undefined behavior: Missing error information about email save (2)");
+            $GLOBALS['log']->warn("Undefined behavior: Missing error information about email save");
         }
         if ($db->getAffectedRowCount($result) != 1) {
             $GLOBALS['log']->debug("Primary or reply-to Email address has not change");


### PR DESCRIPTION
This fixes issue #10676 that duplicates the new email by replacing the old email and also creating a new one upon an email address change for a user.

## Description
Due to me fixing the issue https://github.com/salesagility/SuiteCRM/issues/10433 with PR https://github.com/salesagility/SuiteCRM/pull/10434,
The unintended result is that the user updates the email address in the DB as well as creating and relating the new email address, this results in a duplicate record in the email_addresses table.

## Motivation and Context
An unintentional logic change by fixing the MySQL query, this reverts it back to how it was before.

## How To Test This
Change user's email address in admin then check email_addresses table for duplicated record.
This PR leaves the old email address unchanged.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->