### PR TITLE
Fix #10674 - Enable CLI session reload and fix GoogleSync token persi…

### DIFF
--- a/include/GoogleSync/GoogleSyncBase.php
+++ b/include/GoogleSync/GoogleSyncBase.php
@@ -232,7 +232,7 @@ class GoogleSyncBase
             if (!empty($refreshToken)) {
                 $client->fetchAccessTokenWithRefreshToken($refreshToken);
                 // Save new token to user preference
-                $this->workingUser->setPreference('GoogleApiToken', base64_encode(json_encode($client->getAccessToken())), 'GoogleSync');
+                $this->workingUser->setPreference('GoogleApiToken', base64_encode(json_encode($client->getAccessToken())), 0, 'GoogleSync');
                 $this->workingUser->savePreferencesToDB();
             } elseif (empty($refreshToken)) {
                 throw new GoogleSyncException('Refresh token is missing', GoogleSyncException::NO_REFRESH_TOKEN);

--- a/modules/UserPreferences/UserPreference.php
+++ b/modules/UserPreferences/UserPreference.php
@@ -212,6 +212,11 @@ class UserPreference extends SugarBean
 
         $user = $this->_userFocus;
 
+        // if we’re running under cron / php-cli, reload and bail
+        if (PHP_SAPI === 'cli') {
+            return $this->reloadPreferences($category);
+        }
+
         if ($user->object_name != 'User') {
             return;
         }
@@ -252,13 +257,13 @@ class UserPreference extends SugarBean
         $result = $db->query("SELECT contents FROM user_preferences WHERE assigned_user_id='$user->id' AND category = '" . $category . "' AND deleted = 0", false, 'Failed to load user preferences');
         $row = $db->fetchByAssoc($result);
         if ($row) {
-            if (!$GLOBALS['current_user']->id || $GLOBALS['current_user']->user_name === $user->user_name){
+            if (PHP_SAPI === 'cli' || $GLOBALS['current_user']->user_name === $user->user_name){
                 $_SESSION[$user->user_name . '_PREFERENCES'][$category] = unserialize(base64_decode($row['contents']));
             }
             $user->user_preferences[$category] = unserialize(base64_decode($row['contents']));
             return true;
         } else {
-            if (!$GLOBALS['current_user']->id || $GLOBALS['current_user']->user_name === $user->user_name){
+            if (PHP_SAPI === 'cli' || $GLOBALS['current_user']->user_name === $user->user_name){
                 $_SESSION[$user->user_name . '_PREFERENCES'][$category] = array();
             }
             $user->user_preferences[$category] = array();


### PR DESCRIPTION
##Description

This pull request contains two related bug fixes for SuiteCRM’s Google Calendar sync:

Enable CLI-driven session reload
The reloadPreferences() method in modules/UserPreferences/UserPreference.php was only populating $_SESSION when the web’s current_user matched the target user. Since cron jobs always run as Admin under the PHP CLI SAPI, the GoogleSync user’s session bucket was never loaded—causing their preferences to be reset on every run.

Added a PHP_SAPI === 'cli' check so that under cron we always reload the user’s preferences into $_SESSION.

Fix GoogleApiToken persistence
In include/GoogleSync/GoogleSyncBase.php, the call to

```sh
$this->workingUser->setPreference('GoogleApiToken', base64_encode(json_encode($client->getAccessToken())), 'GoogleSync');
```
was inadvertently saving the new token to the global category due to the method signature. As a result, each run treated the token as missing and refreshed it every minute.

Changed the call to

```sh
$this->workingUser->setPreference('GoogleApiToken', base64_encode(json_encode($client->getAccessToken())), 0, 'GoogleSync');
```

so the token is stored correctly in the GoogleSync category and only refreshed when truly expired.

Closes #10637

## Motivation and Context

Issue 1: Cron-driven Google sync never sees the saved token in $_SESSION because sessions are only populated for web users. This caused the google-sync user to always be redirected to user wizard since it had no session saved.

Issue 2: Incorrect setPreference() usage meant the token was saved under the wrong category, so even a correctly populated session would still appear empty for GoogleSync.

Together, these fixes ensure that:

- The existing token is loaded under cron,

- New tokens are saved in the right place,

- The sync only refreshes tokens when necessary.


## How To Test This
1. Prepare

In the UI, authorize Google Calendar for a non-admin user.

Confirm that a valid GoogleApiToken + GoogleApiRefreshToken appear under the GoogleSync category in user_preferences.

2. Verify CLI reload

```sh
php cron.php --job="Sync Google calendars"
```

- First run: should log the existing token and skip refresh.

- Second run (immediately after): must not log “Refreshing Access Token” again, and the token in the DB remains unchanged.

3. Verify web behavior

Log in as that user in the browser and perform an action that reads a preference. Ensure their preferences still load normally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
