### PR TITLE
Fix incorrect Timezone on datetimecombo fields went in Email Template during mass update

### DIFF
--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -42,7 +42,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-require_once('include/EditView/EditView2.php');
+require_once 'include/EditView/EditView2.php';
 
 /**
  * MassUpdate class for updating multiple records at once
@@ -77,7 +77,7 @@ class MassUpdate
      */
     public function getDisplayMassUpdateForm($bool, $multi_select_popup = false)
     {
-        require_once('include/formbase.php');
+        require_once 'include/formbase.php';
 
         if (!$multi_select_popup) {
             $form = '<form action="index.php" method="post" name="displayMassUpdate" id="displayMassUpdate">' . "\n";
@@ -177,8 +177,8 @@ eoq;
      */
     public function handleMassUpdate()
     {
-        require_once('include/formbase.php');
-        global $current_user, $db, $disable_date_format, $timedate, $app_list_strings;
+        require_once 'include/formbase.php';
+        global $current_user, $db, $timedate, $app_list_strings;
 
         foreach ($_POST as $post => $value) {
             if (is_array($value)) {
@@ -235,13 +235,6 @@ eoq;
                 }
             }
         }
-
-        //We need to disable_date_format so that date values for the beans remain in database format
-        //notice we make this call after the above section since the calls to TimeDate class there could wind up
-        //making it's way to the UserPreferences objects in which case we want to enable the global date formatting
-        //to correctly retrieve the user's date format preferences
-        $old_value = $disable_date_format;
-        $disable_date_format = true;
 
         if (!empty($_REQUEST['uid'])) {
             $_POST['mass'] = explode(',', $_REQUEST['uid']);
@@ -435,7 +428,6 @@ eoq;
                 }
             }
         }
-        $disable_date_format = $old_value;
     }
 
     /**


### PR DESCRIPTION
Fix value for datetimecombo fields sent within an email template during a massupdate

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
Prevents datetimecombo values being sent in email templates with the incorrect timezone 


<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
Our client uses mass update extensively and have had issues with emails sent during BST always being an hour out.

This is the closest we have got to solving the issue
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
setup a workflow to send an email where the email template contains datetimecombo fields.
mass update records for the module a workflow was created for in the previous step during BST (British Summer Time)
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->