### PR TITLE
Fix #10689 - It is not possible to use a custom ldap authentication logic

### DIFF
--- a/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php
+++ b/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php
@@ -42,6 +42,12 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
+// If there is a custom version of this file, use it instead
+if(file_exists('custom/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php')){
+    require_once('custom/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php');
+    die();
+}
+
 /**
  * This file is where the user authentication occurs. No redirection should happen in this file.
  *


### PR DESCRIPTION
## Description
This PR allows the system to use a custom version of `modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php` if it exists in the `custom` directory. This enables developers to implement custom authentication logic via LDAP without directly modifying core files.

## Motivation and Context
The current SuiteCRM architecture does not provide a straightforward way to extend or modify the LDAP authentication process without altering the core `LDAPAuthenticateUser.php` file. This creates issues with maintainability and upgrade paths for instances requiring custom authentication logic. By allowing the use of `custom/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php`, this PR addresses this limitation, providing a cleaner and more sustainable solution for custom LDAP integration.

## How To Test This
1. Create a custom file: `custom/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php`
2. Add modified authentication logic within this custom file (e.g., add a `log_message` to confirm its execution).
3. Attempt to authenticate a user via LDAP.
4. Verify that the custom logic in `custom/modules/Users/authentication/LDAPAuthenticate/LDAPAuthenticateUser.php` is applied and executed, rather than the core file.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Security fix
- [ ] Performance improvement
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation update
- [ ] Other (please describe):

### Final checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the SuiteCRM Contributor Guide and Code Standards.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have performed a self-review of my own code.