### PR TITLE
Fix #10691 - Global search input field does not get focus automatically on smaller screens

### DIFF
--- a/include/javascript/sugar_3.js
+++ b/include/javascript/sugar_3.js
@@ -628,3 +628,4 @@ function convertReportDateTimeToDB(dateValue,timeValue){var date_match=dateValue
 if(time_match[1]<10){time_match[1]='0'+time_match[1];}
 return date_match[date_reg_positions['Y']]+"-"+date_match[date_reg_positions['m']]+"-"+date_match[date_reg_positions['d']]+' '+time_match[1]+':'+time_match[2]+':00';}
 return'';}
+$(document).ready(function(){$('button#searchbutton').on('click',function(){setTimeout(()=>{$(this).parent('li').find('input#query_string').focus();},200);});})

--- a/jssource/src_files/include/javascript/sugar_3.js
+++ b/jssource/src_files/include/javascript/sugar_3.js
@@ -5073,3 +5073,13 @@ function convertReportDateTimeToDB(dateValue, timeValue) {
   }
   return '';
 }
+
+
+$(document).ready(function(){
+  $('button#searchbutton').on('click', function() {
+      // Set focus in global search input
+      setTimeout(() => {
+          $(this).parent('li').find('input#query_string').focus();
+      }, 200);
+  });
+})


### PR DESCRIPTION
## Description
This pull request addresses an issue where the global search input field on screens with a width less than 1560px does not automatically receive focus after clicking the magnifying glass icon. This improvement ensures that once the global search is activated, the focus is automatically assigned to the search input field, eliminating the need for an additional click and enhancing user experience.

## Motivation and context
The current behavior requires an extra click on the input field to start typing after enabling the global search on smaller screens. This adds an unnecessary step and degrades the user experience. By automatically focusing the input field, we streamline the search process and improve usability, especially for users on devices with smaller displays.

## How to test this
1. Access SuiteCRM on a screen with a width less than 1560px (e.g., by resizing your browser window).
2. Click on the magnifying glass icon to enable the global search.
3. Observe that the input field is enabled and automatically receives focus, allowing you to start typing immediately without an additional click.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code refactoring or cleanup)
- [ ] Performance improvement (a change that improves code execution performance)
- [ ] Other (please describe):

### final checklist
- [x] I have reviewed my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Add new tests to ensure this change has no regressions
- [x] All new and existing tests passed