### PR TITLE
Fix #10693 - Incorrect security group inheritance on record modification

### DIFF
--- a/modules/SecurityGroups/SecurityGroup.php
+++ b/modules/SecurityGroups/SecurityGroup.php
@@ -191,7 +191,7 @@ class SecurityGroup extends SecurityGroup_sugar
         global $sugar_config;
         self::assign_default_groups($focus, $isUpdate); //this must be first because it does not check for dups
 
-        self::inherit_assigned($focus);
+        self::inherit_assigned($focus, $isUpdate);
         self::inherit_parent($focus, $isUpdate);
 
         //don't do creator inheritance if popup selector method is chosen and a user is making the request...
@@ -298,10 +298,10 @@ class SecurityGroup extends SecurityGroup_sugar
     /**
      * @param SugarBean $focus
      */
-    public static function inherit_assigned($focus)
+    public static function inherit_assigned($focus, $isUpdate)
     {
         global $sugar_config;
-        if (isset($sugar_config['securitysuite_inherit_assigned']) && $sugar_config['securitysuite_inherit_assigned'] == true) {
+        if (isset($sugar_config['securitysuite_inherit_assigned']) && $sugar_config['securitysuite_inherit_assigned'] == true && $isUpdate == false) {
             if (!empty($focus->assigned_user_id)) {
                 $assigned_user_id = $focus->db->quote($focus->assigned_user_id);
                 //inherit only for those that support Security Groups


### PR DESCRIPTION
## Description
This pull request modifies the Security Suite's "Inherit from Assigned To User" functionality to ensure that security group inheritance only occurs upon the **creation** of a new record. Subsequent modifications to the record will no longer trigger the re-application of the assigned user's security groups.

- resolve #10693 

## Motivation and Context
The previous behavior led to inconsistent security group assignments and potential data access issues for records that had been modified after their initial creation. This fix ensures that the "Inherit from Assigned To User" setting functions as intended, providing more predictable and correct security group management within SuiteCRM.

## How To Test This
1.  **Enable "Inherit from Assigned To User"**: Navigate to Admin > Security Suite Settings and ensure only "Inherit from Assigned To User" is checked.
2.  **Create User and Groups**: Create a new user (e.g., `test_user`) and assign them to two or more security groups (e.g., "Group A", "Group B").
3.  **Create a New Record**:
    * Create a new record in a module (e.g., Contacts, Accounts).
    * Set the "Assigned To" field to `test_user`.
    * Save the record.
    * **Verify Initial Inheritance**: Check the security subpanel for the newly created record. It should now correctly display "Group A" and "Group B" inherited from `test_user`.
4.  **Remove Security Groups**:
    * From the record's security subpanel, remove "Group A" and "Group B" manually. Save the changes.
5.  **Modify the Record**:
    * Edit the record (e.g., change the description, update a phone number).
    * Save the changes.
6.  **Verify No Re-Inheritance**: Check the security subpanel again. "Group A" and "Group B" **should not** have been re-added to the record. If they are not present, the fix is working correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [X] My change requires a change to the documentation. **It might be a good idea to explicitly state in the documentation that security group inheritance applies only at the time of record creation.**
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->