### PR TITLE
Fix #10621 - Localize checkbox values in PDF templates

### DIFF
--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -90,9 +90,9 @@ class templateParser
                     $repl_arr[$key . "_" . $fieldName] = (string)$focus->$fieldName;
                 } elseif ($field_def['type'] == 'bool') {
                     if ($focus->{$fieldName} == "1") {
-                        $repl_arr[$key . "_" . $fieldName] = "true";
+                        $repl_arr[$key . "_" . $fieldName] = translate('checkbox_dom', '', '1');
                     } else {
-                        $repl_arr[$key . "_" . $fieldName] = "false";
+                        $repl_arr[$key . "_" . $fieldName] = translate('checkbox_dom', '', '2');
                     }
                 } elseif ($field_def['type'] == 'image') {
                     $secureLink = $sugar_config['site_url'] . '/' . "public/" . $focus->id . '_' . $fieldName;


### PR DESCRIPTION
## Description
Previously, checkbox fields in PDF templates always displayed as "true" or "false" in English, regardless of the user's language settings. This fix replaces the hardcoded strings with calls to the translate() function using the existing 'checkbox_dom' language list, ensuring checkbox values are properly localized.

## Motivation and Context
- Checkbox values now display as "Yes"/"No" in English
- Values are properly translated for other installed language packs
- Administrators can customize these values through language files

## How To Test This
  1. Create a PDF Template:
    - Go to Admin → PDF Templates (or AOS → PDF Templates)
    - Click Create PDF Template
    - Select a module that has checkbox fields (e.g., Accounts, Contacts)
    - In the template body, add checkbox field variables like:
    Active Status: $account_active_c
  Email Opt Out: $email_opt_out
  Do Not Call: $do_not_call
  2. Create/Edit a Record:
    - Go to the module you selected (e.g., Accounts)
    - Create or edit a record
    - Set some checkbox fields to checked (Yes) and others unchecked (No)
    - Save the record
  3. Generate the PDF:
    - Open the record you created
    - Click Actions → Print as PDF
    - Select your template
    - Generate the PDF
  4. Verify Results:
    - Checkbox values should show as "Yes" or "No" (in English)
    - Not as "true", "false", "1", or "0"
    - If using other languages, should show localized values

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
 [ X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
[X ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
