### PR TITLE
Fix #10722 - Set date_entered after save update

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -2369,9 +2369,6 @@ class SugarBean
             $this->save_relationship_changes($isUpdate);
             $GLOBALS['saving_relationships'] = false;
         }
-        if ($isUpdate && !$this->update_date_entered) {
-            unset($this->date_entered);
-        }
         // call the custom business logic
         $custom_logic_arguments = [];
         $custom_logic_arguments['check_notify'] = $check_notify;
@@ -2411,7 +2408,15 @@ class SugarBean
         $this->_sendNotifications($check_notify);
 
         if ($isUpdate) {
+            $tmp_date_entered = $this->date_entered;
+            if (!empty($this->fetched_row['date_entered'])) {
+                $tmp_date_entered = $this->fetched_row['date_entered'];
+            }
+            if (!$this->update_date_entered) {
+                unset($this->date_entered);
+            }
             $this->db->update($this);
+            $this->date_entered = $tmp_date_entered;
         } else {
             $this->db->insert($this);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Re-sets date_entered after an update save

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix for issue #10722 - prevents crashes on Workflow valid bean check after save

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create multiple Workflows, calling modify record and/or calculate fields
2. Create and save an appropriate record, ensuring any Workflow Conditions are met
3. The Workflows should run and complete without error

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->