### PR TITLE
Fix #10535 - Error when changing relationships

### DIFF
--- a/modules/ModuleBuilder/parsers/parser.label.php
+++ b/modules/ModuleBuilder/parsers/parser.label.php
@@ -276,15 +276,15 @@ class ParserLabel
         // will overwrite stuff in custom/modules/{ModuleName}/Ext/Language/en_us.lang.ext.php after
         //  Quick Repair and Rebuild is applied.
         if ($forRelationshipLabel) {
-            if (!empty($_POST[view_module]) && !empty($_POST[relationship_name]) && !empty($_POST[rhs_label]) && !empty($_POST[lhs_module])) {
+            if (!empty($_POST['view_module']) && !empty($_POST['relationship_name']) && !empty($_POST['rhs_label']) && !empty($_POST['lhs_module'])) {
                 // 1. Overwrite custom/Extension/modules/{ModuleName}/Ext/Language
                 $extension_basepath = 'custom/Extension/modules/'.$_POST[view_module].'/Ext/Language';
-                mkdir_recursive($extension_basepath);
+                mkdir_recursive($extension_basepath);[
 
                 $headerString = "<?php\n//THIS FILE IS AUTO GENERATED, DO NOT MODIFY\n";
                 $out = $headerString;
 
-                $extension_filename = "$extension_basepath/$language.custom".$_POST[relationship_name].'.php';
+                $extension_filename = "$extension_basepath/$language.custom".$_POST['relationship_name'].'.php';
 
                 $mod_strings = array();
                 if (file_exists($extension_filename)) {
@@ -294,8 +294,8 @@ class ParserLabel
 
                 foreach ($labels as $key => $value) {
                     foreach ($mod_strings as $key_mod_string => $value_mod_string) {
-                        if (strpos($key_mod_string, strtoupper($_POST[relationship_name])) !== false) {
-                            $mod_strings[$key_mod_string] = to_html(strip_tags(from_html($_POST[rhs_label]))); // must match encoding used in view.labels.php
+                        if (strpos($key_mod_string, strtoupper($_POST['relationship_name'])) !== false) {
+                            $mod_strings[$key_mod_string] = to_html(strip_tags(from_html($_POST['rhs_label']))); // must match encoding used in view.labels.php
                         }
                     }
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Array keys that should be strings are instead passed as non existing constants


## Description
I got the issue when editing and saving a M2M relationship. Just opening it, editing a name and saving it was enough to get it.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
