### PR TITLE
SugarApplication::redirect adds "Location", calling with "Location" doubles it result is not working

### DIFF
--- a/modules/Users/User.php
+++ b/modules/Users/User.php
@@ -684,7 +684,7 @@ class User extends Person implements EmailInterface
 
         if (!$this->verify_data()) {
             SugarApplication::appendErrorMessage($this->error_string);
-            return SugarApplication::redirect('Location: index.php?action=Error&module=Users');
+            return SugarApplication::redirect('index.php?action=Error&module=Users');
         }
 
         if (
@@ -718,11 +718,11 @@ class User extends Person implements EmailInterface
             if (!$this->change_password($_POST['old_password'], $_POST['new_password'])) {
                 if (isset($_POST['page']) && $_POST['page'] === 'EditView') {
                     SugarApplication::appendErrorMessage($this->error_string);
-                    SugarApplication::redirect("Location: index.php?action=EditView&module=Users&record=" . $_POST['record']);
+                    SugarApplication::redirect("index.php?action=EditView&module=Users&record=" . $_POST['record']);
                 }
                 if (isset($_POST['page']) && $_POST['page'] === 'Change') {
                     SugarApplication::appendErrorMessage($this->error_string);
-                    SugarApplication::redirect("Location: index.php?action=ChangePassword&module=Users&record=" . $_POST['record']);
+                    SugarApplication::redirect("index.php?action=ChangePassword&module=Users&record=" . $_POST['record']);
                 }
             }
         }


### PR DESCRIPTION
SugarApplication::redirect adds "Location", calling with "Location" doubles it result is not working

SugarApplication::redirect add "Location", calling with "Location" doubles it result is not working

Maybe the same for line 721 and 725.

Reproduce: 
Add User
Add User with same username, results in error in browser console:

index.php?module=Use…action=DetailView:1 Failed to launch 'location:%20index.php?action=Error&module=Users' because the scheme does not have a registered handler.

And the User already exists error does not show
