### PR TITLE
Enhanced Feature: Added Redis Password and configuration documentation to SugarCacheRedis.php

### DIFF
--- a/include/SugarCache/SugarCacheRedis.php
+++ b/include/SugarCache/SugarCacheRedis.php
@@ -38,6 +38,14 @@
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
+/**
+ * Redis database number
+ * Can be overridden in config_override.php:
+ * $sugar_config['external_cache']['redis']['host'] = 'localhost';
+ * $sugar_config['external_cache']['redis']['port'] = 6379;
+ * $sugar_config['external_cache']['redis']['password'] = 'Your-Password';
+ * $sugar_config['external_cache']['redis']['database'] = 0;
+ */
 
 require_once('include/SugarCache/SugarCacheAbstract.php');
 
@@ -56,6 +64,16 @@ class SugarCacheRedis extends SugarCacheAbstract
      */
     protected $_port = 6379;
     
+    /**
+     * @var Redis password string
+     */
+    protected $_password = '';
+    
+    /**
+     * @var Redis database number int
+     */
+    protected $_database = 0;
+
     /**
      * @var Redis object
      */
@@ -102,8 +120,16 @@ class SugarCacheRedis extends SugarCacheAbstract
                 $this->_redis = new Redis();
                 $this->_host = SugarConfig::getInstance()->get('external_cache.redis.host', $this->_host);
                 $this->_port = SugarConfig::getInstance()->get('external_cache.redis.port', $this->_port);
+                $this->_password = SugarConfig::getInstance()->get('external_cache.redis.password', $this->_password);
+                $this->_database = SugarConfig::getInstance()->get('external_cache.redis.database', $this->_database);
                 if (!$this->_redis->connect($this->_host, $this->_port)) {
                     return false;
+                }
+                if (!empty($this->_password)) {
+                    $this->_redis->auth($this->_password);
+                }
+                if ($this->_database > 0) {
+                    $this->_redis->select($this->_database);
                 }
             }
         } catch (RedisException $e) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Existing Redis integration does not support Redis authentication. This change adds support for Redis passwords for enhanced security. 

## Description

- Added a few lines of code to enable the Redis password.

## Motivation and Context

On servers with shared Redis, it's important to secure the Redis database from other users and services. I have been using the most recent version of SuiteCRM 8.9.x for a few months. Every upgrade overwrites my changes and crashes SuiteCRM until we replace the SugarCacheRedis.php file or remove the extra lines from config_override.php, a major headache that causes a bit of downtime.

## How To Test This

- Set up Redis with authentication enabled.
- Enter your settings in the config_override.php file in the example below.
- Enter redis-cli or valkey-cli and look for populated values of the assigned database.

## Configuration Example (config_override.php)
Users can now see that this property can be configured with:
$sugar_config['external_cache']['redis']['host'] = 'localhost';
$sugar_config['external_cache']['redis']['port'] = 6379;
$sugar_config['external_cache']['redis']['password'] = 'YOURPASSWORD';
$sugar_config['external_cache']['redis']['database'] = 1;

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ X ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ X ] My change requires a change to the documentation.
- [ X ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->