### PR TITLE
Fix #9450 - Prevent Spaces in Grouped Report Ids

### DIFF
--- a/modules/AOR_Reports/AOR_Report.js
+++ b/modules/AOR_Reports/AOR_Report.js
@@ -197,7 +197,7 @@ function changeReportPage(record, offset, group_value, table_id) {
 
   $.get(query).done(
     function (data) {
-      $('#report_table_' + table_id + group_value).replaceWith(data);
+      $('#report_table_' + table_id).replaceWith(data);
     }
   );
 }

--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -584,6 +584,8 @@ class AOR_Report extends Basic
                     $groupDisplay = $app_strings['LBL_NONE'];
                 }
 
+                $reportGroupID = create_guid();
+
                 // Fix #5427 If download pdf then not use tab-content and add css inline to work with mpdf
                 $pdf_style = "";
                 $action = $_REQUEST['action'];
@@ -593,21 +595,21 @@ class AOR_Report extends Basic
 
                 $html .= '<div class="panel panel-default">
                             <div class="panel-heading" style="' . $pdf_style . '">
-                                <a class="" role="button" data-toggle="collapse" href="#detailpanel_report_group_' . $groupValue . '" aria-expanded="false">
+                                <a class="" role="button" data-toggle="collapse" href="#detailpanel_report_group_' . $reportGroupID . '" aria-expanded="false">
                                     <div class="col-xs-10 col-sm-11 col-md-11">
                                         ' . $groupDisplay . '
                                     </div>
                                 </a>
                             </div>';
                 if ($action != 'DownloadPDF') {
-                    $html .= '<div class="panel-body panel-collapse collapse in" id="detailpanel_report_group_' . $groupValue . '">
+                    $html .= '<div class="panel-body panel-collapse collapse in" id="detailpanel_report_group_' . $reportGroupID . '">
                                 <div class="tab-content">';
                 } else {
                     $html .= '</div>';
                 }
 
 
-                $html .= $this->build_report_html($offset, $links, $groupValue, create_guid(), $extra);
+                $html .= $this->build_report_html($offset, $links, $groupValue, $reportGroupID, $extra);
                 $html .= ($action == 'downloadPDF') ? '' : '</div></div></div>';
                 // End
             }
@@ -656,7 +658,7 @@ class AOR_Report extends Basic
         }
 
         $html = '<div class="list-view-rounded-corners">';
-        $html.='<table id="report_table_'.$tableIdentifier.$group_value.'" width="100%" border="0" class="list view table-responsive aor_reports">';
+        $html.='<table id="report_table_'.$tableIdentifier.'" width="100%" border="0" class="list view table-responsive aor_reports">';
 
         $sql = "SELECT id FROM aor_fields WHERE aor_report_id = '" . $this->id . "' AND deleted = 0 ORDER BY field_order ASC";
         $result = $this->db->query($sql);

--- a/modules/AOR_Reports/Dashlets/AORReportsDashlet/dashlet.tpl
+++ b/modules/AOR_Reports/Dashlets/AORReportsDashlet/dashlet.tpl
@@ -9,6 +9,7 @@
                                 record : record,
                                 offset : offset,
                                 table_id : table_id,
+                                group: group_value,
                                 'parameter_id' : params['ids'],
                                 'parameter_operator' : params['operators'],
                                 'parameter_type' : params['types'],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
Fixes an issue where using the group value label in the html id of a grouped report section causes issues with pagination and panel opening/closing

Also fixes an issue where grouped reports in a report Dashlet paginates incorrectly due to the missing group value in the js click function

## How To Test This

1. Create a report on Contacts and set the Main Group to Job Title
2. Make sure there are job titles containing spaces in the report data and that there are enough results to require pagination for the group section.
3. See that Job Titles with spaces in them do not paginate
4. See that the Group panel does not close when clicked

Dashlet issue
1. Add a reports dashlet with the same report
2. See that pagination causes multiple groups to paginate and breaks the report.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->