### PR TITLE
Fix #10780 issue with language file being overwritten

### DIFF
--- a/include/CalendarSync/infrastructure/registry/CalendarProviderRegistry.php
+++ b/include/CalendarSync/infrastructure/registry/CalendarProviderRegistry.php
@@ -49,6 +49,7 @@ class CalendarProviderRegistry
 {
 
     protected const EXTENSION_BASE_PATH = 'include/CalendarSync/Extension/CalendarProviders';
+    protected const LANGUAGE_EXTENSION_PATH = 'custom/Extension/application/Ext/Language';
     /** @var array<string, CalendarProviderType>|null */
     protected static array|null $cachedProviders = null;
     /** @var array<string, CalendarProviderType> */
@@ -164,37 +165,110 @@ class CalendarProviderRegistry
     }
 
     /**
-     * Writes calendar source types to language extension files for custom application configuration.
-     * Ensures directories exist and properly writes override labels for calendar source types.
+     * Writes calendar source types to the dedicated language extension file and triggers
+     * a language rebuild so the consolidated file is updated safely.
+     * Only writes when the source types have actually changed (new providers, modifications, or removals).
      *
      * @return void
      */
-    protected function writeCalendarSourceTypesToExtension(): void
-    {
+    protected function writeCalendarSourceTypesToExtension(): void {
         require_once 'include/utils.php';
         require_once 'include/utils/file_utils.php';
 
         $language = get_current_language();
-        $calendar_source_types = $this->getCalendarSourceTypes();
+        $calendarSourceTypes = $this->getCalendarSourceTypes();
 
-        if (empty($calendar_source_types)) {
+        if (empty($calendarSourceTypes)) {
             return;
         }
 
+        if ($this->languageExtensionMatchesSourceTypes($language, $calendarSourceTypes)) {
+            return;
+        }
+
+        $this->writeLanguageExtension($language, $calendarSourceTypes);
+        $this->rebuildLanguageCache($language);
+    }
+
+    /**
+     * Returns the path to the dedicated language extension file for the calendar registry.
+     *
+     * @param string $language The language code (e.g. 'en_us')
+     *
+     * @return string
+     */
+    protected function getLanguageExtensionPath(string $language): string {
+        return self::LANGUAGE_EXTENSION_PATH . "/$language.registry_calendar.php";
+    }
+
+    /**
+     * Checks whether the existing language extension file already contains the given source types.
+     *
+     * @param string                $language            The language code
+     * @param array<string, string> $calendarSourceTypes The current source types from the registry
+     *
+     * @return bool
+     */
+    protected function languageExtensionMatchesSourceTypes(string $language, array $calendarSourceTypes): bool {
+        $path = $this->getLanguageExtensionPath($language);
+
+        if (!file_exists($path)) {
+            return false;
+        }
+
+        $app_list_strings = [];
+        include $path;
+
+        $existingTypes = $app_list_strings['calendar_source_types'] ?? [];
+
+        ksort($existingTypes);
+        ksort($calendarSourceTypes);
+
+        return $existingTypes === $calendarSourceTypes;
+    }
+
+    /**
+     * Writes calendar source types to the dedicated language extension file.
+     *
+     * @param string                $language            The language code
+     * @param array<string, string> $calendarSourceTypes The source types to write
+     *
+     * @return void
+     */
+    protected function writeLanguageExtension(string $language, array $calendarSourceTypes): void {
+        global $log;
+        $path = $this->getLanguageExtensionPath($language);
+
+        if (!is_dir(dirname($path))
+            && !mkdir($concurrentDirectory = dirname($path), 0755, true)
+            && !is_dir($concurrentDirectory)) {
+            throw new RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
+        }
+
         $theName = "app_list_strings['calendar_source_types']";
+        write_override_label_to_file($theName, $calendarSourceTypes, $path);
 
-        $registryLanguageExtensionPath = "custom/Extension/application/Ext/Language/$language.registry_calendar.php";
-        $languageExtensionPath = "custom/application/Ext/Language/$language.lang.ext.php";
+        $log->debug("[CalendarProviderRegistry][writeLanguageExtension] Updated language extension for $language");
+    }
 
-        if (!is_dir(dirname($registryLanguageExtensionPath)) && !mkdir($concurrentDirectory = dirname($registryLanguageExtensionPath), 0755, true) && !is_dir($concurrentDirectory)) {
-            throw new RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
-        }
-        if (!is_dir(dirname($languageExtensionPath)) && !mkdir($concurrentDirectory = dirname($languageExtensionPath), 0755, true) && !is_dir($concurrentDirectory)) {
-            throw new RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
-        }
+    /**
+     * Rebuilds the consolidated language file and clears the cache.
+     *
+     * @param string $language The language code to rebuild
+     *
+     * @return void
+     */
+    protected function rebuildLanguageCache(string $language): void {
+        global $log;
+        require_once 'ModuleInstall/ModuleInstaller.php';
 
-        write_override_label_to_file($theName, $calendar_source_types, $registryLanguageExtensionPath);
-        write_override_label_to_file($theName, $calendar_source_types, $languageExtensionPath, 'a');
+        $mi = new ModuleInstaller();
+        $mi->silent = true;
+        $mi->rebuild_languages([$language => $language]);
+
+        sugar_cache_clear('app_list_strings.' . $language);
+
+        $log->debug("[CalendarProviderRegistry][rebuildLanguageCache] Rebuilt language cache for $language");
     }
 
     /**


### PR DESCRIPTION
Remove function and function call from constructor as its it not required

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
The Calendar sync overwrites the contents of custom/application/Ext/Language/en_us.lang.ext.php

Add check to see if a new provider has been added prior to rebuilding the language file

Once this file has been updated a Quick Repair and Rebuild will add the contents to en_us.lang.ext.php
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
When custom/application/Ext/Language/en_us.lang.ext.php is overwritten dropdown and module titles are removed

<!--- Why is this change required? What problem does it solve? -->

## How To Test This
Save meeting and see language ext file is not overwritten
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->