### PR TITLE
REL #9788 Remove outer ( ) from query.

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -875,7 +875,7 @@ class SugarBean
                     $final_query .= ' UNION ALL ( ' . $tmp_final_query . ' )';
                 } else {
                     $final_query_rows = '(' . $parentbean->create_list_count_query($tmp_final_query, $parameters) . ')';
-                    $final_query = '(' . $tmp_final_query . ')';
+                    $final_query = $tmp_final_query;
                     $first = false;
                 }
             }
@@ -929,7 +929,6 @@ class SugarBean
                     $query = ' UNION ALL ( ' . $query . ' )';
                     $final_query_rows .= " UNION ALL ";
                 } else {
-                    $query = '(' . $query . ')';
                     $first = false;
                 }
                 $query_array = $subquery['query_array'];


### PR DESCRIPTION
Changes implemented in MySQL 8.0.31 cause SQL queries that pull data for subpannels to fail. If the outer ( ) is removed from the query, it will complete normally.

Issues #9788

Issues duplicated #10119 #10515

Same PR as https://github.com/SuiteCRM/SuiteCRM/pull/9843 but it was closed without merging. 

##  Description
Changes implemented in MySQL 8.0.31 cause SQL queries that pull data for subpannels to fail. If the outer ( ) is removed from the query, it will complete normally.

The code that adds the outer ( ) to the query is located on lines Suite CRM/data/SugarBean.php. By removing these lines the query if fixed.

## Motivation and Context
If the MySQL environment is updated to MySQL 8.0.31 the subpannels that depend on these SQL queries will fail.

## How To Test
1. Update MySQL to 8.0.31 on host server
2. Create Account with linked subpanel data (contacts, opportunities, leads, ect)
3. Subpanels must have data for the error to occur.
4. Open Account detail page & suitecrm.log to see error.
5. Apply PR and tests again. 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->