### PR TITLE
Fix SuiteCRM#8400 - Add definitions for js vars SUGAR.measurements and UA when show_header is false

### DIFF
--- a/include/MVC/View/SugarView.php
+++ b/include/MVC/View/SugarView.php
@@ -971,6 +971,8 @@ JS;
 <html {$langHeader}>
 <head>
 EOHTML;
+                echo SugarThemeRegistry::current()->getJS();
+                echo "<script type='text/javascript'> UA = YAHOO.env.ua; </script>";
             }
 
             $js_vars = array(


### PR DESCRIPTION
## Description

Setting show_header option to false in any view avoids rendering some specific javascript files and lines.

Particulary when using subpanels in the view, the definitions of js variables UA (which is in _head.tpl) and SUGAR.measurements (in style.js) are missing.

These are used in SubPanelTiles.js and SubPanelTiles.tpl with no previous checking on their value. This throws javascript errors which end up stopping further execution.


Fixes #8400

## Motivation and Context

See https://github.com/SuiteCRM/SuiteCRM/issues/8400

## How To Test This

1. Set show_header option to false in any DetailView.
2. Set subpaneldefs to show a subpanel.
3. Access the view.
4. Check that no js errors are thrown with devtools on the browser. https://github.com/SuiteCRM/SuiteCRM/issues/8400

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->