### PR TITLE
CORE issue 10805 Email history(body) not preserved when replying to an email

### DIFF
--- a/modules/Emails/EmailsController.php
+++ b/modules/Emails/EmailsController.php
@@ -872,7 +872,7 @@ class EmailsController extends SugarController
         }
 
         // Move body into original message
-        if (!empty($this->bean->description_html)) {
+        /*if (!empty($this->bean->description_html)) {
             $this->bean->description = '<br>' . $mod_strings['LBL_ORIGINAL_MESSAGE_SEPARATOR'] . '<br>' .
                 $this->bean->description_html;
         } else {
@@ -882,7 +882,15 @@ class EmailsController extends SugarController
             }
         }
 
-        $this->bean->description_html = '';
+        $this->bean->description_html = '';*/
+
+        if (!empty($this->bean->description_html)) {
+            $this->bean->description = $this->bean->description_html;
+        } else {
+            if (!empty($this->bean->description)) {
+                $this->bean->description = $this->bean->description;
+            }
+        }
     }
 
 


### PR DESCRIPTION
## Description

Fixed an issue where the e-mail history was not preserved when replying to an e-mail.

When using the "Reply" action on an existing e-mail, the original message content was not included in the reply body. This resulted in missing conversation history and made it difficult to track previous communication.

This fix ensures that the original e-mail content is properly appended to the reply body when generating a reply.

## Related Issue

Email history not preserved when replying to an e-mail.

(If you created a GitHub issue, replace this line with: Fixes #ISSUE_NUMBER)

## Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How to Test

1. Open an existing e-mail in SuiteCRM.
2. Click the **Reply** button.
3. Verify that the original e-mail content is included in the reply body.
4. Send the reply and confirm that the e-mail history is preserved.

## Notes

This is a CORE fix related to the reply message generation logic in the Emails module.

File :
/modules/Emails/EmailsController.php