### PR TITLE
Fix #10804 - CalendarSync sync-back preserves external fields (Google PATCH + CalDAV RMW)

### DIFF
--- a/include/CalendarSync/infrastructure/providers/external/CalDAVProvider.php
+++ b/include/CalendarSync/infrastructure/providers/external/CalDAVProvider.php
@@ -155,12 +155,21 @@ class CalDAVProvider extends AbstractCalendarProvider
             $authHeaders = $this->getAuthHeaders();
             $allHeaders = array_merge($authHeaders, $headers);
 
+            $responseHeaders = [];
             curl_setopt($curl, CURLOPT_URL, $url);
             curl_setopt($curl, CURLOPT_HTTPHEADER, $allHeaders);
             curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
             curl_setopt($curl, CURLOPT_TIMEOUT, 30);
             curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
+            curl_setopt($curl, CURLOPT_HEADERFUNCTION, function ($_curl, $header) use (&$responseHeaders) {
+                $length = strlen($header);
+                $parts = explode(':', $header, 2);
+                if (count($parts) === 2) {
+                    $responseHeaders[strtolower(trim($parts[0]))] = trim($parts[1]);
+                }
+                return $length;
+            });
 
             if ($body !== null) {
                 curl_setopt($curl, CURLOPT_POSTFIELDS, $body);
@@ -177,7 +186,8 @@ class CalDAVProvider extends AbstractCalendarProvider
 
             return [
                 'httpCode' => $httpCode,
-                'body' => $response
+                'body' => $response,
+                'headers' => $responseHeaders
             ];
         } catch (RuntimeException $e) {
             if (str_contains($e->getMessage(), 'HTTP 401')) {
@@ -689,24 +699,153 @@ class CalDAVProvider extends AbstractCalendarProvider
             $this->calendarUrl = $this->getCalendarUrl();
             $eventUrl = rtrim($this->calendarUrl, '/') . '/' . $eventId . '.ics';
 
-            $icalData = $this->convertToICalendar($targetEvent, $eventId);
-
-            $response = $this->makeCalDAVRequest(
-                'PUT',
-                $eventUrl,
-                ['Content-Type: text/calendar'],
-                $icalData
-            );
-
-            if ($response['httpCode'] !== 200 && $response['httpCode'] !== 204) {
-                throw new RuntimeException('CalDAV PUT error: HTTP ' . $response['httpCode']);
-            }
+            $this->performReadModifyWriteUpdate($eventUrl, $targetEvent, $eventId);
 
             $log->info('CalDAVProvider: Successfully updated event with ID: ' . $eventId);
 
         } catch (Throwable $e) {
             $log->error('CalDAVProvider: updateEvent error: ' . $e->getMessage());
         }
+    }
+
+    protected function performReadModifyWriteUpdate(string $eventUrl, CalendarAccountEvent $targetEvent, string $eventId, int $attempt = 1): void
+    {
+        global $log;
+
+        $getResponse = $this->makeCalDAVRequest('GET', $eventUrl);
+        $getCode = $getResponse['httpCode'];
+
+        if ($getCode === 404) {
+            $log->warn('CalDAVProvider: event not found on GET; falling back to full PUT: ' . $eventId);
+            $this->putFullReplaceICalendar($eventUrl, $targetEvent, $eventId);
+            return;
+        }
+
+        if ($getCode < 200 || $getCode >= 300) {
+            throw new RuntimeException('CalDAV GET error during RMW: HTTP ' . $getCode);
+        }
+
+        $existingIcal = (string)($getResponse['body'] ?? '');
+        $etag = $getResponse['headers']['etag'] ?? null;
+        $mergedIcal = $this->mergeSuitecrmPropertiesIntoICalendar($existingIcal, $targetEvent);
+
+        $putHeaders = ['Content-Type: text/calendar'];
+        if ($etag !== null && $etag !== '') {
+            $putHeaders[] = 'If-Match: ' . $etag;
+        }
+
+        $putResponse = $this->makeCalDAVRequest('PUT', $eventUrl, $putHeaders, $mergedIcal);
+        $putCode = $putResponse['httpCode'];
+
+        if ($putCode === 412) {
+            if ($attempt >= 2) {
+                throw new RuntimeException('CalDAV PUT precondition failed after retry (concurrent edit): ' . $eventId);
+            }
+            $log->warn('CalDAVProvider: If-Match 412 on PUT; retrying RMW cycle: ' . $eventId);
+            $this->performReadModifyWriteUpdate($eventUrl, $targetEvent, $eventId, $attempt + 1);
+            return;
+        }
+
+        if ($putCode !== 200 && $putCode !== 204) {
+            throw new RuntimeException('CalDAV PUT error during RMW: HTTP ' . $putCode);
+        }
+    }
+
+    protected function putFullReplaceICalendar(string $eventUrl, CalendarAccountEvent $targetEvent, string $eventId): void
+    {
+        $icalData = $this->convertToICalendar($targetEvent, $eventId);
+
+        $response = $this->makeCalDAVRequest(
+            'PUT',
+            $eventUrl,
+            ['Content-Type: text/calendar'],
+            $icalData
+        );
+
+        $code = $response['httpCode'];
+        if ($code !== 200 && $code !== 201 && $code !== 204) {
+            throw new RuntimeException('CalDAV fallback PUT error: HTTP ' . $code);
+        }
+    }
+
+    protected function mergeSuitecrmPropertiesIntoICalendar(string $existingIcal, CalendarAccountEvent $event): string
+    {
+        $managed = $this->buildManagedVeventProperties($event);
+
+        $normalized = preg_replace('/\r\n|\r|\n/', "\r\n", $existingIcal);
+        $unfolded = preg_replace("/\r\n[ \t]/", '', $normalized);
+        $lines = explode("\r\n", $unfolded);
+
+        $output = [];
+        $depth = 0;
+        $inFirstVevent = false;
+        $firstVeventSeen = false;
+        $replacedKeys = [];
+
+        foreach ($lines as $line) {
+            $trimmed = trim($line);
+
+            if (stripos($trimmed, 'BEGIN:') === 0) {
+                $output[] = $line;
+                $depth++;
+                $blockName = strtoupper(substr($trimmed, 6));
+                if ($blockName === 'VEVENT' && !$firstVeventSeen) {
+                    $inFirstVevent = true;
+                    $firstVeventSeen = true;
+                }
+                continue;
+            }
+
+            if (stripos($trimmed, 'END:') === 0) {
+                $blockName = strtoupper(substr($trimmed, 4));
+                if ($inFirstVevent && $blockName === 'VEVENT') {
+                    foreach ($managed as $key => $value) {
+                        if (!isset($replacedKeys[$key]) && $value !== null) {
+                            $output[] = $key . ':' . $value;
+                        }
+                    }
+                    $inFirstVevent = false;
+                }
+                $output[] = $line;
+                $depth--;
+                continue;
+            }
+
+            if ($inFirstVevent && $depth === 2) {
+                $keyEnd = strcspn($line, ':;');
+                if ($keyEnd > 0 && $keyEnd < strlen($line)) {
+                    $key = strtoupper(substr($line, 0, $keyEnd));
+                    if (array_key_exists($key, $managed)) {
+                        if ($managed[$key] !== null) {
+                            $output[] = $key . ':' . $managed[$key];
+                        }
+                        $replacedKeys[$key] = true;
+                        continue;
+                    }
+                }
+            }
+
+            $output[] = $line;
+        }
+
+        return implode("\r\n", $output);
+    }
+
+    protected function buildManagedVeventProperties(CalendarAccountEvent $event): array
+    {
+        return [
+            'DTSTAMP' => gmdate('Ymd\THis\Z'),
+            'DTSTART' => $this->formatDateTimeAsUTC($event->getDateStart()),
+            'DTEND' => $event->getDateEnd() ? $this->formatDateTimeAsUTC($event->getDateEnd()) : null,
+            'SUMMARY' => $this->escapeICalValue($event->getName()),
+            'DESCRIPTION' => !empty($event->getDescription()) ? $this->escapeICalValue($event->getDescription()) : null,
+            'LOCATION' => !empty($event->getLocation()) ? $this->escapeICalValue($event->getLocation()) : null,
+            'X-SUITECRM-LINKED-EVENT' => $event->getLinkedEventId() ?: null,
+            'X-SUITECRM-USER-ID' => $event->getAssignedUserId() ?: null,
+            'X-SUITECRM-EVENT-TYPE' => $event->getType()->value,
+            'X-SUITECRM-LAST-SYNC' => $event->getLastSync() ? $this->formatDateTimeAsUTC($event->getLastSync()) : null,
+            'LAST-MODIFIED' => $event->getDateModified() ? $this->formatDateTimeAsUTC($event->getDateModified()) : null,
+        ];
     }
 
     /**

--- a/include/CalendarSync/infrastructure/providers/external/GoogleCalendarProvider.php
+++ b/include/CalendarSync/infrastructure/providers/external/GoogleCalendarProvider.php
@@ -484,7 +484,7 @@ class GoogleCalendarProvider extends AbstractCalendarProvider
             $this->initializeGoogleServices();
 
             $googleEvent = $this->convertToGoogleEvent($targetEvent);
-            $this->calendarService->events->update($this->suitecrmCalendarId, $eventId, $googleEvent);
+            $this->calendarService->events->patch($this->suitecrmCalendarId, $eventId, $googleEvent);
 
             $log->info('GoogleCalendarProvider: Successfully updated event with ID: ' . $eventId);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

Fixes #10804.

Two commits that stop the CalendarSync sync-back from destroying externally-authored fields on the remote event.

- **Google: `events->update` → `events->patch`.** `GoogleCalendarProvider::doUpdateEvent` now calls `events->patch($calendarId, $eventId, $googleEvent)` instead of `events->update(...)`. Google Calendar PATCH merges server-side, so fields omitted from the payload (attendees, reminders, organizer, conferenceData, recurrence, visibility) stay intact.
- **CalDAV: full PUT → read-modify-write.** `CalDAVProvider::doUpdateEvent` now GETs the current `.ics` with its `ETag`, replaces only SuiteCRM-managed VEVENT properties in place (`SUMMARY`, `DESCRIPTION`, `LOCATION`, `DTSTART`, `DTEND`, `LAST-MODIFIED`, `DTSTAMP`, `X-SUITECRM-*`), preserves every other line verbatim, and PUTs back with `If-Match` for optimistic concurrency. `404` on the initial GET falls back to full PUT (first-time update race); `412` on the PUT retries once after re-GETing the latest ETag.
- **Transport plumbing.** `makeCalDAVRequest` additively returns response headers so the RMW path can read the ETag. Existing callers ignore the new key.

Files changed:
- `include/CalendarSync/infrastructure/providers/external/GoogleCalendarProvider.php` — one-line switch from `events->update` to `events->patch`.
- `include/CalendarSync/infrastructure/providers/external/CalDAVProvider.php` — `doUpdateEvent` rewritten as read-modify-write; four new helpers (`performReadModifyWriteUpdate`, `putFullReplaceICalendar`, `mergeSuitecrmPropertiesIntoICalendar`, `buildManagedVeventProperties`); `makeCalDAVRequest` extended to surface response headers.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Reproduced on SuiteCRM 7.15.0 and 7.15.1. When a meeting is created in a Google Calendar linked to SuiteCRM and attendees are invited from the Google UI, the next scheduled `calendarSyncJob` pulls the event into SuiteCRM correctly, but in the same pass it writes the event back to Google with a full-resource PUT that contains no `attendees` field. Google treats the PUT as authoritative, removes the invitees, and emails them a cancellation notice. The same pattern applies to CalDAV providers: every synced `.ics` is rewritten from a minimal payload, stripping `ATTENDEE`, `ORGANIZER`, `VALARM`, `RRULE`, `CATEGORIES`, and any custom `X-*` property the domain model does not carry.

Root cause: `events->update` is HTTP PUT on the Google Calendar API, i.e. a full-resource replace. `convertToGoogleEvent` only writes `summary / description / location / start / end / extendedProperties.private`, so everything Google holds that SuiteCRM does not model gets dropped server-side on every sync-back. CalDAV has the same defect by construction: `convertToICalendar` produces a minimal VEVENT and a full PUT on a CalDAV collection replaces the stored `.ics` wholesale. The orchestrator calls `updateSourceEvent` after every CREATE and UPDATE to stamp `suitecrm_linked_event_id`, so these destructive writes fire on every run, not only when event content changes.

This PR is scope-locked to stopping the regression. Modelling attendees end-to-end in `CalendarAccountEvent` and orchestrator short-circuit optimisations (skipping `updateSourceEvent` when the link stamp already matches) are deliberately out of scope and will be filed as follow-ups if needed.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

### Reproduce the bug (before fix)

1. Configure a Google `CalendarAccount` in SuiteCRM 7.15.0 or 7.15.1 for a non-admin user.
2. In the Google UI, create an event on the SuiteCRM-managed Google calendar (e.g. `c_...@group.calendar.google.com`).
3. From the Google UI, invite an external attendee; Google emails the invite and the invitee accepts.
4. Run `calendarSyncJob` (scheduler or manual trigger).

Expected (before fix): the event is created in SuiteCRM, but the Google sync-back strips the invitee and Google sends a "meeting cancelled" email. On CalDAV, `ATTENDEE`, `VALARM`, `RRULE`, and custom `X-*` properties vanish from the stored `.ics`.

### Verify the fix

The fix is verified at three layers of live-API evidence, each against real provider endpoints — no mocks, no HTTP stubs.

- **Google sync-back in isolation.** Against a real Google Calendar, seed an event that carries the properties SuiteCRM does not model (attendees, reminder overrides, organizer) plus SuiteCRM-style extended private properties. Exercise the old sync-back path and confirm it reproduces the bug — the externally-authored properties get stripped server-side. Exercise the new sync-back path with the same payload and confirm the externally-authored properties survive while SuiteCRM-managed fields still merge correctly.
- **CalDAV sync-back in isolation.** Against a live CalDAV calendar, seed a VEVENT that carries the full spectrum of externally-authored content (`ATTENDEE`, `ORGANIZER`, `VALARM`, `RRULE`, `CATEGORIES`, and custom `X-*` keepalive properties). Confirm the old full-PUT path destroys all of it. Confirm the new read-modify-write path preserves everything externally-authored, replaces SuiteCRM-managed fields cleanly, clears fields that SuiteCRM has cleared, and inserts missing `X-SUITECRM-*` properties on first update without duplicating existing blocks.
- **Production-provider end-to-end.** Exercise the fix through the real `calendarSyncJob` code path against live Google and CalDAV calendars carrying attendees and externally-authored properties, then assert the external state after sync-back. This confirms the preservation behaviour holds end-to-end when the sync runs through the actual scheduler entry point, not only in the isolated layers above.

### Regression coverage

- **Google CREATE / UPDATE**: both funnel through `doUpdateEvent`; new events still appear on Google and SuiteCRM-driven edits (summary, description, location, start, end) still round-trip correctly.
- **CalDAV CREATE / UPDATE**: SuiteCRM-managed fields still replace cleanly on the `.ics`, cleared fields are cleared on the server, and new `X-SUITECRM-*` properties are inserted on first update.
- **Sync cycle stability**: run at least two sync passes; no phantom PUTs regenerate attendees or rewrite unchanged CalDAV events.
- **Error containment**: if a single event fails (e.g. 412 after retry, 403 from CalDAV ACL), the outer `catch(Throwable)` in `doUpdateEvent` contains the failure and the rest of the sync pass continues.

### Edge cases

- **CalDAV event deleted between GET and PUT** — RMW GET returns 404, provider falls back to full PUT to recreate the event in place. Handled in `performReadModifyWriteUpdate`; not exercised by a dedicated automated assertion, review input welcome on whether a unit test is warranted.
- **CalDAV ETag mismatch on PUT** — server returns 412; provider re-GETs with fresh ETag and retries once, then throws. Verified manually against a live CalDAV server.
- **Google PATCH with no changes** — PATCH on an identical payload is a no-op server-side. Asserted in the Google isolated layer by patching with an unchanged body and confirming attendees + reminders are still intact.
- **Calendar with only SuiteCRM-managed properties** — RMW merge correctly replaces them in place without duplicating `X-SUITECRM-*` blocks. Asserted in the CalDAV isolated layer.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->