### PR TITLE
Fix #10825 - Truncated value when saving large values in workflow and report conditions

### DIFF
--- a/modules/AOR_Conditions/vardefs.php
+++ b/modules/AOR_Conditions/vardefs.php
@@ -161,7 +161,7 @@ $dictionary['AOR_Condition'] = array(
     'required' => false,
     'name' => 'value',
     'vname' => 'LBL_VALUE',
-    'type' => 'varchar',
+    'type' => 'text',
     'massupdate' => 0,
     'comments' => '',
     'help' => '',
@@ -172,7 +172,6 @@ $dictionary['AOR_Condition'] = array(
     'reportable' => true,
     'unified_search' => false,
     'merge_filter' => 'disabled',
-    'len' => '255',
     'size' => '20',
   ),
         'parameter' =>

--- a/modules/AOW_Conditions/vardefs.php
+++ b/modules/AOW_Conditions/vardefs.php
@@ -147,7 +147,7 @@ $dictionary['AOW_Condition'] = array(
     'required' => false,
     'name' => 'value',
     'vname' => 'LBL_VALUE',
-    'type' => 'varchar',
+    'type' => 'text',
     'massupdate' => 0,
     'comments' => '',
     'help' => '',
@@ -158,7 +158,6 @@ $dictionary['AOW_Condition'] = array(
     'reportable' => true,
     'unified_search' => false,
     'merge_filter' => 'disabled',
-    'len' => '255',
     'size' => '20',
   ),
   'aow_workflow' =>


### PR DESCRIPTION
## Description
The default 255 characters to save condition values in reports and workflows is not enough when, for example, a large multienum is used. This can get truncated leaving only a subset of the chosen values in the condition.

## Motivation and Context
Allows larger values to be saved without being truncated.

## How To Test This
See isse #10825

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.