### PR TITLE
Fix #10827 - Documents are not sent via email in case thread

### DIFF
--- a/modules/AOP_Case_Updates/AOP_Case_Updates.php
+++ b/modules/AOP_Case_Updates/AOP_Case_Updates.php
@@ -77,6 +77,7 @@ class AOP_Case_Updates extends Basic
     public $contact_id;
     public $internal;
     public $notes;
+    private $attachmentArray = array();
 
     public function __construct()
     {
@@ -104,7 +105,7 @@ class AOP_Case_Updates extends Basic
      * @param bool $check_notify
      * @return string
      */
-    public function save($check_notify = false)
+    public function save($check_notify = false, $attachments = false)
     {
         $this->name = SugarCleaner::cleanHtml($this->name);
         $this->parseDescription();
@@ -118,6 +119,10 @@ class AOP_Case_Updates extends Basic
             $hook = new CustomCaseUpdatesHook();
         } else {
             $hook = new CaseUpdatesHook();
+        }
+        if($attachments !== false)
+        {
+            $this->attachmentArray = $attachments;
         }
         $hook->sendCaseUpdate($this);
 
@@ -286,6 +291,13 @@ class AOP_Case_Updates extends Basic
         $mailer->Body = $text['body'] . $signatureHTML;
         $mailer->isHTML(true);
         $mailer->AltBody = $text['body_alt'] . $signaturePlain;
+        if(isset($this->attachmentArray))
+        {
+            foreach($this->attachmentArray as $emailAttachment)
+            {
+                $mailer->addAttachment($emailAttachment[0],$emailAttachment[1]);
+            }
+        }
         $mailer->From = $emailSettings['from_address'];
         isValidEmailAddress($mailer->From);
         $mailer->FromName = $emailSettings['from_name'];

--- a/modules/AOP_Case_Updates/CaseUpdatesHook.php
+++ b/modules/AOP_Case_Updates/CaseUpdatesHook.php
@@ -109,7 +109,7 @@ class CaseUpdatesHook
             return;
         }
         //Grab the update field and create a new update with it.
-        $text = $case->update_text;
+        $text = urldecode($case->update_text);
         if (!$text && empty($_FILES['case_update_file'])) {
             //No text or files, so nothing really to save.
             return;
@@ -125,9 +125,10 @@ class CaseUpdatesHook
         }
         $case_update->description = nl2br($text);
         $case_update->case_id = $case->id;
-        $case_update->save();
 
         $fileCount = $this->arrangeFilesArray();
+        $files = array();
+        $attachNotes = array();
 
         for ($x = 0; $x < $fileCount; ++$x) {
             if ($_FILES['case_update_file']['error'][$x] === UPLOAD_ERR_NO_FILE) {
@@ -142,7 +143,13 @@ class CaseUpdatesHook
             $note->file_mime_type = $uploadFile->mime_type;
             $note->filename = $uploadFile->get_stored_file_name();
             $note->save();
-            $uploadFile->final_move($note->id);
+            $attachNotes[] = $note;
+            $uploaded = $uploadFile->final_move($note->id);
+            if($uploaded === true)
+            {
+                $fileNameOrigin = $_FILES['case_update_file' . $x]['name'];
+                $files[] = array('upload/'.$note->id, $fileNameOrigin);
+            }
         }
         $postPrefix = 'case_update_id_';
         foreach ($_POST as $key => $val) {
@@ -159,9 +166,23 @@ class CaseUpdatesHook
             $note->file_mime_type = $doc->last_rev_mime_type;
             $note->filename = $doc->filename;
             $note->save();
-            $srcFile = "upload://{$doc->document_revision_id}";
-            $destFile = "upload://{$note->id}";
+            $attachNotes[] = $note;
+            $srcFile = "upload/{$doc->document_revision_id}";
+            $destFile = "upload/{$note->id}";
+
             copy($srcFile, $destFile);
+            if(isset($_REQUEST['return_action'])) {
+                if ($_REQUEST['return_action'] === 'DetailView') {
+                    $files[] = array($destFile, $doc->filename);
+                }
+            }
+        }
+        $case_update->save(false, $files);
+
+        foreach ($attachNotes as $atNote)
+        {
+            $atNote->parent_id = $case_update->id;
+            $atNote->save();
         }
     }
 

--- a/modules/AOP_Case_Updates/Case_Updates.php
+++ b/modules/AOP_Case_Updates/Case_Updates.php
@@ -55,14 +55,49 @@ function display_updates($focus)
     $showImage = SugarThemeRegistry::current()->getImageURL('advanced_search.gif');
 
     //Javascript for Asynchronous update
-    $html = <<<A
-<script>
+    $thisView = '';
+    $html = "<script>".PHP_EOL;
+    if(isset($_REQUEST['action']))
+    {
+        $thisView = $_REQUEST['action'];
+    }
+    $html .= <<<A
+const regex = new RegExp('case_update_id_*');
 var hideUpdateImage = '$hideImage';
 var showUpdateImage = '$showImage';
 function collapseAllUpdates(){
     $('.caseUpdateImage').attr("src",showUpdateImage);
     $('.caseUpdate').slideUp('fast');
 }
+
+function iterateChildren(childElement, formObj, theView)
+{
+    var upFiles = formObj;
+
+    if(childElement.children.length > 0)
+    {
+        for (var child of childElement.children) {
+            upFiles  = iterateChildren(child, upFiles, theView);
+        }
+    }
+    else
+    {
+        if(childElement.id === 'case_update_file[]')
+        {
+            upFiles.push(['case_update_file[]', childElement.files[0]]);
+        }
+        else if(theView === 'DetailView')
+        {
+            const isMatch = regex.test(childElement.id);
+            if(isMatch)
+            {
+                upFiles.push([childElement.id, childElement.value]);
+            }
+        }
+    }
+    return upFiles;
+}
+
 function expandAllUpdates(){
     $('.caseUpdateImage').attr("src",hideUpdateImage);
     $('.caseUpdate').slideDown('fast');
@@ -103,23 +138,41 @@ function caseUpdates(record){
 
     //Post parameters
 
-    var params =
-        "record="+record+"&module=Cases&return_module=Cases&action=Save&return_id="+record+"&return_action=DetailView&relate_to=Cases&relate_id="+record+"&offset=1&update_text="
-        + update_data + "&internal=" + internal;
+        var thisView = '$thisView';
+
+        let params = new FormData();
+        params.append('record', record);
+        params.append('module', 'Cases');
+        params.append('return_module', 'Cases');
+        params.append('action', 'Save');
+        params.append('return_id', record);
+        params.append('return_action', 'DetailView');
+        params.append('relate_to', 'Cases');
+        params.append('relate_id', record);
+        params.append('offset', '1');
+        params.append('update_text', update_data);
+        params.append('internal', internal);
+
+        let attachmentsForm = document.getElementById('case_update_form_span');
+        if(attachmentsForm != null)
+        {
+            let uploadedFiles = iterateChildren(attachmentsForm, [], thisView);
+            for(let i = 0; i < uploadedFiles.length; i++)
+            {
+                params.append(uploadedFiles[i][0],uploadedFiles[i][1]);
+            }
+        }
+
 
     var xmlhttp = new XMLHttpRequest();
     xmlhttp.open("POST", "index.php", true);
 
-
-    xmlhttp.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
-    xmlhttp.setRequestHeader("Content-length", params.length);
     xmlhttp.setRequestHeader("Connection", "close");
 
     //When button is clicked
     xmlhttp.onreadystatechange = function() {
 
         if(xmlhttp.readyState == 4 && xmlhttp.status == 200) {
-
 
             showSubPanel('history', null, true);
             //Reload the case updates stream and history panels
@@ -145,21 +198,23 @@ function caseUpdates(record){
 }
 
         xmlhttp.send(params);
-
-
+attElements = document.getElementsByClassName('caseDocumentWrapper');
+Array.from(attElements).forEach((attElement) => {
+    attElement.remove();
+});
 
 }
 </script>
 A;
 
-    $updates = $focus->get_linked_beans('aop_case_updates', 'AOP_Case_Updates');
-    if (!$updates || is_null($focus->id)) {
-        $html .= quick_edit_case_updates($focus);
+$updates = $focus->get_linked_beans('aop_case_updates', 'AOP_Case_Updates');
+if (!$updates || is_null($focus->id)) {
+    $html .= quick_edit_case_updates($focus);
 
-        return $html;
-    }
+    return $html;
+}
 
-    $html .= <<<EOD
+$html .= <<<EOD
 <script>
 $(document).ready(function(){
     collapseAllUpdates();
@@ -174,28 +229,28 @@ $(document).ready(function(){
 <div>
 EOD;
 
-    usort(
-        $updates,
-        function ($a, $b) {
-            $aDate = $a->fetched_row['date_entered'];
-            $bDate = $b->fetched_row['date_entered'];
-            if ($aDate < $bDate) {
-                return -1;
-            } elseif ($aDate > $bDate) {
-                return 1;
-            }
-
-            return 0;
+usort(
+    $updates,
+    function ($a, $b) {
+        $aDate = $a->fetched_row['date_entered'];
+        $bDate = $b->fetched_row['date_entered'];
+        if ($aDate < $bDate) {
+            return -1;
+        } elseif ($aDate > $bDate) {
+            return 1;
         }
-    );
 
-    foreach ($updates as $update) {
-        $html .= display_single_update($update, $hideImage);
+        return 0;
     }
-    $html .= '</div>';
-    $html .= quick_edit_case_updates($focus);
+);
 
-    return $html;
+foreach ($updates as $update) {
+    $html .= display_single_update($update, $hideImage);
+}
+$html .= '</div>';
+$html .= quick_edit_case_updates($focus);
+
+return $html;
 }
 
 /**
@@ -204,11 +259,27 @@ EOD;
 function display_update_form()
 {
     global $mod_strings, $app_strings;
+
+    // Change TPL based on which view it sits on
+    $formStart = '';
+    $formEnd = '';
+    $formName = 'EditView';
+    if(isset($_REQUEST['action']))
+    {
+        if($_REQUEST['action'] === 'DetailView')
+        {
+            $formStart = '<form id="DetailViewAttachments">';
+            $formEnd = '</form>';
+            $formName = 'DetailViewAttachments';
+        }
+    }
+
     $sugar_smarty = new Sugar_Smarty();
     $sugar_smarty->assign('MOD', $mod_strings);
     $sugar_smarty->assign('APP', $app_strings);
+    $sugar_smarty->assign('FORM', $formName);
 
-    return $sugar_smarty->fetch('modules/AOP_Case_Updates/tpl/caseUpdateForm.tpl');
+    return $formStart.$sugar_smarty->fetch('modules/AOP_Case_Updates/tpl/caseUpdateForm.tpl').$formEnd;
 }
 
 /**
@@ -228,17 +299,17 @@ function getUpdateDisplayHead(SugarBean $update)
     }
     $html = "<a href='' onclick='toggleCaseUpdate(\"" . $update->id . "\");return false;'>";
     $html .= "<img  id='caseUpdate" .
-             $update->id .
-             "Image' class='caseUpdateImage' src='" .
-             SugarThemeRegistry::current()->getImageURL('basic_search.gif') .
-             "'>";
+        $update->id .
+        "Image' class='caseUpdateImage' src='" .
+        SugarThemeRegistry::current()->getImageURL('basic_search.gif') .
+        "'>";
     $html .= '</a>';
     $html .= '<span>' .
-             ($update->internal ? '<strong>' . $mod_strings['LBL_INTERNAL'] . '</strong> ' : '') .
-             $name .
-             ' ' .
-             $update->date_entered .
-             '</span><br>';
+        ($update->internal ? '<strong>' . $mod_strings['LBL_INTERNAL'] . '</strong> ' : '') .
+        $name .
+        ' ' .
+        $update->date_entered .
+        '</span><br>';
     $notes = $update->get_linked_beans('notes', 'Notes');
     if ($notes) {
         $html .= $mod_strings['LBL_AOP_CASE_ATTACHMENTS'];

--- a/modules/AOP_Case_Updates/tpl/caseUpdateForm.tpl
+++ b/modules/AOP_Case_Updates/tpl/caseUpdateForm.tpl
@@ -64,7 +64,7 @@
                 sqs_objects = new Array;
             }
             sqs_objects['EditView_case_document_name_'+docCount]={
-                "form":"EditView",
+                "form":"{/literal}{$FORM}{literal}",
                 "method":"query",
                 'modules': 'Documents',
                 "field_list":["name","id"],
@@ -74,8 +74,8 @@
                 "limit":"30",
                 "no_match_text":"No Match"};
             SUGAR.util.doWhen(
-                    "typeof(sqs_objects) != 'undefined' && typeof(sqs_objects['EditView_case_document_name_"+docCount+"']) != 'undefined'",
-                    enableQS
+                "typeof(sqs_objects) != 'undefined' && typeof(sqs_objects['EditView_case_document_name_"+docCount+"']) != 'undefined'",
+                enableQS
             );
 
             $('.caseDocumentTypeSelect').change();
@@ -108,8 +108,7 @@
                                 "",
                                 true,
                                 false,
-                                {"call_back_function":"set_return","form_name":"EditView","field_to_name_array":{"id":"case_document_id","name":"case_document_name"}},
-                                "single",
+                                {"call_back_function":"set_return","form_name":"{/literal}{$FORM}{literal}","field_to_name_array":{"id":"case_document_id","name":"case_document_name"}},
                                 true
                                 );' >
                         {/literal}


### PR DESCRIPTION
## Description
This allows internal and external documents to be sent via email when updating a case thread. This works on both edit and detail views where the attachment form is available on the view. This also adds a link to the attachment on the case thread.

## Motivation and Context
Unable to send an attachment using the case thread system. 

## How To Test This
See issue #10827

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
