### PR TITLE
Fix #10830 - Primary email doesn't update when importing

### DIFF
--- a/modules/Import/Importer.php
+++ b/modules/Import/Importer.php
@@ -388,6 +388,21 @@ class Importer
         }
 
         if ($do_save) {
+            if(!empty($focus->emailAddress->addresses) && !empty($focus->email1)) {
+                if (is_array($focus->emailAddress->addresses))
+                {
+                    foreach ($focus->emailAddress->addresses as $k => $v) {
+                        if (!empty($v['primary_address']) && $v['primary_address'] === '1') {
+                            $beanEmail = strtolower(trim($focus->emailAddress->addresses[$k]['email_address']));
+                            $importedEmail = strtolower(trim($focus->email1));
+                            if ($beanEmail !== $importedEmail) {
+                                unset($focus->emailAddress->addresses[$k]);
+                                $focus->emailAddress->addAddress($importedEmail, true, false, $focus->invalid_email, $focus->email_opt_out);
+                            }
+                        }
+                    }
+                }
+            }
             $this->saveImportBean($focus, $newRecord);
             // Update the created/updated counter
             $this->importSource->markRowAsImported($newRecord);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->

## Description
Primary email address does not change when importing records that contain the primary email field. This ensures when the field is mapped to the 'Email Address' field on import, the primary email address is updated.

## Motivation and Context
Allows updating email for records using the importer.

## How To Test This
See issue #10830

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->