### PR TITLE
FIX #10845 Elasticsearch: Add support for unified_search flag to exclude fields from index and search

### DIFF
--- a/lib/Search/Index/AbstractIndexer.php
+++ b/lib/Search/Index/AbstractIndexer.php
@@ -50,7 +50,7 @@ use ReflectionClass;
 use SuiteCRM\Log\CliLoggerHandler;
 use SuiteCRM\Log\SugarLoggerHandler;
 use SuiteCRM\Search\Index\Documentify\AbstractDocumentifier;
-use SuiteCRM\Search\Index\Documentify\JsonSerializerDocumentifier;
+use SuiteCRM\Search\Index\Documentify\SearchDefsDocumentifier;
 use SuiteCRM\Search\SearchWrapper;
 
 /**
@@ -79,7 +79,7 @@ abstract class AbstractIndexer
 
     public function __construct()
     {
-        $this->documentifier = new JsonSerializerDocumentifier();
+        $this->documentifier = new SearchDefsDocumentifier();
         $this->modulesToIndex = SearchWrapper::getModules();
         $this->setupLogger();
     }

--- a/lib/Search/Index/Documentify/SearchDefsDocumentifier.php
+++ b/lib/Search/Index/Documentify/SearchDefsDocumentifier.php
@@ -140,7 +140,7 @@ class SearchDefsDocumentifier extends AbstractDocumentifier
             if (in_array($key, $badKeys)) {
                 continue;
             }
-            // Respect vardef unified_search = false: skip fields explicitly excluded from search
+            // Check vardef unified_search = false: skip fields explicitly excluded from search
             if (isset($fieldDefs[$key]['unified_search']) && $fieldDefs[$key]['unified_search'] === false) {
                 $this->logger->debug("[$module]->$key skipped: unified_search=false in vardefs");
                 continue;
@@ -179,7 +179,7 @@ class SearchDefsDocumentifier extends AbstractDocumentifier
             }
         }
 
-        // injects the standard metadata fields, skipping any with unified_search=false in vardefs
+        // injects the standard metadata fields as they are not present in the searchdefs, skipping any with unified_search=false in vardefs
         $metaFields = array_filter($this->getMetaData(), function ($field) use ($fieldDefs) {
             return !(isset($fieldDefs[$field]['unified_search']) && $fieldDefs[$field]['unified_search'] === false);
         });

--- a/lib/Search/Index/Documentify/SearchDefsDocumentifier.php
+++ b/lib/Search/Index/Documentify/SearchDefsDocumentifier.php
@@ -51,7 +51,6 @@ use ParserSearchFields;
 use SuiteCRM\Log\CliLoggerHandler;
 use SuiteCRM\Log\SugarLoggerHandler;
 use SuiteCRM\Utility\ArrayMapper;
-use VardefManager;
 
 require_once 'modules/ModuleBuilder/parsers/parser.searchfields.php';
 

--- a/lib/Search/Index/Documentify/SearchDefsDocumentifier.php
+++ b/lib/Search/Index/Documentify/SearchDefsDocumentifier.php
@@ -43,6 +43,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
+use BeanFactory;
 use Exception;
 use LoggerManager;
 use Monolog\Logger;
@@ -50,6 +51,7 @@ use ParserSearchFields;
 use SuiteCRM\Log\CliLoggerHandler;
 use SuiteCRM\Log\SugarLoggerHandler;
 use SuiteCRM\Utility\ArrayMapper;
+use VardefManager;
 
 require_once 'modules/ModuleBuilder/parsers/parser.searchfields.php';
 
@@ -81,9 +83,13 @@ class SearchDefsDocumentifier extends AbstractDocumentifier
             LoggerManager::getLogger()->error('Failed to start Monolog loggers');
         }
 
-        $this->mapper = ArrayMapper::make()
-            ->loadYaml(__DIR__ . '/SearchDefsDocumentifier.yml')
-            ->setHideEmptyValues(true);
+        $this->mapper = ArrayMapper::make();
+        if (file_exists('custom/lib/Search/Index/Documentify/SearchDefsDocumentifier.yml')) {
+            $this->mapper->loadYaml('custom/lib/Search/Index/Documentify/SearchDefsDocumentifier.yml');
+        } else {
+            $this->mapper->loadYaml(__DIR__ . '/SearchDefsDocumentifier.yml');
+        }
+        $this->mapper->setHideEmptyValues(true);
     }
 
     /** @inheritdoc */
@@ -121,6 +127,10 @@ class SearchDefsDocumentifier extends AbstractDocumentifier
 
         $fields = $parser->getSearchFields()[$module];
 
+        // Load field_defs once to check unified_search vardef attribute
+        $bean = BeanFactory::getBean($module);
+        $fieldDefs = $bean->getFieldDefinitions();
+
         $parsedFields = [];
 
         $badKeys = ['favorites_only', 'open_only', 'do_not_call', 'email', 'optinprimary'];
@@ -128,6 +138,11 @@ class SearchDefsDocumentifier extends AbstractDocumentifier
 
         foreach ($fields as $key => $field) {
             if (in_array($key, $badKeys)) {
+                continue;
+            }
+            // Respect vardef unified_search = false: skip fields explicitly excluded from search
+            if (isset($fieldDefs[$key]['unified_search']) && $fieldDefs[$key]['unified_search'] === false) {
+                $this->logger->debug("[$module]->$key skipped: unified_search=false in vardefs");
                 continue;
             }
 
@@ -152,12 +167,23 @@ class SearchDefsDocumentifier extends AbstractDocumentifier
             }
 
             foreach ($field['db_field'] as $db_field) {
+                if (isset($fieldDefs[$db_field]['unified_search']) && $fieldDefs[$db_field]['unified_search'] === false) {
+                    $this->logger->debug("[$module]->$key.$db_field skipped: unified_search=false in vardefs");
+                    continue;
+                }
                 $parsedFields[$key][] = $db_field;
+            }
+            // drop the key entirely if all db_fields were excluded
+            if (isset($parsedFields[$key]) && empty($parsedFields[$key])) {
+                unset($parsedFields[$key]);
             }
         }
 
-        // injects the standard metadata fields as they are not present in the searchdefs
-        $parsedFields = array_merge($parsedFields, $this->getMetaData());
+        // injects the standard metadata fields, skipping any with unified_search=false in vardefs
+        $metaFields = array_filter($this->getMetaData(), function ($field) use ($fieldDefs) {
+            return !(isset($fieldDefs[$field]['unified_search']) && $fieldDefs[$field]['unified_search'] === false);
+        });
+        $parsedFields = array_merge($parsedFields, array_values($metaFields));
 
         return $parsedFields;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->

Allow exclude field from search same as it working with Basic Search
See issue details here https://github.com/SuiteCRM/SuiteCRM/issues/10845
Added option to override `/lib/Search/Index/Documentify/SearchDefsDocumentifier.yml` by custom without core override `custom/lib/Search/Index/Documentify/SearchDefsDocumentifier.yml`, copy and chage.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

I want to set searchable only name, email end phone, I created file `custom/Extension/modules/Accounts/Ext/Vardefs/vardefs.php` and set all unused in search fields:
```
<?php

$dictionary['Account']['fields']['test_c']['unified_search'] = false;
$dictionary['Account']['fields']['account_type']['unified_search'] = false;
$dictionary['Account']['fields']['industry']['unified_search'] = false;
$dictionary['Account']['fields']['website']['unified_search'] = false;

$dictionary['Account']['fields']['billing_address_street']['unified_search'] = false;
$dictionary['Account']['fields']['billing_address_city']['unified_search'] = false;
$dictionary['Account']['fields']['billing_address_state']['unified_search'] = false;
$dictionary['Account']['fields']['billing_address_postalcode']['unified_search'] = false;
$dictionary['Account']['fields']['billing_address_country']['unified_search'] = false;

$dictionary['Account']['fields']['shipping_address_street']['unified_search'] = false;
$dictionary['Account']['fields']['shipping_address_city']['unified_search'] = false;
$dictionary['Account']['fields']['shipping_address_state']['unified_search'] = false;
$dictionary['Account']['fields']['shipping_address_postalcode']['unified_search'] = false;
$dictionary['Account']['fields']['shipping_address_country']['unified_search'] = false;

$dictionary['Account']['fields']['date_entered']['unified_search'] = false;
$dictionary['Account']['fields']['created_by']['unified_search'] = false;
$dictionary['Account']['fields']['created_by_name']['unified_search'] = false;

$dictionary['Account']['fields']['date_modified']['unified_search'] = false;
$dictionary['Account']['fields']['modified_by_name']['unified_search'] = false;
$dictionary['Account']['fields']['modified_user_id']['unified_search'] = false;

$dictionary['Account']['fields']['assigned_user_id']['unified_search'] = false;
$dictionary['Account']['fields']['assigned_user_name']['unified_search'] = false;
$dictionary['Account']['fields']['assigned_owner_name']['unified_search'] = false;

```

The ElasticSearch index looks like:

```
{
  "name": {
    "name": "TJ O'Rourke Inc1"
  },
  "account_type": "Customer",
  "industry": "Machinery",
  "address": {
    "billing": {
      "street": "999 Baker Way",
      "city": "Santa Fe",
      "state": "NY",
      "postalcode": "81459",
      "country": "USA"
    },
    "shipping": {
      "street": "999 Baker Way",
      "city": "Santa Fe",
      "state": "NY",
      "postalcode": "81459",
      "country": "USA"
    }
  },
  "phone": {
    "office": "3333024302"
  },
  "website": "www.sugarkid.co.jp",
  "meta": {
    "assigned": {
      "user_id": "seed_will_id",
      "user_name": "will"
    },
    "created": {
      "date": "05/27/2026 11:01",
      "user_id": "1",
      "user_name": "admin"
    },
    "modified": {
      "date": "05/31/2026 16:29",
      "user_id": "1",
      "user_name": "admin"
    }
  },
  "email": [
    "kid.support.sugar@example.co.jp"
  ]
}
```

After fix:
```
{
  "name": {
    "name": "TJ O'Rourke Inc1"
  },
  "phone": {
    "office": "3333024302"
  },
  "email": [
    "kid.support.sugar@example.co.jp"
  ]
}
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
**Better Search Relevance:**
Searching across too many fields returns noisy results.
For example, a search for a street name might return an Account whose address matches, cluttering results when the user was only looking for an Account Name.

**Reduced Storage:**
Excluding large, unnecessary fields (like addresses or long descriptions) will significantly reduce Elasticsearch disk usage.

**Faster Search Speed:**
Searching through less data and only across relevant fields will noticeably improve query performance.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
See issue details here https://github.com/SuiteCRM/SuiteCRM/issues/10845


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->