### PR TITLE
Fix #10859 - OAuth window loses connection to the opener on request

### DIFF
--- a/modules/ExternalOAuthConnection/js/broadcast.js
+++ b/modules/ExternalOAuthConnection/js/broadcast.js
@@ -1,0 +1,4 @@
+const channel = new BroadcastChannel("auth");
+channel.addEventListener ("message", (event) => {
+    window.externalOAuthConnectionFields.setValue(event.data[0], event.data[1]);
+});

--- a/modules/ExternalOAuthConnection/metadata/editviewdefs.php
+++ b/modules/ExternalOAuthConnection/metadata/editviewdefs.php
@@ -71,10 +71,11 @@ $viewdefs['ExternalOAuthConnection'] = [
                 ],
             ],
             'javascript' => '
-                <script type="text/javascript">
+                 <script type="text/javascript">
                     {suite_combinescripts
                         files="modules/ExternalOAuthConnection/js/fields.js,
-                               modules/ExternalOAuthConnection/js/authenticate.js
+                               modules/ExternalOAuthConnection/js/authenticate.js,
+                               modules/ExternalOAuthConnection/js/broadcast.js
                               "}
                 </script>
             '

--- a/modules/ExternalOAuthConnection/tpl/setToken.tpl
+++ b/modules/ExternalOAuthConnection/tpl/setToken.tpl
@@ -41,11 +41,14 @@
 *}
 <body>
 <script>
-  {if !empty($token)}
-      {foreach from=$token key=k item=v}
-        window.opener.externalOAuthConnectionFields.setValue('{$k}', '{$v}');
-      {/foreach}
-  {/if}
-  window.close();
+    var data;
+    const channel = new BroadcastChannel('auth');
+    {if !empty($token)}
+        {foreach from=$token key=k item=v}
+            data = ['{$k}', '{$v}'];
+            channel.postMessage(data);
+        {/foreach}
+    {/if}
+    window.close();
 </script>
 </body>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->

## Description
When authenticating in the OAuth connection screen, the authentication window can lose connection to the opening window preventing the token from being passed back to the form to be saved for outbound/inbound email setup. This does not happen in every case.

## Motivation and Context
Uses the broadcast method to communicate with the opening window so that when the connection is lost to the opener, the token call still be passed back to the form.

## How To Test This
See issue #10859

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->