### PR TITLE
Fix #10874 issue with Associated user not linking correctly

### DIFF
--- a/modules/OAuth2Clients/metadata/listviewdefs.php
+++ b/modules/OAuth2Clients/metadata/listviewdefs.php
@@ -56,7 +56,6 @@ $listViewDefs[$module_name] = [
     'assigned_user_name' => [
         'label' => 'LBL_USER',
         'module' => 'Users',
-        'id' => 'USER_ID',
         'default' => true,
         'sortable' => true,
     ],

--- a/modules/OAuth2Tokens/metadata/listviewdefs.php
+++ b/modules/OAuth2Tokens/metadata/listviewdefs.php
@@ -89,7 +89,6 @@ $listViewDefs[$module_name] = [
     'assigned_user_name' => [
         'label' => 'LBL_USER',
         'module' => 'Users',
-        'id' => 'USER_ID',
         'default' => true,
         'sortable' => true,
     ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Removed the 'id' in the assigned_user_name definition in the listviewdefs of OAuth2Clients and OAuth2Tokens to stop the field from using the token/client id when linking to the associated user.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Correctly links to the associated user.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
See issue #10874 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->