### PR TITLE
Fix/#8989 dbfailure on export filtered relate field

### DIFF
--- a/export.php
+++ b/export.php
@@ -82,16 +82,12 @@ if (!empty($_REQUEST['sample'])) {
     } else {
         $ids = array();
         $bean = BeanFactory::getBean($the_module);
-
-        if(trim($_SESSION["export_where"]) !== "where " . strtolower($_REQUEST["module"]) .".deleted=0"){
+        $currentQuery = generateSearchWhere($the_module, $_REQUEST['current_post']);
+        if (!empty($currentQuery['where'])) {
             // handle select all queries with filters
-            $whereArr = explode(" ", trim($_SESSION['export_where']));
-            if ($whereArr[0] === trim('where')) {
-                array_shift($whereArr);
-            }
             $query = $bean->create_new_list_query(
                 "",
-                implode(" ", $whereArr),
+                $currentQuery['where'],
                 array(),
                 array(),
                 0,

--- a/metadata/email_marketing_prospect_listsMetaData.php
+++ b/metadata/email_marketing_prospect_listsMetaData.php
@@ -85,6 +85,11 @@ $dictionary['email_marketing_prospect_lists'] = array(
                                 'prospect_list_id'
                         )
         ),
+        array(
+            'name' => 'idx_emp_prospect_list_id',
+            'type' => 'index',
+            'fields' => array('prospect_list_id', 'deleted')
+        ),
     ),
     
     'relationships' => array(

--- a/metadata/fp_events_prospects_1MetaData.php
+++ b/metadata/fp_events_prospects_1MetaData.php
@@ -96,5 +96,16 @@ $dictionary["fp_events_prospects_1"] = array(
         1 => 'fp_events_prospects_1prospects_idb',
       ),
     ),
+    2 =>
+    array(
+      'name' => 'idx_events_prospects_prospect_id',
+      'type' => 'index',
+      'fields' =>
+      array(
+        0 => 'fp_events_prospects_1prospects_idb',
+        1 => 'deleted',
+        2 => 'fp_events_prospects_1fp_events_ida',
+      ),
+    ),
   ),
 );

--- a/metadata/prospect_list_campaignsMetaData.php
+++ b/metadata/prospect_list_campaignsMetaData.php
@@ -80,12 +80,12 @@ $dictionary['prospect_list_campaigns'] = array(
         array(
             'name' => 'idx_pro_id',
             'type' => 'index',
-            'fields' => array('prospect_list_id')
+            'fields' => array('prospect_list_id', 'deleted')
         ),
         array(
             'name' => 'idx_cam_id',
             'type' => 'index',
-            'fields' => array('campaign_id')
+            'fields' => array('campaign_id', 'deleted')
         ),
         array(
             'name' => 'idx_prospect_list_campaigns',

--- a/metadata/prospect_lists_prospectsMetaData.php
+++ b/metadata/prospect_lists_prospectsMetaData.php
@@ -90,6 +90,8 @@ $dictionary['prospect_lists_prospects'] = array(
             'fields' => array(
                 'prospect_list_id',
                 'deleted',
+                'related_type',
+                'related_id',
             ),
         ),
         array(

--- a/modules/ProspectLists/vardefs.php
+++ b/modules/ProspectLists/vardefs.php
@@ -227,7 +227,7 @@ $dictionary['ProspectList'] = array(
         array(
             'name' => 'idx_prospect_list_name',
             'type' => 'index',
-            'fields' => array('name')
+            'fields' => array('name', 'deleted')
         ),
     ),
     'relationships' => array(


### PR DESCRIPTION
## Description
Fix #8989  & add optimised indexes for target list joins - Extends existing indexes so the query resolves the join from the index alone, instead of a per-row lookup or full scan.

## How To Test This
See #8989

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->